### PR TITLE
(1933) Add internationalisation

### DIFF
--- a/nest-cli.json
+++ b/nest-cli.json
@@ -1,4 +1,7 @@
 {
   "collection": "@nestjs/schematics",
-  "sourceRoot": "src"
+  "sourceRoot": "src",
+  "compilerOptions": {
+    "assets": ["i18n/**/*"]
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "file-loader": "^6.2.0",
         "govuk-frontend": "^3.14.0",
         "jwt-decode": "^3.1.2",
+        "nestjs-i18n": "^8.2.2",
         "nunjucks": "^3.2.3",
         "pg": "^8.7.1",
         "reflect-metadata": "^0.1.13",
@@ -3846,6 +3847,11 @@
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.5.tgz",
       "integrity": "sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q==",
       "dev": true
+    },
+    "node_modules/accept-language-parser": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/accept-language-parser/-/accept-language-parser-1.5.0.tgz",
+      "integrity": "sha1-iHfFQECo3LWeCgfZwf3kIpgzR5E="
     },
     "node_modules/accepts": {
       "version": "1.3.7",
@@ -11171,6 +11177,30 @@
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
     },
+    "node_modules/nestjs-i18n": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/nestjs-i18n/-/nestjs-i18n-8.2.2.tgz",
+      "integrity": "sha512-xjmr9wFnDDJqEOPRjLxDCpKpHHvFY+pLk4UQch2lj9VqXXA507u250C5eYVNLQM6T3sbuj6i2cKH+JqGB3AvNQ==",
+      "dependencies": {
+        "accept-language-parser": "^1.5.0",
+        "chokidar": "^3.5.1",
+        "cookie": "^0.4.1",
+        "string-format": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "*",
+        "@nestjs/core": "*",
+        "rxjs": "*"
+      }
+    },
+    "node_modules/nestjs-i18n/node_modules/cookie": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+      "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/nestjs-seeder": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/nestjs-seeder/-/nestjs-seeder-0.2.0.tgz",
@@ -14318,6 +14348,11 @@
       "version": "0.10.31",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
       "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+    },
+    "node_modules/string-format": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/string-format/-/string-format-2.0.0.tgz",
+      "integrity": "sha512-bbEs3scLeYNXLecRRuk6uJxdXUSj6le/8rNPHChIJTn2V79aXVTR1EH2OH5zLKKoz0V02fOUKZZcw01pLUShZA=="
     },
     "node_modules/string-length": {
       "version": "4.0.2",
@@ -19426,6 +19461,11 @@
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.5.tgz",
       "integrity": "sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q==",
       "dev": true
+    },
+    "accept-language-parser": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/accept-language-parser/-/accept-language-parser-1.5.0.tgz",
+      "integrity": "sha1-iHfFQECo3LWeCgfZwf3kIpgzR5E="
     },
     "accepts": {
       "version": "1.3.7",
@@ -25027,6 +25067,24 @@
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
     },
+    "nestjs-i18n": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/nestjs-i18n/-/nestjs-i18n-8.2.2.tgz",
+      "integrity": "sha512-xjmr9wFnDDJqEOPRjLxDCpKpHHvFY+pLk4UQch2lj9VqXXA507u250C5eYVNLQM6T3sbuj6i2cKH+JqGB3AvNQ==",
+      "requires": {
+        "accept-language-parser": "^1.5.0",
+        "chokidar": "^3.5.1",
+        "cookie": "^0.4.1",
+        "string-format": "^2.0.0"
+      },
+      "dependencies": {
+        "cookie": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+          "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA=="
+        }
+      }
+    },
     "nestjs-seeder": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/nestjs-seeder/-/nestjs-seeder-0.2.0.tgz",
@@ -27322,6 +27380,11 @@
       "version": "0.10.31",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
       "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+    },
+    "string-format": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/string-format/-/string-format-2.0.0.tgz",
+      "integrity": "sha512-bbEs3scLeYNXLecRRuk6uJxdXUSj6le/8rNPHChIJTn2V79aXVTR1EH2OH5zLKKoz0V02fOUKZZcw01pLUShZA=="
     },
     "string-length": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "file-loader": "^6.2.0",
     "govuk-frontend": "^3.14.0",
     "jwt-decode": "^3.1.2",
+    "nestjs-i18n": "^8.2.2",
     "nunjucks": "^3.2.3",
     "pg": "^8.7.1",
     "reflect-metadata": "^0.1.13",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -2,6 +2,10 @@ process.env.NODE_ENV ||= 'development';
 
 import { Module } from '@nestjs/common';
 import { ConfigModule, ConfigService } from '@nestjs/config';
+import { I18nModule, I18nJsonParser } from 'nestjs-i18n';
+
+import * as path from 'path';
+
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { TypeOrmModule } from '@nestjs/typeorm';
@@ -24,6 +28,14 @@ import dbConfiguration from './config/db.config';
       useFactory: async (configService: ConfigService) => ({
         ...(await configService.get('database')),
       }),
+    }),
+    I18nModule.forRoot({
+      fallbackLanguage: 'en',
+      parser: I18nJsonParser,
+      parserOptions: {
+        path: path.join(__dirname, '/i18n/'),
+        watch: process.env.NODE_ENV === 'development',
+      },
     }),
     UsersModule,
     ProfessionsModule,

--- a/src/config/nunjucks.config.ts
+++ b/src/config/nunjucks.config.ts
@@ -28,9 +28,12 @@ export const nunjucksConfig = async (
   );
   env.addFilter(
     't',
-    async (text, callback) => {
+    async (...args) => {
+      const callback = args.pop();
+      const text = args[0];
+      const personalisation = args.length < 2 ? {} : args[1];
       try {
-        const result = await i18nHelper.translate(text);
+        const result = await i18nHelper.translate(text, personalisation);
         callback(null, result);
       } catch (error) {
         callback(error);

--- a/src/config/nunjucks.config.ts
+++ b/src/config/nunjucks.config.ts
@@ -5,6 +5,7 @@ import { NestExpressApplication } from '@nestjs/platform-express';
 import * as nunjucks from 'nunjucks';
 
 import { AssetsHelper } from '../helpers/assets.helper';
+import { I18nHelper } from '../helpers/i18n.helper';
 
 export const nunjucksConfig = async (
   app: NestExpressApplication,
@@ -13,6 +14,7 @@ export const nunjucksConfig = async (
   const express = app.getHttpAdapter().getInstance();
   const entrypoints = require('../../public/entrypoints.json');
   const assetsHelper = new AssetsHelper(entrypoints);
+  const i18nHelper = new I18nHelper(app);
 
   const env = nunjucks.configure(views, {
     noCache: process.env.NODE_ENV === 'development' ? true : false,
@@ -23,6 +25,18 @@ export const nunjucksConfig = async (
   env.addGlobal(
     'encore_entry_script_tags',
     await assetsHelper.entryScriptTags(),
+  );
+  env.addFilter(
+    't',
+    async (text, callback) => {
+      try {
+        const result = await i18nHelper.translate(text);
+        callback(null, result);
+      } catch (error) {
+        callback(error);
+      }
+    },
+    true,
   );
 
   return env;

--- a/src/helpers/i18n.helper.spec.ts
+++ b/src/helpers/i18n.helper.spec.ts
@@ -19,7 +19,13 @@ describe('AssetsHelper', () => {
   it('returns a translated string', async () => {
     await helper.translate('hello world');
 
-    expect(service.translate).toHaveBeenCalledWith('hello world');
+    expect(service.translate).toHaveBeenCalledWith('hello world', { args: {} });
   });
+
+  it('accepts optional personalisation options', async () => {
+    await helper.translate('hello world', { foo: 'bar' });
+    expect(service.translate).toHaveBeenCalledWith('hello world', {
+      args: { foo: 'bar' },
+    });
   });
 });

--- a/src/helpers/i18n.helper.spec.ts
+++ b/src/helpers/i18n.helper.spec.ts
@@ -1,0 +1,25 @@
+import { I18nHelper } from './i18n.helper';
+import { createMock } from '@golevelup/ts-jest';
+import { NestExpressApplication } from '@nestjs/platform-express';
+import { I18nService } from 'nestjs-i18n';
+
+describe('AssetsHelper', () => {
+  let service: I18nService;
+  let app: NestExpressApplication;
+  let helper: I18nHelper;
+
+  beforeEach(async () => {
+    service = createMock<I18nService>();
+    app = createMock<NestExpressApplication>({
+      get: () => service,
+    });
+    helper = new I18nHelper(app);
+  });
+
+  it('returns a translated string', async () => {
+    await helper.translate('hello world');
+
+    expect(service.translate).toHaveBeenCalledWith('hello world');
+  });
+  });
+});

--- a/src/helpers/i18n.helper.ts
+++ b/src/helpers/i18n.helper.ts
@@ -22,9 +22,13 @@ export class I18nHelper {
    * Get a translated string from the i18n reference
    *
    * @param {text} - The translation reference (e.g `user.greeting`)
+   * @param {any} - Any personalisations that need to be passed tho the translation
    * @returns {string} - The translated string (e.g `Hello world!`)
    */
-  public async translate(text: string): Promise<string> {
-    return await this.i18nService.translate(text);
+  public async translate(
+    text: string,
+    personalisation: any = {},
+  ): Promise<string> {
+    return await this.i18nService.translate(text, { args: personalisation });
   }
 }

--- a/src/helpers/i18n.helper.ts
+++ b/src/helpers/i18n.helper.ts
@@ -1,0 +1,30 @@
+import { NestExpressApplication } from '@nestjs/platform-express';
+import { I18nService } from 'nestjs-i18n';
+
+/**
+ * Returns a string from a translation reference
+ *
+ * This class allows us to use the NestJS i18n Service
+ * to get a translation string from a reference.
+ *
+ * @constructor
+ * @param {NestExpressApplication} app - A reference to the NestJS Express
+ * application (this allows us to get a reference to the I18nService)
+ */
+export class I18nHelper {
+  i18nService: I18nService;
+
+  constructor(private app: NestExpressApplication) {
+    this.i18nService = app.get<I18nService>(I18nService);
+  }
+
+  /**
+   * Get a translated string from the i18n reference
+   *
+   * @param {text} - The translation reference (e.g `user.greeting`)
+   * @returns {string} - The translated string (e.g `Hello world!`)
+   */
+  public async translate(text: string): Promise<string> {
+    return await this.i18nService.translate(text);
+  }
+}

--- a/src/i18n/en/app.json
+++ b/src/i18n/en/app.json
@@ -1,0 +1,12 @@
+{
+  "name": "Regulated Professions Register",
+  "welcome": "Welcome {name}",
+  "superadmin": "You are a superadmin",
+  "back": "Back",
+  "continue": "Continue",
+  "change": "Change",
+  "start": "Start",
+  "errors": {
+    "heading": "There is a problem"
+  }
+}

--- a/src/i18n/en/errors.json
+++ b/src/i18n/en/errors.json
@@ -1,0 +1,8 @@
+{
+  "forbidden": {
+    "heading": "You have not been authorized to see this page",
+    "message": "Whilst you have successfully signed in you have not been authorised to see this page.",
+    "resolution": "Please try <a href='/login' class='govuk-link'>logging in</a> again.",
+    "help": "If you believe this to be in error, please contact the person who invited you to the service."
+  }
+}

--- a/src/i18n/en/users.json
+++ b/src/i18n/en/users.json
@@ -1,0 +1,8 @@
+{
+  "form": {
+    "label": {
+      "name": "Name",
+      "email": "Email address"
+    }
+  }
+}

--- a/src/i18n/en/users.json
+++ b/src/i18n/en/users.json
@@ -3,6 +3,33 @@
     "label": {
       "name": "Name",
       "email": "Email address"
-    }
+    },
+    "hint": {
+      "name": "For example, Clare Jones.",
+      "email": "For example, clarejones@beis.gov.uk."
+    },
+    "button": {
+      "create": "Create user"
+    },
+    "errors": {
+      "email": {
+        "alreadyExists": "A user with this email address already exists"
+      }
+    },
+    "headings": {
+      "main": "Creating RPR user",
+      "checkAnswers": "Check your answers before creating this user",
+      "personalDetails": "Personal details"
+    },
+    "checkAnswers": "Check your answers before creating this user"
+  },
+  "headings": {
+    "done": "User added",
+    "next": "What happens next?"
+  },
+  "body": {
+    "panel": "User <strong>{email}</strong> has been added",
+    "confirmation": "We have sent the user a confirmation email.",
+    "backToDashboard": "Back to the dashboard"
   }
 }

--- a/views/admin/base.njk
+++ b/views/admin/base.njk
@@ -4,7 +4,7 @@
   {{
     govukHeader({
       homepageUrl: "/",
-      serviceName: "Regulated Professions Register",
+      serviceName: ("app.name" | t),
         navigation: [
           {
             href: "/logout",

--- a/views/admin/dashboard.njk
+++ b/views/admin/dashboard.njk
@@ -1,5 +1,5 @@
 {% extends "./base.njk" %}
 
 {% block content %}
-<h1 class="govuk-heading-l">Welcome {{ name }}</h1>
+<h1 class="govuk-heading-l">{{ "app.welcome" | t({name: name}) }}</h1>
 {% endblock %}

--- a/views/admin/superadmin.njk
+++ b/views/admin/superadmin.njk
@@ -1,6 +1,6 @@
 {% extends "./base.njk" %}
 
 {% block content %}
-<h1 class="govuk-heading-l">Welcome {{ name }}</h1>
-<p class="govuk-body">You are a superadmin</p>
+<h1 class="govuk-heading-l">{{ "app.welcome" | t({name: name}) }}</h1>
+<p class="govuk-body">{{ "app.superadmin" | t }}</p>
 {% endblock %}

--- a/views/errors/forbidden.njk
+++ b/views/errors/forbidden.njk
@@ -1,11 +1,11 @@
 {% extends "../base.njk" %}
 
 {% block content %}
-<h1 class="govuk-heading-l">You have not been authorized to see this page</h1>
+<h1 class="govuk-heading-l">{{ "errors.forbidden.heading" | t }}</h1>
 
-<p class="govuk-body">Whilst you have successfully signed in you have not been authorised to see this page.</p>
+<p class="govuk-body">{{ "errors.forbidden.message" | t }}</p>
 
-<p class="govuk-body">Please try <a href="/login" class="govuk-link">logging in</a> again.</p>
+<p class="govuk-body">{{ "errors.forbidden.resolution" | t | safe}}</p>
 
-<p class="govuk-body">If you believe this to be in error, please contact the person who invited you to the service.</p>
+<p class="govuk-body">{{ "errors.forbidden.help" | t }}</p>
 {% endblock %}

--- a/views/shared/_errors.njk
+++ b/views/shared/_errors.njk
@@ -1,7 +1,7 @@
 {% if errors %}
 <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary">
   <h2 class="govuk-error-summary__title" id="error-summary-title">
-    There is a problem
+    {{ "app.errors.heading" | t }}
   </h2>
   <div class="govuk-error-summary__body">
     <ul class="govuk-list govuk-error-summary__list">

--- a/views/users/confirm.njk
+++ b/views/users/confirm.njk
@@ -15,34 +15,34 @@
       <div class="govuk-grid-column-two-thirds">
 
         {{ govukBackLink({
-          text: "Back",
+          text: ("app.back" | t),
           href: "personal-details"
         }) }}
 
         {% if userAlreadyExists %}
 
         {{ govukErrorSummary({
-          titleText: "There is a problem",
+          titleText: ("app.errors.heading" | t),
           errorList: [
             {
-              text: "A user with this email address already exists"
+              text: ("users.form.errors.email.alreadyExists" | t)
             }
           ]
         }) }}
 
         {% endif %}
 
-        <span class="govuk-caption-xl">Creating RPR user</span>
-        <h1 class="govuk-heading-xl">Check your answers before creating this user</h1>
+        <span class="govuk-caption-xl">{{ "users.form.headings.main" | t }}</span>
+        <h1 class="govuk-heading-xl">{{ "users.form.headings.checkAnswers" | t }}</h1>
 
-        <h2 class="govuk-heading-m">Personal details</h2>
+        <h2 class="govuk-heading-m">{{ "users.form.headings.personalDetails" | t }}</h2>
 
 
         {{ govukSummaryList({
           rows: [
             {
               key: {
-                text: "Name"
+                text: ("users.form.label.name" | t)
               },
               value: {
                 text: name
@@ -51,15 +51,15 @@
                 items: [
                   {
                     href: "personal-details?edit=true",
-                    text: "Change",
-                    visuallyHiddenText: "name"
+                    text: ("app.change" | t),
+                    visuallyHiddenText: ("users.form.label.name" | t)
                   }
                 ]
               }
             },
             {
               key: {
-                text: "Email address"
+                text: ("users.form.label.email" | t)
               },
               value: {
                 text: email
@@ -68,8 +68,8 @@
                 items: [
                   {
                     href: "personal-details?edit=true",
-                    text: "Change",
-                    visuallyHiddenText: "email address"
+                    text: ("app.change" | t),
+                    visuallyHiddenText: ("users.form.label.email" | t)
                   }
                 ]
               }
@@ -79,7 +79,7 @@
 
         <form method="post" action="confirm">
           {{ govukButton({
-            text: "Create user",
+            text: ("users.form.button.create" | t),
             preventDoubleClick: true,
             type: "submit",
             id: "submit-button"

--- a/views/users/done.njk
+++ b/views/users/done.njk
@@ -9,18 +9,17 @@
 
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
-
         {{ govukPanel({
-          titleText: "User added",
-          html: "User <strong>" + email + "</strong> has been added"
+          titleText: ("users.headings.done" | t),
+          html: ("users.body.panel" | t({email: email}) | safe)
         }) }}
 
-        <p class="govuk-body">We have sent the user a confirmation email.</p>
+        <p class="govuk-body">{{ "users.body.confirmation" | t  }}</p>
 
-        <h3 class="govuk-heading-m">What happens next?</h3>
+        <h3 class="govuk-heading-m">{{ "users.headings.next" | t  }}</h3>
 
-        <p class="govuk-body"><a href="../create-new-user">Click here</a> to go back to the dashboard.</p>
-        
+        <p class="govuk-body"><a href="../create-new-user">{{ "users.body.backToDashboard" | t }}</a></p>
+
       </div>
 
       <div class="govuk-grid-column-one-third">

--- a/views/users/new.njk
+++ b/views/users/new.njk
@@ -5,20 +5,20 @@
 {% block content %}
 
 <div class="govuk-width-container">
-  <a href="#" class="govuk-back-link">Back</a>
+  <a href="#" class="govuk-back-link">{{ "app.back" | t }}</a>
 
   <main class="govuk-main-wrapper">
 
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
-        
+
         <p class="govuk-body">Use this section of the site to add a new user.</p>
 
         <form method="post" action="create-new-user">
           {{ govukButton({
             id: "submit-button",
             type: "Submit",
-            text: "Start"
+            text: ("app.start" | t)
           }) }}
         </form>
 

--- a/views/users/personal-details/new.njk
+++ b/views/users/personal-details/new.njk
@@ -14,34 +14,34 @@
 
         {% if edit %}
           {{ govukBackLink({
-            text: "Back",
+            text: ( "app.back" | t ),
             href: "confirm"
           }) }}
         {% else %}
           {{ govukBackLink({
-            text: "Back",
+            text: ( "app.back" | t ),
             href: "../create-new-user"
           }) }}
         {% endif %}
 
         {% include "../../shared/_errors.njk" %}
 
-        <span class="govuk-caption-xl">Creating RPR user</span>
-        <h1 class="govuk-heading-xl">Personal details</h1>
+        <span class="govuk-caption-xl">{{ "users.form.headings.main" | t }}</span>
+        <h1 class="govuk-heading-xl">{{ "users.form.headings.personalDetails" | t }}</h1>
 
         <form method="post" action="personal-details">
 
           <input type="hidden" name="edit" value="{{ edit }}" />
-          
+
           <a name="name">
             {{ govukInput({
               label: {
-                text: "Name",
+                text: ('users.form.label.name' | t),
                 classes: "govuk-label--l",
                 isPageHeading: true
               },
               hint: {
-                text: "For example, Clare Jones."
+                text: ('users.form.hint.name' | t)
               },
               id: "name-input",
               name: "name",
@@ -53,12 +53,12 @@
           <a name="email">
             {{ govukInput({
               label: {
-                text: "Email address",
+                text: ('users.form.label.email' | t),
                 classes: "govuk-label--l",
                 isPageHeading: true
               },
               hint: {
-                text: "For example, clarejones@beis.gov.uk."
+                text: ('users.form.hint.email' | t)
               },
               id: "email-input",
               name: "email",
@@ -68,7 +68,7 @@
           </a>
 
           {{ govukButton({
-            text: "Continue",
+            text: ('app.continue' | t),
             type: "submit",
             id: "continue-button"
           }) }}


### PR DESCRIPTION
This moves all the text used in the views in the application to use i18n translations. This is bestpractice because:

a) It allows us to be DRY and if something changes in one place, we can change it elsewhere
b) It sets us up to be able to use other languages (e.g. Welsh) in the future
c) It makes it easier for content designers to change things in the app without digging through template files.