### PR TITLE
Remove test code from the utils module

### DIFF
--- a/src/common/create-mock-request.ts
+++ b/src/common/create-mock-request.ts
@@ -1,0 +1,17 @@
+import { createMock, DeepMocked } from '@golevelup/ts-jest';
+import { Request } from 'express';
+
+export function createMockRequest(
+  referrer: string,
+  host: string,
+): DeepMocked<Request> {
+  return createMock<Request>({
+    get: (header) => {
+      if (header === 'Referrer') {
+        return referrer;
+      } else if (header === 'host') {
+        return host;
+      }
+    },
+  });
+}

--- a/src/common/utils.spec.ts
+++ b/src/common/utils.spec.ts
@@ -1,6 +1,7 @@
 import { createMock, DeepMocked } from '@golevelup/ts-jest';
 import { Request } from 'express';
-import { backLink, createMockRequest } from './utils';
+import { backLink } from './utils';
+import { createMockRequest } from './create-mock-request';
 
 describe('utils', () => {
   describe('backLink', () => {

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -1,5 +1,4 @@
 import { Request } from 'express';
-import { createMock, DeepMocked } from '@golevelup/ts-jest';
 
 export function backLink(req: Request): string {
   const referrer = req.get('Referrer') || '';
@@ -8,19 +7,4 @@ export function backLink(req: Request): string {
   if (referrer.match('^https?://' + host)) {
     return referrer;
   }
-}
-
-export function createMockRequest(
-  referrer: string,
-  host: string,
-): DeepMocked<Request> {
-  return createMock<Request>({
-    get: (header) => {
-      if (header === 'Referrer') {
-        return referrer;
-      } else if (header === 'host') {
-        return host;
-      }
-    },
-  });
 }

--- a/src/users/personal-details/personal-details.controller.spec.ts
+++ b/src/users/personal-details/personal-details.controller.spec.ts
@@ -5,7 +5,7 @@ import { UsersService } from '../users.service';
 import { User } from '../user.entity';
 import { PersonalDetailsController } from './personal-details.controller';
 import { createMock, DeepMocked } from '@golevelup/ts-jest';
-import { createMockRequest } from '../../common/utils';
+import { createMockRequest } from '../../common/create-mock-request';
 
 const name = 'Example Name';
 const email = 'name@example.com';

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -6,6 +6,7 @@
     "util",
     "dist",
     "**/*spec.ts",
+    "src/common/create-mock-request.ts",
     "./ormconfig.ts"
   ]
 }


### PR DESCRIPTION
`createMockRequest` relies on a dev dependency which fails production builds.
To fix this we have split it out to its own module and told `nest build` to
ignore it in `tsconfig.build.json`.