### PR TITLE
(1963) Persist draft Professions in the database, rather than the session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,5 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
+
+- Create draft Professions in the database, rather than using session storage when adding a new profession

--- a/cypress/integration/admin/professions/add-a-profession.spec.ts
+++ b/cypress/integration/admin/professions/add-a-profession.spec.ts
@@ -43,8 +43,5 @@ describe('Adding a new profession', () => {
         .should('contain', heading)
         .should('contain', 'Example Profession');
     });
-
-    cy.visit('/professions/example-profession');
-    cy.get('body').should('contain', 'Example Profession');
   });
 });

--- a/src/db/migrate/1639999394470-AddConfirmedFieldToProfessions.ts
+++ b/src/db/migrate/1639999394470-AddConfirmedFieldToProfessions.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddConfirmedFieldToProfessions1639999394470
+  implements MigrationInterface
+{
+  name = 'AddConfirmedFieldToProfessions1639999394470';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "professions" ADD "confirmed" boolean NOT NULL DEFAULT false`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "professions" DROP COLUMN "confirmed"`,
+    );
+  }
+}

--- a/src/db/migrate/1640095229241-MakeProfessionFieldsNullable.ts
+++ b/src/db/migrate/1640095229241-MakeProfessionFieldsNullable.ts
@@ -1,0 +1,67 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class MakeProfessionFieldsNullable1640095229241
+  implements MigrationInterface
+{
+  name = 'MakeProfessionFieldsNullable1640095229241';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_c60993e6f4badf770634fd393c"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "professions" ALTER COLUMN "name" DROP NOT NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "professions" ALTER COLUMN "alternateName" DROP NOT NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "professions" ALTER COLUMN "slug" DROP NOT NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "professions" DROP CONSTRAINT "UQ_c60993e6f4badf770634fd393c7"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "professions" ALTER COLUMN "description" DROP NOT NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "professions" ALTER COLUMN "regulationType" DROP NOT NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "professions" ALTER COLUMN "reservedActivities" DROP NOT NULL`,
+    );
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX "IDX_47cbed2342f1e1452b9af26f38" ON "professions" ("slug") WHERE "slug" IS NOT NULL`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_47cbed2342f1e1452b9af26f38"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "professions" ALTER COLUMN "reservedActivities" SET NOT NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "professions" ALTER COLUMN "regulationType" SET NOT NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "professions" ALTER COLUMN "description" SET NOT NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "professions" ADD CONSTRAINT "UQ_c60993e6f4badf770634fd393c7" UNIQUE ("slug")`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "professions" ALTER COLUMN "slug" SET NOT NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "professions" ALTER COLUMN "alternateName" SET NOT NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "professions" ALTER COLUMN "name" SET NOT NULL`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_c60993e6f4badf770634fd393c" ON "professions" ("slug") `,
+    );
+  }
+}

--- a/src/professions/admin/add-profession/check-your-answers.controller.spec.ts
+++ b/src/professions/admin/add-profession/check-your-answers.controller.spec.ts
@@ -1,7 +1,6 @@
 import { DeepMocked, createMock } from '@golevelup/ts-jest';
 import { TestingModule, Test } from '@nestjs/testing';
 import { I18nService } from 'nestjs-i18n';
-import { IndustriesService } from '../../../industries/industries.service';
 import { Industry } from '../../../industries/industry.entity';
 import { Profession } from '../../profession.entity';
 import { ProfessionsService } from '../../professions.service';
@@ -10,19 +9,26 @@ import { CheckYourAnswersController } from './check-your-answers.controller';
 describe('CheckYourAnswersController', () => {
   let controller: CheckYourAnswersController;
   let professionsService: DeepMocked<ProfessionsService>;
-  let industriesService: DeepMocked<IndustriesService>;
   let i18nService: DeepMocked<I18nService>;
+  let profession: DeepMocked<Profession>;
 
   beforeEach(async () => {
-    professionsService = createMock<ProfessionsService>();
-    industriesService = createMock<IndustriesService>();
+    profession = createMock<Profession>({
+      id: 'profession-id',
+      name: 'Gas Safe Engineer',
+      occupationLocations: ['GB-ENG'],
+      industries: [new Industry('industries.construction')],
+    });
+
+    professionsService = createMock<ProfessionsService>({
+      find: async () => profession,
+    });
     i18nService = createMock<I18nService>();
 
     const module: TestingModule = await Test.createTestingModule({
       controllers: [CheckYourAnswersController],
       providers: [
         { provide: ProfessionsService, useValue: professionsService },
-        { provide: IndustriesService, useValue: industriesService },
         { provide: I18nService, useValue: i18nService },
       ],
     }).compile();
@@ -35,24 +41,6 @@ describe('CheckYourAnswersController', () => {
   describe('view', () => {
     describe('when a Profession has been created with the persisted ID', () => {
       it('fetches the draft Profession from the persisted ID, and renders the answers on the page', async () => {
-        const session = {
-          'profession-id': 'profession-id',
-        };
-
-        const industry = new Industry('industries.construction');
-
-        const draftProfession = new Profession(
-          'Gas Safe Engineer',
-          null,
-          null,
-          null,
-          ['GB-ENG'],
-          null,
-          [industry],
-        );
-
-        professionsService.find.mockImplementation(async () => draftProfession);
-
         i18nService.translate.mockImplementation(async (text) => {
           switch (text) {
             case 'industries.construction':
@@ -64,28 +52,12 @@ describe('CheckYourAnswersController', () => {
           }
         });
 
-        const templateParams = await controller.show(session);
+        const templateParams = await controller.show('profession-id');
         expect(templateParams.name).toEqual('Gas Safe Engineer');
         expect(templateParams.nations).toEqual(['England']);
         expect(templateParams.industries).toEqual([
           'Construction & Engineering',
         ]);
-        expect(professionsService.find).toHaveBeenCalledWith('profession-id');
-      });
-    });
-
-    describe('when a Profession with the persisted ID cannot be found', () => {
-      it('throws an error', async () => {
-        const session = {
-          'profession-id': 'profession-id',
-        };
-
-        professionsService.find.mockImplementation(async () => undefined);
-
-        await expect(
-          async () => await controller.show(session),
-        ).rejects.toThrowError('Draft profession not found');
-
         expect(professionsService.find).toHaveBeenCalledWith('profession-id');
       });
     });

--- a/src/professions/admin/add-profession/check-your-answers.controller.ts
+++ b/src/professions/admin/add-profession/check-your-answers.controller.ts
@@ -3,6 +3,7 @@ import { I18nService } from 'nestjs-i18n';
 
 import { Nation } from '../../../nations/nation';
 import { ProfessionsService } from '../../professions.service';
+import { CheckYourAnswersTemplate } from './interfaces/check-your-answers.template';
 
 @Controller('admin/professions')
 export class CheckYourAnswersController {
@@ -13,12 +14,7 @@ export class CheckYourAnswersController {
 
   @Get(':id/check-your-answers')
   @Render('professions/admin/add-profession/check-your-answers')
-  async show(@Param('id') id: string): Promise<{
-    name: string;
-    nations: string[];
-    industries: string[];
-    professionId: string;
-  }> {
+  async show(@Param('id') id: string): Promise<CheckYourAnswersTemplate> {
     const draftProfession = await this.professionsService.find(id);
 
     if (!draftProfession) {

--- a/src/professions/admin/add-profession/check-your-answers.controller.ts
+++ b/src/professions/admin/add-profession/check-your-answers.controller.ts
@@ -1,26 +1,25 @@
-import { Controller, Get, Render, Session } from '@nestjs/common';
+import { Controller, Get, Param, Render } from '@nestjs/common';
 import { I18nService } from 'nestjs-i18n';
 
 import { Nation } from '../../../nations/nation';
 import { ProfessionsService } from '../../professions.service';
 
-@Controller('admin/professions/new/check-your-answers')
+@Controller('admin/professions')
 export class CheckYourAnswersController {
   constructor(
     private readonly professionsService: ProfessionsService,
     private readonly i18nService: I18nService,
   ) {}
 
-  @Get()
+  @Get(':id/check-your-answers')
   @Render('professions/admin/add-profession/check-your-answers')
-  async show(@Session() session: Record<string, any>): Promise<{
+  async show(@Param('id') id: string): Promise<{
     name: string;
     nations: string[];
     industries: string[];
+    professionId: string;
   }> {
-    const professionId = session['profession-id'];
-
-    const draftProfession = await this.professionsService.find(professionId);
+    const draftProfession = await this.professionsService.find(id);
 
     if (!draftProfession) {
       throw new Error('Draft profession not found');
@@ -39,6 +38,7 @@ export class CheckYourAnswersController {
     );
 
     return {
+      professionId: id,
       name: draftProfession.name,
       nations: selectedNations,
       industries: industryNames,

--- a/src/professions/admin/add-profession/confirmation.controller.spec.ts
+++ b/src/professions/admin/add-profession/confirmation.controller.spec.ts
@@ -44,7 +44,7 @@ describe('ConfirmationController', () => {
     });
   });
 
-  describe('create', () => {
+  describe('confirm', () => {
     describe('when all required fields are present in the session', () => {
       it('creates a Profession, with minimal fields', async () => {
         const constructionUUID = 'construction-uuid';
@@ -63,12 +63,12 @@ describe('ConfirmationController', () => {
 
         industriesService.findByIds.mockImplementation(async () => [industry]);
 
-        await controller.create(session);
+        await controller.confirm(session);
 
         expect(industriesService.findByIds).toHaveBeenCalledWith([
           constructionUUID,
         ]);
-        expect(professionsService.create).toHaveBeenCalledWith(
+        expect(professionsService.confirm).toHaveBeenCalledWith(
           expect.objectContaining({
             name: 'Gas Safe Engineer',
             industries: [industry],
@@ -81,7 +81,7 @@ describe('ConfirmationController', () => {
     describe('when the session is empty', () => {
       it('should throw an exception', () => {
         expect(async () => {
-          await controller.create({});
+          await controller.confirm({});
         }).rejects.toThrowError();
       });
     });

--- a/src/professions/admin/add-profession/confirmation.controller.ts
+++ b/src/professions/admin/add-profession/confirmation.controller.ts
@@ -1,56 +1,26 @@
-import {
-  Controller,
-  Get,
-  Post,
-  Redirect,
-  Render,
-  Session,
-} from '@nestjs/common';
-import { IndustriesService } from '../../../industries/industries.service';
-import { Profession } from '../../profession.entity';
+import { Controller, Get, Param, Post, Render, Res } from '@nestjs/common';
+import { Response } from 'express';
 
 import { ProfessionsService } from '../../professions.service';
 
-@Controller('admin/professions/new/confirmation')
+@Controller('admin/professions')
 export class ConfirmationController {
-  constructor(
-    private professionsService: ProfessionsService,
-    private industriesService: IndustriesService,
-  ) {}
+  constructor(private professionsService: ProfessionsService) {}
 
-  @Post()
-  @Redirect('/admin/professions/new/confirmation')
-  async confirm(@Session() session: Record<string, any>) {
-    const draftProfession = await this.fetchProfessionOrThrow(session);
+  @Post('/:id/confirmation')
+  async create(@Res() res: Response, @Param('id') id: string) {
+    const profession = await this.professionsService.find(id);
 
-    this.professionsService.confirm(draftProfession);
+    await this.professionsService.confirm(profession);
+
+    res.redirect(`/admin/professions/${id}/confirmation`);
   }
 
-  @Get()
+  @Get('/:id/confirmation')
   @Render('professions/admin/add-profession/confirmation')
-  async viewConfirmation(@Session() session: Record<string, any>) {
-    const profession = await this.fetchProfessionOrThrow(session);
-
-    session['profession-id'] = undefined;
+  async new(@Param('id') id: string) {
+    const profession = await this.professionsService.find(id);
 
     return { name: profession.name };
-  }
-
-  private async fetchProfessionOrThrow(
-    session: Record<string, any>,
-  ): Promise<Profession> {
-    const professionId = session['profession-id'];
-
-    if (professionId === undefined) {
-      throw new Error();
-    }
-
-    const profession = await this.professionsService.find(professionId);
-
-    if (!profession) {
-      throw new Error('Draft profession not found');
-    }
-
-    return profession;
   }
 }

--- a/src/professions/admin/add-profession/confirmation.controller.ts
+++ b/src/professions/admin/add-profession/confirmation.controller.ts
@@ -32,15 +32,15 @@ export class ConfirmationController {
 
     const profession = new Profession(
       topLevelDetails.name,
-      '',
-      '',
-      '',
+      null,
+      null,
+      null,
       topLevelDetails.nations,
-      '',
+      null,
       industries,
       null,
-      [],
-      [],
+      null,
+      null,
     );
 
     await this.professionsService.create(profession);

--- a/src/professions/admin/add-profession/confirmation.controller.ts
+++ b/src/professions/admin/add-profession/confirmation.controller.ts
@@ -21,7 +21,7 @@ export class ConfirmationController {
 
   @Post()
   @Redirect('/admin/professions/new/confirmation')
-  async create(@Session() session: Record<string, any>) {
+  async confirm(@Session() session: Record<string, any>) {
     const addProfessionSession = session['add-profession'];
     const topLevelDetails: TopLevelDetailsDto =
       addProfessionSession['top-level-details'];
@@ -43,7 +43,7 @@ export class ConfirmationController {
       null,
     );
 
-    await this.professionsService.create(profession);
+    await this.professionsService.confirm(profession);
   }
 
   @Get()

--- a/src/professions/admin/add-profession/confirmation.controller.ts
+++ b/src/professions/admin/add-profession/confirmation.controller.ts
@@ -2,13 +2,14 @@ import { Controller, Get, Param, Post, Render, Res } from '@nestjs/common';
 import { Response } from 'express';
 
 import { ProfessionsService } from '../../professions.service';
+import { ConfirmationTemplate } from './interfaces/confirmation.template';
 
 @Controller('admin/professions')
 export class ConfirmationController {
   constructor(private professionsService: ProfessionsService) {}
 
   @Post('/:id/confirmation')
-  async create(@Res() res: Response, @Param('id') id: string) {
+  async create(@Res() res: Response, @Param('id') id: string): Promise<void> {
     const profession = await this.professionsService.find(id);
 
     await this.professionsService.confirm(profession);
@@ -18,7 +19,7 @@ export class ConfirmationController {
 
   @Get('/:id/confirmation')
   @Render('professions/admin/add-profession/confirmation')
-  async new(@Param('id') id: string) {
+  async new(@Param('id') id: string): Promise<ConfirmationTemplate> {
     const profession = await this.professionsService.find(id);
 
     return { name: profession.name };

--- a/src/professions/admin/add-profession/interfaces/check-your-answers.template.ts
+++ b/src/professions/admin/add-profession/interfaces/check-your-answers.template.ts
@@ -1,0 +1,6 @@
+export interface CheckYourAnswersTemplate {
+  name: string;
+  nations: string[];
+  industries: string[];
+  professionId: string;
+}

--- a/src/professions/admin/add-profession/interfaces/checkboxArgs.ts
+++ b/src/professions/admin/add-profession/interfaces/checkboxArgs.ts
@@ -1,0 +1,5 @@
+export interface CheckboxArgs {
+  value: string;
+  text: string;
+  checked: boolean;
+}

--- a/src/professions/admin/add-profession/interfaces/confirmation.template.ts
+++ b/src/professions/admin/add-profession/interfaces/confirmation.template.ts
@@ -1,0 +1,3 @@
+export interface ConfirmationTemplate {
+  name: string;
+}

--- a/src/professions/admin/add-profession/interfaces/top-level-details.template.ts
+++ b/src/professions/admin/add-profession/interfaces/top-level-details.template.ts
@@ -1,0 +1,8 @@
+import { CheckboxArgs } from './checkboxArgs';
+
+export interface TopLevelDetailsTemplate {
+  name: string | null;
+  industriesCheckboxArgs: CheckboxArgs[];
+  nationsCheckboxArgs: CheckboxArgs[];
+  errors: object | undefined;
+}

--- a/src/professions/admin/add-profession/interfaces/top-level-details.ts
+++ b/src/professions/admin/add-profession/interfaces/top-level-details.ts
@@ -1,6 +1,0 @@
-export interface TopLevelDetailsTemplate {
-  name: string | null;
-  industriesCheckboxArgs: { text: string; value: string; checked?: boolean }[];
-  nationsCheckboxArgs: { text: string; value: string: checked?: boolean }[];
-  errors: object | undefined;
-}

--- a/src/professions/admin/add-profession/interfaces/top-level-details.ts
+++ b/src/professions/admin/add-profession/interfaces/top-level-details.ts
@@ -1,6 +1,6 @@
 export interface TopLevelDetailsTemplate {
-  professionId: string;
-  industriesCheckboxArgs: { text: string; value: string }[];
-  nationsCheckboxArgs: { text: string; value: string }[];
+  name: string | null;
+  industriesCheckboxArgs: { text: string; value: string; checked?: boolean }[];
+  nationsCheckboxArgs: { text: string; value: string: checked?: boolean }[];
   errors: object | undefined;
 }

--- a/src/professions/admin/add-profession/interfaces/top-level-details.ts
+++ b/src/professions/admin/add-profession/interfaces/top-level-details.ts
@@ -1,0 +1,6 @@
+export interface TopLevelDetailsTemplate {
+  professionId: string;
+  industriesCheckboxArgs: { text: string; value: string }[];
+  nationsCheckboxArgs: { text: string; value: string }[];
+  errors: object | undefined;
+}

--- a/src/professions/admin/add-profession/top-level-information.controller.spec.ts
+++ b/src/professions/admin/add-profession/top-level-information.controller.spec.ts
@@ -26,6 +26,8 @@ describe('TopLevelInformationController', () => {
   beforeEach(async () => {
     profession = createMock<Profession>({
       id: 'profession-id',
+      industries: null,
+      occupationLocations: null,
     });
 
     industriesService = createMock<IndustriesService>();
@@ -50,42 +52,119 @@ describe('TopLevelInformationController', () => {
   });
 
   describe('edit', () => {
-    it('should fetch all Industries and Nations to be displayed in an option select', async () => {
-      const templateArgs = await controller.edit('profession-id');
+    describe('when editing a just-created, blank Profession', () => {
+      const blankProfession = new Profession();
+      blankProfession.id = 'profession-id';
 
-      expect(templateArgs).toEqual({
-        professionId: 'profession-id',
-        industriesCheckboxArgs: [
-          {
-            text: 'industries.health',
-            value: 'health-uuid',
-          },
-          {
-            text: 'industries.constructionAndEngineering',
-            value: 'construction-uuid',
-          },
-        ],
-        nationsCheckboxArgs: [
-          {
-            text: 'nations.england',
-            value: 'GB-ENG',
-          },
-          {
-            text: 'nations.scotland',
-            value: 'GB-SCT',
-          },
-          {
-            text: 'nations.wales',
-            value: 'GB-WLS',
-          },
-          {
-            text: 'nations.northernIreland',
-            value: 'GB-NIR',
-          },
-        ],
-        errors: undefined,
+      it('should fetch all Industries and Nations to be displayed in an option select, with none of them checked', async () => {
+        professionsService.find.mockImplementation(async () => blankProfession);
+
+        const templateArgs = await controller.edit('profession-id');
+
+        expect(templateArgs).toEqual({
+          name: null,
+          industriesCheckboxArgs: [
+            {
+              text: 'industries.health',
+              value: 'health-uuid',
+              checked: false,
+            },
+            {
+              text: 'industries.constructionAndEngineering',
+              value: 'construction-uuid',
+              checked: false,
+            },
+          ],
+          nationsCheckboxArgs: [
+            {
+              text: 'nations.england',
+              value: 'GB-ENG',
+              checked: false,
+            },
+            {
+              text: 'nations.scotland',
+              value: 'GB-SCT',
+              checked: false,
+            },
+            {
+              text: 'nations.wales',
+              value: 'GB-WLS',
+              checked: false,
+            },
+            {
+              text: 'nations.northernIreland',
+              value: 'GB-NIR',
+              checked: false,
+            },
+          ],
+          errors: undefined,
+        });
+        expect(industriesService.all).toHaveBeenCalled();
       });
-      expect(industriesService.all).toHaveBeenCalled();
+    });
+
+    describe('when an existing Profession is found', () => {
+      const selectedIndustry = new Industry('industries.health');
+      selectedIndustry.id = 'health-uuid';
+
+      const existingProfession = new Profession(
+        'Example Profession',
+        null,
+        null,
+        null,
+        ['GB-ENG', 'GB-SCT'],
+        null,
+        [selectedIndustry],
+      );
+      existingProfession.id = 'profession-id';
+
+      it('should pre-fill the Profession name and pre-select checkboxes for selected Nations and Industries', async () => {
+        professionsService.find.mockImplementation(
+          async () => existingProfession,
+        );
+
+        const templateArgs = await controller.edit('profession-id');
+
+        expect(templateArgs).toEqual({
+          name: 'Example Profession',
+          industriesCheckboxArgs: [
+            {
+              text: 'industries.health',
+              value: 'health-uuid',
+              checked: true,
+            },
+            {
+              text: 'industries.constructionAndEngineering',
+              value: 'construction-uuid',
+              checked: false,
+            },
+          ],
+          nationsCheckboxArgs: [
+            {
+              text: 'nations.england',
+              value: 'GB-ENG',
+              checked: true,
+            },
+            {
+              text: 'nations.scotland',
+              value: 'GB-SCT',
+              checked: true,
+            },
+            {
+              text: 'nations.wales',
+              value: 'GB-WLS',
+              checked: false,
+            },
+            {
+              text: 'nations.northernIreland',
+              value: 'GB-NIR',
+              checked: false,
+            },
+          ],
+          errors: undefined,
+        });
+        expect(industriesService.all).toHaveBeenCalled();
+      });
     });
   });
 

--- a/src/professions/admin/add-profession/top-level-information.controller.ts
+++ b/src/professions/admin/add-profession/top-level-information.controller.ts
@@ -24,26 +24,42 @@ export class TopLevelInformationController {
     private readonly industriesService: IndustriesService,
   ) {}
 
-  @Get(`/:id/top-level-information/edit`)
+  @Get('/:id/top-level-information/edit')
   @Render('professions/admin/add-profession/top-level-information')
   async edit(
     @Param('id') id: string,
     errors: object | undefined = undefined,
   ): Promise<TopLevelDetailsTemplate> {
+    const profession = await this.professionsService.find(id);
+
     const industries = await this.industriesService.all();
 
-    const industriesCheckboxArgs = industries.map((industry) => ({
-      text: industry.name,
-      value: industry.id,
-    }));
+    const industriesCheckboxArgs = industries.map((industry) => {
+      const hasSelectedIndustry = !!(profession.industries || []).find(
+        (selectedIndustry) => industry.id === selectedIndustry.id,
+      );
 
-    const nationsCheckboxArgs = Nation.all().map((nation) => ({
-      text: nation.name,
-      value: nation.code,
-    }));
+      return {
+        text: industry.name,
+        value: industry.id,
+        checked: hasSelectedIndustry,
+      };
+    });
+
+    const nationsCheckboxArgs = Nation.all().map((nation) => {
+      const hasSelectedNation = (profession.occupationLocations || []).includes(
+        nation.code,
+      );
+
+      return {
+        text: nation.name,
+        value: nation.code,
+        checked: hasSelectedNation,
+      };
+    });
 
     return {
-      professionId: id,
+      name: profession.name,
       industriesCheckboxArgs,
       nationsCheckboxArgs,
       errors,

--- a/src/professions/admin/add-profession/top-level-information.controller.ts
+++ b/src/professions/admin/add-profession/top-level-information.controller.ts
@@ -15,7 +15,7 @@ import { ValidationFailedError } from '../../../validation/validation-failed.err
 import { Profession } from '../../profession.entity';
 import { ProfessionsService } from '../../professions.service';
 import { TopLevelDetailsDto } from './dto/top-level-details.dto';
-import { TopLevelDetailsTemplate } from './interfaces/top-level-details';
+import { TopLevelDetailsTemplate } from './interfaces/top-level-details.template';
 
 @Controller('admin/professions')
 export class TopLevelInformationController {

--- a/src/professions/admin/add-profession/top-level-information.controller.ts
+++ b/src/professions/admin/add-profession/top-level-information.controller.ts
@@ -4,11 +4,16 @@ import { Validator } from '../../../helpers/validator';
 import { IndustriesService } from '../../../industries/industries.service';
 import { Nation } from '../../../nations/nation';
 import { ValidationFailedError } from '../../../validation/validation-failed.error';
+import { Profession } from '../../profession.entity';
+import { ProfessionsService } from '../../professions.service';
 import { TopLevelDetailsDto } from './dto/top-level-details.dto';
 
 @Controller('admin/professions/new/top-level-information')
 export class TopLevelInformationController {
-  constructor(private industriesService: IndustriesService) {}
+  constructor(
+    private readonly professionsService: ProfessionsService,
+    private readonly industriesService: IndustriesService,
+  ) {}
 
   @Get()
   async new(
@@ -51,11 +56,25 @@ export class TopLevelInformationController {
       return;
     }
 
-    if (session['add-profession'] === undefined) {
-      session['add-profession'] = {};
-    }
+    const topLevelDetails: TopLevelDetailsDto = topLevelDetailsDto;
 
-    session['add-profession']['top-level-details'] = topLevelDetailsDto;
+    const industries = await this.industriesService.findByIds(
+      topLevelDetails.industries,
+    );
+
+    const draftProfession: Profession = await this.professionsService.confirm(
+      new Profession(
+        topLevelDetails.name,
+        null,
+        null,
+        null,
+        topLevelDetails.nations,
+        null,
+        industries,
+      ),
+    );
+
+    session['draft-profession-id'] = draftProfession.id;
 
     res.redirect('/admin/professions/new/check-your-answers');
   }

--- a/src/professions/profession.entity.ts
+++ b/src/professions/profession.entity.ts
@@ -55,6 +55,9 @@ export class Profession {
   @JoinTable()
   legislations: Legislation[];
 
+  @Column({ default: false })
+  confirmed: boolean;
+
   @CreateDateColumn({
     type: 'timestamp',
     default: () => 'CURRENT_TIMESTAMP(6)',
@@ -79,6 +82,7 @@ export class Profession {
     qualification?: Qualification,
     reservedActivities?: string[],
     legislations?: Legislation[],
+    confirmed?: boolean,
   ) {
     this.name = name || null;
     this.alternateName = alternateName || null;
@@ -90,5 +94,6 @@ export class Profession {
     this.qualification = qualification || null;
     this.reservedActivities = reservedActivities || null;
     this.legislations = legislations || null;
+    this.confirmed = confirmed || false;
   }
 }

--- a/src/professions/profession.entity.ts
+++ b/src/professions/profession.entity.ts
@@ -18,23 +18,23 @@ export class Profession {
   @PrimaryGeneratedColumn('uuid')
   id: string;
 
-  @Column()
+  @Column({ nullable: true })
   name: string;
 
-  @Column()
+  @Column({ nullable: true })
   alternateName: string;
 
-  @Index()
-  @Column({ unique: true })
+  @Index({ unique: true, where: '"slug" IS NOT NULL' })
+  @Column({ nullable: true })
   slug: string;
 
-  @Column()
+  @Column({ nullable: true })
   description: string;
 
   @Column('text', { array: true, nullable: true })
   occupationLocations: string[];
 
-  @Column()
+  @Column({ nullable: true })
   regulationType: string;
 
   @ManyToMany(() => Industry, { nullable: true, eager: true })
@@ -46,7 +46,7 @@ export class Profession {
   })
   qualification: Qualification;
 
-  @Column('text', { array: true })
+  @Column('text', { array: true, nullable: true })
   reservedActivities: string[];
 
   @ManyToMany(() => Legislation, {
@@ -80,15 +80,15 @@ export class Profession {
     reservedActivities?: string[],
     legislations?: Legislation[],
   ) {
-    this.name = name || '';
-    this.alternateName = alternateName || '';
-    this.slug = slug || '';
-    this.description = description || '';
-    this.occupationLocations = occupationLocations || [];
-    this.regulationType = regulationType || '';
+    this.name = name || null;
+    this.alternateName = alternateName || null;
+    this.slug = slug || null;
+    this.description = description || null;
+    this.occupationLocations = occupationLocations || null;
+    this.regulationType = regulationType || null;
     this.industries = industries || null;
     this.qualification = qualification || null;
-    this.reservedActivities = reservedActivities || [];
+    this.reservedActivities = reservedActivities || null;
     this.legislations = legislations || null;
   }
 }

--- a/src/professions/professions.controller.spec.ts
+++ b/src/professions/professions.controller.spec.ts
@@ -1,6 +1,7 @@
 import { createMock, DeepMocked } from '@golevelup/ts-jest';
 import { NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
+import { Response } from 'express';
 import { I18nService } from 'nestjs-i18n';
 import { Industry } from '../industries/industry.entity';
 import { Profession } from './profession.entity';
@@ -18,6 +19,7 @@ const exampleProfession = new Profession(
   '',
   [industry],
 );
+exampleProfession.id = 'profession-id';
 
 describe('ProfessionsController', () => {
   let controller: ProfessionsController;
@@ -25,7 +27,11 @@ describe('ProfessionsController', () => {
   let i18nService: DeepMocked<I18nService>;
 
   beforeEach(async () => {
-    professionsService = createMock<ProfessionsService>();
+    professionsService = createMock<ProfessionsService>({
+      save: async () => {
+        return exampleProfession;
+      },
+    });
     i18nService = createMock<I18nService>();
 
     const module: TestingModule = await Test.createTestingModule({
@@ -49,6 +55,19 @@ describe('ProfessionsController', () => {
   describe('new', () => {
     it('should return an empty object', () => {
       expect(controller.new()).toEqual({});
+    });
+  });
+
+  describe('create', () => {
+    it('should create a Profession and redirect', async () => {
+      const res = createMock<Response>();
+
+      await controller.create(res);
+
+      expect(professionsService.save).toHaveBeenCalled();
+      expect(res.redirect).toHaveBeenCalledWith(
+        `/admin/professions/${exampleProfession.id}/top-level-information/edit`,
+      );
     });
   });
 

--- a/src/professions/professions.controller.ts
+++ b/src/professions/professions.controller.ts
@@ -3,11 +3,15 @@ import {
   Get,
   NotFoundException,
   Param,
+  Post,
   Render,
+  Res,
 } from '@nestjs/common';
+import { Response } from 'express';
 import { I18nService } from 'nestjs-i18n';
 import { Nation } from '../nations/nation';
 import { ShowTemplate } from './interfaces/show-template.interface';
+import { Profession } from './profession.entity';
 import { ProfessionsService } from './professions.service';
 
 @Controller()
@@ -23,7 +27,16 @@ export class ProfessionsController {
     return {};
   }
 
-  @Get('professions/:slug')
+  @Post('admin/professions')
+  async create(@Res() res: Response): Promise<void> {
+    const profession = await this.professionsService.save(new Profession());
+
+    res.redirect(
+      `/admin/professions/${profession.id}/top-level-information/edit`,
+    );
+  }
+
+  @Get('/professions/:slug')
   @Render('professions/show')
   async show(@Param('slug') slug: string): Promise<ShowTemplate> {
     const profession = await this.professionsService.findBySlug(slug);

--- a/src/professions/professions.service.spec.ts
+++ b/src/professions/professions.service.spec.ts
@@ -85,9 +85,9 @@ describe('Profession', () => {
   describe('all', () => {
     it('should return all Professions', async () => {
       const repoSpy = jest.spyOn(repo, 'find');
-      const posts = await service.all();
+      const professions = await service.all();
 
-      expect(posts).toEqual(professionArray);
+      expect(professions).toEqual(professionArray);
       expect(repoSpy).toHaveBeenCalled();
     });
   });
@@ -95,9 +95,9 @@ describe('Profession', () => {
   describe('find', () => {
     it('should return a Profession', async () => {
       const repoSpy = jest.spyOn(repo, 'findOne');
-      const post = await service.find('some-uuid');
+      const profession = await service.find('some-uuid');
 
-      expect(post).toEqual(profession);
+      expect(profession).toEqual(profession);
       expect(repoSpy).toHaveBeenCalledWith('some-uuid');
     });
   });
@@ -105,9 +105,9 @@ describe('Profession', () => {
   describe('findBySlug', () => {
     it('should return a profession', async () => {
       const repoSpy = jest.spyOn(repo, 'findOne');
-      const post = await service.findBySlug('some-slug');
+      const profession = await service.findBySlug('some-slug');
 
-      expect(post).toEqual(profession);
+      expect(profession).toEqual(profession);
       expect(repoSpy).toHaveBeenCalledWith({ where: { slug: 'some-slug' } });
     });
   });

--- a/src/professions/professions.service.spec.ts
+++ b/src/professions/professions.service.spec.ts
@@ -112,6 +112,17 @@ describe('Profession', () => {
     });
   });
 
+  describe('save', () => {
+    it('should save a Profession', async () => {
+      const profession = new Profession('Example Profession');
+      const repoSpy = jest.spyOn(repo, 'save');
+
+      await service.save(profession);
+
+      expect(repoSpy).toHaveBeenCalledWith(profession);
+    });
+  });
+
   describe('create', () => {
     it('should save the profession with the "base" slug when there are no colliding slugs', async () => {
       const profession = new Profession('Example Profession');

--- a/src/professions/professions.service.spec.ts
+++ b/src/professions/professions.service.spec.ts
@@ -151,8 +151,9 @@ describe('Profession', () => {
             null,
             null,
             true,
-          ),
-            expect(result.slug).toEqual('example-profession');
+          );
+
+          expect(result.slug).toEqual('example-profession');
         });
       });
 

--- a/src/professions/professions.service.spec.ts
+++ b/src/professions/professions.service.spec.ts
@@ -124,87 +124,95 @@ describe('Profession', () => {
   });
 
   describe('confirm', () => {
-    it('should save the profession with the "base" slug when there are no colliding slugs', async () => {
-      const profession = new Profession('Example Profession');
+    describe('setting the slug on a Profession', () => {
+      describe('when there are no colliding slugs', () => {
+        it('should save the Profession with the "base" slug', async () => {
+          const profession = new Profession('Example Profession');
 
-      manager.findOne.mockReturnValue(null);
+          manager.findOne.mockReturnValue(null);
 
-      const result = await service.confirm(profession);
+          const result = await service.confirm(profession);
 
-      expect(manager.findOne).toBeCalledTimes(1);
+          expect(manager.findOne).toBeCalledTimes(1);
 
-      expect(manager.findOne).toBeCalledWith(Profession, {
-        where: { slug: 'example-profession' },
+          expect(manager.findOne).toBeCalledWith(Profession, {
+            where: { slug: 'example-profession' },
+          });
+
+          expect(manager.save).toHaveBeenCalledWith(
+            new Profession('Example Profession', '', 'example-profession'),
+          );
+          expect(result.slug).toEqual('example-profession');
+        });
       });
 
-      expect(manager.save).toHaveBeenCalledWith(
-        new Profession('Example Profession', '', 'example-profession'),
-      );
-      expect(result.slug).toEqual('example-profession');
-    });
+      describe('when there is a single colliding slug', () => {
+        it('should save the Profession with a slug appended with "-1"', async () => {
+          const profession = new Profession('Example Profession');
 
-    it('should save the profession with a slug appended with "-1" when there is a colliding slug', async () => {
-      const profession = new Profession('Example Profession');
+          manager.findOne
+            .mockImplementationOnce(async () => {
+              return new Profession();
+            })
+            .mockReturnValue(null);
 
-      manager.findOne
-        .mockImplementationOnce(async () => {
-          return new Profession();
-        })
-        .mockReturnValue(null);
+          const result = await service.confirm(profession);
 
-      const result = await service.confirm(profession);
+          expect(manager.findOne).toBeCalledTimes(2);
 
-      expect(manager.findOne).toBeCalledTimes(2);
+          expect(manager.findOne).toBeCalledWith(Profession, {
+            where: { slug: 'example-profession' },
+          });
+          expect(manager.findOne).toBeCalledWith(Profession, {
+            where: { slug: 'example-profession-1' },
+          });
 
-      expect(manager.findOne).toBeCalledWith(Profession, {
-        where: { slug: 'example-profession' },
-      });
-      expect(manager.findOne).toBeCalledWith(Profession, {
-        where: { slug: 'example-profession-1' },
-      });
-
-      expect(manager.save).toHaveBeenCalledWith(
-        new Profession('Example Profession', '', 'example-profession-1'),
-      );
-      expect(result.slug).toEqual('example-profession-1');
-    });
-
-    it('should save the profession with a slug appended with a unique postfix where there are multiple colliding slugs', async () => {
-      const profession = new Profession('Example Profession');
-
-      manager.findOne
-        .mockImplementationOnce(async () => {
-          return new Profession();
-        })
-        .mockImplementationOnce(async () => {
-          return new Profession();
-        })
-        .mockImplementationOnce(async () => {
-          return new Profession();
-        })
-        .mockReturnValue(null);
-
-      const result = await service.confirm(profession);
-
-      expect(manager.findOne).toBeCalledTimes(4);
-
-      expect(manager.findOne).toBeCalledWith(Profession, {
-        where: { slug: 'example-profession' },
-      });
-      expect(manager.findOne).toBeCalledWith(Profession, {
-        where: { slug: 'example-profession-1' },
-      });
-      expect(manager.findOne).toBeCalledWith(Profession, {
-        where: { slug: 'example-profession-2' },
-      });
-      expect(manager.findOne).toBeCalledWith(Profession, {
-        where: { slug: 'example-profession-3' },
+          expect(manager.save).toHaveBeenCalledWith(
+            new Profession('Example Profession', '', 'example-profession-1'),
+          );
+          expect(result.slug).toEqual('example-profession-1');
+        });
       });
 
-      expect(manager.save).toHaveBeenCalledWith(
-        new Profession('Example Profession', '', 'example-profession-3'),
-      );
-      expect(result.slug).toEqual('example-profession-3');
+      describe('when there are multiple colliding slugs', () => {
+        it('should save the Profession with a slug appended with a unique postfix', async () => {
+          const profession = new Profession('Example Profession');
+
+          manager.findOne
+            .mockImplementationOnce(async () => {
+              return new Profession();
+            })
+            .mockImplementationOnce(async () => {
+              return new Profession();
+            })
+            .mockImplementationOnce(async () => {
+              return new Profession();
+            })
+            .mockReturnValue(null);
+
+          const result = await service.confirm(profession);
+
+          expect(manager.findOne).toBeCalledTimes(4);
+
+          expect(manager.findOne).toBeCalledWith(Profession, {
+            where: { slug: 'example-profession' },
+          });
+          expect(manager.findOne).toBeCalledWith(Profession, {
+            where: { slug: 'example-profession-1' },
+          });
+          expect(manager.findOne).toBeCalledWith(Profession, {
+            where: { slug: 'example-profession-2' },
+          });
+          expect(manager.findOne).toBeCalledWith(Profession, {
+            where: { slug: 'example-profession-3' },
+          });
+
+          expect(manager.save).toHaveBeenCalledWith(
+            new Profession('Example Profession', '', 'example-profession-3'),
+          );
+          expect(result.slug).toEqual('example-profession-3');
+        });
+      });
     });
   });
 });

--- a/src/professions/professions.service.spec.ts
+++ b/src/professions/professions.service.spec.ts
@@ -123,13 +123,13 @@ describe('Profession', () => {
     });
   });
 
-  describe('create', () => {
+  describe('confirm', () => {
     it('should save the profession with the "base" slug when there are no colliding slugs', async () => {
       const profession = new Profession('Example Profession');
 
       manager.findOne.mockReturnValue(null);
 
-      const result = await service.create(profession);
+      const result = await service.confirm(profession);
 
       expect(manager.findOne).toBeCalledTimes(1);
 
@@ -152,7 +152,7 @@ describe('Profession', () => {
         })
         .mockReturnValue(null);
 
-      const result = await service.create(profession);
+      const result = await service.confirm(profession);
 
       expect(manager.findOne).toBeCalledTimes(2);
 
@@ -184,7 +184,7 @@ describe('Profession', () => {
         })
         .mockReturnValue(null);
 
-      const result = await service.create(profession);
+      const result = await service.confirm(profession);
 
       expect(manager.findOne).toBeCalledTimes(4);
 

--- a/src/professions/professions.service.spec.ts
+++ b/src/professions/professions.service.spec.ts
@@ -139,10 +139,20 @@ describe('Profession', () => {
             where: { slug: 'example-profession' },
           });
 
-          expect(manager.save).toHaveBeenCalledWith(
-            new Profession('Example Profession', '', 'example-profession'),
-          );
-          expect(result.slug).toEqual('example-profession');
+          new Profession(
+            'Example Profession',
+            '',
+            'example-profession',
+            '',
+            null,
+            '',
+            null,
+            null,
+            null,
+            null,
+            true,
+          ),
+            expect(result.slug).toEqual('example-profession');
         });
       });
 
@@ -168,7 +178,19 @@ describe('Profession', () => {
           });
 
           expect(manager.save).toHaveBeenCalledWith(
-            new Profession('Example Profession', '', 'example-profession-1'),
+            new Profession(
+              'Example Profession',
+              '',
+              'example-profession-1',
+              '',
+              null,
+              '',
+              null,
+              null,
+              null,
+              null,
+              true,
+            ),
           );
           expect(result.slug).toEqual('example-profession-1');
         });
@@ -208,9 +230,69 @@ describe('Profession', () => {
           });
 
           expect(manager.save).toHaveBeenCalledWith(
-            new Profession('Example Profession', '', 'example-profession-3'),
+            new Profession(
+              'Example Profession',
+              '',
+              'example-profession-3',
+              '',
+              null,
+              '',
+              null,
+              null,
+              null,
+              null,
+              true,
+            ),
           );
           expect(result.slug).toEqual('example-profession-3');
+        });
+      });
+    });
+
+    describe('marking the Profession as "Confirmed"', () => {
+      describe('when the Profession has not yet been confirmed', () => {
+        it('confirms the Profession', async () => {
+          const profession = new Profession('Example Profession');
+
+          manager.findOne
+            .mockImplementationOnce(async () => {
+              return profession;
+            })
+            .mockResolvedValue(null);
+
+          const result = await service.confirm(profession);
+
+          expect(result.confirmed).toEqual(true);
+        });
+
+        describe('when the Profession has already been confirmed', () => {
+          it('throws an error', async () => {
+            const existingProfession = new Profession(
+              'Example Profession',
+              '',
+              'example-profession-3',
+              '',
+              null,
+              '',
+              null,
+              null,
+              null,
+              null,
+              true,
+            );
+
+            manager.findOne
+              .mockImplementationOnce(async () => {
+                return existingProfession;
+              })
+              .mockResolvedValue(null);
+
+            await expect(async () =>
+              service.confirm(existingProfession),
+            ).rejects.toThrowError('Profession has already been confirmed');
+
+            expect(manager.save).not.toHaveBeenCalled();
+          });
         });
       });
     });

--- a/src/professions/professions.service.ts
+++ b/src/professions/professions.service.ts
@@ -25,6 +25,10 @@ export class ProfessionsService {
     return this.repository.findOne({ where: { slug } });
   }
 
+  async save(user: Profession): Promise<Profession> {
+    return this.repository.save(user);
+  }
+
   async create(profession: Profession): Promise<Profession> {
     const queryRunner = this.connection.createQueryRunner();
 

--- a/src/professions/professions.service.ts
+++ b/src/professions/professions.service.ts
@@ -41,6 +41,9 @@ export class ProfessionsService {
       let retryCount = 0;
 
       while (true) {
+        if (profession.confirmed) {
+          throw new Error('Profession has already been confirmed');
+        }
         const slug = generateSlug(profession.name, retryCount);
         const result = await queryRunner.manager.findOne<Profession>(
           Profession,
@@ -53,6 +56,7 @@ export class ProfessionsService {
           retryCount++;
         } else {
           profession.slug = slug;
+          profession.confirmed = true;
           await queryRunner.manager.save(profession);
           await queryRunner.commitTransaction();
           break;

--- a/src/professions/professions.service.ts
+++ b/src/professions/professions.service.ts
@@ -29,7 +29,7 @@ export class ProfessionsService {
     return this.repository.save(user);
   }
 
-  async create(profession: Profession): Promise<Profession> {
+  async confirm(profession: Profession): Promise<Profession> {
     const queryRunner = this.connection.createQueryRunner();
 
     await queryRunner.connect();

--- a/views/professions/admin/add-profession/confirmation.njk
+++ b/views/professions/admin/add-profession/confirmation.njk
@@ -21,7 +21,8 @@
           <h2 class="govuk-heading-m">{{ ("professions.form.body.confirmation.next" | t) }}</h2>
 
           <p class="govuk-body">
-            <a href="/admin">{{ ("app.backToDashboard" | t) }}</p>
+            <a href="/admin">{{ ("app.backToDashboard" | t) }}</a>
+          </p>
 
         </div>
       </div>

--- a/views/professions/admin/add-profession/new.njk
+++ b/views/professions/admin/add-profession/new.njk
@@ -16,7 +16,7 @@
 
           <p class="govuk-body">{{ ('professions.form.description' | t) }}</p>
 
-          <form method="get" action="/admin/professions/new/top-level-information">
+          <form method="post" action="/admin/professions">
             {{
               govukButton({
                 id: "submit-button",

--- a/views/professions/admin/add-profession/top-level-information.njk
+++ b/views/professions/admin/add-profession/top-level-information.njk
@@ -18,7 +18,7 @@
 
           <h1 class="govuk-heading-l">{{ ("professions.form.headings.topLevelInformation" | t) }}</h1>
 
-          <form method="post" action="/admin/professions/new/top-level-information">
+          <form method="post" action="./">
             {{
               govukInput({
                 label: {

--- a/views/professions/admin/add-profession/top-level-information.njk
+++ b/views/professions/admin/add-profession/top-level-information.njk
@@ -27,7 +27,8 @@
                   isPageHeading: false
                 },
                 id: "name",
-                name: "name"
+                name: "name",
+                value: name
               })
             }}
 


### PR DESCRIPTION
We now create a blank profession at the start of the journey, fetch it on each page via the ID in the URL params (which we're happy with using, rather than a slug, as this is internal-facing behaviour), and update it.

This will make it much easier for us to:
- Build functionality for us to edit Professions in the future
- Add changelinks

It also paves the way with a pattern for adding the remaining screens to the Add a profession journey.

Still to come, in future PRs:
- Change links on the "Check your answers" page
- Functional back buttons
- Additional pages
- Put this all behind authentication guards

Apologies for the size of one of the commits here, I hope it's not too painful to review.