### PR TITLE
Add Timestamps to all database entities

### DIFF
--- a/src/db/migrate/1639655762299-AddTimestampsToEntities.ts
+++ b/src/db/migrate/1639655762299-AddTimestampsToEntities.ts
@@ -1,0 +1,81 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddTimestampsToEntities1639655762299
+  implements MigrationInterface
+{
+  name = 'AddTimestampsToEntities1639655762299';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "industries" ADD "created_at" TIMESTAMP NOT NULL DEFAULT ('now'::text)::timestamp(6) with time zone`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "industries" ADD "updated_at" TIMESTAMP NOT NULL DEFAULT ('now'::text)::timestamp(6) with time zone`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "legislations" ADD "created_at" TIMESTAMP NOT NULL DEFAULT ('now'::text)::timestamp(6) with time zone`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "legislations" ADD "updated_at" TIMESTAMP NOT NULL DEFAULT ('now'::text)::timestamp(6) with time zone`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "qualifications" ADD "created_at" TIMESTAMP NOT NULL DEFAULT ('now'::text)::timestamp(6) with time zone`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "qualifications" ADD "updated_at" TIMESTAMP NOT NULL DEFAULT ('now'::text)::timestamp(6) with time zone`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "professions" ADD "created_at" TIMESTAMP NOT NULL DEFAULT ('now'::text)::timestamp(6) with time zone`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "professions" ADD "updated_at" TIMESTAMP NOT NULL DEFAULT ('now'::text)::timestamp(6) with time zone`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "organisations" ADD "created_at" TIMESTAMP NOT NULL DEFAULT ('now'::text)::timestamp(6) with time zone`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "organisations" ADD "updated_at" TIMESTAMP NOT NULL DEFAULT ('now'::text)::timestamp(6) with time zone`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "users" ADD "created_at" TIMESTAMP NOT NULL DEFAULT ('now'::text)::timestamp(6) with time zone`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "users" ADD "updated_at" TIMESTAMP NOT NULL DEFAULT ('now'::text)::timestamp(6) with time zone`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "users" DROP COLUMN "updated_at"`);
+    await queryRunner.query(`ALTER TABLE "users" DROP COLUMN "created_at"`);
+    await queryRunner.query(
+      `ALTER TABLE "organisations" DROP COLUMN "updated_at"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "organisations" DROP COLUMN "created_at"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "professions" DROP COLUMN "updated_at"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "professions" DROP COLUMN "created_at"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "qualifications" DROP COLUMN "updated_at"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "qualifications" DROP COLUMN "created_at"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "legislations" DROP COLUMN "updated_at"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "legislations" DROP COLUMN "created_at"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "industries" DROP COLUMN "updated_at"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "industries" DROP COLUMN "created_at"`,
+    );
+  }
+}

--- a/src/industries/industry.entity.ts
+++ b/src/industries/industry.entity.ts
@@ -1,5 +1,10 @@
-import { Entity, PrimaryGeneratedColumn, Column } from 'typeorm';
-
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+} from 'typeorm';
 @Entity({ name: 'industries' })
 export class Industry {
   @PrimaryGeneratedColumn('uuid')
@@ -7,6 +12,19 @@ export class Industry {
 
   @Column()
   name: string;
+
+  @CreateDateColumn({
+    type: 'timestamp',
+    default: () => 'CURRENT_TIMESTAMP(6)',
+  })
+  created_at: Date;
+
+  @UpdateDateColumn({
+    type: 'timestamp',
+    default: () => 'CURRENT_TIMESTAMP(6)',
+    onUpdate: 'CURRENT_TIMESTAMP(6)',
+  })
+  updated_at: Date;
 
   constructor(name?: string) {
     this.name = name || '';

--- a/src/legislations/legislation.entity.ts
+++ b/src/legislations/legislation.entity.ts
@@ -1,4 +1,10 @@
-import { Entity, PrimaryGeneratedColumn, Column } from 'typeorm';
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+} from 'typeorm';
 
 @Entity({ name: 'legislations' })
 export class Legislation {
@@ -10,6 +16,19 @@ export class Legislation {
 
   @Column()
   url: string;
+
+  @CreateDateColumn({
+    type: 'timestamp',
+    default: () => 'CURRENT_TIMESTAMP(6)',
+  })
+  created_at: Date;
+
+  @UpdateDateColumn({
+    type: 'timestamp',
+    default: () => 'CURRENT_TIMESTAMP(6)',
+    onUpdate: 'CURRENT_TIMESTAMP(6)',
+  })
+  updated_at: Date;
 
   constructor(name?: string, url?: string) {
     this.name = name || '';

--- a/src/organisations/organisation.entity.ts
+++ b/src/organisations/organisation.entity.ts
@@ -5,6 +5,8 @@ import {
   Column,
   ManyToMany,
   JoinTable,
+  CreateDateColumn,
+  UpdateDateColumn,
 } from 'typeorm';
 
 @Entity({ name: 'organisations' })
@@ -39,6 +41,19 @@ export class Organisation {
   @ManyToMany(() => Profession)
   @JoinTable()
   professions: Profession[];
+
+  @CreateDateColumn({
+    type: 'timestamp',
+    default: () => 'CURRENT_TIMESTAMP(6)',
+  })
+  created_at: Date;
+
+  @UpdateDateColumn({
+    type: 'timestamp',
+    default: () => 'CURRENT_TIMESTAMP(6)',
+    onUpdate: 'CURRENT_TIMESTAMP(6)',
+  })
+  updated_at: Date;
 
   constructor(
     name?: string,

--- a/src/professions/profession.entity.ts
+++ b/src/professions/profession.entity.ts
@@ -8,6 +8,8 @@ import {
   JoinTable,
   ManyToOne,
   Index,
+  CreateDateColumn,
+  UpdateDateColumn,
 } from 'typeorm';
 import { Industry } from '../industries/industry.entity';
 
@@ -52,6 +54,19 @@ export class Profession {
   })
   @JoinTable()
   legislations: Legislation[];
+
+  @CreateDateColumn({
+    type: 'timestamp',
+    default: () => 'CURRENT_TIMESTAMP(6)',
+  })
+  created_at: Date;
+
+  @UpdateDateColumn({
+    type: 'timestamp',
+    default: () => 'CURRENT_TIMESTAMP(6)',
+    onUpdate: 'CURRENT_TIMESTAMP(6)',
+  })
+  updated_at: Date;
 
   constructor(
     name?: string,

--- a/src/qualifications/qualification.entity.ts
+++ b/src/qualifications/qualification.entity.ts
@@ -1,4 +1,10 @@
-import { Entity, PrimaryGeneratedColumn, Column } from 'typeorm';
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+} from 'typeorm';
 
 @Entity({ name: 'qualifications' })
 export class Qualification {
@@ -19,6 +25,19 @@ export class Qualification {
 
   @Column()
   mandatoryProfessionalExperience: boolean;
+
+  @CreateDateColumn({
+    type: 'timestamp',
+    default: () => 'CURRENT_TIMESTAMP(6)',
+  })
+  created_at: Date;
+
+  @UpdateDateColumn({
+    type: 'timestamp',
+    default: () => 'CURRENT_TIMESTAMP(6)',
+    onUpdate: 'CURRENT_TIMESTAMP(6)',
+  })
+  updated_at: Date;
 
   constructor(
     level?: string,

--- a/src/users/user.entity.ts
+++ b/src/users/user.entity.ts
@@ -1,4 +1,11 @@
-import { Entity, Column, PrimaryGeneratedColumn, Index } from 'typeorm';
+import {
+  Entity,
+  Column,
+  PrimaryGeneratedColumn,
+  Index,
+  CreateDateColumn,
+  UpdateDateColumn,
+} from 'typeorm';
 
 export enum UserRole {
   Admin = 'admin',
@@ -27,6 +34,19 @@ export class User {
     default: [],
   })
   roles: UserRole[];
+
+  @CreateDateColumn({
+    type: 'timestamp',
+    default: () => 'CURRENT_TIMESTAMP(6)',
+  })
+  created_at: Date;
+
+  @UpdateDateColumn({
+    type: 'timestamp',
+    default: () => 'CURRENT_TIMESTAMP(6)',
+    onUpdate: 'CURRENT_TIMESTAMP(6)',
+  })
+  updated_at: Date;
 
   constructor(
     email?: string,


### PR DESCRIPTION
This is best practice, and allows us to better keep track of when data has been created and/or updated.