### PR TITLE
Add database documentation

### DIFF
--- a/doc/0_index.md
+++ b/doc/0_index.md
@@ -1,0 +1,6 @@
+# Regulated Professions Register documentation
+
+## Development
+
+- [Generate migrations](./generate-migrations.md)
+- [Database models](./database-models.md)

--- a/doc/architecture/decisions/0009-use-the-activerecord-pattern-in-typeorm.md
+++ b/doc/architecture/decisions/0009-use-the-activerecord-pattern-in-typeorm.md
@@ -1,0 +1,41 @@
+# 9. Use the ActiveRecord Pattern in TypeORM
+
+Date: 2021-11-18
+
+## Status
+
+Accepted
+
+## Context
+
+We have chosen TypeORM as our ORM library. It supports two popular
+design patterns for interacting with databases - Datamapper and
+ActiveRecord.
+
+With Datamapper, all query methods are defined in separate classes
+called "repositories", and saving, removing, and loading objects is
+done using repositories.
+
+With ActiveRecord, all query methods are defined in the model itself,
+and you save, remove, and load objects using model methods.
+
+## Decision
+
+For this project, we have decided to adopt the ActiveRecord pattern.
+This is because most of the developers currently on this project, and
+developers who will be maintaining it, are used to this pattern from
+working with Ruby on Rails. It is also a pattern that is familiar to
+developers who have worked with frameworks such as Laravel (PHP), and
+Django (Python).
+
+As we are also particularly time pressured, ActiveRecord is a good
+choice, as it's simpler to get up and running with, and requires
+much less boilerplate code.
+
+## Consequences
+
+Not using Datamapper may have an impact on maintainability and
+testability, because the code is much more tightly coupled to the
+database, but given the size and complexity of the application,
+this is a small risk. We can also balance against this risk by
+introducing service objects, if the situation allows.

--- a/doc/database-models.md
+++ b/doc/database-models.md
@@ -1,0 +1,48 @@
+# Database models
+
+We use [TypeORM](https://github.com/typeorm/typeorm) to handle
+communication with the database. By convention, we store the
+models in the same folder as the module where the controller for
+the module is located.
+
+For example, if you have a module called `people` in a folder
+called `people`, your model will be stored in a file called
+`people.entity.ts`. A TypeORM model looks like this:
+
+```typescript
+import { Entity, PrimaryGeneratedColumn, Column, BaseEntity } from 'typeorm';
+
+@Entity()
+export class User extends BaseEntity {
+  @PrimaryGeneratedColumn('uuid') // All of our models should have UUIDs as their primary keys
+  id: number;
+
+  @Column()
+  firstName: string;
+
+  @Column()
+  lastName: string;
+
+  @Column()
+  age: number;
+}
+```
+
+And we can query/update the database like this:
+
+```typescript
+const user = new User();
+user.firstName = 'Timber';
+user.lastName = 'Saw';
+user.age = 25;
+await user.save();
+
+const allUsers = await User.find();
+const firstUser = await User.findOne(1);
+const timber = await User.findOne({ firstName: 'Timber', lastName: 'Saw' });
+
+await timber.remove();
+```
+
+For more information about models in TypeORM,
+see the [TypeORM docs](https://github.com/typeorm/typeorm#readme)

--- a/doc/generate-migrations.md
+++ b/doc/generate-migrations.md
@@ -1,0 +1,32 @@
+# Generate migrations
+
+We use [TypeORM](https://github.com/typeorm/typeorm) to handle
+communication with the database. To generate a migration, run
+the command:
+
+```bash
+npm run typeorm migration:create -- -n YOUR_MIGRATION_NAME
+```
+
+This generates a file in `src/db/migrate` in the following format:
+
+```typescript
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class someMigration1637230798783 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {}
+
+  public async down(queryRunner: QueryRunner): Promise<void> {}
+}
+```
+
+For more information on the format of the migrations, see the
+[TypeORM docs](https://github.com/typeorm/typeorm/blob/master/docs/migrations.md#using-migration-api-to-write-migrations).
+
+Once you've written your migration, start the server with:
+
+```bash
+script/server
+```
+
+The migrations will be automatically run.


### PR DESCRIPTION
We've decided to adopt the ActiveRecord pattern in the interests of getting up and running quickly, so I've added an ADR to this effect, as well as writing some short docs on TypeORM migrations and ActiveRecord models.