### PR TITLE
Add links for existing endpoints at root

### DIFF
--- a/cypress/integration/application.spec.ts
+++ b/cypress/integration/application.spec.ts
@@ -1,7 +1,7 @@
 describe('/', () => {
-  it('Shows hello', () => {
+  it('Shows a landing page', () => {
     cy.visit('/');
-    cy.get('body').should('contain', 'Hello!');
+    cy.get('body').should('contain', 'Check regulated professions');
   });
 
   context('when I am logged in as an admin', () => {

--- a/views/show.njk
+++ b/views/show.njk
@@ -1,5 +1,15 @@
 {% extends "base.njk" %}
 
 {% block content %}
-Hello!
+<h1 class="govuk-heading-l">Check regulated professions</h1>
+
+<p class="govuk-body-m"><a href="/professions/registered-trademark-attorney">Show Registered Trademark Attorney profession</a></p>
+<p class="govuk-body-m"><a href="/professions/secondary-school-teacher-in-state-maintained-schools-england">Show Secondary School Teacher in State maintained schools (England) profession</a></p>
+
+<p class="govuk-body-m"><a href="/admin/users/new">Create new user</a></p>
+<p class="govuk-body-m"><a href="/admin/professions/add-profession">Add a new profession</a></p>
+
+<p class="govuk-body-m"><a href="/admin">Admin</a></p>
+<p class="govuk-body-m"><a href="/logout">Logout</a></p>
+
 {% endblock %}


### PR DESCRIPTION
In lieu of an actual dashboard for now, I wanted to add some links to our placeholder home page for ease of navigating/demoing the site so far