### PR TITLE
Professional details page

### DIFF
--- a/assets/stylesheets/application.scss
+++ b/assets/stylesheets/application.scss
@@ -1,3 +1,7 @@
 $govuk-assets-path: '~govuk-frontend/govuk/assets/';
 
 @import 'govuk/all';
+
+.rpr-details__section-title {
+  text-transform: uppercase;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "rxjs": "^7.4.0",
         "sass": "^1.43.4",
         "sass-loader": "^12.3.0",
+        "slugify": "^1.6.3",
         "typeorm": "^0.2.40"
       },
       "devDependencies": {
@@ -13988,6 +13989,14 @@
         "node": ">=8"
       }
     },
+    "node_modules/slugify": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.3.tgz",
+      "integrity": "sha512-1MPyqnIhgiq+/0iDJyqSJHENdnH5MMIlgJIBxmkRMzTNKlS/QsN5dXsB+MdDq4E6w0g9jFA4XOTRkVDjDae/2w==",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/snake-case": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-1.1.2.tgz",
@@ -27062,6 +27071,11 @@
         "astral-regex": "^2.0.0",
         "is-fullwidth-code-point": "^3.0.0"
       }
+    },
+    "slugify": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.3.tgz",
+      "integrity": "sha512-1MPyqnIhgiq+/0iDJyqSJHENdnH5MMIlgJIBxmkRMzTNKlS/QsN5dXsB+MdDq4E6w0g9jFA4XOTRkVDjDae/2w=="
     },
     "snake-case": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "rxjs": "^7.4.0",
     "sass": "^1.43.4",
     "sass-loader": "^12.3.0",
+    "slugify": "^1.6.3",
     "typeorm": "^0.2.40"
   },
   "devDependencies": {

--- a/src/helpers/slug.helper.spec.ts
+++ b/src/helpers/slug.helper.spec.ts
@@ -1,0 +1,25 @@
+import { generateSlug } from './slug.helper';
+
+describe('generateSlug', () => {
+  it('should generate a URL-safe slug', () => {
+    const result = generateSlug('Example String');
+
+    expect(result).toEqual('example-string');
+  });
+
+  it('should truncate long strings to 100 characters', () => {
+    const result = generateSlug(
+      'A Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Long Name',
+    );
+
+    expect(result).toEqual(
+      'a-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-ver',
+    );
+  });
+
+  it('should remove non-alphanumeric characters', () => {
+    const result = generateSlug('👻 Department 😜 of 🥸 Emoji 🙀');
+
+    expect(result).toEqual('department-of-emoji');
+  });
+});

--- a/src/helpers/slug.helper.ts
+++ b/src/helpers/slug.helper.ts
@@ -1,0 +1,19 @@
+import slugify from 'slugify';
+
+const maxLength = 100;
+
+/**
+ * Transforms a name string into a URL-safe slug
+ *
+ * @param name The name to generate a slug from
+ * @returns The slug generated fro the provided name
+ */
+export function generateSlug(name: string): string {
+  return slugify(name, {
+    remove: /[^a-zA-Z0-9 ]/,
+    replacement: '-',
+    lower: true,
+    strict: true,
+    trim: true,
+  }).slice(0, maxLength);
+}

--- a/src/professions/interfaces/show-template.interface.ts
+++ b/src/professions/interfaces/show-template.interface.ts
@@ -1,3 +1,6 @@
+import { Profession } from '../profession.entity';
+
 export interface ShowTemplate {
-    professionName: string;
+  profession: Profession;
+  backUrl: string;
 }

--- a/src/professions/interfaces/show-template.interface.ts
+++ b/src/professions/interfaces/show-template.interface.ts
@@ -1,3 +1,3 @@
-interface ShowTemplate {
+export interface ShowTemplate {
     professionName: string;
 }

--- a/src/professions/interfaces/show-template.interface.ts
+++ b/src/professions/interfaces/show-template.interface.ts
@@ -1,0 +1,3 @@
+interface ShowTemplate {
+    professionName: string;
+}

--- a/src/professions/profession.entity.ts
+++ b/src/professions/profession.entity.ts
@@ -30,16 +30,22 @@ export class Profession {
   @Column()
   regulationType: string;
 
-  @ManyToOne(() => Industry)
+  @ManyToOne(() => Industry, {
+    eager: true,
+  })
   industry: Industry;
 
-  @ManyToOne(() => Qualification)
+  @ManyToOne(() => Qualification, {
+    eager: true,
+  })
   qualification: Qualification;
 
   @Column('text', { array: true })
   reservedActivities: string[];
 
-  @ManyToMany(() => Legislation)
+  @ManyToMany(() => Legislation, {
+    eager: true,
+  })
   @JoinTable()
   legislations: Legislation[];
 

--- a/src/professions/professions.controller.spec.ts
+++ b/src/professions/professions.controller.spec.ts
@@ -7,6 +7,8 @@ import { ProfessionsService } from './professions.service';
 import { Response } from 'express';
 import { NotFoundException } from '@nestjs/common';
 
+const exampleProfession = new Profession('Example Profession');
+
 describe('ProfessionsController', () => {
   let controller: ProfessionsController;
   let professionsService: DeepMocked<ProfessionsService>;
@@ -40,13 +42,14 @@ describe('ProfessionsController', () => {
 
     it('should render a professions details page', async () => {
       professionsService.find.mockImplementationOnce(async () => {
-        return new Profession('Example Profession');
+        return exampleProfession;
       });
 
       await controller.show('example-profession', 'example-id', res);
 
       expect(res.render).toBeCalledWith('professions/show', {
-        professionName: 'Example Profession',
+        profession: exampleProfession,
+        backUrl: '',
       });
 
       expect(professionsService.find).toBeCalledWith('example-id');

--- a/src/professions/professions.controller.spec.ts
+++ b/src/professions/professions.controller.spec.ts
@@ -1,0 +1,57 @@
+import { createMock, DeepMocked } from '@golevelup/ts-jest';
+import { Test, TestingModule } from '@nestjs/testing';
+import { Profession } from './profession.entity';
+
+import { ProfessionsController } from './professions.controller';
+import { ProfessionsService } from './professions.service';
+
+describe('ProfessionsController', () => {
+  let controller: ProfessionsController;
+  let professionsService: DeepMocked<ProfessionsService>;
+
+  beforeEach(async () => {
+    professionsService = createMock<ProfessionsService>();
+
+    const app: TestingModule = await Test.createTestingModule({
+      providers: [
+        {
+          provide: ProfessionsService,
+          useValue: professionsService,
+        },
+      ],
+      controllers: [ProfessionsController],
+    }).compile();
+
+    controller = app.get<ProfessionsController>(ProfessionsController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  describe('show', () => {
+    it('should return populated template params', async () => {
+      professionsService.find.mockImplementationOnce(async () => {
+        return new Profession('Example Profession');
+      });
+
+      const result = await controller.show('example-slug', 'example-id');
+
+      expect(result).toEqual({
+        professionName: 'Example Profession',
+      });
+
+      expect(professionsService.find).toBeCalledWith('example-id');
+    });
+
+    it('should throw an error when the ID does not match a profession', () => {
+      professionsService.find.mockImplementationOnce(async () => {
+        return null;
+      });
+
+      expect(async () => {
+        await controller.show('example-slug', 'example-invalid-id');
+      }).rejects.toThrowError();
+    });
+  });
+});

--- a/src/professions/professions.controller.ts
+++ b/src/professions/professions.controller.ts
@@ -27,7 +27,7 @@ export class ProfessionsController {
     if (generatedSlug !== slug) {
       res.redirect(301, `/professions/${generatedSlug}/${id}`);
     } else {
-      const templateParams: ShowTemplate = { professionName: profession.name };
+      const templateParams: ShowTemplate = { profession, backUrl: '' };
       res.render('professions/show', templateParams);
     }
   }

--- a/src/professions/professions.controller.ts
+++ b/src/professions/professions.controller.ts
@@ -1,0 +1,23 @@
+import { Controller, Get, Param, Render } from '@nestjs/common';
+import { ProfessionsService } from './professions.service';
+
+@Controller()
+export class ProfessionsController {
+  constructor(private professionsService: ProfessionsService) {}
+
+  @Get('professions/:slug/:id')
+  @Render('professions/read')
+  async show(
+    @Param('slug') slug: string,
+    @Param('id') id: string,
+  ): Promise<ShowTemplate> {
+
+    const profession = await this.professionsService.find(id);
+
+    if (!profession) {
+      throw new Error(`A profession with ID ${id} could not be found`);
+    }
+
+    return { professionName: profession.name };
+  }
+}

--- a/src/professions/professions.module.ts
+++ b/src/professions/professions.module.ts
@@ -1,10 +1,12 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Profession } from './profession.entity';
+import { ProfessionsController } from './professions.controller';
 import { ProfessionsService } from './professions.service';
 
 @Module({
   imports: [TypeOrmModule.forFeature([Profession])],
+  controllers: [ProfessionsController],
   providers: [ProfessionsService],
 })
 export class ProfessionsModule {}

--- a/src/users/personal-details.controller.spec.ts
+++ b/src/users/personal-details.controller.spec.ts
@@ -3,6 +3,7 @@ import { UsersService } from './users.service';
 import { User } from './user.entity';
 import { PersonalDetailsController } from './personal-details.controller';
 import { createMock, DeepMocked } from '@golevelup/ts-jest';
+import { Response } from 'express';
 
 const name = 'Example Name';
 const email = 'name@example.com';
@@ -77,13 +78,10 @@ describe('PersonalDetailsController', () => {
   });
 
   describe('create', () => {
-    let res;
+    let res: DeepMocked<Response>;
 
     beforeEach(() => {
-      res = {
-        render: jest.fn(),
-        redirect: jest.fn(),
-      };
+      res = createMock<Response>();
     });
 
     it('should throw an exception when called in edit mode with an empty session', () => {

--- a/src/users/users.controller.spec.ts
+++ b/src/users/users.controller.spec.ts
@@ -5,6 +5,7 @@ import { UsersService } from './users.service';
 import { ExternalUserCreationService } from './external-user-creation.service';
 import { UsersController } from './users.controller';
 import { UserRole } from './user.entity';
+import { Response } from 'express';
 
 const name = 'Example Name';
 const email = 'name@example.com';
@@ -79,13 +80,10 @@ describe('UsersController', () => {
   });
 
   describe('create', () => {
-    let res;
+    let res: DeepMocked<Response>;
 
     beforeEach(() => {
-      res = {
-        render: jest.fn(),
-        redirect: jest.fn(),
-      };
+      res = createMock<Response>();
     });
 
     it('should throw an exception when called with an empty session', () => {

--- a/views/professions/show.njk
+++ b/views/professions/show.njk
@@ -1,5 +1,7 @@
 {% extends "base.njk" %}
 {% from "govuk/components/panel/macro.njk" import govukPanel %}
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 
 {% block content %}
 
@@ -9,14 +11,214 @@
 
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
-        <h1 class="govuk-heading-xl">{{ professionName }}</h1>
+
+        {{ govukBackLink({
+          text: "Back",
+          href: backUrl
+        }) }}
+
+        <span class="govuk-caption-l">Placeholder Authority</span>
+
+        <h1 class="govuk-heading-xl">{{ profession.name }}</h1>
+
+        <h2 class="govuk-heading-m rpr-details__section-title">Overview</h2>
+
+        {{ govukSummaryList({
+          classes: 'govuk-summary-list--no-border',
+          rows: [
+            {
+              key: {
+                text: "Nations"
+              },
+              value: {
+                text: profession.occupationLocation
+              }
+            },
+            {
+              key: {
+                text: "Industry/Sector"
+              },
+              value: {
+                text: profession.industry.name
+              }
+            }
+          ]
+        }) }}
+
+        <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible" />
+
+        <h2 class="govuk-heading-m rpr-details__section-title">Regulatory/professional bodies</h2>
+
+        {{ govukSummaryList({
+          classes: 'govuk-summary-list--no-border',
+          rows: [
+            {
+              key: {
+                text: "Regulated authority"
+              },
+              value: {
+                text: "Placeholder authority"
+              }
+            },
+            {
+              key: {
+                text: "Address"
+              },
+              value: {
+                html: 'Placeholder address'
+              }
+            },
+            {
+              key: {
+                text: "Email address"
+              },
+              value: {
+                text: "Placeholder email"
+              }
+            },
+            {
+              key: {
+                text: "URL"
+              },
+              value: {
+                text: "Placeholder url"
+              }
+            },          
+            {
+              key: {
+                text: "Phone number"
+              },
+              value: {
+                text: "Placeholder phone numer"
+              }
+            },
+            {
+              key: {
+                text: "Mandatory registration with professional bodies"
+              },
+              value: {
+                text: "Placeholder response"
+              }
+            }
+          ]
+        }) }}
+
+        <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+
+        <h2 class="govuk-heading-m rpr-details__section-title">Regulated activities</h2>
+
+        {% set escapedActivites = [] %}
+        {% for activity in profession.reservedActivities %}
+          {% set escapedActivites = (escapedActivites.push(activity | escape), escapedActivites) %}
+        {% endfor %}
+        
+        {{ govukSummaryList({
+          classes: 'govuk-summary-list--no-border',
+          rows: [
+            {
+              key: {
+                text: "Reserved activities"
+              },
+              value: {
+                html: ["<ul class=\"govuk-list\"><li>", (escapedActivites | join("</li><li>")), "</li></ul>"] | join
+              }
+            },
+            {
+              key: {
+                text: "Description of activities/regulation description"
+              },
+              value: {
+                text: profession.description
+              }
+            }
+          ]
+        }) }}
+
+        <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+
+        <h2 class="govuk-heading-m rpr-details__section-title">Qualification information</h2>
+
+        {{ govukSummaryList({
+          classes: 'govuk-summary-list--no-border',
+          rows: [
+            {
+              key: {
+                text: "Qualification level"
+              },
+              value: {
+                text: profession.qualification.level
+              }
+            },
+            {
+              key: {
+                text: "Methods to obtain qualification"
+              },
+              value: {
+                text: profession.qualification.methodToObtain
+              }
+            },
+            {
+              key: {
+                text: "Most common path to obtain qualification"
+              },
+              value: {
+                text: profession.qualification.commonPathToObtain
+              }
+            },
+            {
+              key: {
+                text: "Duration of qualification"
+              },
+              value: {
+                text: profession.qualification.educationDuration
+              }
+            },
+            {
+              key: {
+                text: "Existence of mandatory professional experience"
+              },
+              value: {
+                text: "Yes" if profession.qualification.mandatoryProfessionalExperience else "No"
+              }
+            }
+          ]
+        }) }}
+
+        <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+
+        <h2 class="govuk-heading-m rpr-details__section-title">Legislation</h2>
+
+        {% for legislation in profession.legislations %}
+
+          {{ govukSummaryList({
+          classes: 'govuk-summary-list--no-border',
+          rows: [
+            {
+              key: {
+                text: "National legislation"
+              },
+              value: {
+                text: legislation.name
+              }
+            },
+            {
+              key: {
+                text: "Legislation link"
+              },
+              value: {
+                html: ["<a class=\"govuk-link\" href=\"", (legislation.url | escape), "\">", (legislation.url | escape),  "</a>" ] | join
+              }
+            }
+          ]
+          }) }}
+        {% endfor %}
       </div>
 
       <div class="govuk-grid-column-one-third">
-
+        
       </div>
-    </div>
 
+    </div>
   </main>
 </div>
 

--- a/views/professions/show.njk
+++ b/views/professions/show.njk
@@ -1,0 +1,23 @@
+{% extends "base.njk" %}
+{% from "govuk/components/panel/macro.njk" import govukPanel %}
+
+{% block content %}
+
+<div class="govuk-width-container">
+
+  <main class="govuk-main-wrapper">
+
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <h1 class="govuk-heading-xl">{{ professionName }}</h1>
+      </div>
+
+      <div class="govuk-grid-column-one-third">
+
+      </div>
+    </div>
+
+  </main>
+</div>
+
+{% endblock %}


### PR DESCRIPTION
This PR:
* Setups up an endpoint for displaying professional details
* Displays professional detail following the design [here](https://rpr-prototype.herokuapp.com/beta-sprint-2/public-facing-v1/profession-1-plastic-surgery) 
* Established canonical user-friendly URLs, and redirects if the canonical URL is not used

This PR punts on the problem of where the back link should go. Given this needs to work without Javascript, we'll need to keep track of where the user has come from. It may be that this is worthy of its own story, to handle back links across the service. If a page has multiple entry points, it may be non-trivial where 'Back' should go.

Where we don't yet have data, I've err-ed towards making it obvious we're using placeholder data, rather than risk dummy static data getting left in the page.