### PR TITLE
Add Brewfile and node_modules to dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,3 +10,5 @@ docker-compose.ci.yml
 docker-compose.yml
 Dockerfile
 README.md
+node_modules
+Brewfile


### PR DESCRIPTION
The production code doesn't need the Brewfile or the local node_modules