### PR TITLE
(1783) Add very basic functionality for adding a profession

### DIFF
--- a/cypress/integration/admin/professions/add-a-profession.spec.ts
+++ b/cypress/integration/admin/professions/add-a-profession.spec.ts
@@ -25,7 +25,9 @@ describe('Adding a new profession', () => {
     });
 
     cy.get('body').should('contain', 'Example Profession');
-    cy.get('body').should('contain', 'England');
+    cy.translate('nations.england').then((england) => {
+      cy.get('body').should('contain', england);
+    });
     cy.get('body').should('contain', 'Construction & Engineering');
 
     cy.translate('professions.form.button.create').then((buttonText) => {

--- a/cypress/integration/admin/professions/add-a-profession.spec.ts
+++ b/cypress/integration/admin/professions/add-a-profession.spec.ts
@@ -1,0 +1,41 @@
+describe('Adding a new profession', () => {
+  it('I can add a new profession', () => {
+    cy.visit('/admin/professions/add-profession');
+
+    cy.translate('app.start').then((buttonText) => {
+      cy.get('button').contains(buttonText).click();
+    });
+
+    cy.translate('professions.form.headings.topLevelInformation').then(
+      (heading) => {
+        cy.get('body').should('contain', heading);
+      },
+    );
+
+    cy.get('input[name="name"]').type('Example Profession');
+    cy.get('select[name="nation"]').select('England');
+    cy.get('select[name="industryId"]').select('Construction & Engineering');
+
+    cy.translate('app.continue').then((buttonText) => {
+      cy.get('button').contains(buttonText).click();
+    });
+
+    cy.translate('professions.form.headings.checkAnswers').then((heading) => {
+      cy.get('body').should('contain', heading);
+    });
+
+    cy.get('body').should('contain', 'Example Profession');
+    cy.get('body').should('contain', 'England');
+    cy.get('body').should('contain', 'Construction & Engineering');
+
+    cy.translate('professions.form.button.create').then((buttonText) => {
+      cy.get('button').contains(buttonText).click();
+    });
+
+    cy.translate('professions.form.headings.confirmation').then((heading) => {
+      cy.get('body')
+        .should('contain', heading)
+        .should('contain', 'Example Profession');
+    });
+  });
+});

--- a/cypress/support/index.ts
+++ b/cypress/support/index.ts
@@ -29,7 +29,7 @@ declare global {
       translate(
         translation: string,
         personalisations?: object,
-      ): Chainable<String>;
+      ): Chainable<string>;
     }
   }
 }

--- a/nest-cli.json
+++ b/nest-cli.json
@@ -2,6 +2,6 @@
   "collection": "@nestjs/schematics",
   "sourceRoot": "src",
   "compilerOptions": {
-    "assets": ["i18n/**/*"]
+    "assets": ["i18n/**/*", "config/nations.json"]
   }
 }

--- a/src/config/nations.json
+++ b/src/config/nations.json
@@ -1,0 +1,18 @@
+[
+  {
+    "code": "GB-ENG",
+    "name": "nations.england"
+  },
+  {
+    "code": "GB-NIR",
+    "name": "nations.northernIreland"
+  },
+  {
+    "code": "GB-SCT",
+    "name": "nations.scotland"
+  },
+  {
+    "code": "GB-WLS",
+    "name": "nations.wales"
+  }
+]

--- a/src/config/nunjucks.config.ts
+++ b/src/config/nunjucks.config.ts
@@ -42,5 +42,28 @@ export const nunjucksConfig = async (
     true,
   );
 
+  env.addFilter(
+    'tOptionSelect',
+    async (...args) => {
+      const callback = args.pop();
+      const optionSelectArgs = args[0];
+      const personalisation = args.length < 2 ? {} : args[1];
+      const result = await Promise.all(
+        optionSelectArgs.map(async (arg: { text: string; value: string }) => {
+          try {
+            return {
+              text: await i18nHelper.translate(arg['text'], personalisation),
+              value: arg['value'],
+            };
+          } catch (error) {
+            callback(error);
+          }
+        }),
+      );
+      callback(null, result);
+    },
+    true,
+  );
+
   return env;
 };

--- a/src/i18n/en/app.json
+++ b/src/i18n/en/app.json
@@ -8,5 +8,6 @@
   "start": "Start",
   "errors": {
     "heading": "There is a problem"
-  }
+  },
+  "backToDashboard": "Back to the dashboard"
 }

--- a/src/i18n/en/nations.json
+++ b/src/i18n/en/nations.json
@@ -1,0 +1,6 @@
+{
+  "england": "England",
+  "northernIreland": "Northern Ireland",
+  "scotland": "Scotland",
+  "wales": "Wales"
+}

--- a/src/i18n/en/professions.json
+++ b/src/i18n/en/professions.json
@@ -1,0 +1,39 @@
+{
+  "form": {
+    "headings": {
+      "main": "Add a new profession",
+      "topLevelInformation": "Top level information",
+      "checkAnswers": "Check your answers",
+      "confirmation": "New profession created"
+    },
+    "description": "Use this section of the site to add a new profession",
+    "label": {
+      "topLevelInformation": {
+        "name": "Name of regulated profession",
+        "nation": "Nation",
+        "industry": "Industry / sector"
+      }
+    },
+    "button": {
+      "create": "Create profession"
+    },
+    "select": {
+      "topLevelInformation": {
+        "nations": {
+          "england": "England",
+          "anywhere": "Anywhere in the United Kingdom",
+          "northernIreland": "Northern Ireland",
+          "scotland": "Scotland",
+          "wales": "Wales"
+        }
+      }
+    },
+    "body": {
+      "confirmation": {
+        "panel": "<strong>{name}</strong> has been added",
+        "emailNotification": "We have sent you a confirmation email.",
+        "next": "What happens next?"
+      }
+    }
+  }
+}

--- a/src/nations/nation.spec.ts
+++ b/src/nations/nation.spec.ts
@@ -1,0 +1,32 @@
+import { Nation } from './nation';
+
+describe(Nation, () => {
+  describe('.all', () => {
+    it('returns all nations in the Nations config file', () => {
+      expect(Nation.all()).toEqual([
+        new Nation('nations.england', 'GB-ENG'),
+        new Nation('nations.northernIreland', 'GB-NIR'),
+        new Nation('nations.scotland', 'GB-SCT'),
+        new Nation('nations.wales', 'GB-WLS'),
+      ]);
+    });
+  });
+
+  describe('.find', () => {
+    describe('when a Nation exists with the requested code in the Nations config', () => {
+      it('returns that Nation', () => {
+        expect(Nation.find('GB-ENG')).toEqual(
+          new Nation('nations.england', 'GB-ENG'),
+        );
+      });
+    });
+
+    describe('when a Nation with the requested code does not exist in the Nations config', () => {
+      it('throws an error', () => {
+        expect(() => {
+          Nation.find('nothing');
+        }).toThrow('Could not find requested Nation');
+      });
+    });
+  });
+});

--- a/src/nations/nation.ts
+++ b/src/nations/nation.ts
@@ -1,0 +1,26 @@
+export class Nation {
+  name: string;
+  code: string;
+
+  constructor(name: string, code: string) {
+    this.name = name;
+    this.code = code;
+  }
+
+  static all(): Nation[] {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const nations: Nation[] = require('../config/nations.json');
+
+    return nations;
+  }
+
+  static find(code: string): Nation {
+    const selectedNation = Nation.all().find((nation) => nation.code === code);
+
+    if (!selectedNation) {
+      throw new Error('Could not find requested Nation');
+    }
+
+    return new Nation(selectedNation.name, selectedNation.code);
+  }
+}

--- a/src/professions/admin/add-profession/check-your-answers.controller.spec.ts
+++ b/src/professions/admin/add-profession/check-your-answers.controller.spec.ts
@@ -22,13 +22,13 @@ describe('CheckYourAnswersController', () => {
   });
 
   describe('view', () => {
-    it('returns the answers persisted in the session, looking up the Industry name', async () => {
+    it('returns the answers persisted in the session, looking up the Industry and Nation name', async () => {
       const constructionUUID = 'construction-uuid';
       const session = {
         'add-profession': {
           'top-level-details': {
             name: 'Gas Safe Engineer',
-            nation: 'england',
+            nation: 'GB-ENG',
             industryId: constructionUUID,
           },
         },
@@ -41,7 +41,7 @@ describe('CheckYourAnswersController', () => {
 
       expect(await controller.show(session)).toEqual({
         name: 'Gas Safe Engineer',
-        nation: 'england',
+        nation: 'nations.england',
         industry: 'Construction & Engineering',
       });
       expect(industriesService.find).toHaveBeenCalledWith(constructionUUID);

--- a/src/professions/admin/add-profession/check-your-answers.controller.spec.ts
+++ b/src/professions/admin/add-profession/check-your-answers.controller.spec.ts
@@ -1,0 +1,54 @@
+import { DeepMocked, createMock } from '@golevelup/ts-jest';
+import { TestingModule, Test } from '@nestjs/testing';
+import { IndustriesService } from '../../../industries/industries.service';
+import { Industry } from '../../../industries/industry.entity';
+import { CheckYourAnswersController } from './check-your-answers.controller';
+
+describe('CheckYourAnswersController', () => {
+  let controller: CheckYourAnswersController;
+  let industriesService: DeepMocked<IndustriesService>;
+
+  beforeEach(async () => {
+    industriesService = createMock<IndustriesService>();
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [CheckYourAnswersController],
+      providers: [{ provide: IndustriesService, useValue: industriesService }],
+    }).compile();
+
+    controller = module.get<CheckYourAnswersController>(
+      CheckYourAnswersController,
+    );
+  });
+
+  describe('view', () => {
+    it('returns the answers persisted in the session, looking up the Industry name', async () => {
+      const constructionUUID = 'construction-uuid';
+      const session = {
+        'add-profession': {
+          'top-level-details': {
+            name: 'Gas Safe Engineer',
+            nation: 'england',
+            industryId: constructionUUID,
+          },
+        },
+      };
+
+      const industry = new Industry('Construction & Engineering');
+      industry.id = constructionUUID;
+
+      industriesService.find.mockImplementation(async () => industry);
+
+      expect(await controller.show(session)).toEqual({
+        name: 'Gas Safe Engineer',
+        nation: 'england',
+        industry: 'Construction & Engineering',
+      });
+      expect(industriesService.find).toHaveBeenCalledWith(constructionUUID);
+    });
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+});

--- a/src/professions/admin/add-profession/check-your-answers.controller.ts
+++ b/src/professions/admin/add-profession/check-your-answers.controller.ts
@@ -1,6 +1,7 @@
 import { Controller, Get, Render, Session } from '@nestjs/common';
 
 import { IndustriesService } from '../../../industries/industries.service';
+import { Nation } from '../../../nations/nation';
 import { TopLevelDetailsDto } from './dto/top-level-details.dto';
 
 @Controller('admin/professions/new/check-your-answers')
@@ -22,9 +23,11 @@ export class CheckYourAnswersController {
       topLevelDetails.industryId,
     );
 
+    const selectedNation = Nation.find(topLevelDetails.nation);
+
     return {
       name: topLevelDetails.name,
-      nation: topLevelDetails.nation,
+      nation: selectedNation.name,
       industry: selectedIndustry.name,
     };
   }

--- a/src/professions/admin/add-profession/check-your-answers.controller.ts
+++ b/src/professions/admin/add-profession/check-your-answers.controller.ts
@@ -1,0 +1,31 @@
+import { Controller, Get, Render, Session } from '@nestjs/common';
+
+import { IndustriesService } from '../../../industries/industries.service';
+import { TopLevelDetailsDto } from './dto/top-level-details.dto';
+
+@Controller('admin/professions/new/check-your-answers')
+export class CheckYourAnswersController {
+  constructor(private industriesService: IndustriesService) {}
+
+  @Get()
+  @Render('professions/admin/add-profession/check-your-answers')
+  async show(@Session() session: Record<string, any>): Promise<{
+    name: string;
+    nation: string;
+    industry: string;
+  }> {
+    const addProfessionSession = session['add-profession'];
+    const topLevelDetails: TopLevelDetailsDto =
+      addProfessionSession['top-level-details'];
+
+    const selectedIndustry = await this.industriesService.find(
+      topLevelDetails.industryId,
+    );
+
+    return {
+      name: topLevelDetails.name,
+      nation: topLevelDetails.nation,
+      industry: selectedIndustry.name,
+    };
+  }
+}

--- a/src/professions/admin/add-profession/confirmation.controller.spec.ts
+++ b/src/professions/admin/add-profession/confirmation.controller.spec.ts
@@ -1,0 +1,91 @@
+import { DeepMocked, createMock } from '@golevelup/ts-jest';
+import { TestingModule, Test } from '@nestjs/testing';
+import { IndustriesService } from '../../../industries/industries.service';
+import { Industry } from '../../../industries/industry.entity';
+import { ProfessionsService } from '../../professions.service';
+import { ConfirmationController } from './confirmation.controller';
+
+describe('ConfirmationController', () => {
+  let controller: ConfirmationController;
+  let professionsService: DeepMocked<ProfessionsService>;
+  let industriesService: DeepMocked<IndustriesService>;
+
+  beforeEach(async () => {
+    professionsService = createMock<ProfessionsService>();
+    industriesService = createMock<IndustriesService>();
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [ConfirmationController],
+      providers: [
+        { provide: ProfessionsService, useValue: professionsService },
+        { provide: IndustriesService, useValue: industriesService },
+      ],
+    }).compile();
+
+    controller = module.get<ConfirmationController>(ConfirmationController);
+  });
+
+  describe('viewConfirmation', () => {
+    it('looks the name of the profession from the session', async () => {
+      const constructionUUID = 'construction-uuid';
+      const session = {
+        'add-profession': {
+          'top-level-details': {
+            name: 'Gas Safe Engineer',
+            nation: 'england',
+            industryId: constructionUUID,
+          },
+        },
+      };
+
+      expect(await controller.viewConfirmation(session)).toEqual({
+        name: 'Gas Safe Engineer',
+      });
+    });
+  });
+
+  describe('create', () => {
+    describe('when all required fields are present in the session', () => {
+      it('creates a Profession, with minimal fields', async () => {
+        const constructionUUID = 'construction-uuid';
+        const session = {
+          'add-profession': {
+            'top-level-details': {
+              name: 'Gas Safe Engineer',
+              nation: 'england',
+              industryId: constructionUUID,
+            },
+          },
+        };
+
+        const industry = new Industry('Construction & Engineering');
+        industry.id = constructionUUID;
+
+        industriesService.find.mockImplementation(async () => industry);
+
+        await controller.create(session);
+
+        expect(industriesService.find).toHaveBeenCalledWith(constructionUUID);
+        expect(professionsService.create).toHaveBeenCalledWith(
+          expect.objectContaining({
+            name: 'Gas Safe Engineer',
+            industry: industry,
+            occupationLocation: 'england',
+          }),
+        );
+      });
+    });
+
+    describe('when the session is empty', () => {
+      it('should throw an exception', () => {
+        expect(async () => {
+          await controller.create({});
+        }).rejects.toThrowError();
+      });
+    });
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+});

--- a/src/professions/admin/add-profession/confirmation.controller.ts
+++ b/src/professions/admin/add-profession/confirmation.controller.ts
@@ -1,0 +1,54 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Redirect,
+  Render,
+  Session,
+} from '@nestjs/common';
+import { IndustriesService } from '../../../industries/industries.service';
+import { Qualification } from '../../../qualifications/qualification.entity';
+import { Profession } from '../../profession.entity';
+
+import { ProfessionsService } from '../../professions.service';
+
+@Controller('admin/professions/new/confirmation')
+export class ConfirmationController {
+  constructor(
+    private professionsService: ProfessionsService,
+    private industriesService: IndustriesService,
+  ) {}
+
+  @Post()
+  @Redirect('/admin/professions/new/confirmation')
+  async create(@Session() session: Record<string, any>) {
+    const addProfessionSession = session['add-profession'];
+    const topLevelDetails = addProfessionSession['top-level-details'];
+
+    const industry = await this.industriesService.find(
+      topLevelDetails.industryId,
+    );
+
+    const profession = new Profession(
+      topLevelDetails.name,
+      '',
+      '',
+      topLevelDetails.nation,
+      '',
+      industry,
+      new Qualification(),
+      [],
+      [],
+    );
+
+    this.professionsService.create(profession);
+  }
+
+  @Get()
+  @Render('professions/admin/add-profession/confirmation')
+  async viewConfirmation(@Session() session: Record<string, any>) {
+    const addProfessionSession = session['add-profession'];
+
+    return { name: addProfessionSession['top-level-details'].name };
+  }
+}

--- a/src/professions/admin/add-profession/dto/top-level-details.dto.ts
+++ b/src/professions/admin/add-profession/dto/top-level-details.dto.ts
@@ -1,0 +1,12 @@
+import { IsNotEmpty } from 'class-validator';
+
+export class TopLevelDetailsDto {
+  @IsNotEmpty()
+  name: string;
+
+  @IsNotEmpty()
+  nation: string;
+
+  @IsNotEmpty()
+  industryId: string;
+}

--- a/src/professions/admin/add-profession/top-level-information.controller.spec.ts
+++ b/src/professions/admin/add-profession/top-level-information.controller.spec.ts
@@ -34,7 +34,7 @@ describe('TopLevelInformationController', () => {
   });
 
   describe('new', () => {
-    it('should fetch all Industries to be displayed in an option select', async () => {
+    it('should fetch all Industries and Nations to be displayed in an option select', async () => {
       await controller.new(response);
 
       expect(response.render).toHaveBeenCalledWith(
@@ -48,6 +48,24 @@ describe('TopLevelInformationController', () => {
             {
               text: 'Construction & Engineering',
               value: 'construction-uuid',
+            },
+          ],
+          nationsOptionSelectArgs: [
+            {
+              text: 'nations.england',
+              value: 'GB-ENG',
+            },
+            {
+              text: 'nations.northernIreland',
+              value: 'GB-NIR',
+            },
+            {
+              text: 'nations.scotland',
+              value: 'GB-SCT',
+            },
+            {
+              text: 'nations.wales',
+              value: 'GB-WLS',
             },
           ],
         },
@@ -119,6 +137,24 @@ describe('TopLevelInformationController', () => {
               {
                 text: 'Construction & Engineering',
                 value: 'construction-uuid',
+              },
+            ],
+            nationsOptionSelectArgs: [
+              {
+                text: 'nations.england',
+                value: 'GB-ENG',
+              },
+              {
+                text: 'nations.northernIreland',
+                value: 'GB-NIR',
+              },
+              {
+                text: 'nations.scotland',
+                value: 'GB-SCT',
+              },
+              {
+                text: 'nations.wales',
+                value: 'GB-WLS',
               },
             ],
             errors: { name: { text: 'name should not be empty' } },

--- a/src/professions/admin/add-profession/top-level-information.controller.spec.ts
+++ b/src/professions/admin/add-profession/top-level-information.controller.spec.ts
@@ -1,0 +1,50 @@
+import { DeepMocked, createMock } from '@golevelup/ts-jest';
+import { TestingModule, Test } from '@nestjs/testing';
+import { IndustriesService } from '../../../industries/industries.service';
+import { Industry } from '../../../industries/industry.entity';
+import { TopLevelInformationController } from './top-level-information.controller';
+
+describe('TopLevelInformationController', () => {
+  let controller: TopLevelInformationController;
+  let industriesService: DeepMocked<IndustriesService>;
+
+  const healthIndustry = new Industry('Health');
+  healthIndustry.id = 'health-uuid';
+  const constructionIndustry = new Industry('Construction & Engineering');
+  constructionIndustry.id = 'construction-uuid';
+
+  const industries = [healthIndustry, constructionIndustry];
+
+  beforeEach(async () => {
+    industriesService = createMock<IndustriesService>();
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [TopLevelInformationController],
+      providers: [{ provide: IndustriesService, useValue: industriesService }],
+    }).compile();
+
+    controller = module.get<TopLevelInformationController>(
+      TopLevelInformationController,
+    );
+  });
+
+  describe('new', () => {
+    it('should fetch all Industries to be displayed in an option select', async () => {
+      industriesService.all.mockImplementationOnce(async () => industries);
+
+      expect(await controller.new()).toEqual({
+        industriesOptionSelectArgs: [
+          {
+            text: 'Health',
+            value: 'health-uuid',
+          },
+          {
+            text: 'Construction & Engineering',
+            value: 'construction-uuid',
+          },
+        ],
+      });
+      expect(industriesService.all).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/professions/admin/add-profession/top-level-information.controller.spec.ts
+++ b/src/professions/admin/add-profession/top-level-information.controller.spec.ts
@@ -1,5 +1,6 @@
 import { DeepMocked, createMock } from '@golevelup/ts-jest';
 import { TestingModule, Test } from '@nestjs/testing';
+import { Response } from 'express';
 import { IndustriesService } from '../../../industries/industries.service';
 import { Industry } from '../../../industries/industry.entity';
 import { TopLevelInformationController } from './top-level-information.controller';
@@ -7,6 +8,7 @@ import { TopLevelInformationController } from './top-level-information.controlle
 describe('TopLevelInformationController', () => {
   let controller: TopLevelInformationController;
   let industriesService: DeepMocked<IndustriesService>;
+  let response: DeepMocked<Response>;
 
   const healthIndustry = new Industry('Health');
   healthIndustry.id = 'health-uuid';
@@ -23,6 +25,9 @@ describe('TopLevelInformationController', () => {
       providers: [{ provide: IndustriesService, useValue: industriesService }],
     }).compile();
 
+    industriesService.all.mockImplementation(async () => industries);
+    response = createMock<Response>();
+
     controller = module.get<TopLevelInformationController>(
       TopLevelInformationController,
     );
@@ -30,21 +35,101 @@ describe('TopLevelInformationController', () => {
 
   describe('new', () => {
     it('should fetch all Industries to be displayed in an option select', async () => {
-      industriesService.all.mockImplementationOnce(async () => industries);
+      await controller.new(response);
 
-      expect(await controller.new()).toEqual({
-        industriesOptionSelectArgs: [
-          {
-            text: 'Health',
-            value: 'health-uuid',
-          },
-          {
-            text: 'Construction & Engineering',
-            value: 'construction-uuid',
-          },
-        ],
-      });
+      expect(response.render).toHaveBeenCalledWith(
+        'professions/admin/add-profession/top-level-information',
+        {
+          industriesOptionSelectArgs: [
+            {
+              text: 'Health',
+              value: 'health-uuid',
+            },
+            {
+              text: 'Construction & Engineering',
+              value: 'construction-uuid',
+            },
+          ],
+        },
+      );
       expect(industriesService.all).toHaveBeenCalled();
     });
+  });
+
+  describe('addTopLevelInformation', () => {
+    describe('when all required parameters are entered', () => {
+      it('redirects to the Check your answers page and stores top level information data in the session', async () => {
+        const session = {
+          'add-profession': {},
+        };
+
+        const topLevelDetails = {
+          name: 'Gas Safe Engineer',
+          nation: 'england',
+          industryId: 'construction-uuid',
+        };
+
+        await controller.addTopLevelInformation(
+          session,
+          topLevelDetails,
+          response,
+        );
+
+        expect(session).toEqual({
+          'add-profession': {
+            'top-level-details': {
+              name: 'Gas Safe Engineer',
+              nation: 'england',
+              industryId: 'construction-uuid',
+            },
+          },
+        });
+        expect(response.redirect).toHaveBeenCalledWith(
+          '/admin/professions/new/check-your-answers',
+        );
+      });
+    });
+
+    describe('when a required parameter is not entered', () => {
+      it('renders the top level information view and displays an error to the user', async () => {
+        const session = {
+          'add-profession': {},
+        };
+
+        const topLevelDetailsWithMissingName = {
+          name: '',
+          nation: 'england',
+          industryId: 'construction-uuid',
+        };
+
+        await controller.addTopLevelInformation(
+          session,
+          topLevelDetailsWithMissingName,
+          response,
+        );
+
+        expect(response.render).toHaveBeenCalledWith(
+          'professions/admin/add-profession/top-level-information',
+          {
+            industriesOptionSelectArgs: [
+              {
+                text: 'Health',
+                value: 'health-uuid',
+              },
+              {
+                text: 'Construction & Engineering',
+                value: 'construction-uuid',
+              },
+            ],
+            errors: { name: { text: 'name should not be empty' } },
+          },
+        );
+        expect(industriesService.all).toHaveBeenCalled();
+      });
+    });
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
   });
 });

--- a/src/professions/admin/add-profession/top-level-information.controller.ts
+++ b/src/professions/admin/add-profession/top-level-information.controller.ts
@@ -1,0 +1,22 @@
+import { Controller, Get, Render } from '@nestjs/common';
+import { IndustriesService } from '../../../industries/industries.service';
+
+@Controller('admin/professions/add-profession/top-level-information')
+export class TopLevelInformationController {
+  constructor(private industriesService: IndustriesService) {}
+
+  @Get()
+  @Render('professions/admin/add-profession/top-level-information')
+  async new(): Promise<{
+    industriesOptionSelectArgs: { text: string; value: string }[];
+  }> {
+    const industries = await this.industriesService.all();
+
+    const industriesOptionSelectArgs = industries.map((industry) => ({
+      text: industry.name,
+      value: industry.id,
+    }));
+
+    return { industriesOptionSelectArgs };
+  }
+}

--- a/src/professions/admin/add-profession/top-level-information.controller.ts
+++ b/src/professions/admin/add-profession/top-level-information.controller.ts
@@ -1,15 +1,19 @@
-import { Controller, Get, Render } from '@nestjs/common';
+import { Body, Controller, Get, Post, Res, Session } from '@nestjs/common';
+import { Response } from 'express';
+import { Validator } from '../../../helpers/validator';
 import { IndustriesService } from '../../../industries/industries.service';
+import { ValidationFailedError } from '../../../validation/validation-failed.error';
+import { TopLevelDetailsDto } from './dto/top-level-details.dto';
 
-@Controller('admin/professions/add-profession/top-level-information')
+@Controller('admin/professions/new/top-level-information')
 export class TopLevelInformationController {
   constructor(private industriesService: IndustriesService) {}
 
   @Get()
-  @Render('professions/admin/add-profession/top-level-information')
-  async new(): Promise<{
-    industriesOptionSelectArgs: { text: string; value: string }[];
-  }> {
+  async new(
+    @Res() res: Response,
+    errors: object | undefined = undefined,
+  ): Promise<void> {
     const industries = await this.industriesService.all();
 
     const industriesOptionSelectArgs = industries.map((industry) => ({
@@ -17,6 +21,35 @@ export class TopLevelInformationController {
       value: industry.id,
     }));
 
-    return { industriesOptionSelectArgs };
+    res.render('professions/admin/add-profession/top-level-information', {
+      industriesOptionSelectArgs,
+      errors,
+    });
+  }
+
+  @Post()
+  async addTopLevelInformation(
+    @Session() session: Record<string, any>,
+    @Body() topLevelDetailsDto, // unfortunately we can't type this here without a validation error being thrown outside of this
+    @Res() res: Response,
+  ): Promise<void> {
+    const validator = await Validator.validate(
+      TopLevelDetailsDto,
+      topLevelDetailsDto,
+    );
+
+    if (!validator.valid()) {
+      const errors = new ValidationFailedError(validator.errors).fullMessages();
+      this.new(res, errors);
+      return;
+    }
+
+    if (session['add-profession'] === undefined) {
+      session['add-profession'] = {};
+    }
+
+    session['add-profession']['top-level-details'] = topLevelDetailsDto;
+
+    res.redirect('/admin/professions/new/check-your-answers');
   }
 }

--- a/src/professions/admin/add-profession/top-level-information.controller.ts
+++ b/src/professions/admin/add-profession/top-level-information.controller.ts
@@ -2,6 +2,7 @@ import { Body, Controller, Get, Post, Res, Session } from '@nestjs/common';
 import { Response } from 'express';
 import { Validator } from '../../../helpers/validator';
 import { IndustriesService } from '../../../industries/industries.service';
+import { Nation } from '../../../nations/nation';
 import { ValidationFailedError } from '../../../validation/validation-failed.error';
 import { TopLevelDetailsDto } from './dto/top-level-details.dto';
 
@@ -21,8 +22,14 @@ export class TopLevelInformationController {
       value: industry.id,
     }));
 
+    const nationsOptionSelectArgs = Nation.all().map((nation) => ({
+      text: nation.name,
+      value: nation.code,
+    }));
+
     res.render('professions/admin/add-profession/top-level-information', {
       industriesOptionSelectArgs,
+      nationsOptionSelectArgs,
       errors,
     });
   }

--- a/src/professions/professions.controller.spec.ts
+++ b/src/professions/professions.controller.spec.ts
@@ -1,0 +1,21 @@
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { ProfessionsController } from './professions.controller';
+
+describe('ProfessionsController', () => {
+  let controller: ProfessionsController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [ProfessionsController],
+    }).compile();
+
+    controller = module.get<ProfessionsController>(ProfessionsController);
+  });
+
+  describe('new', () => {
+    it('should return an empty object', () => {
+      expect(controller.new()).toEqual({});
+    });
+  });
+});

--- a/src/professions/professions.controller.ts
+++ b/src/professions/professions.controller.ts
@@ -1,0 +1,10 @@
+import { Controller, Get, Render } from '@nestjs/common';
+
+@Controller()
+export class ProfessionsController {
+  @Get('admin/professions/add-profession')
+  @Render('professions/admin/add-profession/new')
+  new(): Record<string, any> {
+    return {};
+  }
+}

--- a/src/professions/professions.module.ts
+++ b/src/professions/professions.module.ts
@@ -7,6 +7,7 @@ import { TopLevelInformationController } from './admin/add-profession/top-level-
 import { IndustriesService } from '../industries/industries.service';
 import { Industry } from '../industries/industry.entity';
 import { CheckYourAnswersController } from './admin/add-profession/check-your-answers.controller';
+import { ConfirmationController } from './admin/add-profession/confirmation.controller';
 
 @Module({
   imports: [
@@ -18,6 +19,7 @@ import { CheckYourAnswersController } from './admin/add-profession/check-your-an
     ProfessionsController,
     TopLevelInformationController,
     CheckYourAnswersController,
+    ConfirmationController,
   ],
 })
 export class ProfessionsModule {}

--- a/src/professions/professions.module.ts
+++ b/src/professions/professions.module.ts
@@ -2,9 +2,11 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Profession } from './profession.entity';
 import { ProfessionsService } from './professions.service';
+import { ProfessionsController } from './professions.controller';
 
 @Module({
   imports: [TypeOrmModule.forFeature([Profession])],
   providers: [ProfessionsService],
+  controllers: [ProfessionsController],
 })
 export class ProfessionsModule {}

--- a/src/professions/professions.module.ts
+++ b/src/professions/professions.module.ts
@@ -3,10 +3,16 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { Profession } from './profession.entity';
 import { ProfessionsService } from './professions.service';
 import { ProfessionsController } from './professions.controller';
+import { TopLevelInformationController } from './admin/add-profession/top-level-information.controller';
+import { IndustriesService } from '../industries/industries.service';
+import { Industry } from '../industries/industry.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Profession])],
-  providers: [ProfessionsService],
-  controllers: [ProfessionsController],
+  imports: [
+    TypeOrmModule.forFeature([Profession]),
+    TypeOrmModule.forFeature([Industry]),
+  ],
+  providers: [ProfessionsService, IndustriesService],
+  controllers: [ProfessionsController, TopLevelInformationController],
 })
 export class ProfessionsModule {}

--- a/src/professions/professions.module.ts
+++ b/src/professions/professions.module.ts
@@ -6,6 +6,7 @@ import { ProfessionsController } from './professions.controller';
 import { TopLevelInformationController } from './admin/add-profession/top-level-information.controller';
 import { IndustriesService } from '../industries/industries.service';
 import { Industry } from '../industries/industry.entity';
+import { CheckYourAnswersController } from './admin/add-profession/check-your-answers.controller';
 
 @Module({
   imports: [
@@ -13,6 +14,10 @@ import { Industry } from '../industries/industry.entity';
     TypeOrmModule.forFeature([Industry]),
   ],
   providers: [ProfessionsService, IndustriesService],
-  controllers: [ProfessionsController, TopLevelInformationController],
+  controllers: [
+    ProfessionsController,
+    TopLevelInformationController,
+    CheckYourAnswersController,
+  ],
 })
 export class ProfessionsModule {}

--- a/src/professions/professions.service.spec.ts
+++ b/src/professions/professions.service.spec.ts
@@ -55,6 +55,9 @@ describe('Profession', () => {
             findOne: () => {
               return profession;
             },
+            insert: () => {
+              return {};
+            },
           },
         },
       ],
@@ -81,6 +84,15 @@ describe('Profession', () => {
 
       expect(post).toEqual(profession);
       expect(repoSpy).toHaveBeenCalledWith('some-uuid');
+    });
+  });
+
+  describe('create', () => {
+    it('should save and return a Profession', async () => {
+      const repoSpy = jest.spyOn(repo, 'insert');
+      await service.create(profession);
+
+      expect(repoSpy).toHaveBeenCalledWith(profession);
     });
   });
 });

--- a/src/professions/professions.service.ts
+++ b/src/professions/professions.service.ts
@@ -18,4 +18,8 @@ export class ProfessionsService {
   find(id: string): Promise<Profession> {
     return this.repository.findOne(id);
   }
+
+  async create(profession: Profession): Promise<void> {
+    await this.repository.insert(profession);
+  }
 }

--- a/views/professions/admin/add-profession/check-your-answers.njk
+++ b/views/professions/admin/add-profession/check-your-answers.njk
@@ -14,7 +14,7 @@
 
           <h1 class="govuk-heading-l">{{ ("professions.form.headings.checkAnswers" | t) }}</h1>
 
-          <form method="post" action="#">
+          <form method="post" action="confirmation">
             {{
               govukSummaryList({
                 rows: [

--- a/views/professions/admin/add-profession/check-your-answers.njk
+++ b/views/professions/admin/add-profession/check-your-answers.njk
@@ -1,0 +1,93 @@
+{% extends "base.njk" %}
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% block content %}
+
+  <div class="govuk-width-container">
+    <a href="#" class="govuk-back-link">{{ ("app.back" | t) }}</a>
+
+    <main class="govuk-main-wrapper">
+
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+
+          <h1 class="govuk-heading-l">{{ ("professions.form.headings.checkAnswers" | t) }}</h1>
+
+          <form method="post" action="#">
+            {{
+              govukSummaryList({
+                rows: [
+                  {
+                    key: {
+                      text: ("professions.form.label.topLevelInformation.name" | t)
+                    },
+                    value: {
+                      text: name
+                    },
+                    actions: {
+                      items: [
+                        {
+                          href: "#",
+                          text: ("app.change" | t),
+                          visuallyHiddenText: ("professions.form.label.topLevelInformation.name" | t)
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    key: {
+                      text: ("professions.form.label.topLevelInformation.nation" | t)
+                    },
+                    value: {
+                      text: nation
+                    },
+                    actions: {
+                      items: [
+                        {
+                          href: "#",
+                          text: ("app.change" | t),
+                          visuallyHiddenText: ("professions.form.label.topLevelInformation.nation" | t)
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    key: {
+                      text: ("professions.form.label.topLevelInformation.industry" | t)
+                    },
+                    value: {
+                      text: industry
+                    },
+                    actions: {
+                      items: [
+                        {
+                          href: "#",
+                          text: ("app.change" | t),
+                          visuallyHiddenText: ("professions.form.label.topLevelInformation.industry" | t)
+                        }
+                      ]
+                    }
+                  }
+                ]
+              })
+            }}
+            {{
+              govukButton({
+                id: "submit-button",
+                type: "Submit",
+                preventDoubleClick: true,
+                text: ("professions.form.button.create" | t)
+              })
+            }}
+          </form>
+
+        </div>
+
+        <div class="govuk-grid-column-one-third"></div>
+      </div>
+
+    </main>
+  </div>
+
+{% endblock %}

--- a/views/professions/admin/add-profession/check-your-answers.njk
+++ b/views/professions/admin/add-profession/check-your-answers.njk
@@ -40,7 +40,7 @@
                       text: ("professions.form.label.topLevelInformation.nation" | t)
                     },
                     value: {
-                      text: nation
+                      text: (nation | t)
                     },
                     actions: {
                       items: [

--- a/views/professions/admin/add-profession/confirmation.njk
+++ b/views/professions/admin/add-profession/confirmation.njk
@@ -1,0 +1,32 @@
+{% extends "base.njk" %}
+{% from "govuk/components/panel/macro.njk" import govukPanel %}
+
+{% block content %}
+
+  <div class="govuk-width-container">
+
+    <main class="govuk-main-wrapper">
+
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+          {{
+            govukPanel({
+              titleText: ("professions.form.headings.confirmation" | t),
+              html: ("professions.form.body.confirmation.panel" | t({name: name}) | safe)
+            })
+          }}
+
+          <p class="govuk-body">{{ ("professions.form.body.confirmation.emailNotification" | t) }}</p>
+
+          <h2 class="govuk-heading-m">{{ ("professions.form.body.confirmation.next" | t) }}</h2>
+
+          <p class="govuk-body">
+            <a href="/admin">{{ ("app.backToDashboard" | t) }}</p>
+
+        </div>
+      </div>
+
+    </main>
+  </div>
+
+{% endblock %}

--- a/views/professions/admin/add-profession/new.njk
+++ b/views/professions/admin/add-profession/new.njk
@@ -1,0 +1,37 @@
+{% extends "base.njk" %}
+{% from "govuk/components/input/macro.njk" import govukInput %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% block content %}
+
+  <div class="govuk-width-container">
+    <a href="#" class="govuk-back-link">{{ ('app.back' | t) }}</a>
+
+    <main class="govuk-main-wrapper">
+
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+
+          <h1 class="govuk-heading-l">{{ ('professions.form.headings.main' | t) }}</h1>
+
+          <p class="govuk-body">{{ ('professions.form.description' | t) }}</p>
+
+          <form method="post" action="#">
+            {{
+              govukButton({
+                id: "submit-button",
+                type: "Submit",
+                text: ('app.start' | t)
+              })
+            }}
+          </form>
+
+        </div>
+
+        <div class="govuk-grid-column-one-third"></div>
+      </div>
+
+    </main>
+  </div>
+
+{% endblock %}

--- a/views/professions/admin/add-profession/new.njk
+++ b/views/professions/admin/add-profession/new.njk
@@ -16,7 +16,7 @@
 
           <p class="govuk-body">{{ ('professions.form.description' | t) }}</p>
 
-          <form method="post" action="#">
+          <form method="get" action="/admin/professions/new/top-level-information">
             {{
               govukButton({
                 id: "submit-button",

--- a/views/professions/admin/add-profession/top-level-information.njk
+++ b/views/professions/admin/add-profession/top-level-information.njk
@@ -37,28 +37,7 @@
                 label: {
                   text: ("professions.form.label.topLevelInformation.nation" | t)
                 },
-                items: [
-                  {
-                    value: "Anywhere in the United Kingdom",
-                    text: ("professions.form.select.topLevelInformation.nations.anywhere" | t)
-                  },
-                  {
-                    value: "England",
-                    text: ("professions.form.select.topLevelInformation.nations.england" | t)
-                  },
-                  {
-                    value: "Northern Ireland",
-                    text: ("professions.form.select.topLevelInformation.nations.northernIreland" | t)
-                  },
-                  {
-                    value: "Scotland",
-                    text: ("professions.form.select.topLevelInformation.nations.scotland" | t)
-                  },
-                  {
-                    value: "Wales",
-                    text: ("professions.form.select.topLevelInformation.nations.wales" | t)
-                  }
-                ]
+                items: nationsOptionSelectArgs | tOptionSelect
               })
             }}
 

--- a/views/professions/admin/add-profession/top-level-information.njk
+++ b/views/professions/admin/add-profession/top-level-information.njk
@@ -1,0 +1,90 @@
+{% extends "base.njk" %}
+{% from "govuk/components/input/macro.njk" import govukInput %}
+{% from "govuk/components/select/macro.njk" import govukSelect %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% block content %}
+
+  <div class="govuk-width-container">
+    <a href="#" class="govuk-back-link">{{ ('app.back' | t) }}</a>
+
+    <main class="govuk-main-wrapper">
+
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+
+          <h1 class="govuk-heading-l">{{ ("professions.form.headings.topLevelInformation" | t) }}</h1>
+
+          <form method="post" action="#">
+            {{
+              govukInput({
+                label: {
+                  text: ("professions.form.label.topLevelInformation.name" | t),
+                  classes: "govuk-label--m",
+                  isPageHeading: false
+                },
+                id: "name",
+                name: "name"
+              })
+            }}
+
+            {{
+              govukSelect({
+                id: "nation",
+                name: "nation",
+                label: {
+                  text: ("professions.form.label.topLevelInformation.nation" | t)
+                },
+                items: [
+                  {
+                    value: "Anywhere in the United Kingdom",
+                    text: ("professions.form.select.topLevelInformation.nations.anywhere" | t)
+                  },
+                  {
+                    value: "England",
+                    text: ("professions.form.select.topLevelInformation.nations.england" | t)
+                  },
+                  {
+                    value: "Northern Ireland",
+                    text: ("professions.form.select.topLevelInformation.nations.northernIreland" | t)
+                  },
+                  {
+                    value: "Scotland",
+                    text: ("professions.form.select.topLevelInformation.nations.scotland" | t)
+                  },
+                  {
+                    value: "Wales",
+                    text: ("professions.form.select.topLevelInformation.nations.wales" | t)
+                  }
+                ]
+              })
+            }}
+
+            {{
+              govukSelect({
+                id: "industryId",
+                name: "industryId",
+                label: {
+                  text: ("professions.form.label.topLevelInformation.industry" | t)
+                },
+                items: industriesOptionSelectArgs
+              })
+            }}
+
+            {{
+              govukButton({
+                id: "submit-button",
+                type: "Submit",
+                text: ("app.continue" | t)
+
+              })
+            }}
+          </form>
+
+        </div>
+      </div>
+
+    </main>
+  </div>
+
+{% endblock %}

--- a/views/professions/admin/add-profession/top-level-information.njk
+++ b/views/professions/admin/add-profession/top-level-information.njk
@@ -8,6 +8,8 @@
   <div class="govuk-width-container">
     <a href="#" class="govuk-back-link">{{ ('app.back' | t) }}</a>
 
+    {% include "../../../shared/_errors.njk" %}
+
     <main class="govuk-main-wrapper">
 
       <div class="govuk-grid-row">
@@ -15,7 +17,7 @@
 
           <h1 class="govuk-heading-l">{{ ("professions.form.headings.topLevelInformation" | t) }}</h1>
 
-          <form method="post" action="#">
+          <form method="post" action="/admin/professions/new/top-level-information">
             {{
               govukInput({
                 label: {


### PR DESCRIPTION
## Changes in this PR

This builds the first screen for adding a new profession - "Top level details", as well as a Check your answers page and a Confirmation screen. There's still lots to do, as well as 3 or 4 more steps in the journey, but I'd like to get some feedback on how this is at the moment, and ideally get the PR merged before adding more, to keep things small and easy to review.

## Still to do (in future PRs)

- Switch "Nation" dropdown to a list of checkboxes, as there may be multiple Nations associated with a Profession.
- Put this journey behind an admin guard.
- **Question**: does it feel right to use the Industry ID value here, or should we look it up by name?

### Validations 
- Ensure session data is valid for the step the user is at in the journey
- Ensure we can't submit with an empty session
- Handle duplicate professions

## Screenshots

### Start the journey

![image](https://user-images.githubusercontent.com/19826940/145396470-48ee0f3f-22ac-4dcf-be52-8fb78a0ba1c9.png)

### Add top level information (Nations list will be replaced with a list of checkboxes in future)

![image](https://user-images.githubusercontent.com/19826940/145396923-5ffa8567-7a42-4164-91bd-6fe002815973.png)

### Check your answers

![image](https://user-images.githubusercontent.com/19826940/145396759-93bc60e7-3ea0-4d04-8458-98e2ed26bf83.png)

## Confirmation

![image](https://user-images.githubusercontent.com/19826940/145396825-81b09a51-aa04-4d41-9f89-0e30d9479928.png)
