### PR TITLE
Fix saving professions

### DIFF
--- a/src/professions/admin/add-profession/confirmation.controller.ts
+++ b/src/professions/admin/add-profession/confirmation.controller.ts
@@ -7,7 +7,6 @@ import {
   Session,
 } from '@nestjs/common';
 import { IndustriesService } from '../../../industries/industries.service';
-import { Qualification } from '../../../qualifications/qualification.entity';
 import { Profession } from '../../profession.entity';
 
 import { ProfessionsService } from '../../professions.service';
@@ -36,7 +35,7 @@ export class ConfirmationController {
       topLevelDetails.nation,
       '',
       industry,
-      new Qualification(),
+      null,
       [],
       [],
     );

--- a/src/professions/admin/add-profession/confirmation.controller.ts
+++ b/src/professions/admin/add-profession/confirmation.controller.ts
@@ -40,7 +40,7 @@ export class ConfirmationController {
       [],
     );
 
-    this.professionsService.create(profession);
+    await this.professionsService.create(profession);
   }
 
   @Get()

--- a/src/professions/profession.entity.ts
+++ b/src/professions/profession.entity.ts
@@ -59,9 +59,9 @@ export class Profession {
     this.description = description || '';
     this.occupationLocation = occupationLocation || '';
     this.regulationType = regulationType || '';
-    this.industry = industry || new Industry();
-    this.qualification = qualification || new Qualification();
+    this.industry = industry || null;
+    this.qualification = qualification || null;
     this.reservedActivities = reservedActivities || [];
-    this.legislations = legislations;
+    this.legislations = legislations || null;
   }
 }

--- a/src/professions/professions.service.spec.ts
+++ b/src/professions/professions.service.spec.ts
@@ -55,8 +55,8 @@ describe('Profession', () => {
             findOne: () => {
               return profession;
             },
-            insert: () => {
-              return {};
+            save: () => {
+              return profession;
             },
           },
         },
@@ -87,9 +87,9 @@ describe('Profession', () => {
     });
   });
 
-  describe('create', () => {
-    it('should save and return a Profession', async () => {
-      const repoSpy = jest.spyOn(repo, 'insert');
+  describe('save', () => {
+    it('should save the Profession', async () => {
+      const repoSpy = jest.spyOn(repo, 'save');
       await service.create(profession);
 
       expect(repoSpy).toHaveBeenCalledWith(profession);

--- a/src/professions/professions.service.ts
+++ b/src/professions/professions.service.ts
@@ -19,7 +19,7 @@ export class ProfessionsService {
     return this.repository.findOne(id);
   }
 
-  async create(profession: Profession): Promise<void> {
-    await this.repository.insert(profession);
+  async create(profession: Profession): Promise<Profession> {
+    return this.repository.save(profession);
   }
 }


### PR DESCRIPTION
 Switch to using `.save`, not `.insert` to create Professions

`.insert` only creates the specified entity, and doesn't run any
callbacks or create any relations, so the Industry ID wasn't being set
as a foreign key here.

Switching to `.save` exposed a flaw in our understanding too, as we
can't create a new `Qualification` here (or any other foreign keys) as
we do in the `Profession` entity's constructor. We've updated the
constructor to set foreign keys as `null` instead when a value isn't
supplied. We'll soon be able to add the real `Qualification`,
`Legislation` etc, so won't need to create a new instance of an object
here anyway - we'll be looking it up.