### PR TITLE
(1896) Create a user model

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -5,6 +5,7 @@ import { ConfigModule, ConfigService } from '@nestjs/config';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { UsersModule } from './users/users.module';
 
 import dbConfiguration from './config/db.config';
 
@@ -20,6 +21,7 @@ import dbConfiguration from './config/db.config';
         ...(await configService.get('database')),
       }),
     }),
+    UsersModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/db/migrate/1637317177058-create_users.ts
+++ b/src/db/migrate/1637317177058-create_users.ts
@@ -1,0 +1,40 @@
+import { MigrationInterface, QueryRunner, Table } from 'typeorm';
+
+export class createUsers1637317177058 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // required for `uuid_generate_v4()`
+    await queryRunner.query(`CREATE EXTENSION IF NOT EXISTS "uuid-ossp"`);
+
+    await queryRunner.createTable(
+      new Table({
+        name: 'users',
+        columns: [
+          {
+            name: 'id',
+            type: 'uuid',
+            isPrimary: true,
+            isUnique: true,
+            default: 'uuid_generate_v4()',
+          },
+          {
+            name: 'name',
+            type: 'varchar',
+          },
+          {
+            name: 'email',
+            type: 'varchar',
+          },
+          {
+            name: 'identifier',
+            type: 'varchar',
+          },
+        ],
+      }),
+      true,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TABLE users`);
+  }
+}

--- a/src/users/user.entity.ts
+++ b/src/users/user.entity.ts
@@ -1,0 +1,22 @@
+import { Entity, Column, PrimaryGeneratedColumn } from 'typeorm';
+
+@Entity({ name: 'users' })
+export class User {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  email: string;
+
+  @Column()
+  name: string;
+
+  @Column()
+  identifier: string;
+
+  constructor(email?: string, name?: string, identifier?: string) {
+    this.email = email || '';
+    this.name = name || '';
+    this.identifier = identifier || '';
+  }
+}

--- a/src/users/user.service.spec.ts
+++ b/src/users/user.service.spec.ts
@@ -1,0 +1,56 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+
+import { User } from './user.entity';
+import { UserService } from './user.service';
+
+const user = new User('email@example.com', 'name', '212121');
+const userArray = [user, new User('email2@example.com', 'name2', '1234')];
+
+describe('User', () => {
+  let service: UserService;
+  let repo: Repository<User>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        UserService,
+        {
+          provide: getRepositoryToken(User),
+          useValue: {
+            find: () => {
+              return userArray;
+            },
+            findOne: () => {
+              return user;
+            },
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<UserService>(UserService);
+    repo = module.get<Repository<User>>(getRepositoryToken(User));
+  });
+
+  describe('all', () => {
+    it('should return all users', async () => {
+      const repoSpy = jest.spyOn(repo, 'find');
+      const posts = await service.all();
+
+      expect(posts).toEqual(userArray);
+      expect(repoSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe('find', () => {
+    it('should return a user', async () => {
+      const repoSpy = jest.spyOn(repo, 'findOne');
+      const post = await service.find('some-uuid');
+
+      expect(post).toEqual(user);
+      expect(repoSpy).toHaveBeenCalledWith('some-uuid');
+    });
+  });
+});

--- a/src/users/user.service.ts
+++ b/src/users/user.service.ts
@@ -1,0 +1,21 @@
+import { Repository } from 'typeorm';
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+
+import { User } from './user.entity';
+
+@Injectable()
+export class UserService {
+  constructor(
+    @InjectRepository(User)
+    private repository: Repository<User>,
+  ) {}
+
+  all(): Promise<User[]> {
+    return this.repository.find();
+  }
+
+  find(id: string): Promise<User> {
+    return this.repository.findOne(id);
+  }
+}

--- a/src/users/users.module.ts
+++ b/src/users/users.module.ts
@@ -1,0 +1,3 @@
+import { Module } from '@nestjs/common';
+@Module({})
+export class UsersModule {}

--- a/src/users/users.module.ts
+++ b/src/users/users.module.ts
@@ -2,7 +2,10 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { User } from './user.entity';
+import { UserService } from './user.service';
+
 @Module({
   imports: [TypeOrmModule.forFeature([User])],
+  providers: [UserService],
 })
 export class UsersModule {}

--- a/src/users/users.module.ts
+++ b/src/users/users.module.ts
@@ -1,3 +1,8 @@
 import { Module } from '@nestjs/common';
-@Module({})
+import { TypeOrmModule } from '@nestjs/typeorm';
+
+import { User } from './user.entity';
+@Module({
+  imports: [TypeOrmModule.forFeature([User])],
+})
 export class UsersModule {}


### PR DESCRIPTION
This creates a basic model to store information about users, who will eventually be logging in to the system. As per #9, we've opted to use the DataMapper pattern over ActiveRecord for ease of testing.