### PR TITLE
(1887) Add Organisation model

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -8,6 +8,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { UsersModule } from './users/users.module';
 import { ProfessionModule } from './profession/profession.module';
 import { LegislationModule } from './legislation/legislation.module';
+import { OrganisationModule } from './organisation/organisation.module';
 
 import dbConfiguration from './config/db.config';
 
@@ -26,6 +27,7 @@ import dbConfiguration from './config/db.config';
     UsersModule,
     ProfessionModule,
     LegislationModule,
+    OrganisationModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/config/db.config.ts
+++ b/src/config/db.config.ts
@@ -8,7 +8,7 @@ export default registerAs('database', () => {
     type: 'postgres',
     url: process.env.DATABASE_URL,
     entities: ['./dist/**/*.entity.js'],
-    synchronize: process.env.NODE_ENV === 'development',
+    synchronize: false,
     migrations: ['./dist/db/migrate/*.js'],
     migrationsRun: true,
     dropSchema: process.env.NODE_ENV == 'test',

--- a/src/db/migrate/1638188999748-CreateOrganisations.ts
+++ b/src/db/migrate/1638188999748-CreateOrganisations.ts
@@ -1,0 +1,15 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreateOrganisations1638188999748 implements MigrationInterface {
+  name = 'CreateOrganisations1638188999748';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE "organisations" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "name" character varying NOT NULL, "alternateName" character varying, "address" character varying NOT NULL, "url" character varying NOT NULL, "email" character varying NOT NULL, "contactUrl" character varying, "telephone" character varying NOT NULL, "fax" character varying, CONSTRAINT "PK_7bf54cba378d5b2f1d4c10ef4df" PRIMARY KEY ("id"))`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TABLE "organisations"`);
+  }
+}

--- a/src/db/migrate/1638189658799-LinkProfessionsToOrganisations.ts
+++ b/src/db/migrate/1638189658799-LinkProfessionsToOrganisations.ts
@@ -1,0 +1,43 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class LinkProfessionsToOrganisations1638189658799
+  implements MigrationInterface
+{
+  name = 'LinkProfessionsToOrganisations1638189658799';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE "organisations_professions_professions" ("organisationsId" uuid NOT NULL, "professionsId" uuid NOT NULL, CONSTRAINT "PK_c268ed7d6fadbca0fbb3235f7c5" PRIMARY KEY ("organisationsId", "professionsId"))`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_a9ec1d94b540664d64a95e8ed8" ON "organisations_professions_professions" ("organisationsId") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_4869f654502ff020fa3c855361" ON "organisations_professions_professions" ("professionsId") `,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "organisations_professions_professions" ADD CONSTRAINT "FK_a9ec1d94b540664d64a95e8ed84" FOREIGN KEY ("organisationsId") REFERENCES "organisations"("id") ON DELETE CASCADE ON UPDATE CASCADE`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "organisations_professions_professions" ADD CONSTRAINT "FK_4869f654502ff020fa3c8553618" FOREIGN KEY ("professionsId") REFERENCES "professions"("id") ON DELETE CASCADE ON UPDATE CASCADE`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "organisations_professions_professions" DROP CONSTRAINT "FK_4869f654502ff020fa3c8553618"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "organisations_professions_professions" DROP CONSTRAINT "FK_a9ec1d94b540664d64a95e8ed84"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_4869f654502ff020fa3c855361"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_a9ec1d94b540664d64a95e8ed8"`,
+    );
+    await queryRunner.query(
+      `DROP TABLE "organisations_professions_professions"`,
+    );
+  }
+}

--- a/src/organisation/organisation.entity.ts
+++ b/src/organisation/organisation.entity.ts
@@ -1,4 +1,11 @@
-import { Entity, PrimaryGeneratedColumn, Column } from 'typeorm';
+import { Profession } from '../profession/profession.entity';
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  ManyToMany,
+  JoinTable,
+} from 'typeorm';
 
 @Entity({ name: 'organisations' })
 export class Organisation {
@@ -28,4 +35,8 @@ export class Organisation {
 
   @Column({ nullable: true })
   fax: string;
+
+  @ManyToMany(() => Profession)
+  @JoinTable()
+  professions: Profession[];
 }

--- a/src/organisation/organisation.entity.ts
+++ b/src/organisation/organisation.entity.ts
@@ -39,4 +39,26 @@ export class Organisation {
   @ManyToMany(() => Profession)
   @JoinTable()
   professions: Profession[];
+
+  constructor(
+    name?: string,
+    alternateName?: string,
+    address?: string,
+    url?: string,
+    email?: string,
+    contactUrl?: string,
+    telephone?: string,
+    fax?: string,
+    professions?: Profession[],
+  ) {
+    this.name = name || '';
+    this.alternateName = alternateName || '';
+    this.address = address || '';
+    this.url = url || '';
+    this.email = email || '';
+    this.contactUrl = contactUrl || '';
+    this.telephone = telephone || '';
+    this.fax = fax;
+    this.professions = professions;
+  }
 }

--- a/src/organisation/organisation.entity.ts
+++ b/src/organisation/organisation.entity.ts
@@ -1,0 +1,31 @@
+import { Entity, PrimaryGeneratedColumn, Column } from 'typeorm';
+
+@Entity({ name: 'organisations' })
+export class Organisation {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  name: string;
+
+  @Column({ nullable: true })
+  alternateName: string;
+
+  @Column()
+  address: string;
+
+  @Column()
+  url: string;
+
+  @Column()
+  email: string;
+
+  @Column({ nullable: true })
+  contactUrl: string;
+
+  @Column()
+  telephone: string;
+
+  @Column({ nullable: true })
+  fax: string;
+}

--- a/src/organisation/organisation.module.ts
+++ b/src/organisation/organisation.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Organisation } from './organisation.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Organisation])],
+})
+export class OrganisationModule {}

--- a/src/organisation/organisation.module.ts
+++ b/src/organisation/organisation.module.ts
@@ -1,8 +1,10 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Organisation } from './organisation.entity';
+import { OrganisationService } from './organisation.service';
 
 @Module({
   imports: [TypeOrmModule.forFeature([Organisation])],
+  providers: [OrganisationService],
 })
 export class OrganisationModule {}

--- a/src/organisation/organisation.service.spec.ts
+++ b/src/organisation/organisation.service.spec.ts
@@ -1,0 +1,66 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Organisation } from './organisation.entity';
+import { OrganisationService } from './organisation.service';
+
+describe('OrganisationService', () => {
+  let service: OrganisationService;
+  let repo: Repository<Organisation>;
+
+  const organisation = new Organisation(
+    'Department of Business, Energy and Industrial Strategy',
+    'BEIS',
+    '123 Fake Street',
+    'www.beis.gov.uk',
+    'beis@example.com',
+    'contact-us.example.com',
+    '0123456789',
+    '0123456780',
+    [],
+  );
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        OrganisationService,
+        {
+          provide: getRepositoryToken(Organisation),
+          useValue: {
+            find: () => {
+              return [organisation];
+            },
+            findOne: () => {
+              return organisation;
+            },
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<OrganisationService>(OrganisationService);
+    repo = module.get<Repository<Organisation>>(
+      getRepositoryToken(Organisation),
+    );
+  });
+
+  describe('all', () => {
+    it('returns all Organisations', async () => {
+      const repoSpy = jest.spyOn(repo, 'find');
+      const organisations = await service.all();
+
+      expect(organisations).toEqual([organisation]);
+      expect(repoSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe('find', () => {
+    it('returns an Organisation', async () => {
+      const repoSpy = jest.spyOn(repo, 'findOne');
+      const organisations = await service.find('some-uuid');
+
+      expect(organisations).toEqual(organisation);
+      expect(repoSpy).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/organisation/organisation.service.ts
+++ b/src/organisation/organisation.service.ts
@@ -1,0 +1,20 @@
+import { Repository } from 'typeorm';
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Organisation } from './organisation.entity';
+
+@Injectable()
+export class OrganisationService {
+  constructor(
+    @InjectRepository(Organisation)
+    private repository: Repository<Organisation>,
+  ) {}
+
+  all(): Promise<Organisation[]> {
+    return this.repository.find();
+  }
+
+  find(id: string): Promise<Organisation> {
+    return this.repository.findOne(id);
+  }
+}


### PR DESCRIPTION
## Changes in this PR

Adds new Organisation model and migrations for it. I'm not 100% sure on which fields should be nullable here, but I've taken a logical guess based on our initial data modelling diagrams.

This PR also switches off the synchronisation behaviour added in #11, as it conflicts with our new method of always running migrations.