### PR TITLE
Use Terraform to host application on GPaas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,10 @@ lerna-debug.log*
 /public
 /.env.development
 /.env.test
+
+# Terraform
+.terraformrc*
+terraform.rc*
+*.tfstate*
+*.tfvars*
+.terraform/

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/cloudfoundry-community/cloudfoundry" {
+  version     = "0.15.0"
+  constraints = "0.15.0"
+  hashes = [
+    "h1:QgYJEWmQ+k3cH20D8K2WFMUdAxfcF1BiSu1wocz/9kg=",
+    "zh:143c1624ee5c2813c32126467fb9c56053bbfcae275d6ce61c7b59c259c4b8e0",
+    "zh:18a5cb24695a1521cb8ee1e488234c337228af1b471b30a284db41c4362c6149",
+    "zh:261595c1bd8105160e8c505d76be5f49d3bd12bb7aa6882ac6315cc5727aec55",
+    "zh:2e8627bf812848fe1b232e4fe91e21eaedc3759f8997ffc5a9f201757627e835",
+    "zh:4a19d909843952b9cbf6b0445c3627d22c5caaa2ad8db1eab2f382d5faff3402",
+    "zh:4e78b3de83b2686c66c2b2e0d8a7c910ed423fd5b7b853bcc0fd05b851c6bd28",
+    "zh:713e43a21a1d3aaddfa0bf841a2cc1e2c06160917bdd443e6eac99b620d668fa",
+    "zh:a36d3e5406f96abaf9a6eb89663b7fa504d0c68521a7334c498525e8018ad7f9",
+    "zh:aa3abf232a49f66031f2a1a032f53604a51d8c9b0a3a297591d7a57949943c40",
+    "zh:b2ccc93024f1ed6e18fd92e199be12ea148383a4f5d8c3ab9e632ae88b0f5263",
+    "zh:b85379c01fc963289203170731880fb89f10047d63c45566750826ad9aff39cb",
+    "zh:c5d59b6fe39f7f4f2c556209906aa9cbb31cc0630d225fb0abd48c6de1089f2e",
+    "zh:c956d630c087fc2ede5967e89249b2477a552185c2d4167292002fc5fd1b380c",
+    "zh:edf41138788f7b16ed572f1fad940ba75f3c7b9a7c06f6876c31bf281de1257a",
+    "zh:f873bbff4c7ae1c6b7c5ba0dd42552526435d9b1bd373b18ea4169e965e4d283",
+  ]
+}

--- a/terraform/app.tf
+++ b/terraform/app.tf
@@ -1,0 +1,32 @@
+# Create the web app.
+
+resource "cloudfoundry_app" "beis-rpr-app" {
+  name                       = "beis-rpr-${var.environment}"
+  space                      = cloudfoundry_space.space.id
+  instances                  = 2
+  disk_quota                 = 3072
+  timeout                    = 300
+  docker_image = "thedxw/beis-rpr:${var.docker_tag}"
+  docker_credentials = {
+    username = var.docker_username
+    password = var.docker_password
+  }
+  strategy                   = "blue-green-v2"
+  health_check_http_endpoint = "/"
+  service_binding { service_instance = cloudfoundry_service_instance.beis-rpr-postgres.id }
+  environment = {
+    "AUTH0_CLIENT_ID"     = var.auth0_client_id
+    "AUTH0_CLIENT_SECRET" = var.auth0_client_secret
+    "AUTH0_DOMAIN"        = var.auth0_domain
+    "AUTH0_REDIRECT_URL"  = var.auth0_redirect_url
+    "APP_SECRET"          = var.app_secret
+    "AUTH_USERNAME"       = var.auth_username
+    "AUTH_PASSWORD"       = var.auth_password
+    "HOST_URL"            = var.host_url
+  }
+  # routes need to be declared with the app for blue green deployments to work
+  routes {
+    route = cloudfoundry_route.beis-rpr-route.id
+  }
+
+}

--- a/terraform/domains.tf
+++ b/terraform/domains.tf
@@ -1,0 +1,4 @@
+# Get data for the default domain on the PaaS
+data "cloudfoundry_domain" "default" {
+  name = "london.cloudapps.digital"
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,28 @@
+# Create and use a S3 bucket in the terraform space of the BEIS org to store state
+# cf create-space terraform
+# cf target -s terraform
+# cf create-service aws-s3-bucket default terraform-state
+# cf create-service-key terraform-state terraform-state-key -c '{"allow_external_access": true}'
+# cf service-key terraform-state terraform-state-key
+# store the credentials in 1password
+# set AWS_SECRET_ACCESS_KEY and AWS_ACCESS_KEY_ID
+
+terraform {
+  backend "s3" {
+    key    = "terraform"
+    bucket = "paas-s3-broker-prod-lon-ff1d10f6-b00f-4b73-9131-af87e71e25e0"
+    region = "eu-west-2"
+  }
+  required_providers {
+    cloudfoundry = {
+      source  = "cloudfoundry-community/cloudfoundry"
+      version = "0.15.0"
+    }
+  }
+}
+
+# Use the cloudfoundry provider
+# CF_PASSWORD and CF_USER need to be set as environment variables
+provider "cloudfoundry" {
+  api_url = "https://api.london.cloud.service.gov.uk"
+}

--- a/terraform/org.tf
+++ b/terraform/org.tf
@@ -1,0 +1,3 @@
+data "cloudfoundry_org" "beis-rpr" {
+  name = "beis-rpr"
+}

--- a/terraform/postgres.tf
+++ b/terraform/postgres.tf
@@ -1,0 +1,24 @@
+# Get data about the postgres service on the PaaS
+# so we can get the guid of the service plan we want to use.
+data "cloudfoundry_service" "postgres" {
+  name = "postgres"
+}
+
+# Create a postgres database named with the environment.
+# Enable the pgcrypto and plpgsql extensions.
+# Increase the timeouts since the default of 15 minutes is too
+# short for postgres db creation
+
+resource "cloudfoundry_service_instance" "beis-rpr-postgres" {
+  name         = "beis-rpr-${var.environment}-postgres"
+  space        = cloudfoundry_space.space.id
+  service_plan = data.cloudfoundry_service.postgres.service_plans["small-ha-13"]
+  json_params  = "{\"enable_extensions\": [\"pgcrypto\",\"plpgsql\"]}"
+  timeouts {
+    create = "2h"
+    delete = "2h"
+    update = "2h"
+  }
+  replace_on_params_change       = false
+  replace_on_service_plan_change = false
+}

--- a/terraform/routes.tf
+++ b/terraform/routes.tf
@@ -1,0 +1,7 @@
+# Create a route for the app using the default domain
+# and useful hostname based on environment
+resource "cloudfoundry_route" "beis-rpr-route" {
+  domain   = data.cloudfoundry_domain.default.id
+  space    = cloudfoundry_space.space.id
+  hostname = "beis-rpr-${var.environment}"
+}

--- a/terraform/space.tf
+++ b/terraform/space.tf
@@ -1,0 +1,7 @@
+# This creates a space but does not add any users to it.
+# Until you add your user to the space via the UI with space manager
+# and space developer permissions the rest of the terraform will fail
+resource "cloudfoundry_space" "space" {
+  name = var.environment
+  org  = data.cloudfoundry_org.beis-rpr.id
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,58 @@
+variable "environment" {
+  type        = string
+  description = "the environment the app is running in"
+}
+
+variable "auth0_client_id" {
+  type        = string
+  description = "AUTH0 Client ID"
+}
+
+variable "auth0_client_secret" {
+  type        = string
+  description = "AUTH0 Client Secret"
+}
+
+variable "auth0_domain" {
+  type        = string
+  description = "AUTH0 domain"
+}
+
+variable "auth0_redirect_url" {
+  type        = string
+  description = "AUTH0 redirect url"
+}
+
+variable "app_secret" {
+  type        = string
+  description = "App Secret"
+}
+
+variable "auth_username" {
+  type        = string
+  description = "Auth username"
+}
+variable "auth_password" {
+  type        = string
+  description = "Auth password"
+}
+
+variable "host_url" {
+  type        = string
+  description = "Host URL"
+}
+
+variable "docker_tag" {
+  type        = string
+  description = "The Docker tag to be pushed"
+}
+
+variable "docker_password" {
+  type        = string
+  description = "The Docker Hub user password"
+}
+
+variable "docker_username" {
+  type        = string
+  description = "The Docker Hub username"
+}


### PR DESCRIPTION
A lot of this setup was copied across from [BEIS
RODA](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/develop/terraform),
but we've removed things we're not using yet for this project.

This will allow us to deploy both staging and production (and other)
environments to GPaaS by setting the relevant environment variables.