### PR TITLE
Setup script improvements: install Node & don't run migrations

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,0 +1,2 @@
+brew "nodenv"
+brew "postgresql" unless system "which -s psql"

--- a/script/setup
+++ b/script/setup
@@ -11,6 +11,11 @@ app_name=$(basename "$PWD")
 dev_db="$app_name-development"
 test_db="$app_name-test"
 
+if ! brew bundle check >/dev/null 2>&1; then
+  echo "==> Installing Homebrew dependencies…"
+  brew bundle install --verbose --no-lock
+fi
+
 echo "==> Dropping and recreating the database..."
 
 dropdb "$dev_db" > /dev/null 2>&1 || true
@@ -24,7 +29,7 @@ echo "==> Creating env files for dev and test..."
 echo "DATABASE_URL=postgres://postgres@localhost:5432/$dev_db" > .env.development
 echo "DATABASE_URL=postgres://postgres@localhost:5432/$test_db" > .env.test
 
-echo "==> Installing dependencies..."
+echo "==> Installing application dependencies..."
 
 nodenv install --skip-existing
 npm install

--- a/script/setup
+++ b/script/setup
@@ -26,6 +26,7 @@ echo "DATABASE_URL=postgres://postgres@localhost:5432/$test_db" > .env.test
 
 echo "==> Installing dependencies..."
 
+nodenv install --skip-existing
 npm install
 
 echo "==> Running database migrations"

--- a/script/setup
+++ b/script/setup
@@ -29,10 +29,6 @@ echo "==> Installing dependencies..."
 nodenv install --skip-existing
 npm install
 
-echo "==> Running database migrations"
-
-npm run typeorm migration:run
-
 echo "==> Building assets..."
 
 npm run build:assets


### PR DESCRIPTION
A setup script should install all necessary dependencies. We weren't installing the version of Node here. However, this introduces another dependency on `nodenv`, which we don't install as part of the script - should we?

Running the migrations failed for me running locally, due to not having a `NODE_ENV` variable set at the time of running the script. It runs as part of `npm run start:dev` anyway with the right env variables, so it should be fine to remove here.