### PR TITLE
Add an auto rebase action

### DIFF
--- a/.github/workflows/automatic-rebase.yml
+++ b/.github/workflows/automatic-rebase.yml
@@ -1,0 +1,77 @@
+on:
+  issue_comment:
+    types:
+      - created
+  pull_request_target:
+    types:
+      - auto_merge_enabled
+
+env:
+  AUTO_REBASE_PERSONAL_ACCESS_TOKEN: ${{ secrets.AUTO_REBASE_PERSONAL_ACCESS_TOKEN }}
+
+jobs:
+  check-token:
+    if: |
+      (
+        github.event.issue.pull_request &&
+        contains(github.event.comment.body, '/rebase')
+      ) ||
+      github.event_name == 'pull_request_target'
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - if: '! env.AUTO_REBASE_PERSONAL_ACCESS_TOKEN'
+        name: Prompt to add a token
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          issue-number: ${{ github.event.issue.number || github.event.number }}
+          body: |
+            To automatically rebase, you need to add a [personal access token](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token) with the name `AUTO_REBASE_PERSONAL_ACCESS_TOKEN` to the [secrets section of this repo](https://github.com/${{ github.event.repository.full_name }}/settings/secrets/actions).
+
+            Once this is done, you can try the `/rebase` command again.
+
+      - if: github.event.comment
+        name: React to the triggering comment
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          comment-id: ${{ github.event.comment.id }}
+          reactions: ${{ env.AUTO_REBASE_PERSONAL_ACCESS_TOKEN && '+1' || '-1' }}
+
+      - if: '! env.AUTO_REBASE_PERSONAL_ACCESS_TOKEN'
+        name: Return a failing state if we have no token
+        run: exit 1
+
+  rebase:
+    needs: check-token
+    name: Rebase
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          token: ${{ env.AUTO_REBASE_PERSONAL_ACCESS_TOKEN }}
+          fetch-depth: 0
+
+      - name: Rebase on top of the default branch
+        uses: cirrus-actions/rebase@1.4
+        env:
+          GITHUB_TOKEN: ${{ env.AUTO_REBASE_PERSONAL_ACCESS_TOKEN }}
+
+      - if: failure()
+        name: Notify of the failure
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          issue-number: ${{ github.event.issue.number || github.event.number }}
+          body: |
+            Automatic rebasing for this issue has failed :disappointed:
+
+            You'll have to rebase this one manually, I'm afraid.
+
+      - if: success() && github.event.comment
+        name: React to the triggering comment
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          comment-id: ${{ github.event.comment.id }}
+          reactions: hooray


### PR DESCRIPTION
We have the repo set up to make sure branches are up to date before merging. While Github has a button to update a branch, this adds a merge commit, which makes the history messy.

This PR adds a Github action that listens for a comment with `/rebase` in the body and then automatically rebases against the target branch.

It also automatically rebases if the branch is set to automerge, meaning if a branch is behind, but has been approved, you can set it to automerge and let the robots do the work!

The action requires a `AUTO_REBASE_PERSONAL_ACCESS_TOKEN`, which I've already added to the repo.