### PR TITLE
Remove unused variable

### DIFF
--- a/src/users/personal-details.controller.spec.ts
+++ b/src/users/personal-details.controller.spec.ts
@@ -7,10 +7,6 @@ import { createMock, DeepMocked } from '@golevelup/ts-jest';
 const name = 'Example Name';
 const email = 'name@example.com';
 
-const populatedSession = {
-  'user-creation-flow': { name, email },
-};
-
 describe('PersonalDetailsController', () => {
   let controller: PersonalDetailsController;
   let userService: DeepMocked<UserService>;


### PR DESCRIPTION
Removes an unused variable that gets shadowed lower down, and was causing a linting warning