### PR TITLE
Add empty `docker-entrypoint`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,8 @@ RUN if [ "$NODE_ENV" = "production" ]; then \
 
 EXPOSE 3000
 
+ENTRYPOINT [ "./docker-entrypoint.sh" ]
+
 CMD ["node", "dist/main"]
 
 # ------------------------------------------------------------------------------

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -e
+
+echo "Starting docker entrypoint…"
+
+echo "Finished docker entrypoint."
+exec "$@"


### PR DESCRIPTION
We could choose to run seeds in here, or some other setup stuff if we
need to. It's the standard way of writing Dockerfiles.