### PR TITLE
(1931) Add Qualifications model and link to Professions

### DIFF
--- a/src/db/migrate/1638545051677-CreateQualifications.ts
+++ b/src/db/migrate/1638545051677-CreateQualifications.ts
@@ -1,0 +1,15 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreateQualifications1638545051677 implements MigrationInterface {
+  name = 'CreateQualifications1638545051677';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE "qualifications" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "level" character varying NOT NULL, "methodToObtain" character varying NOT NULL, "commonPathToObtain" character varying NOT NULL, "educationDuration" character varying NOT NULL, "mandatoryProfessionalExperience" boolean NOT NULL, CONSTRAINT "PK_9ed4d526ac3b76ba3f1c1080433" PRIMARY KEY ("id"))`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TABLE "qualifications"`);
+  }
+}

--- a/src/db/migrate/1638546810198-AddQualificationsToProfessions.ts
+++ b/src/db/migrate/1638546810198-AddQualificationsToProfessions.ts
@@ -1,0 +1,37 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddQualificationsToProfessions1638546810198
+  implements MigrationInterface
+{
+  name = 'AddQualificationsToProfessions1638546810198';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "professions" RENAME COLUMN "qualificationLevel" TO "qualificationId"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "professions" DROP COLUMN "qualificationId"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "professions" ADD "qualificationId" uuid`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "professions" ADD CONSTRAINT "FK_e2c4688b8f8b296d88e0945f796" FOREIGN KEY ("qualificationId") REFERENCES "qualifications"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "professions" DROP CONSTRAINT "FK_e2c4688b8f8b296d88e0945f796"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "professions" DROP COLUMN "qualificationId"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "professions" ADD "qualificationId" character varying NOT NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "professions" RENAME COLUMN "qualificationId" TO "qualificationLevel"`,
+    );
+  }
+}

--- a/src/profession/profession.entity.ts
+++ b/src/profession/profession.entity.ts
@@ -1,10 +1,12 @@
 import { Legislation } from '../legislation/legislation.entity';
+import { Qualification } from '../qualification/qualification.entity';
 import {
   Entity,
   PrimaryGeneratedColumn,
   Column,
   ManyToMany,
   JoinTable,
+  ManyToOne,
 } from 'typeorm';
 
 @Entity({ name: 'professions' })
@@ -27,8 +29,8 @@ export class Profession {
   @Column()
   regulationType: string;
 
-  @Column()
-  qualificationLevel: string;
+  @ManyToOne(() => Qualification)
+  qualification: Qualification;
 
   @Column('text', { array: true })
   reservedActivities: string[];
@@ -43,7 +45,7 @@ export class Profession {
     description?: string,
     occupationLocation?: string,
     regulationType?: string,
-    qualificationLevel?: string,
+    qualification?: Qualification,
     reservedActivities?: string[],
     legislations?: Legislation[],
   ) {
@@ -52,7 +54,7 @@ export class Profession {
     this.description = description || '';
     this.occupationLocation = occupationLocation || '';
     this.regulationType = regulationType || '';
-    this.qualificationLevel = qualificationLevel || '';
+    this.qualification = qualification || new Qualification();
     this.reservedActivities = reservedActivities || [];
     this.legislations = legislations;
   }

--- a/src/profession/profession.service.spec.ts
+++ b/src/profession/profession.service.spec.ts
@@ -1,6 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
+import { Qualification } from '../qualification/qualification.entity';
 
 import { Profession } from './profession.entity';
 import { ProfessionService } from './profession.service';
@@ -11,7 +12,7 @@ const profession = new Profession(
   'Gas installers work on gas appliances and installations.',
   'All regions',
   'Reserves of activities',
-  'ATT - Attestation of competence , Art. 11 a',
+  new Qualification('ATT - Attestation of competence , Art. 11 a'),
   [
     'Gas Safe Register is the official list of gas engineers in the UK, Isle of Man and Guernsey. To work on gas appliances and installations you must be on the gas safe register. The register exists to protect the public from unsafe gas work (EN)',
   ],
@@ -24,7 +25,9 @@ const professionArray = [
     'Social workers are trained to: make assessments, taking account of a range of factors',
     'England',
     'Protected title',
-    'PS3 - Diploma of post-secondary level (3-4 years) , Art. 11 d',
+    new Qualification(
+      'PS3 - Diploma of post-secondary level (3-4 years) , Art. 11 d',
+    ),
     [
       'England, must be registered with the Health and Care Professions Council (HCPC)',
       'Northern Ireland, must be registered with the Northern Ireland Social Care Council (NISCC)',

--- a/src/qualification/qualification.entity.ts
+++ b/src/qualification/qualification.entity.ts
@@ -1,0 +1,37 @@
+import { Entity, PrimaryGeneratedColumn, Column } from 'typeorm';
+
+@Entity({ name: 'qualifications' })
+export class Qualification {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  level: string;
+
+  @Column()
+  methodToObtain: string;
+
+  @Column()
+  commonPathToObtain: string;
+
+  @Column()
+  educationDuration: string;
+
+  @Column()
+  mandatoryProfessionalExperience: boolean;
+
+  constructor(
+    level?: string,
+    methodToObtain?: string,
+    commonPathToObtain?: string,
+    educationDuration?: string,
+    mandatoryProfessionalExperience?: boolean,
+  ) {
+    this.level = level || '';
+    this.methodToObtain = methodToObtain || '';
+    this.commonPathToObtain = commonPathToObtain || '';
+    this.educationDuration = educationDuration || '';
+    this.mandatoryProfessionalExperience =
+      mandatoryProfessionalExperience || true;
+  }
+}

--- a/src/qualification/qualification.module.ts
+++ b/src/qualification/qualification.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Qualification } from './qualification.entity';
+import { QualificationService } from './qualification.service';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Qualification])],
+  providers: [QualificationService],
+})
+export class QualificationModule {}

--- a/src/qualification/qualification.service.spec.ts
+++ b/src/qualification/qualification.service.spec.ts
@@ -1,0 +1,63 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+
+import { Qualification } from './qualification.entity';
+import { QualificationService } from './qualification.service';
+
+const qualification = new Qualification(
+  'ATT - Attestation of competence , Art. 11 a',
+  'Accredited Certification Scheme accredited by the United Kongdom Accrediation Service UKAS in accordance with ISO EN 17024 or an approprate National/Scottish Vocational Qualification at level 2',
+  'General secondary education',
+  '1 Year',
+  false,
+);
+
+describe('Qualification service', () => {
+  let service: QualificationService;
+  let repo: Repository<Qualification>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        QualificationService,
+        {
+          provide: getRepositoryToken(Qualification),
+          useValue: {
+            find: () => {
+              return [qualification];
+            },
+            findOne: () => {
+              return qualification;
+            },
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<QualificationService>(QualificationService);
+    repo = module.get<Repository<Qualification>>(
+      getRepositoryToken(Qualification),
+    );
+  });
+
+  describe('all', () => {
+    it('should return all Legislations', async () => {
+      const repoSpy = jest.spyOn(repo, 'find');
+      const posts = await service.all();
+
+      expect(posts).toEqual([qualification]);
+      expect(repoSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe('find', () => {
+    it('should return a Qualification', async () => {
+      const repoSpy = jest.spyOn(repo, 'findOne');
+      const post = await service.find('some-uuid');
+
+      expect(post).toEqual(qualification);
+      expect(repoSpy).toHaveBeenCalledWith('some-uuid');
+    });
+  });
+});

--- a/src/qualification/qualification.service.ts
+++ b/src/qualification/qualification.service.ts
@@ -1,0 +1,21 @@
+import { Repository } from 'typeorm';
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+
+import { Qualification } from './qualification.entity';
+
+@Injectable()
+export class QualificationService {
+  constructor(
+    @InjectRepository(Qualification)
+    private repository: Repository<Qualification>,
+  ) {}
+
+  all(): Promise<Qualification[]> {
+    return this.repository.find();
+  }
+
+  find(id: string): Promise<Qualification> {
+    return this.repository.findOne(id);
+  }
+}


### PR DESCRIPTION
Adds `Qualifications` model. This represents the required qualifications necessary for a profession in the UK. We initially captured only the `qualification_level` on a `Profession`, but to pave the way for building the functionality to add a new Profession, we're adding these additional fields now to support the following page in the near future:

<img width="537" alt="image" src="https://user-images.githubusercontent.com/19826940/144630342-f5db92d2-b1d5-4415-856c-4fb2263729c5.png">
