### PR TITLE
(1901) Get user from database

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,13 @@ dependencies, runs the DB migrations, and builds the assets:
 script/setup
 ```
 
+To just update dependencies and database seeds, you can run the bootstrap
+command:
+
+```
+script/bootstrap
+```
+
 ## Running the application
 
 ```

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -16,5 +16,10 @@
 // Import commands.js using ES2015 syntax:
 import './commands';
 
+// Seed the database before running the specs
+before(() => {
+  cy.exec('npm run seed:test');
+});
+
 // Alternatively you can use CommonJS syntax:
 // require('./commands')

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "express-openid-connect": "^2.5.1",
         "file-loader": "^6.2.0",
         "govuk-frontend": "^3.14.0",
+        "jwt-decode": "^3.1.2",
         "nunjucks": "^3.2.3",
         "pg": "^8.7.1",
         "reflect-metadata": "^0.1.13",
@@ -10121,6 +10122,11 @@
         "json-schema": "0.2.3",
         "verror": "1.10.0"
       }
+    },
+    "node_modules/jwt-decode": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz",
+      "integrity": "sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A=="
     },
     "node_modules/keyv": {
       "version": "4.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,6 +46,7 @@
         "eslint-config-prettier": "^8.3.0",
         "eslint-plugin-prettier": "^4.0.0",
         "jest": "^27.2.5",
+        "nestjs-seeder": "^0.2.0",
         "prettier": "^2.3.2",
         "puppeteer": "^11.0.0",
         "source-map-support": "^0.5.20",
@@ -7451,6 +7452,12 @@
         "node >=0.6.0"
       ]
     },
+    "node_modules/faker": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/faker/-/faker-4.1.0.tgz",
+      "integrity": "sha1-HkW7vsxndLPBlfrSg1EJxtdIzD8=",
+      "dev": true
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -10810,6 +10817,15 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
+    },
+    "node_modules/nestjs-seeder": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/nestjs-seeder/-/nestjs-seeder-0.2.0.tgz",
+      "integrity": "sha512-HPvFgDITpY2a1MG73VD06QVQM6jjpqqaoPmExg0LHV7II9o5gDV1DdcMpkjSRKR90aLbv2FMsbdtII7t/M9zeA==",
+      "dev": true,
+      "dependencies": {
+        "faker": "^4.1.0"
+      }
     },
     "node_modules/next-tick": {
       "version": "1.0.0",
@@ -21585,6 +21601,12 @@
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
       "dev": true
     },
+    "faker": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/faker/-/faker-4.1.0.tgz",
+      "integrity": "sha1-HkW7vsxndLPBlfrSg1EJxtdIzD8=",
+      "dev": true
+    },
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -23588,6 +23610,11 @@
         "verror": "1.10.0"
       }
     },
+    "jwt-decode": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz",
+      "integrity": "sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A=="
+    },
     "keyv": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.0.4.tgz",
@@ -24117,6 +24144,15 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
+    },
+    "nestjs-seeder": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/nestjs-seeder/-/nestjs-seeder-0.2.0.tgz",
+      "integrity": "sha512-HPvFgDITpY2a1MG73VD06QVQM6jjpqqaoPmExg0LHV7II9o5gDV1DdcMpkjSRKR90aLbv2FMsbdtII7t/M9zeA==",
+      "dev": true,
+      "requires": {
+        "faker": "^4.1.0"
+      }
     },
     "next-tick": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,11 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "start-server-and-test start:test http://localhost:3000 cy:run"
+    "test:e2e": "start-server-and-test start:test http://localhost:3000 cy:run",
+    "seed": "npm run build && node dist/seeder",
+    "seed:refresh": "npm run build && node dist/seeder --refresh",
+    "seed:test": "npm run build && NODE_ENV=test node dist/seeder",
+    "seed:test:refresh": "npm run build && NODE_ENV=test node dist/seeder --refresh"
   },
   "dependencies": {
     "@nestjs/common": "^8.0.0",
@@ -68,6 +72,7 @@
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-prettier": "^4.0.0",
     "jest": "^27.2.5",
+    "nestjs-seeder": "^0.2.0",
     "prettier": "^2.3.2",
     "puppeteer": "^11.0.0",
     "source-map-support": "^0.5.20",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "express-openid-connect": "^2.5.1",
     "file-loader": "^6.2.0",
     "govuk-frontend": "^3.14.0",
+    "jwt-decode": "^3.1.2",
     "nunjucks": "^3.2.3",
     "pg": "^8.7.1",
     "reflect-metadata": "^0.1.13",

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+# script/bootstrap: Resolve all dependencies that the application requires to
+#                   run.
+
+set -e
+
+cd "$(dirname "$0")/.."
+
+echo "==> Installing application dependencies..."
+
+nodenv install --skip-existing
+npm install
+
+echo "==> Building assets..."
+
+npm run build:assets
+
+echo "==> Seeding database..."
+
+npm run seed

--- a/script/setup
+++ b/script/setup
@@ -29,12 +29,5 @@ echo "==> Creating env files for dev and test..."
 echo "DATABASE_URL=postgres://postgres@localhost:5432/$dev_db" > .env.development
 echo "DATABASE_URL=postgres://postgres@localhost:5432/$test_db" > .env.test
 
-echo "==> Installing application dependencies..."
-
-nodenv install --skip-existing
-npm install
-
-echo "==> Building assets..."
-
-npm run build:assets
+script/bootstrap
 

--- a/seeds/users.json
+++ b/seeds/users.json
@@ -1,0 +1,7 @@
+[
+  {
+    "email": "beis-rpr@dxw.com",
+    "name": "beis-rpr",
+    "identifier": "auth0|61a0f8d2d6e3f3006b5b722e"
+  }
+]

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,7 +4,6 @@ import { NestFactory } from '@nestjs/core';
 import { NestExpressApplication } from '@nestjs/platform-express';
 import { ValidationPipe } from '@nestjs/common';
 import { ValidationError } from 'class-validator';
-import { auth } from 'express-openid-connect';
 
 import * as nunjucks from 'nunjucks';
 import * as path from 'path';
@@ -13,12 +12,14 @@ import { AppModule } from './app.module';
 import { AssetsHelper } from './helpers/assets.helper';
 import { ValidationFailedError } from './validation/validation-failed.error';
 import { UnauthorizedExceptionFilter } from './common/unauthorized-exception.filter';
+import { AuthenticationMidleware } from './middleware/authentication.middleware';
 
 async function bootstrap() {
   const app = await NestFactory.create<NestExpressApplication>(AppModule);
   const express = app.getHttpAdapter().getInstance();
   const entrypoints = require('../public/entrypoints.json');
   const assetsHelper = new AssetsHelper(entrypoints);
+  const authenticationMiddleware = new AuthenticationMidleware(app);
 
   const assets = path.join(__dirname, '..', 'public');
   const views = [
@@ -44,21 +45,7 @@ async function bootstrap() {
   app.setBaseViewsDir(views);
   app.setViewEngine('njk');
 
-  app.use(
-    auth({
-      issuerBaseURL: process.env['AUTH0_DOMAIN'],
-      baseURL: process.env['HOST_URL'],
-      clientID: process.env['AUTH0_CLIENT_ID'],
-      clientSecret: process.env['AUTH0_CLIENT_SECRET'],
-      secret: process.env['APP_SECRET'],
-      authRequired: false,
-      auth0Logout: true,
-      authorizationParams: {
-        response_type: 'code',
-        scope: 'openid profile email',
-      },
-    }),
-  );
+  app.use(authenticationMiddleware.auth());
 
   app.useGlobalFilters(new UnauthorizedExceptionFilter());
   app.useGlobalPipes(

--- a/src/middleware/authentication.middleware.spec.ts
+++ b/src/middleware/authentication.middleware.spec.ts
@@ -1,0 +1,53 @@
+import { ForbiddenException } from '@nestjs/common';
+import { NestExpressApplication } from '@nestjs/platform-express';
+
+import { createMock } from '@golevelup/ts-jest';
+
+import { AuthenticationMidleware } from './authentication.middleware';
+import { User } from '../users/user.entity';
+
+describe('AuthenticationMidleware', () => {
+  let middleware: AuthenticationMidleware;
+  let user: User;
+
+  beforeEach(async () => {
+    const app = createMock<NestExpressApplication>({
+      select: () => ({
+        get: () => ({
+          findByExternalIdentifier: () => user,
+        }),
+      }),
+    });
+
+    middleware = new AuthenticationMidleware(app);
+  });
+
+  describe('afterCallback', () => {
+    it('returns the user with the other credentials when the user exists', async () => {
+      user = new User('email@example.com', 'name', '212121');
+
+      const session = {
+        id_token:
+          'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.e30.Et9HFtf9R3GEMA0IICOfFMVXY7kkTX1wr4qCyhIf58U',
+      };
+
+      expect(await middleware.afterCallback(session)).toEqual({
+        ...session,
+        user,
+      });
+    });
+
+    it('throws an error if the user does not exist', async () => {
+      user = undefined;
+
+      const session = {
+        id_token:
+          'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.e30.Et9HFtf9R3GEMA0IICOfFMVXY7kkTX1wr4qCyhIf58U',
+      };
+
+      await expect(async () => {
+        await middleware.afterCallback(session);
+      }).rejects.toThrowError(ForbiddenException);
+    });
+  });
+});

--- a/src/middleware/authentication.middleware.ts
+++ b/src/middleware/authentication.middleware.ts
@@ -1,0 +1,78 @@
+import { ForbiddenException } from '@nestjs/common';
+import { NestExpressApplication } from '@nestjs/platform-express';
+import { RequestHandler } from 'express';
+import { auth } from 'express-openid-connect';
+
+import jwt_decode from 'jwt-decode';
+
+import { UsersModule } from '../users/users.module';
+import { UserService } from '../users/user.service';
+
+/**
+ * Set up an instance of the `express-openid-connect` authentication middleware for
+ * use in the application. Using this in a class allows us to access the database
+ * to fetch a user from the database and include it in the session.
+ *
+ * @constructor
+ * @param {NestExpressApplication} app - The instance of the NestJS application being set up
+ *
+ */
+export class AuthenticationMidleware {
+  userService: UserService;
+
+  constructor(private app: NestExpressApplication) {
+    this.userService = this.app.select(UsersModule).get(UserService);
+  }
+
+  /**
+   * Set the configuration of the `express-openid-connect` authentication middleware
+   * and return it
+   *
+   * @returns {RequestHandler} - The authentication middleware
+   */
+  public auth(): RequestHandler {
+    return auth({
+      issuerBaseURL: process.env['AUTH0_DOMAIN'],
+      baseURL: process.env['HOST_URL'],
+      clientID: process.env['AUTH0_CLIENT_ID'],
+      clientSecret: process.env['AUTH0_CLIENT_SECRET'],
+      secret: process.env['APP_SECRET'],
+      authRequired: false,
+      auth0Logout: true,
+      authorizationParams: {
+        response_type: 'code',
+        scope: 'openid profile email',
+      },
+      afterCallback: async (_req, _res, session) => {
+        return await this.afterCallback(session);
+      },
+    });
+  }
+
+  /**
+   * Hook into the callback that gets used after a successful authentication, search
+   * for our local user and inject it into the session.
+   *
+   * The user will be available in the application as `request.appSession.user`
+   *
+   * @param session
+   * @returns The session variables to be set in `request.appSession`
+   *
+   * @throws {ForbiddenException} - If the user does not exist in the database
+   */
+  public async afterCallback(session: any): Promise<any> {
+    const userInfo = jwt_decode(session.id_token);
+    const user = await this.userService.findByExternalIdentifier(
+      userInfo['sub'],
+    );
+
+    if (user === undefined) {
+      throw new ForbiddenException();
+    }
+
+    return {
+      ...session,
+      user,
+    };
+  }
+}

--- a/src/seeder.ts
+++ b/src/seeder.ts
@@ -1,0 +1,26 @@
+process.env.NODE_ENV ||= 'development';
+
+import { seeder } from 'nestjs-seeder';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { ConfigService, ConfigModule } from '@nestjs/config';
+
+import { User } from './users/user.entity';
+import { UsersSeeder } from './users/users.seeder';
+
+import dbConfiguration from './config/db.config';
+
+seeder({
+  imports: [
+    ConfigModule.forRoot({
+      isGlobal: true,
+      load: [dbConfiguration],
+    }),
+    TypeOrmModule.forRootAsync({
+      inject: [ConfigService],
+      useFactory: async (configService: ConfigService) => ({
+        ...(await configService.get('database')),
+      }),
+    }),
+    TypeOrmModule.forFeature([User]),
+  ],
+}).run([UsersSeeder]);

--- a/src/users/user.service.spec.ts
+++ b/src/users/user.service.spec.ts
@@ -53,4 +53,18 @@ describe('User', () => {
       expect(repoSpy).toHaveBeenCalledWith('some-uuid');
     });
   });
+
+  describe('findByExternalIdentifier', () => {
+    it('should return a user', async () => {
+      const repoSpy = jest.spyOn(repo, 'findOne');
+      const post = await service.findByExternalIdentifier(
+        'external-identifier',
+      );
+
+      expect(post).toEqual(user);
+      expect(repoSpy).toHaveBeenCalledWith({
+        where: { identifier: 'external-identifier' },
+      });
+    });
+  });
 });

--- a/src/users/user.service.ts
+++ b/src/users/user.service.ts
@@ -18,4 +18,10 @@ export class UserService {
   find(id: string): Promise<User> {
     return this.repository.findOne(id);
   }
+
+  findByExternalIdentifier(externalIdentifier: string): Promise<User> {
+    return this.repository.findOne({
+      where: { identifier: externalIdentifier },
+    });
+  }
 }

--- a/src/users/users.seeder.ts
+++ b/src/users/users.seeder.ts
@@ -1,0 +1,31 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+
+import { Injectable } from '@nestjs/common';
+import { Repository } from 'typeorm';
+
+import { Seeder } from 'nestjs-seeder';
+import { InjectRepository } from '@nestjs/typeorm';
+
+import { User } from './user.entity';
+
+@Injectable()
+export class UsersSeeder implements Seeder {
+  constructor(
+    @InjectRepository(User)
+    private readonly userRepository: Repository<User>,
+  ) {}
+
+  async seed(): Promise<any> {
+    const userData = require('../../seeds/users.json');
+
+    const users: Array<User> = userData.map((user: any) => {
+      return new User(user.email, user.name, user.identifier);
+    });
+
+    return this.userRepository.save(users);
+  }
+
+  async drop(): Promise<any> {
+    return this.userRepository.delete({});
+  }
+}


### PR DESCRIPTION
This builds on #18 to make sure we have the information about the user from our local database. I've utilised the [`afterCallback`](https://auth0.github.io/express-openid-connect/interfaces/configparams.html#aftercallback) functionality in `express-openid-connect` to leverage this.

To get the tests working here, I've introduced a seed command which uses [nestjs-seeder](https://github.com/edwardanthony/nestjs-seeder) to import the user we expect to have to the test database at runtime. This looks to be a super-useful think we should be able to leverage for a lot of other stuff too.