### PR TITLE
Add first few Architecture Decision Records (ADRs) for chosen tooling

### DIFF
--- a/.adr-dir
+++ b/.adr-dir
@@ -1,0 +1,1 @@
+doc/architecture/decisions

--- a/doc/architecture/decisions/0001-record-architecture-decisions.md
+++ b/doc/architecture/decisions/0001-record-architecture-decisions.md
@@ -1,0 +1,19 @@
+# 1. Record architecture decisions
+
+Date: 2021-11-16
+
+## Status
+
+Accepted
+
+## Context
+
+We need to record the architectural decisions made on this project.
+
+## Decision
+
+We will use Architecture Decision Records, as [described by Michael Nygard](http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions).
+
+## Consequences
+
+See Michael Nygard's article, linked above. For a lightweight ADR toolset, see Nat Pryce's [adr-tools](https://github.com/npryce/adr-tools).

--- a/doc/architecture/decisions/0002-use-nestjs-as-our-application-framework.md
+++ b/doc/architecture/decisions/0002-use-nestjs-as-our-application-framework.md
@@ -1,0 +1,47 @@
+# 2. Use NestJS as our application framework
+
+Date: 2021-11-16
+
+## Status
+
+Accepted
+
+## Context
+
+We expect this application to be actively developed for a significant time, and
+to continue to evolve to meet evolving user needs.
+
+For a long-running project, it is helpful to have a well-defined application
+structure and standard, covering concerns like established MVC patterns, TDD,
+dependency injection, conventions over configuration, and toolchain. This helps
+both the productivity of existing developers, but helps with knowledge transfer
+around the team as new developers are brought on.
+
+[Express](https://expressjs.com/) markets itself as the "Fast, unopinionated,
+minimalist web framework for Node.js". While this provides a lot of flexibility
+and freedom to follow your own path, it does not provide any guidance or
+opinions around the application architecture, nor best practice patterns that
+should be followed.
+
+## Decision
+
+We will use [NestJS](https://nestjs.com/) as an application framework for our
+service, in order to boost development speed, productivity, and knowledge
+transfer.
+
+Although there are multiple application frameworks we could have chosen, we
+believe that NestJS provides a well-defined application structure for our needs
+and a consistent and well-documented developer experience. NestJS has a healthy
+established community, good documentation, and is open source.
+
+## Consequences
+
+Choosing a widely-adopted, opinionated framework like NestJS that wraps around
+Node and Express will allow the team to focus on delivering features at pace
+without having to spend too long deciding on architecture and design choices.
+
+Developers joining the project may be unfamiliar with NestJS. To mitigate this,
+we will include setup scripts and link to NestJS documentation where helpful in
+the README and commit messages to make onboarding as easy as possible. We
+believe that this will provide a significantly clearer onboarding experience
+than would exist for a self-written framework.

--- a/doc/architecture/decisions/0003-use-typescript.md
+++ b/doc/architecture/decisions/0003-use-typescript.md
@@ -1,0 +1,25 @@
+# 3. Use TypeScript
+
+Date: 2021-11-16
+
+## Status
+
+Accepted
+
+## Context
+
+We want to be confident about the code we write, and for it to be
+self-documenting as much as possible. TypeScript is a compiled language with
+optional typing. It's a superset of JavaScript, so is familiar to developers
+who know JavaScript. It has wide editor support. It is fully supported by
+NestJS too.
+
+## Decision
+
+We will use TypeScript for our server-side code by default.
+
+## Consequences
+
+This adds some overhead to developers, as they need to become familiar with
+TypeScript if they aren't. It can also add some overhead when using
+dependencies without existing type definitions.

--- a/doc/architecture/decisions/0004-use-eslint.md
+++ b/doc/architecture/decisions/0004-use-eslint.md
@@ -1,0 +1,31 @@
+# 4. Use ESLint
+
+Date: 2021-11-16
+
+## Status
+
+Accepted
+
+## Context
+
+We want to enforce consistency in our code, and catch as many errors
+automatically as we are able to. Linting the code is good practice to achieve
+these aims. [ESLint](https://eslint.org/) is the standard linter for modern
+JavaScript, and has good support for TypeScript though plugins.
+
+## Decision
+
+We will check code style using ESLint.
+
+We will let Prettier have precedence when ESLint and Prettier conflict in their
+styles.
+
+We will use the recommended configuration for plugins where possible.
+
+We will run ESLint as part of the test suite.
+
+## Consequences
+
+ESLint enables us to agree on and enforce a code style without having to keep
+it in the heads of developers, meaning we shouldn't have to discuss individual
+code style violations as they come up.

--- a/doc/architecture/decisions/0005-use-cypress-for-end-to-end-testing.md
+++ b/doc/architecture/decisions/0005-use-cypress-for-end-to-end-testing.md
@@ -1,0 +1,31 @@
+# 5. Use Cypress for end-to-end testing
+
+Date: 2021-11-16
+
+## Status
+
+Accepted
+
+## Context
+
+We want to be able to automate testing end-to-end user journeys through our
+application. Cypress is an alternative to Selenium that runs in the browser to
+do this for us, offering both headless and in-browser methods of running the
+tests.
+
+## Decision
+
+We will use Cypress for end-to-end tests. Because of the overhead involved in
+writing end-to-end tests, we'll opt for mostly testing happy paths in the
+application and rely on unit and more focused integration tests for edge cases.
+
+## Consequences
+
+There will be some overhead in writing tests in Cypress, but this will ensure
+we catch any regressions introduced by changes to the codebase.
+
+There are some limitations to using Cypress as an integration framework,
+particularly that it may not be possible to test situations in the browser
+where JavaScript is disabled for any reason, which presents some difficulties
+in trying to [build a resilient frontend using progressive
+enhancement](https://www.gov.uk/service-manual/technology/using-progressive-enhancement#building-more-complex-services).

--- a/doc/architecture/decisions/0006-use-typeorm.md
+++ b/doc/architecture/decisions/0006-use-typeorm.md
@@ -1,0 +1,27 @@
+# 6. Use TypeORM
+
+Date: 2021-11-16
+
+## Status
+
+Accepted
+
+## Context
+
+An Object-Relational Mapping (ORM) library provides helpful methods for
+interacting with a database, providing an abstraction layer above the database
+itself. It's well-suited to writing software with an MVC
+(Model-View-Controller) pattern, which we're following with NestJS. NestJS
+provides out-of-the-box support for TypeORM via the `@nestjs/typeorm` package.
+
+## Decision
+
+We will use TypeORM as our ORM library, as it is written in TypeScript and
+integrates well with the NestJS framework.
+
+## Consequences
+
+There may be some initial overhead in getting up to speed with the DSL for
+TypeORM, but as TypeORM integrates well with NestJS, it will make interacting
+with our database a lot easier for developers by doing a lot of the work for
+us.

--- a/doc/architecture/decisions/0007-use-a-changelog-for-tracking-changes-in-a-release.md
+++ b/doc/architecture/decisions/0007-use-a-changelog-for-tracking-changes-in-a-release.md
@@ -1,0 +1,27 @@
+# 7. Use a changelog for tracking changes in a release
+
+Date: 2021-11-16
+
+## Status
+
+Accepted
+
+## Context
+
+Documenting changes for a release can be challenging. It often involves reading
+back through commit messages and PRs, looking for and classifying changes,
+which is a time consuming and error prone process.
+
+## Decision
+
+We will use a changelog (`CHANGELOG.md`) in the [Keep a Changelog
+1.0.0](https://keepachangelog.com/en/1.0.0/) format to be updated when code
+changes happen, rather than at release time.
+
+## Consequences
+
+This will make compiling releases much simpler, as the process for determining
+changes in a release is simply a matter of looking at the changelog.
+
+This does add some overhead to making code changes, and requires that releases
+update the changelog as part of their process, but those overheads are small.

--- a/doc/architecture/decisions/0008-use-prettier-to-format-typescript-code.md
+++ b/doc/architecture/decisions/0008-use-prettier-to-format-typescript-code.md
@@ -1,0 +1,31 @@
+# 8. Use Prettier to format TypeScript code
+
+Date: 2021-11-16
+
+## Status
+
+Accepted
+
+## Context
+
+We want to ensure we're all using one code style, that is familiar across
+projects. [Prettier](https://prettier.io/) is an opinionated code formatter with
+support for most, if not all, of the languages in the JavaScript ecosystem. As
+of writing, it is used by over
+[1 million repositories](https://github.com/prettier/prettier/network/dependents?package_id=UGFja2FnZS00OTAwMTEyNTI%3D)
+on GitHub, including React itself, and has become a standard.
+
+## Decision
+
+We will enforce that everything supported by Prettier has its style enforced by
+it.
+
+We will set up Git hooks to automatically run the formatter before committing.
+
+We will set continuous integration up to reject commits that are not correctly
+formatted.
+
+## Consequences
+
+This adds some overhead to developers committing code, but that can be mitigated
+using Git hooks and editor integrations.


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->

## Changes in this PR

Adds the first bunch of ADRs (Architecture Decision Records) to the project to document the motivation behind the architectural decisions we've made on the project, which is helpful for future readers to the codebase.

See: [Documenting architecture decisions](https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions)
for more information.

This adds ADRs for:

- NestJS
- TypeScript
- ESLint
- Cypress
- TypeORM
- Keeping a changelog
- Prettier