### PR TITLE
Professions details page

### DIFF
--- a/assets/stylesheets/application.scss
+++ b/assets/stylesheets/application.scss
@@ -1,3 +1,7 @@
 $govuk-assets-path: '~govuk-frontend/govuk/assets/';
 
 @import 'govuk/all';
+
+.rpr-details__section-title {
+  text-transform: uppercase;
+}

--- a/cypress/integration/admin/professions/add-a-profession.spec.ts
+++ b/cypress/integration/admin/professions/add-a-profession.spec.ts
@@ -39,5 +39,8 @@ describe('Adding a new profession', () => {
         .should('contain', heading)
         .should('contain', 'Example Profession');
     });
+
+    cy.visit('/professions/example-profession');
+    cy.get('body').should('contain', 'Example Profession');
   });
 });

--- a/cypress/integration/professions/show.spec.ts
+++ b/cypress/integration/professions/show.spec.ts
@@ -1,0 +1,31 @@
+describe('Showing a profession', () => {
+  it('I can view a profession', () => {
+    cy.visit('/professions/registered-trademark-attorney');
+
+    cy.get('body').should('contain', 'Registered Trademark Attorney');
+    cy.get('body').should('contain', 'Law');
+    cy.get('body').should('contain', 'The Trade Marks Act 1994');
+
+    cy.translate('professions.show.overview.heading').then((heading) => {
+      cy.get('body').should('contain', heading);
+    });
+
+    cy.translate('professions.show.bodies.heading').then((heading) => {
+      cy.get('body').should('contain', heading);
+    });
+
+    cy.translate('professions.show.regulatedActivities.heading').then(
+      (heading) => {
+        cy.get('body').should('contain', heading);
+      },
+    );
+
+    cy.translate('professions.show.qualification.heading').then((heading) => {
+      cy.get('body').should('contain', heading);
+    });
+
+    cy.translate('professions.show.legislation.heading').then((heading) => {
+      cy.get('body').should('contain', heading);
+    });
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "rxjs": "^7.4.0",
         "sass": "^1.43.4",
         "sass-loader": "^12.3.0",
+        "slugify": "^1.6.3",
         "typeorm": "^0.2.40"
       },
       "devDependencies": {
@@ -14018,6 +14019,14 @@
         "node": ">=8"
       }
     },
+    "node_modules/slugify": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.3.tgz",
+      "integrity": "sha512-1MPyqnIhgiq+/0iDJyqSJHENdnH5MMIlgJIBxmkRMzTNKlS/QsN5dXsB+MdDq4E6w0g9jFA4XOTRkVDjDae/2w==",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/snake-case": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-1.1.2.tgz",
@@ -27120,6 +27129,11 @@
         "astral-regex": "^2.0.0",
         "is-fullwidth-code-point": "^3.0.0"
       }
+    },
+    "slugify": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.3.tgz",
+      "integrity": "sha512-1MPyqnIhgiq+/0iDJyqSJHENdnH5MMIlgJIBxmkRMzTNKlS/QsN5dXsB+MdDq4E6w0g9jFA4XOTRkVDjDae/2w=="
     },
     "snake-case": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "rxjs": "^7.4.0",
     "sass": "^1.43.4",
     "sass-loader": "^12.3.0",
+    "slugify": "^1.6.3",
     "typeorm": "^0.2.40"
   },
   "devDependencies": {

--- a/seeds/professions.json
+++ b/seeds/professions.json
@@ -2,6 +2,7 @@
   {
     "name": "Registered Trademark Attorney",
     "alternateName": "Patent Agent / Trademark agent",
+    "slug": "registered-trademark-attorney",
     "description": "Registration protection and exploitation of trade marks",
     "occupationLocation": "All regions",
     "regulationType": "Reserves of activities",
@@ -18,6 +19,7 @@
   {
     "name": "Secondary School Teacher in State maintained schools (England)",
     "alternateName": "Secondary school teacher",
+    "slug": "secondary-school-teacher-in-state-maintained-schools-england",
     "description": "Teaching work (known as specified work), as an activity, is regulated by law through the Education (Specified Work) (England) Regulations 2012/762. Regulation 5 lists the activities which are classed as specified work for the purposes of teaching in a school maintained by a local authority - which includes a maintained nursery - and a special school not so maintained:\n planning and preparing lessons and courses for pupils;\ndelivering lessons to pupils;\nassessing the development, progress and attainment of pupils; and\n reporting on the development, progress and attainment of pupils.",
     "occupationLocation": "England",
     "regulationType": "N/A",

--- a/src/db/migrate/1639393653586-AddSlugToProfession.ts
+++ b/src/db/migrate/1639393653586-AddSlugToProfession.ts
@@ -1,0 +1,27 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddSlugToProfession1639393653586 implements MigrationInterface {
+  name = 'AddSlugToProfession1639393653586';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "professions" ADD "slug" character varying NOT NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "professions" ADD CONSTRAINT "UQ_c60993e6f4badf770634fd393c7" UNIQUE ("slug")`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_c60993e6f4badf770634fd393c" ON "professions" ("slug") `,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_c60993e6f4badf770634fd393c"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "professions" DROP CONSTRAINT "UQ_c60993e6f4badf770634fd393c7"`,
+    );
+    await queryRunner.query(`ALTER TABLE "professions" DROP COLUMN "slug"`);
+  }
+}

--- a/src/helpers/slug.helper.spec.ts
+++ b/src/helpers/slug.helper.spec.ts
@@ -1,0 +1,25 @@
+import { generateSlug } from './slug.helper';
+
+describe('generateSlug', () => {
+  it('should generate a URL-safe slug', () => {
+    const result = generateSlug('Example String');
+
+    expect(result).toEqual('example-string');
+  });
+
+  it('should truncate long strings to 100 characters', () => {
+    const result = generateSlug(
+      'A Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Long Name',
+    );
+
+    expect(result).toEqual(
+      'a-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-ver',
+    );
+  });
+
+  it('should remove non-alphanumeric characters', () => {
+    const result = generateSlug('👻 Department 😜 of 🥸 Emoji 🙀');
+
+    expect(result).toEqual('department-of-emoji');
+  });
+});

--- a/src/helpers/slug.helper.spec.ts
+++ b/src/helpers/slug.helper.spec.ts
@@ -2,7 +2,7 @@ import { generateSlug } from './slug.helper';
 
 describe('generateSlug', () => {
   it('should generate a URL-safe slug', () => {
-    const result = generateSlug('Example String');
+    const result = generateSlug('Example String', 0);
 
     expect(result).toEqual('example-string');
   });
@@ -10,6 +10,7 @@ describe('generateSlug', () => {
   it('should truncate long strings to 100 characters', () => {
     const result = generateSlug(
       'A Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Long Name',
+      0,
     );
 
     expect(result).toEqual(
@@ -18,8 +19,16 @@ describe('generateSlug', () => {
   });
 
   it('should remove non-alphanumeric characters', () => {
-    const result = generateSlug('👻 Department 😜 of 🥸 Emoji 🙀');
+    const result = generateSlug('👻 Department 😜 of 🥸 Emoji 🙀', 0);
 
     expect(result).toEqual('department-of-emoji');
+  });
+
+  it('should append the attempt number where `retryCount` is non-zero', () => {
+    const retryOne = generateSlug('Example String', 1);
+    const retryLarge = generateSlug('Example String', 53786);
+
+    expect(retryOne).toEqual('example-string-1');
+    expect(retryLarge).toEqual('example-string-53786');
   });
 });

--- a/src/helpers/slug.helper.ts
+++ b/src/helpers/slug.helper.ts
@@ -10,12 +10,14 @@ const maxLength = 100;
  *   slug
  * @returns The slug generated from the provided name
  */
-export function generateSlug(name: string): string {
-  return slugify(name, {
+export function generateSlug(name: string, retryCount: number): string {
+  const base = slugify(name, {
     remove: /[^a-zA-Z0-9 ]/,
     replacement: '-',
     lower: true,
     strict: true,
     trim: true,
   }).slice(0, maxLength);
+
+  return retryCount === 0 ? base : `${base}-${retryCount}`;
 }

--- a/src/helpers/slug.helper.ts
+++ b/src/helpers/slug.helper.ts
@@ -1,0 +1,21 @@
+import slugify from 'slugify';
+
+const maxLength = 100;
+
+/**
+ * Transforms a name string into a URL-safe slug
+ *
+ * @param name The name to generate a slug from
+ * @param retryCount The number of times we've attempted to generate a unique
+ *   slug
+ * @returns The slug generated from the provided name
+ */
+export function generateSlug(name: string): string {
+  return slugify(name, {
+    remove: /[^a-zA-Z0-9 ]/,
+    replacement: '-',
+    lower: true,
+    strict: true,
+    trim: true,
+  }).slice(0, maxLength);
+}

--- a/src/i18n/en/app.json
+++ b/src/i18n/en/app.json
@@ -9,5 +9,7 @@
   "errors": {
     "heading": "There is a problem"
   },
-  "backToDashboard": "Back to the dashboard"
+  "backToDashboard": "Back to the dashboard",
+  "yes": "Yes",
+  "no": "No"
 }

--- a/src/i18n/en/professions.json
+++ b/src/i18n/en/professions.json
@@ -35,5 +35,40 @@
         "next": "What happens next?"
       }
     }
+  },
+  "show": {
+    "overview": {
+      "heading": "Overview",
+      "nations": "Nations",
+      "industry": "Industry / sector"
+    },
+    "bodies": {
+      "heading": "Regulatory / professional bodies",
+      "regulatedAuthority": "Regulated authority",
+      "name": "Name",
+      "address": "Address",
+      "emailAddress": "Email address",
+      "url": "URL",
+      "phoneNumber": "Phone number",
+      "mandatoryRegistration": "Mandatory registration with professional bodies"
+    },
+    "regulatedActivities": {
+      "heading": "Regulated activities",
+      "reservedActivities": "Reserved activities",
+      "description": "Description of activities / regulation description"
+    },
+    "qualification": {
+      "heading": "Qualification information",
+      "level": "Qualificiation level",
+      "methods": "Methods to obtain qualification",
+      "commonPath": "Most common path to obtain qualification",
+      "duration": "Duration of qualification",
+      "mandatoryExperience": "Existence of mandatory professional experience"
+    },
+    "legislation": {
+      "heading": "Legislation",
+      "nationalLegislation": "National legislation",
+      "legislationLink": "Legislation link"
+    }
   }
 }

--- a/src/professions/admin/add-profession/confirmation.controller.ts
+++ b/src/professions/admin/add-profession/confirmation.controller.ts
@@ -32,6 +32,7 @@ export class ConfirmationController {
       topLevelDetails.name,
       '',
       '',
+      '',
       topLevelDetails.nation,
       '',
       industry,

--- a/src/professions/interfaces/show-template.interface.ts
+++ b/src/professions/interfaces/show-template.interface.ts
@@ -1,0 +1,3 @@
+export interface ShowTemplate {
+  professionName: string;
+}

--- a/src/professions/interfaces/show-template.interface.ts
+++ b/src/professions/interfaces/show-template.interface.ts
@@ -1,3 +1,6 @@
+import { Profession } from '../profession.entity';
+
 export interface ShowTemplate {
-  professionName: string;
+  profession: Profession;
+  backUrl: string;
 }

--- a/src/professions/profession.entity.ts
+++ b/src/professions/profession.entity.ts
@@ -7,6 +7,7 @@ import {
   ManyToMany,
   JoinTable,
   ManyToOne,
+  Index,
 } from 'typeorm';
 import { Industry } from '../industries/industry.entity';
 
@@ -20,6 +21,10 @@ export class Profession {
 
   @Column()
   alternateName: string;
+
+  @Index()
+  @Column({ unique: true })
+  slug: string;
 
   @Column()
   description: string;
@@ -52,6 +57,7 @@ export class Profession {
   constructor(
     name?: string,
     alternateName?: string,
+    slug?: string,
     description?: string,
     occupationLocation?: string,
     regulationType?: string,
@@ -62,6 +68,7 @@ export class Profession {
   ) {
     this.name = name || '';
     this.alternateName = alternateName || '';
+    this.slug = slug || '';
     this.description = description || '';
     this.occupationLocation = occupationLocation || '';
     this.regulationType = regulationType || '';

--- a/src/professions/profession.entity.ts
+++ b/src/professions/profession.entity.ts
@@ -30,16 +30,22 @@ export class Profession {
   @Column()
   regulationType: string;
 
-  @ManyToOne(() => Industry)
+  @ManyToOne(() => Industry, {
+    eager: true,
+  })
   industry: Industry;
 
-  @ManyToOne(() => Qualification)
+  @ManyToOne(() => Qualification, {
+    eager: true,
+  })
   qualification: Qualification;
 
   @Column('text', { array: true })
   reservedActivities: string[];
 
-  @ManyToMany(() => Legislation)
+  @ManyToMany(() => Legislation, {
+    eager: true,
+  })
   @JoinTable()
   legislations: Legislation[];
 

--- a/src/professions/professions.controller.spec.ts
+++ b/src/professions/professions.controller.spec.ts
@@ -1,21 +1,64 @@
+import { createMock, DeepMocked } from '@golevelup/ts-jest';
+import { NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
+import { Profession } from './profession.entity';
 
 import { ProfessionsController } from './professions.controller';
+import { ProfessionsService } from './professions.service';
 
 describe('ProfessionsController', () => {
   let controller: ProfessionsController;
+  let professionsService: DeepMocked<ProfessionsService>;
 
   beforeEach(async () => {
+    professionsService = createMock<ProfessionsService>();
+
     const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        {
+          provide: ProfessionsService,
+          useValue: professionsService,
+        },
+      ],
       controllers: [ProfessionsController],
     }).compile();
 
     controller = module.get<ProfessionsController>(ProfessionsController);
   });
 
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
   describe('new', () => {
     it('should return an empty object', () => {
       expect(controller.new()).toEqual({});
+    });
+  });
+
+  describe('show', () => {
+    it('should return populated template params', async () => {
+      professionsService.find.mockImplementationOnce(async () => {
+        return new Profession('Example Profession');
+      });
+
+      const result = await controller.show('example-id');
+
+      expect(result).toEqual({
+        professionName: 'Example Profession',
+      });
+
+      expect(professionsService.find).toBeCalledWith('example-id');
+    });
+
+    it('should throw an error when the ID does not match a profession', () => {
+      professionsService.find.mockImplementationOnce(async () => {
+        return null;
+      });
+
+      expect(async () => {
+        await controller.show('example-invalid-id');
+      }).rejects.toThrowError(NotFoundException);
     });
   });
 });

--- a/src/professions/professions.controller.spec.ts
+++ b/src/professions/professions.controller.spec.ts
@@ -6,6 +6,8 @@ import { Profession } from './profession.entity';
 import { ProfessionsController } from './professions.controller';
 import { ProfessionsService } from './professions.service';
 
+const exampleProfession = new Profession('Example Profession');
+
 describe('ProfessionsController', () => {
   let controller: ProfessionsController;
   let professionsService: DeepMocked<ProfessionsService>;
@@ -38,14 +40,15 @@ describe('ProfessionsController', () => {
 
   describe('show', () => {
     it('should return populated template params', async () => {
-      professionsService.find.mockImplementationOnce(async () => {
-        return new Profession('Example Profession');
-      });
+      professionsService.find.mockImplementationOnce(
+        async () => exampleProfession,
+      );
 
       const result = await controller.show('example-id');
 
       expect(result).toEqual({
-        professionName: 'Example Profession',
+        profession: exampleProfession,
+        backUrl: '',
       });
 
       expect(professionsService.find).toBeCalledWith('example-id');

--- a/src/professions/professions.controller.spec.ts
+++ b/src/professions/professions.controller.spec.ts
@@ -40,27 +40,27 @@ describe('ProfessionsController', () => {
 
   describe('show', () => {
     it('should return populated template params', async () => {
-      professionsService.find.mockImplementationOnce(
+      professionsService.findBySlug.mockImplementationOnce(
         async () => exampleProfession,
       );
 
-      const result = await controller.show('example-id');
+      const result = await controller.show('example-slug');
 
       expect(result).toEqual({
         profession: exampleProfession,
         backUrl: '',
       });
 
-      expect(professionsService.find).toBeCalledWith('example-id');
+      expect(professionsService.findBySlug).toBeCalledWith('example-slug');
     });
 
-    it('should throw an error when the ID does not match a profession', () => {
-      professionsService.find.mockImplementationOnce(async () => {
+    it('should throw an error when the slug does not match a profession', () => {
+      professionsService.findBySlug.mockImplementationOnce(async () => {
         return null;
       });
 
       expect(async () => {
-        await controller.show('example-invalid-id');
+        await controller.show('example-invalid-slug');
       }).rejects.toThrowError(NotFoundException);
     });
   });

--- a/src/professions/professions.controller.ts
+++ b/src/professions/professions.controller.ts
@@ -18,14 +18,14 @@ export class ProfessionsController {
     return {};
   }
 
-  @Get('professions/:id')
+  @Get('professions/:slug')
   @Render('professions/show')
-  async show(@Param('id') id: string): Promise<ShowTemplate> {
-    const profession = await this.professionsService.find(id);
+  async show(@Param('slug') slug: string): Promise<ShowTemplate> {
+    const profession = await this.professionsService.findBySlug(slug);
 
     if (!profession) {
       throw new NotFoundException(
-        `A profession with ID ${id} could not be found`,
+        `A profession with ID ${slug} could not be found`,
       );
     }
 

--- a/src/professions/professions.controller.ts
+++ b/src/professions/professions.controller.ts
@@ -1,10 +1,34 @@
-import { Controller, Get, Render } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  NotFoundException,
+  Param,
+  Render,
+} from '@nestjs/common';
+import { ShowTemplate } from './interfaces/show-template.interface';
+import { ProfessionsService } from './professions.service';
 
 @Controller()
 export class ProfessionsController {
+  constructor(private professionsService: ProfessionsService) {}
+
   @Get('admin/professions/add-profession')
   @Render('professions/admin/add-profession/new')
   new(): Record<string, any> {
     return {};
+  }
+
+  @Get('professions/:id')
+  @Render('professions/show')
+  async show(@Param('id') id: string): Promise<ShowTemplate> {
+    const profession = await this.professionsService.find(id);
+
+    if (!profession) {
+      throw new NotFoundException(
+        `A profession with ID ${id} could not be found`,
+      );
+    }
+
+    return { professionName: profession.name };
   }
 }

--- a/src/professions/professions.controller.ts
+++ b/src/professions/professions.controller.ts
@@ -29,6 +29,6 @@ export class ProfessionsController {
       );
     }
 
-    return { professionName: profession.name };
+    return { profession, backUrl: '' };
   }
 }

--- a/src/professions/professions.seeder.ts
+++ b/src/professions/professions.seeder.ts
@@ -12,6 +12,7 @@ import { Legislation } from 'src/legislations/legislation.entity';
 type SeedProfession = {
   name: string;
   alternateName: string;
+  slug: string;
   description: string;
   occupationLocation: string;
   regulationType: string;
@@ -60,6 +61,7 @@ export class ProfessionsSeeder implements Seeder {
         return new Profession(
           profession.name,
           profession.alternateName,
+          profession.slug,
           profession.description,
           profession.occupationLocation,
           profession.regulationType,

--- a/src/professions/professions.service.spec.ts
+++ b/src/professions/professions.service.spec.ts
@@ -10,6 +10,7 @@ import { ProfessionsService } from './professions.service';
 const profession = new Profession(
   'Registered Gas Engineer',
   'Gas installer/repairer',
+  'registered-gas-engineer',
   'Gas installers work on gas appliances and installations.',
   'All regions',
   'Reserves of activities',
@@ -24,6 +25,7 @@ const professionArray = [
   new Profession(
     'Social worker',
     'Social worker',
+    'social-worker',
     'Social workers are trained to: make assessments, taking account of a range of factors',
     'England',
     'Protected title',
@@ -93,6 +95,16 @@ describe('Profession', () => {
       await service.create(profession);
 
       expect(repoSpy).toHaveBeenCalledWith(profession);
+    });
+  });
+
+  describe('findBySlug', () => {
+    it('should return a profession', async () => {
+      const repoSpy = jest.spyOn(repo, 'findOne');
+      const post = await service.findBySlug('some-slug');
+
+      expect(post).toEqual(profession);
+      expect(repoSpy).toHaveBeenCalledWith({ where: { slug: 'some-slug' } });
     });
   });
 });

--- a/src/professions/professions.service.ts
+++ b/src/professions/professions.service.ts
@@ -22,4 +22,8 @@ export class ProfessionsService {
   async create(profession: Profession): Promise<Profession> {
     return this.repository.save(profession);
   }
+
+  findBySlug(slug: string): Promise<Profession> {
+    return this.repository.findOne({ where: { slug } });
+  }
 }

--- a/src/professions/professions.service.ts
+++ b/src/professions/professions.service.ts
@@ -1,14 +1,16 @@
-import { Repository } from 'typeorm';
+import { Connection, Repository } from 'typeorm';
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 
 import { Profession } from './profession.entity';
+import { generateSlug } from '../helpers/slug.helper';
 
 @Injectable()
 export class ProfessionsService {
   constructor(
     @InjectRepository(Profession)
     private repository: Repository<Profession>,
+    private connection: Connection,
   ) {}
 
   all(): Promise<Profession[]> {
@@ -19,11 +21,50 @@ export class ProfessionsService {
     return this.repository.findOne(id);
   }
 
-  async create(profession: Profession): Promise<Profession> {
-    return this.repository.save(profession);
-  }
-
   findBySlug(slug: string): Promise<Profession> {
     return this.repository.findOne({ where: { slug } });
+  }
+
+  async create(profession: Profession): Promise<Profession> {
+    const queryRunner = this.connection.createQueryRunner();
+
+    await queryRunner.connect();
+    await queryRunner.startTransaction();
+
+    let error;
+
+    try {
+      let retryCount = 0;
+
+      while (true) {
+        const slug = generateSlug(profession.name, retryCount);
+        const result = await queryRunner.manager.findOne<Profession>(
+          Profession,
+          {
+            where: { slug },
+          },
+        );
+
+        if (result) {
+          retryCount++;
+        } else {
+          profession.slug = slug;
+          await queryRunner.manager.save(profession);
+          await queryRunner.commitTransaction();
+          break;
+        }
+      }
+    } catch (e) {
+      await queryRunner.rollbackTransaction();
+      error = e;
+    } finally {
+      await queryRunner.release();
+    }
+
+    if (error) {
+      throw error;
+    }
+
+    return profession;
   }
 }

--- a/src/users/personal-details.controller.spec.ts
+++ b/src/users/personal-details.controller.spec.ts
@@ -3,6 +3,7 @@ import { UsersService } from './users.service';
 import { User } from './user.entity';
 import { PersonalDetailsController } from './personal-details.controller';
 import { createMock, DeepMocked } from '@golevelup/ts-jest';
+import { Response } from 'express';
 
 const name = 'Example Name';
 const email = 'name@example.com';
@@ -77,13 +78,10 @@ describe('PersonalDetailsController', () => {
   });
 
   describe('create', () => {
-    let res;
+    let res: DeepMocked<Response>;
 
     beforeEach(() => {
-      res = {
-        render: jest.fn(),
-        redirect: jest.fn(),
-      };
+      res = createMock<Response>();
     });
 
     it('should throw an exception when called in edit mode with an empty session', () => {

--- a/src/users/users.controller.spec.ts
+++ b/src/users/users.controller.spec.ts
@@ -5,6 +5,7 @@ import { UsersService } from './users.service';
 import { ExternalUserCreationService } from './external-user-creation.service';
 import { UsersController } from './users.controller';
 import { UserRole } from './user.entity';
+import { Response } from 'express';
 
 const name = 'Example Name';
 const email = 'name@example.com';
@@ -79,13 +80,10 @@ describe('UsersController', () => {
   });
 
   describe('create', () => {
-    let res;
+    let res: DeepMocked<Response>;
 
     beforeEach(() => {
-      res = {
-        render: jest.fn(),
-        redirect: jest.fn(),
-      };
+      res = createMock<Response>();
     });
 
     it('should throw an exception when called with an empty session', () => {

--- a/views/professions/show.njk
+++ b/views/professions/show.njk
@@ -1,5 +1,7 @@
 {% extends "base.njk" %}
 {% from "govuk/components/panel/macro.njk" import govukPanel %}
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 
 {% block content %}
 
@@ -9,14 +11,214 @@
 
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
-        <h1 class="govuk-heading-xl">{{ professionName }}</h1>
+
+        {{ govukBackLink({
+          text: "Back",
+          href: backUrl
+        }) }}
+
+        <span class="govuk-caption-l">Placeholder Authority</span>
+
+        <h1 class="govuk-heading-xl">{{ profession.name }}</h1>
+
+        <h2 class="govuk-heading-m rpr-details__section-title">Overview</h2>
+
+        {{ govukSummaryList({
+          classes: 'govuk-summary-list--no-border',
+          rows: [
+            {
+              key: {
+                text: "Nations"
+              },
+              value: {
+                text: profession.occupationLocation
+              }
+            },
+            {
+              key: {
+                text: "Industry/Sector"
+              },
+              value: {
+                text: profession.industry.name
+              }
+            }
+          ]
+        }) }}
+
+        <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible" />
+
+        <h2 class="govuk-heading-m rpr-details__section-title">Regulatory/professional bodies</h2>
+
+        {{ govukSummaryList({
+          classes: 'govuk-summary-list--no-border',
+          rows: [
+            {
+              key: {
+                text: "Regulated authority"
+              },
+              value: {
+                text: "Placeholder authority"
+              }
+            },
+            {
+              key: {
+                text: "Address"
+              },
+              value: {
+                html: 'Placeholder address'
+              }
+            },
+            {
+              key: {
+                text: "Email address"
+              },
+              value: {
+                text: "Placeholder email"
+              }
+            },
+            {
+              key: {
+                text: "URL"
+              },
+              value: {
+                text: "Placeholder url"
+              }
+            },          
+            {
+              key: {
+                text: "Phone number"
+              },
+              value: {
+                text: "Placeholder phone numer"
+              }
+            },
+            {
+              key: {
+                text: "Mandatory registration with professional bodies"
+              },
+              value: {
+                text: "Placeholder response"
+              }
+            }
+          ]
+        }) }}
+
+        <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+
+        <h2 class="govuk-heading-m rpr-details__section-title">Regulated activities</h2>
+
+        {% set escapedActivites = [] %}
+        {% for activity in profession.reservedActivities %}
+          {% set escapedActivites = (escapedActivites.push(activity | escape), escapedActivites) %}
+        {% endfor %}
+        
+        {{ govukSummaryList({
+          classes: 'govuk-summary-list--no-border',
+          rows: [
+            {
+              key: {
+                text: "Reserved activities"
+              },
+              value: {
+                html: ["<ul class=\"govuk-list\"><li>", (escapedActivites | join("</li><li>")), "</li></ul>"] | join
+              }
+            },
+            {
+              key: {
+                text: "Description of activities/regulation description"
+              },
+              value: {
+                text: profession.description
+              }
+            }
+          ]
+        }) }}
+
+        <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+
+        <h2 class="govuk-heading-m rpr-details__section-title">Qualification information</h2>
+
+        {{ govukSummaryList({
+          classes: 'govuk-summary-list--no-border',
+          rows: [
+            {
+              key: {
+                text: "Qualification level"
+              },
+              value: {
+                text: profession.qualification.level
+              }
+            },
+            {
+              key: {
+                text: "Methods to obtain qualification"
+              },
+              value: {
+                text: profession.qualification.methodToObtain
+              }
+            },
+            {
+              key: {
+                text: "Most common path to obtain qualification"
+              },
+              value: {
+                text: profession.qualification.commonPathToObtain
+              }
+            },
+            {
+              key: {
+                text: "Duration of qualification"
+              },
+              value: {
+                text: profession.qualification.educationDuration
+              }
+            },
+            {
+              key: {
+                text: "Existence of mandatory professional experience"
+              },
+              value: {
+                text: "Yes" if profession.qualification.mandatoryProfessionalExperience else "No"
+              }
+            }
+          ]
+        }) }}
+
+        <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+
+        <h2 class="govuk-heading-m rpr-details__section-title">Legislation</h2>
+
+        {% for legislation in profession.legislations %}
+
+          {{ govukSummaryList({
+          classes: 'govuk-summary-list--no-border',
+          rows: [
+            {
+              key: {
+                text: "National legislation"
+              },
+              value: {
+                text: legislation.name
+              }
+            },
+            {
+              key: {
+                text: "Legislation link"
+              },
+              value: {
+                html: ["<a class=\"govuk-link\" href=\"", (legislation.url | escape), "\">", (legislation.url | escape),  "</a>" ] | join
+              }
+            }
+          ]
+          }) }}
+        {% endfor %}
       </div>
 
       <div class="govuk-grid-column-one-third">
-
+        
       </div>
-    </div>
 
+    </div>
   </main>
 </div>
 

--- a/views/professions/show.njk
+++ b/views/professions/show.njk
@@ -13,7 +13,7 @@
       <div class="govuk-grid-column-two-thirds">
 
         {{ govukBackLink({
-          text: "Back",
+          text: ("app.back" | t),
           href: backUrl
         }) }}
 
@@ -21,14 +21,14 @@
 
         <h1 class="govuk-heading-xl">{{ profession.name }}</h1>
 
-        <h2 class="govuk-heading-m rpr-details__section-title">Overview</h2>
+        <h2 class="govuk-heading-m rpr-details__section-title">{{ "professions.show.overview.heading" | t }}</h2>
 
         {{ govukSummaryList({
           classes: 'govuk-summary-list--no-border',
           rows: [
             {
               key: {
-                text: "Nations"
+                text: ("professions.show.overview.nations" | t)
               },
               value: {
                 text: profession.occupationLocation
@@ -36,10 +36,10 @@
             },
             {
               key: {
-                text: "Industry/Sector"
+                text: ("professions.show.overview.industry" | t)
               },
               value: {
-                text: profession.industry.name
+                text: (profession.industry.name | t)
               }
             }
           ]
@@ -47,14 +47,14 @@
 
         <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible" />
 
-        <h2 class="govuk-heading-m rpr-details__section-title">Regulatory/professional bodies</h2>
+        <h2 class="govuk-heading-m rpr-details__section-title">{{ "professions.show.bodies.heading" | t }}</h2>
 
         {{ govukSummaryList({
           classes: 'govuk-summary-list--no-border',
           rows: [
             {
               key: {
-                text: "Regulated authority"
+                text: ("professions.show.bodies.regulatedAuthority" | t)
               },
               value: {
                 text: "Placeholder authority"
@@ -62,7 +62,7 @@
             },
             {
               key: {
-                text: "Address"
+                text: ("professions.show.bodies.address" | t)
               },
               value: {
                 html: 'Placeholder address'
@@ -70,7 +70,7 @@
             },
             {
               key: {
-                text: "Email address"
+                text: ("professions.show.bodies.emailAddress" | t)
               },
               value: {
                 text: "Placeholder email"
@@ -78,7 +78,7 @@
             },
             {
               key: {
-                text: "URL"
+                text: ("professions.show.bodies.url" | t)
               },
               value: {
                 text: "Placeholder url"
@@ -86,7 +86,7 @@
             },          
             {
               key: {
-                text: "Phone number"
+                text: ("professions.show.bodies.phoneNumber" | t)
               },
               value: {
                 text: "Placeholder phone numer"
@@ -94,7 +94,7 @@
             },
             {
               key: {
-                text: "Mandatory registration with professional bodies"
+                text: ("professions.show.bodies.mandatoryRegistration" | t)
               },
               value: {
                 text: "Placeholder response"
@@ -105,7 +105,7 @@
 
         <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
-        <h2 class="govuk-heading-m rpr-details__section-title">Regulated activities</h2>
+        <h2 class="govuk-heading-m rpr-details__section-title">{{ "professions.show.regulatedActivities.heading" | t }}</h2>
 
         {% set escapedActivites = [] %}
         {% for activity in profession.reservedActivities %}
@@ -117,7 +117,7 @@
           rows: [
             {
               key: {
-                text: "Reserved activities"
+                text: ("professions.show.regulatedActivities.reservedActivities" | t)
               },
               value: {
                 html: ["<ul class=\"govuk-list\"><li>", (escapedActivites | join("</li><li>")), "</li></ul>"] | join
@@ -125,7 +125,7 @@
             },
             {
               key: {
-                text: "Description of activities/regulation description"
+                text: ("professions.show.regulatedActivities.description" | t)
               },
               value: {
                 text: profession.description
@@ -136,14 +136,14 @@
 
         <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
-        <h2 class="govuk-heading-m rpr-details__section-title">Qualification information</h2>
+        <h2 class="govuk-heading-m rpr-details__section-title">{{ "professions.show.qualification.heading" | t}}</h2>
 
         {{ govukSummaryList({
           classes: 'govuk-summary-list--no-border',
           rows: [
             {
               key: {
-                text: "Qualification level"
+                text: ("professions.show.qualification.level" | t)
               },
               value: {
                 text: profession.qualification.level
@@ -151,7 +151,7 @@
             },
             {
               key: {
-                text: "Methods to obtain qualification"
+                text: ("professions.show.qualification.methods" | t)
               },
               value: {
                 text: profession.qualification.methodToObtain
@@ -159,7 +159,7 @@
             },
             {
               key: {
-                text: "Most common path to obtain qualification"
+                text: ("professions.show.qualification.commonPath" | t)
               },
               value: {
                 text: profession.qualification.commonPathToObtain
@@ -167,7 +167,7 @@
             },
             {
               key: {
-                text: "Duration of qualification"
+                text: ("professions.show.qualification.duration" | t)
               },
               value: {
                 text: profession.qualification.educationDuration
@@ -175,10 +175,10 @@
             },
             {
               key: {
-                text: "Existence of mandatory professional experience"
+                text: ("professions.show.qualification.mandatoryExperience" | t)
               },
               value: {
-                text: "Yes" if profession.qualification.mandatoryProfessionalExperience else "No"
+                text: ("app.yes" | t) if profession.qualification.mandatoryProfessionalExperience else ("app.no" | t)
               }
             }
           ]
@@ -186,7 +186,7 @@
 
         <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
-        <h2 class="govuk-heading-m rpr-details__section-title">Legislation</h2>
+        <h2 class="govuk-heading-m rpr-details__section-title">{{ "professions.show.legislation.heading" | t}}</h2>
 
         {% for legislation in profession.legislations %}
 
@@ -195,7 +195,7 @@
           rows: [
             {
               key: {
-                text: "National legislation"
+                text: ( "professions.show.legislation.nationalLegislation" | t)
               },
               value: {
                 text: legislation.name
@@ -203,7 +203,7 @@
             },
             {
               key: {
-                text: "Legislation link"
+                text: ( "professions.show.legislation.legislationLink" | t)
               },
               value: {
                 html: ["<a class=\"govuk-link\" href=\"", (legislation.url | escape), "\">", (legislation.url | escape),  "</a>" ] | join

--- a/views/professions/show.njk
+++ b/views/professions/show.njk
@@ -1,0 +1,23 @@
+{% extends "base.njk" %}
+{% from "govuk/components/panel/macro.njk" import govukPanel %}
+
+{% block content %}
+
+<div class="govuk-width-container">
+
+  <main class="govuk-main-wrapper">
+
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <h1 class="govuk-heading-xl">{{ professionName }}</h1>
+      </div>
+
+      <div class="govuk-grid-column-one-third">
+
+      </div>
+    </div>
+
+  </main>
+</div>
+
+{% endblock %}


### PR DESCRIPTION
This PR:
* Setups up an endpoint for displaying professional details via `professions/{professionSlug}`
* Displays professional detail following the design [here](https://rpr-prototype.herokuapp.com/beta-sprint-2/public-facing-v1/profession-1-plastic-surgery)
* Adds a `slug` column to the `Profession` entity
* Adds a method to `ProfessionsService` for adding a new profession with a unique slug, and updates existing code for creating a profession to use this

This PR punts on the problem of where the back link should go. Given this needs to work without Javascript, we'll need to keep track of where the user has come from. It may be that this is worthy of its own story, to handle back links across the service. If a page has multiple entry points, it may be non-trivial where 'Back' should go.

Where we don't yet have data, I've err-ed towards making it obvious we're using placeholder data, rather than risk dummy static data getting left in the page.