### PR TITLE
Update callback urls for Heroku

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
 web: npm run start:prod
+release: npm run heroku:set-callback-urls

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "seed": "npm run build && node dist/seeder",
     "seed:refresh": "npm run build && node dist/seeder --refresh",
     "seed:test": "npm run build && NODE_ENV=test node dist/seeder",
-    "seed:test:refresh": "npm run build && NODE_ENV=test node dist/seeder --refresh"
+    "seed:test:refresh": "npm run build && NODE_ENV=test node dist/seeder --refresh",
+    "heroku:set-callback-urls": "ts-node util/set-callback-urls.ts"
   },
   "dependencies": {
     "@nestjs/common": "^8.0.0",

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,4 +1,11 @@
 {
   "extends": "./tsconfig.json",
-  "exclude": ["node_modules", "test", "dist", "**/*spec.ts", "./ormconfig.ts"]
+  "exclude": [
+    "node_modules",
+    "test",
+    "util",
+    "dist",
+    "**/*spec.ts",
+    "./ormconfig.ts"
+  ]
 }

--- a/util/set-callback-urls.ts
+++ b/util/set-callback-urls.ts
@@ -1,0 +1,65 @@
+/*
+ * This is a script that gets run after a successful deploy of a Heroku
+ * review app to register the callback URLs on Auth0 to allow logins to
+ * work properly on Heroku review apps.
+ */
+
+import { ManagementClient } from 'auth0';
+import axios from 'axios';
+
+import * as dotenv from 'dotenv';
+
+dotenv.config({ path: '.env.development' });
+
+const callbackUrls = async (): Promise<string[]> => {
+  interface App {
+    pr_number: string;
+  }
+
+  const response = await axios
+    .get<App[]>(
+      `https://api.heroku.com/pipelines/${process.env['HEROKU_PIPELINE_ID']}/review-apps`,
+      {
+        headers: {
+          Accept: 'application/vnd.heroku+json; version=3',
+          Authorization: `Bearer ${process.env['HEROKU_ACCESS_TOKEN']}`,
+        },
+      },
+    )
+    .then((res) => {
+      return res.data;
+    });
+
+  return response.map((app: App) => {
+    return `https://rpr-review-app-pr-${app.pr_number}.herokuapp.com/callback`;
+  });
+};
+
+(async () => {
+  const auth0 = new ManagementClient({
+    domain: process.env['AUTH0_HOSTNAME'],
+    clientId: process.env['AUTH0_CLIENT_ID'],
+    clientSecret: process.env['AUTH0_CLIENT_SECRET'],
+  });
+  const urls = await callbackUrls();
+
+  console.log(
+    'Registering callback URLs for the currently installed Heroku review apps...',
+  );
+
+  auth0.updateClient(
+    { client_id: process.env['AUTH0_CLIENT_ID'] },
+    {
+      callbacks: [...urls, 'http://localhost:3000/callback'],
+    },
+    function (err: Error) {
+      if (err) {
+        console.log(
+          `Registration failed with the following error: '${err.message}''`,
+        );
+      } else {
+        console.log('Success!');
+      }
+    },
+  );
+})();


### PR DESCRIPTION
This adds a script that gets run after a successful deploy of a Heroku review app to register the callback URLs on Auth0 to allow logins to work properly on Heroku review apps. We include localhost:3000 in this array, because we'll always need this for dev.