### PR TITLE
(1969) Document deployment process

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
     tags:
-      - release
+      - 'release-*'
 
 env:
   DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+## [Unreleased]

--- a/doc/0_index.md
+++ b/doc/0_index.md
@@ -2,5 +2,6 @@
 
 ## Development
 
+- [Deployment](./deployment.md)
 - [Generate migrations](./generate-migrations.md)
 - [Database models](./database-models.md)

--- a/doc/architecture/decisions/0012-deploy-to-production-when-a-new-tag-has-been-pushed.md
+++ b/doc/architecture/decisions/0012-deploy-to-production-when-a-new-tag-has-been-pushed.md
@@ -1,0 +1,33 @@
+# 12. deploy-to-production-when-a-new-tag-has-been-pushed
+
+Date: 2021-12-21
+
+## Status
+
+Accepted
+
+## Context
+
+We now are deploying our code to GOV.UK PaaS (Platform as a Service), and we need to
+agree how we trigger a deployment to production. We've never been happy with the
+approach of `develop`/`main` branches, for staging and production, so we've decided
+to try a new approach.
+
+## Decision
+
+Staging deploys will be triggered by push to `main`, while production deploys will be
+triggered by the push of a new tag in the format `release-$X`, where `$X` is a release
+number, padded to a length of three characters with zeroes.
+
+There will be a deploy script, designed to run on a developer's machine, that will
+automate the process of tagging a new release.
+
+## Consequences
+
+As `main` is now not a record of what is actually deployed, it may be trickier to
+understand what is actually deployed. We will negate this risk by adding a CHANGELOG,
+which will spell out exactly what is deployed against which tag, as well as what
+is currently awaiting deployment.
+
+The deployment script will also guard against this Changelog not being up to date,
+by checking the new release is referenced in the CHANGELOG.

--- a/doc/deployment.md
+++ b/doc/deployment.md
@@ -1,0 +1,59 @@
+# Deployment process
+
+## Production
+
+Production deploys are triggered by the push of a new tag in the format `release-$X`,
+where `$X` is a release number, padded to a length of three characters with zeroes.
+
+To give us a slightly more formal process around what gets deployed and when and also to
+give us visibility into the things that have been deployed, we additionally follow these
+steps when releasing to production:
+
+Releases are documented in the [CHANGELOG](../CHANGELOG.md) following the [Keep a changelog](https://keepachangelog.com/en/1.0.0/) format.
+
+When a new release is deployed to production, a new second-level heading should be created in CHANGELOG.md with the release number and details of what has changed in this release.
+
+The heading should link to a Github URL at the bottom of the file, which shows the differences between the current release and the previous one. For example:
+
+### Example
+
+```
+## [release-1]
+- A change
+- Another change
+
+[release-1]: https://github.com/UKGovernmentBEIS/regulated-professions-register/compare/release-1...release-0
+```
+
+### Steps
+
+1. Create a release branch and make a pull request
+   - Create a branch from main for the release called release-X where X is the release number
+   - Update CHANGELOG.md to:
+     document the changes in this release in a bullet point form
+     add a link to the diff at the bottom of the file
+   - Document the changes in the commit message as well
+   - Push the changes up to Github `git push -u origin release-x`
+   - Create a pull request to merge that release into main with content from the CHANGELOG.md
+   - Get that pull request reviewed and approved
+1. Review and merge the release pull request
+   The pull request should be reviewed to confirm that the changes in the release are safe to ship and that CHANGELOG.md accurately reflects the changes included in the release.
+1. Confirm the release candidate and perform any prerequisites
+   - Confirm the release with any relevant people (product owner, delivery manager, etc)
+   - Think about any dependencies that also need considering: dependent parts of the service that also need updating; environment variables that need changing/adding; third-party services that need to be set up/updated; data migrations to be run
+1. Update your local main branch and run the `script/release` command
+1. Production smoke test
+   Once the code has been deployed to production, carry out a quick smoke test to confirm that the changes have been successfully deployed.
+1. Move all the Azure DevOps cards from "Awaiting deployment" to "Done"
+
+## Staging
+
+Staging deploys are run automatically on a push to the `main` branch. To deploy
+to staging, follow the following steps:
+
+1. Open a pull request back into the `main` branch with your changes
+1. Get that pull request code reviewed and approved
+1. Check that any prerequisite changes to things like environment variables or third-party service configuration is ready
+1. Merge the pull request
+
+The changes should be automatically applied by Github Actions. [You can track the progress of Github Actions jobs at this link](https://github.com/UKGovernmentBEIS/regulated-professions-register/actions/workflows/deploy.yml).

--- a/script/release
+++ b/script/release
@@ -1,0 +1,36 @@
+#!/bin/sh
+
+# script/release: Tag the latest head commit to a specific version, and
+#                 tag that commit as `latest` and push to the origin repo
+
+set -e
+
+cd "$(dirname "$0")/.."
+
+branch=$(git rev-parse --abbrev-ref HEAD)
+
+if [ "$branch" != "main" ]; then
+  echo "You don't appear to be on the \`main\` branch. Switch to main, and try again"
+  exit 1
+fi
+
+latest_tag=$(git describe --tags --abbrev=0)
+latest_version=$(echo "$latest_tag" | sed 's/[a-z0\-]//g')
+next_version=$(printf "%03d\n" $((latest_version + 1)))
+next_tag="release-$next_version"
+
+if grep -Eq "$next_tag" CHANGELOG.md; then
+  echo "Are you sure you want to push the tag \`$next_tag\` to origin? This will deploy the latest code to production. (y/n)"
+  read -r
+  if expr "$REPLY" : "^[Yy]$" > /dev/null; then
+    git tag "$next_tag"
+    git push origin "$next_tag"
+  else
+    echo "Exiting..."
+    exit 1
+  fi
+else
+  echo "Can't find a reference to the release \`$next_tag\` in CHANGELOG.md. Are you sure you've updated it?"
+fi
+
+


### PR DESCRIPTION
This documents the deployment process, as well as adds a script to tag the latest release, with some guards in place to make sure we're on the right branch, and the changelog is updated correctly.