### PR TITLE
(1933) Add internationalisation to e2e tests

### DIFF
--- a/cypress/integration/admin/user/create-new-user.spec.ts
+++ b/cypress/integration/admin/user/create-new-user.spec.ts
@@ -15,8 +15,13 @@ describe('Creating a new user', () => {
       cy.visit('/admin/users/create-new-user');
       cy.get('button').click();
 
-      cy.get('body').should('contain', 'Name');
-      cy.get('body').should('contain', 'Email');
+      cy.translate('users.form.label.name').then((nameLabel) => {
+        cy.get('body').should('contain', nameLabel);
+      });
+
+      cy.translate('users.form.label.email').then((emailLabel) => {
+        cy.get('body').should('contain', emailLabel);
+      });
 
       cy.get('input[name="name"]').type('Example Name');
       cy.get('input[name="email"]').type('name@example.com');
@@ -27,9 +32,11 @@ describe('Creating a new user', () => {
 
       cy.get('button').click();
 
-      cy.get('body')
-        .should('contain', 'User added')
-        .should('contain', 'name@example.com');
+      cy.translate('users.headings.done').then((successMessage) => {
+        cy.get('body')
+          .should('contain', successMessage)
+          .should('contain', 'name@example.com');
+      });
     });
 
     it('I cannot add a user that already exists', () => {
@@ -40,9 +47,10 @@ describe('Creating a new user', () => {
       cy.get('input[name="email"]').type('beis-rpr@dxw.com');
       cy.get('button').click();
 
-      cy.get('body').should(
-        'contain',
-        'A user with this email address already exists',
+      cy.translate('users.form.errors.email.alreadyExists').then(
+        (emailError) => {
+          cy.get('body').should('contain', emailError);
+        },
       );
     });
 
@@ -54,7 +62,9 @@ describe('Creating a new user', () => {
       cy.get('input[name="email"]').type('name2@example.com');
       cy.get('button').click();
 
-      cy.get('a').contains('Change').click();
+      cy.translate('app.change').then((changeLabel) => {
+        cy.get('a').contains(`${changeLabel}`).click();
+      });
 
       cy.get('input[name="email"]').clear().type('name3@example.com');
       cy.get('button').click();
@@ -62,9 +72,11 @@ describe('Creating a new user', () => {
       cy.get('body').should('contain', 'name3@example.com');
       cy.get('button').click();
 
-      cy.get('body')
-        .should('contain', 'User added')
-        .should('contain', 'name3@example.com');
+      cy.translate('users.headings.done').then((successMessage) => {
+        cy.get('body')
+          .should('contain', successMessage)
+          .should('contain', 'name3@example.com');
+      });
     });
   });
 });

--- a/cypress/integration/application.spec.ts
+++ b/cypress/integration/application.spec.ts
@@ -11,12 +11,20 @@ describe('/', () => {
     });
 
     it('shows my username', () => {
-      cy.get('body').should('contain', 'Welcome beis-rpr');
+      cy.translate('app.welcome', { name: 'beis-rpr' }).then(
+        (welcomeMessage) => {
+          cy.get('body').should('contain', welcomeMessage);
+        },
+      );
     });
 
     it('allows me to access the super admin area', () => {
       cy.visit('/admin/superadmin');
-      cy.get('body').should('contain', 'You are a superadmin');
+      cy.translate('app.superadmin', { name: 'beis-rpr' }).then(
+        (superadminMessage) => {
+          cy.get('body').should('contain', superadminMessage);
+        },
+      );
     });
   });
 
@@ -27,15 +35,19 @@ describe('/', () => {
     });
 
     it('shows my username', () => {
-      cy.get('body').should('contain', 'Welcome beis-rpr+editor');
+      cy.translate('app.welcome', { name: 'beis-rpr+editor' }).then(
+        (welcomeMessage) => {
+          cy.get('body').should('contain', welcomeMessage);
+        },
+      );
     });
 
     it('does not allow me to access the super admin area', () => {
       cy.visit('/admin/superadmin');
-      cy.get('body').should(
-        'contain',
-        'You have not been authorized to see this page',
-      );
+
+      cy.translate('errors.forbidden.heading').then((errorMessage) => {
+        cy.get('body').should('contain', errorMessage);
+      });
     });
   });
 });

--- a/cypress/plugins/i18n.ts
+++ b/cypress/plugins/i18n.ts
@@ -1,0 +1,27 @@
+const dir = './src/i18n/en';
+
+export const translate = (
+  translation: string,
+  personalisations: object = {},
+) => {
+  const references = translation.split('.');
+  const filename = references.shift();
+  const result = cy
+    .readFile(`${dir}/${filename}.json`, 'utf8')
+    .then((result) => {
+      for (const i in references) {
+        result = result[references[i]];
+      }
+
+      return result;
+    })
+    .then((result) => {
+      Object.keys(personalisations).forEach((key) => {
+        result = result.replace(`{${key}}`, personalisations[key]);
+      });
+
+      return result;
+    });
+
+  return result;
+};

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -1,4 +1,6 @@
 import { getUnixTime } from 'date-fns';
+import { translate } from '../plugins/i18n';
+
 import puppeteer from 'puppeteer';
 
 /*
@@ -74,3 +76,10 @@ Cypress.Commands.add('loginAuth0', (role = 'admin') => {
     });
   });
 });
+
+Cypress.Commands.add(
+  'translate',
+  (translation: string, personalisations: object = {}) => {
+    return translate(translation, personalisations);
+  },
+);

--- a/cypress/support/index.ts
+++ b/cypress/support/index.ts
@@ -22,6 +22,14 @@ declare global {
        * @example cy.loginAuth0('admin')
        */
       loginAuth0(role: string): Chainable<Element>;
+      /**
+       * Translate an i18n string
+       * @example cy.translate('errors.forbidden.heading')
+       */
+      translate(
+        translation: string,
+        personalisations?: object,
+      ): Chainable<String>;
     }
   }
 }

--- a/cypress/support/index.ts
+++ b/cypress/support/index.ts
@@ -21,7 +21,7 @@ declare global {
        * Login with Auth0.
        * @example cy.loginAuth0('admin')
        */
-      loginAuth0(role: string): Chainable<Element>;
+      loginAuth0(role?: string): Chainable<Element>;
       /**
        * Translate an i18n string
        * @example cy.translate('errors.forbidden.heading')

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "test:e2e": "start-server-and-test start:test http://localhost:3000 cy:run",
     "seed": "npm run build && node dist/seeder",
     "seed:refresh": "npm run build && node dist/seeder --refresh",
-    "seed:test": "npm run build && NODE_ENV=test node dist/seeder",
+    "seed:test": "NODE_ENV=test node dist/seeder",
     "seed:test:refresh": "npm run build && NODE_ENV=test node dist/seeder --refresh",
     "heroku:set-callback-urls": "ts-node util/set-callback-urls.ts"
   },


### PR DESCRIPTION
This adds a helper to the Cypress tests to allow us to use translations when making assertions against copy in our tests. This is best practice because it allows us to change copy without it breaking the tests.