### PR TITLE
In User entity, rename `identifier` to `externalIdentifier`

### DIFF
--- a/seeds/users.json
+++ b/seeds/users.json
@@ -2,6 +2,6 @@
   {
     "email": "beis-rpr@dxw.com",
     "name": "beis-rpr",
-    "identifier": "auth0|61a0f8d2d6e3f3006b5b722e"
+    "externalIdentifier": "auth0|61a0f8d2d6e3f3006b5b722e"
   }
 ]

--- a/src/db/migrate/1638883061678-RenameUserIdentifier.ts
+++ b/src/db/migrate/1638883061678-RenameUserIdentifier.ts
@@ -1,0 +1,23 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class RenameUserIdentifier1638883061678 implements MigrationInterface {
+  name = 'RenameUserIdentifier1638883061678';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "users" RENAME COLUMN "identifier" TO "externalIdentifier"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "users" RENAME CONSTRAINT "UQ_2e7b7debda55e0e7280dc93663d" TO "UQ_21750875a4532d215d4eadaeff6"`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "users" RENAME CONSTRAINT "UQ_21750875a4532d215d4eadaeff6" TO "UQ_2e7b7debda55e0e7280dc93663d"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "users" RENAME COLUMN "externalIdentifier" TO "identifier"`,
+    );
+  }
+}

--- a/src/users/user.entity.ts
+++ b/src/users/user.entity.ts
@@ -12,11 +12,11 @@ export class User {
   name: string;
 
   @Column({ unique: true })
-  identifier: string;
+  externalIdentifier: string;
 
-  constructor(email?: string, name?: string, identifier?: string) {
+  constructor(email?: string, name?: string, externalIdentifier?: string) {
     this.email = email || '';
     this.name = name || '';
-    this.identifier = identifier || '';
+    this.externalIdentifier = externalIdentifier || '';
   }
 }

--- a/src/users/users.controller.spec.ts
+++ b/src/users/users.controller.spec.ts
@@ -6,7 +6,7 @@ import { createMock, DeepMocked } from '@golevelup/ts-jest';
 
 const name = 'Example Name';
 const email = 'name@example.com';
-const identifier = 'example-external-identifier';
+const externalIdentifier = 'example-external-identifier';
 
 describe('UsersController', () => {
   let controller: UsersController;
@@ -17,7 +17,7 @@ describe('UsersController', () => {
   beforeEach(async () => {
     externalUserCreationService = createMock<ExternalUserCreationService>({
       createExternalUser: async () => {
-        return { result: 'user-created', externalIdentifier: identifier };
+        return { result: 'user-created', externalIdentifier };
       },
     });
 
@@ -97,7 +97,11 @@ describe('UsersController', () => {
       expect(externalUserCreationService.createExternalUser).toBeCalledWith(
         email,
       );
-      expect(usersService.add).toBeCalledWith({ name, email, identifier });
+      expect(usersService.add).toBeCalledWith({
+        name,
+        email,
+        externalIdentifier,
+      });
       expect(res.redirect).toBeCalledWith('done');
     });
 
@@ -112,7 +116,7 @@ describe('UsersController', () => {
     it('should render an error if the email already exists externally and in our database', async () => {
       externalUserCreationService.createExternalUser.mockImplementationOnce(
         async () => {
-          return { result: 'user-exists', externalIdentifier: identifier };
+          return { result: 'user-exists', externalIdentifier };
         },
       );
 
@@ -132,7 +136,7 @@ describe('UsersController', () => {
     it('should create a user in our db even if the user already exists externally', async () => {
       externalUserCreationService.createExternalUser.mockImplementationOnce(
         async () => {
-          return { result: 'user-exists', externalIdentifier: identifier };
+          return { result: 'user-exists', externalIdentifier };
         },
       );
 
@@ -145,7 +149,7 @@ describe('UsersController', () => {
       expect(usersService.attemptAdd).toBeCalledWith({
         name,
         email,
-        identifier,
+        externalIdentifier,
       });
       expect(res.redirect).toBeCalledWith('done');
     });

--- a/src/users/users.seeder.ts
+++ b/src/users/users.seeder.ts
@@ -19,7 +19,7 @@ export class UsersSeeder implements Seeder {
     const userData = require('../../seeds/users.json');
 
     const users: Array<User> = userData.map((user: any) => {
-      return new User(user.email, user.name, user.identifier);
+      return new User(user.email, user.name, user.externalIdentifier);
     });
 
     return this.userRepository.save(users);

--- a/src/users/users.service.spec.ts
+++ b/src/users/users.service.spec.ts
@@ -70,7 +70,7 @@ describe('UsersService', () => {
 
       expect(post).toEqual(user);
       expect(repoSpy).toHaveBeenCalledWith({
-        where: { identifier: 'external-identifier' },
+        where: { externalIdentifier: 'external-identifier' },
       });
     });
   });

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -32,7 +32,7 @@ export class UsersService {
 
   findByExternalIdentifier(externalIdentifier: string): Promise<User> {
     return this.repository.findOne({
-      where: { identifier: externalIdentifier },
+      where: { externalIdentifier },
     });
   }
 
@@ -47,7 +47,7 @@ export class UsersService {
 
     try {
       const foundUser = await queryRunner.manager.findOne(User, {
-        identifier: user.identifier,
+        externalIdentifier: user.externalIdentifier,
       });
 
       if (!foundUser) {


### PR DESCRIPTION
Rename for clarity of purpose of `externalIdentifier` in addition to `id`