### PR TITLE
(1959) Professions filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,4 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+
+- A professions search page that allows for filtering professions by keywords, nations, and industries
+
+### Changed
+
 - Create draft Professions in the database, rather than using session storage when adding a new profession

--- a/cypress/integration/professions/search/search.spec.ts
+++ b/cypress/integration/professions/search/search.spec.ts
@@ -32,11 +32,11 @@ describe('Searching a profession', () => {
   it('I can filter by nation', () => {
     cy.visit('/professions/search');
 
-    cy.get('input[name="nations"][value="GB-WLS"]').check();
+    cy.get('input[name="nations[]"][value="GB-WLS"]').check();
 
     cy.get('button').click();
 
-    cy.get('input[name="nations"][value="GB-WLS"]').should('be.checked');
+    cy.get('input[name="nations[]"][value="GB-WLS"]').should('be.checked');
 
     cy.get('body').should('contain', 'Registered Trademark Attorney');
     cy.get('body').should(

--- a/cypress/integration/professions/search/search.spec.ts
+++ b/cypress/integration/professions/search/search.spec.ts
@@ -29,23 +29,59 @@ describe('Searching a profession', () => {
     );
   });
 
-  it('I can enter search filters', () => {
+  it('I can filter by nation', () => {
+    cy.visit('/professions/search');
+
+    cy.get('input[name="nations"][value="GB-WLS"]').check();
+
+    cy.get('button').click();
+
+    cy.get('input[name="nations"][value="GB-WLS"]').should('be.checked');
+
+    cy.get('body').should('contain', 'Registered Trademark Attorney');
+    cy.get('body').should(
+      'not.contain',
+      'Secondary School Teacher in State maintained schools (England)',
+    );
+  });
+
+  it('I can filter by industry', () => {
+    cy.visit('/professions/search');
+
+    cy.translate('industries.education').then((nameLabel) => {
+      cy.get('label').contains(nameLabel).parent().find('input').check();
+    });
+
+    cy.get('button').click();
+
+    cy.translate('industries.education').then((nameLabel) => {
+      cy.get('label')
+        .contains(nameLabel)
+        .parent()
+        .find('input')
+        .should('be.checked');
+    });
+
+    cy.get('body').should(
+      'contain',
+      'Secondary School Teacher in State maintained schools (England)',
+    );
+    cy.get('body').should('not.contain', 'Registered Trademark Attorney');
+  });
+
+  it('I can filter by keyword', () => {
     cy.visit('/professions/search');
 
     cy.get('input[name="keywords"]').type('Attorney');
-    cy.get('input[name="nations"][value="GB-ENG"]').check();
-    cy.get('input[name="nations"][value="GB-NIR"]').check();
-
-    cy.get('input[name="industries"]').eq(0).check();
-    cy.get('input[name="industries"]').eq(2).check();
 
     cy.get('button').click();
 
     cy.get('input[name="keywords"]').should('have.value', 'Attorney');
-    cy.get('input[name="nations"][value="GB-ENG"]').should('be.checked');
-    cy.get('input[name="nations"][value="GB-NIR"]').should('be.checked');
 
-    cy.get('input[name="industries"]').eq(0).should('be.checked');
-    cy.get('input[name="industries"]').eq(2).should('be.checked');
+    cy.get('body').should('contain', 'Registered Trademark Attorney');
+    cy.get('body').should(
+      'not.contain',
+      'Secondary School Teacher in State maintained schools (England)',
+    );
   });
 });

--- a/cypress/integration/professions/search/search.spec.ts
+++ b/cypress/integration/professions/search/search.spec.ts
@@ -9,6 +9,12 @@ describe('Searching a profession', () => {
     );
   });
 
+  it('The search page does not show draft professions', () => {
+    cy.visit('/professions/search');
+
+    cy.get('body').should('not.contain', 'Draft Profession');
+  });
+
   it('I can click a profession to be taken to its details page', () => {
     cy.visit('/professions/search');
 

--- a/seeds/professions.json
+++ b/seeds/professions.json
@@ -14,7 +14,8 @@
       "Reserved instrument activities.",
       "The administration of oaths."
     ],
-    "legislations": ["The Trade Marks Act 1994", "Legal Services Act 2007"]
+    "legislations": ["The Trade Marks Act 1994", "Legal Services Act 2007"],
+    "confirmed": true
   },
   {
     "name": "Secondary School Teacher in State maintained schools (England)",
@@ -29,6 +30,11 @@
     "legislations": [
       "The Education (School Teachers' Qualifications) (England) Regulations 2003/1662 (as amended)",
       "The Education (Induction Arrangements for School Teachers) (England) Regulations 2012/1115 (as amended)"
-    ]
+    ],
+    "confirmed": true
+  },
+  {
+    "name": "Draft Profession",
+    "confirmed": false
   }
 ]

--- a/src/common/interfaces/checkbox-args.interface.ts
+++ b/src/common/interfaces/checkbox-args.interface.ts
@@ -1,5 +1,5 @@
 export interface CheckboxArgs {
-  value: string;
   text: string;
+  value: string;
   checked: boolean;
 }

--- a/src/config/nunjucks.config.ts
+++ b/src/config/nunjucks.config.ts
@@ -42,29 +42,5 @@ export const nunjucksConfig = async (
     true,
   );
 
-  env.addFilter(
-    'tOptionSelect',
-    async (...args) => {
-      const callback = args.pop();
-      const optionSelectArgs = args[0];
-      const personalisation = args.length < 2 ? {} : args[1];
-      const result = await Promise.all(
-        optionSelectArgs.map(async (arg: { text: string; value: string }) => {
-          try {
-            return {
-              ...arg,
-              text: await i18nHelper.translate(arg['text'], personalisation),
-              value: arg['value'],
-            };
-          } catch (error) {
-            callback(error);
-          }
-        }),
-      );
-      callback(null, result);
-    },
-    true,
-  );
-
   return env;
 };

--- a/src/i18n/en/app.json
+++ b/src/i18n/en/app.json
@@ -11,5 +11,6 @@
   },
   "backToDashboard": "Back to the dashboard",
   "yes": "Yes",
-  "no": "No"
+  "no": "No",
+  "unitedKingdom": "United Kingdom"
 }

--- a/src/i18n/en/search.json
+++ b/src/i18n/en/search.json
@@ -6,11 +6,11 @@
     "industries": "Industries:"
   },
   "profession": {
-    "regulatedAuthority": "Regulated authority",
-    "nations": "Nations",
-    "industry": "Industry / sector",
-    "qualificationLevel": "Qualification level"
+    "regulators": "Regulators",
+    "industry": "Industry / sector"
   },
+  "foundSingular": "profession found.",
+  "foundPlural": "professions found.",
   "form": {
     "nameFilter": {
       "label": "Profession that you are looking for",

--- a/src/industries/industries-checkbox.presenter.spec.ts
+++ b/src/industries/industries-checkbox.presenter.spec.ts
@@ -1,0 +1,68 @@
+import { IndustriesCheckboxPresenter } from './industries-checkbox.presenter';
+import { Industry } from './industry.entity';
+
+const exampleIndustry1 = new Industry('industries.example1');
+exampleIndustry1.id = 'example-industry-1';
+
+const exampleIndustry2 = new Industry('industries.example2');
+exampleIndustry2.id = 'example-industry-2';
+
+const exampleIndustry3 = new Industry('industries.example3');
+exampleIndustry3.id = 'example-industry-3';
+
+const exampleIndustries = [
+  exampleIndustry1,
+  exampleIndustry2,
+  exampleIndustry3,
+];
+
+describe('IndustriesCheckboxPresenter', () => {
+  describe('checkboxArgs', () => {
+    it('should return unchecked checkbox arguments when called with one argument', () => {
+      const presenter = new IndustriesCheckboxPresenter(exampleIndustries);
+
+      expect(presenter.checkboxArgs()).toEqual([
+        {
+          text: 'industries.example1',
+          value: 'example-industry-1',
+          checked: false,
+        },
+        {
+          text: 'industries.example2',
+          value: 'example-industry-2',
+          checked: false,
+        },
+        {
+          text: 'industries.example3',
+          value: 'example-industry-3',
+          checked: false,
+        },
+      ]);
+    });
+
+    it('should return some checked checkbox arguments when called with two arguments', () => {
+      const presenter = new IndustriesCheckboxPresenter(exampleIndustries, [
+        exampleIndustry1,
+        exampleIndustry3,
+      ]);
+
+      expect(presenter.checkboxArgs()).toEqual([
+        {
+          text: 'industries.example1',
+          value: 'example-industry-1',
+          checked: true,
+        },
+        {
+          text: 'industries.example2',
+          value: 'example-industry-2',
+          checked: false,
+        },
+        {
+          text: 'industries.example3',
+          value: 'example-industry-3',
+          checked: true,
+        },
+      ]);
+    });
+  });
+});

--- a/src/industries/industries-checkbox.presenter.spec.ts
+++ b/src/industries/industries-checkbox.presenter.spec.ts
@@ -1,3 +1,5 @@
+import { createMock, DeepMocked } from '@golevelup/ts-jest';
+import { I18nService } from 'nestjs-i18n';
 import { IndustriesCheckboxPresenter } from './industries-checkbox.presenter';
 import { Industry } from './industry.entity';
 
@@ -17,48 +19,72 @@ const exampleIndustries = [
 ];
 
 describe('IndustriesCheckboxPresenter', () => {
-  describe('checkboxArgs', () => {
-    it('should return unchecked checkbox arguments when called with one argument', () => {
-      const presenter = new IndustriesCheckboxPresenter(exampleIndustries);
+  let i18nService: DeepMocked<I18nService>;
 
-      expect(presenter.checkboxArgs()).toEqual([
+  beforeEach(async () => {
+    i18nService = createMock<I18nService>();
+
+    i18nService.translate.mockImplementation(async (text) => {
+      switch (text) {
+        case 'industries.example1':
+          return 'Example Industry 1';
+        case 'industries.example2':
+          return 'Example Industry 2';
+        case 'industries.example3':
+          return 'Example Industry 3';
+        default:
+          return '';
+      }
+    });
+  });
+
+  describe('checkboxArgs', () => {
+    it('should return unchecked checkbox arguments when called with an empty list of checked Indutries', () => {
+      const presenter = new IndustriesCheckboxPresenter(
+        exampleIndustries,
+        [],
+        i18nService,
+      );
+
+      expect(presenter.checkboxArgs()).resolves.toEqual([
         {
-          text: 'industries.example1',
+          text: 'Example Industry 1',
           value: 'example-industry-1',
           checked: false,
         },
         {
-          text: 'industries.example2',
+          text: 'Example Industry 2',
           value: 'example-industry-2',
           checked: false,
         },
         {
-          text: 'industries.example3',
+          text: 'Example Industry 3',
           value: 'example-industry-3',
           checked: false,
         },
       ]);
     });
 
-    it('should return some checked checkbox arguments when called with two arguments', () => {
-      const presenter = new IndustriesCheckboxPresenter(exampleIndustries, [
-        exampleIndustry1,
-        exampleIndustry3,
-      ]);
+    it('should return some checked checkbox arguments when called with a non-empty list of checked Industries', () => {
+      const presenter = new IndustriesCheckboxPresenter(
+        exampleIndustries,
+        [exampleIndustry1, exampleIndustry3],
+        i18nService,
+      );
 
-      expect(presenter.checkboxArgs()).toEqual([
+      expect(presenter.checkboxArgs()).resolves.toEqual([
         {
-          text: 'industries.example1',
+          text: 'Example Industry 1',
           value: 'example-industry-1',
           checked: true,
         },
         {
-          text: 'industries.example2',
+          text: 'Example Industry 2',
           value: 'example-industry-2',
           checked: false,
         },
         {
-          text: 'industries.example3',
+          text: 'Example Industry 3',
           value: 'example-industry-3',
           checked: true,
         },

--- a/src/industries/industries-checkbox.presenter.ts
+++ b/src/industries/industries-checkbox.presenter.ts
@@ -1,19 +1,23 @@
+import { I18nService } from 'nestjs-i18n';
 import { CheckboxArgs } from '../common/interfaces/checkbox-args.interface';
 import { Industry } from './industry.entity';
 
 export class IndustriesCheckboxPresenter {
   constructor(
     private readonly allIndustires: Industry[],
-    private readonly checkedIndustries: Industry[] = [],
+    private readonly checkedIndustries: Industry[],
+    private readonly i18nService: I18nService,
   ) {}
 
-  checkboxArgs(): CheckboxArgs[] {
-    return this.allIndustires.map((industry) => ({
-      text: industry.name,
-      value: industry.id,
-      checked: !!this.checkedIndustries.find(
-        (checkedIndustry) => checkedIndustry.id === industry.id,
-      ),
-    }));
+  async checkboxArgs(): Promise<CheckboxArgs[]> {
+    return Promise.all(
+      this.allIndustires.map(async (industry) => ({
+        text: await this.i18nService.translate(industry.name),
+        value: industry.id,
+        checked: !!this.checkedIndustries.find(
+          (checkedIndustry) => checkedIndustry.id === industry.id,
+        ),
+      })),
+    );
   }
 }

--- a/src/industries/industries-checkbox.presenter.ts
+++ b/src/industries/industries-checkbox.presenter.ts
@@ -1,0 +1,19 @@
+import { CheckboxArgs } from '../common/interfaces/checkbox-args.interface';
+import { Industry } from './industry.entity';
+
+export class IndustriesCheckboxPresenter {
+  constructor(
+    private readonly allIndustires: Industry[],
+    private readonly checkedIndustries: Industry[] = [],
+  ) {}
+
+  checkboxArgs(): CheckboxArgs[] {
+    return this.allIndustires.map((industry) => ({
+      text: industry.name,
+      value: industry.id,
+      checked: !!this.checkedIndustries.find(
+        (checkedIndustry) => checkedIndustry.id === industry.id,
+      ),
+    }));
+  }
+}

--- a/src/nations/nation.ts
+++ b/src/nations/nation.ts
@@ -14,10 +14,15 @@ export class Nation {
   }
 
   static all(): Nation[] {
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const nations: Nation[] = require('../config/nations.json');
+    const rawNations: {
+      name: string;
+      code: string;
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+    }[] = require('../config/nations.json');
 
-    return nations;
+    return rawNations.map(
+      (rawNation) => new Nation(rawNation.name, rawNation.code),
+    );
   }
 
   static find(code: string): Nation {

--- a/src/nations/nations-checkbox.presenter.spec.ts
+++ b/src/nations/nations-checkbox.presenter.spec.ts
@@ -1,60 +1,88 @@
+import { createMock, DeepMocked } from '@golevelup/ts-jest';
+import { I18nService } from 'nestjs-i18n';
 import { Nation } from './nation';
 import { NationsCheckboxPresenter } from './nations-checkbox.presenter';
 
 describe('NationsCheckboxPresenter', () => {
-  describe('checkboxArgs', () => {
-    it('should return unchecked checkbox arguments when called with one argument', () => {
-      const presenter = new NationsCheckboxPresenter(Nation.all());
+  let i18nService: DeepMocked<I18nService>;
 
-      expect(presenter.checkboxArgs()).toEqual([
+  beforeEach(async () => {
+    i18nService = createMock<I18nService>();
+
+    i18nService.translate.mockImplementation(async (text) => {
+      switch (text) {
+        case 'nations.england':
+          return 'England';
+        case 'nations.scotland':
+          return 'Scotland';
+        case 'nations.wales':
+          return 'Wales';
+        case 'nations.northernIreland':
+          return 'Northern Ireland';
+        default:
+          return '';
+      }
+    });
+  });
+
+  describe('checkboxArgs', () => {
+    it('should return unchecked checkbox arguments when called with an empty list of Nations', async () => {
+      const presenter = new NationsCheckboxPresenter(
+        Nation.all(),
+        [],
+        i18nService,
+      );
+
+      expect(presenter.checkboxArgs()).resolves.toEqual([
         {
-          text: 'nations.england',
+          text: 'England',
           value: 'GB-ENG',
           checked: false,
         },
         {
-          text: 'nations.scotland',
+          text: 'Scotland',
           value: 'GB-SCT',
           checked: false,
         },
         {
-          text: 'nations.wales',
+          text: 'Wales',
           value: 'GB-WLS',
           checked: false,
         },
         {
-          text: 'nations.northernIreland',
+          text: 'Northern Ireland',
           value: 'GB-NIR',
           checked: false,
         },
       ]);
     });
 
-    it('should return some checked checkbox arguments when called with two arguments', () => {
+    it('should return some checked checkbox arguments when called with a non-empty list of Nations', async () => {
       const nations = Nation.all();
-      const presenter = new NationsCheckboxPresenter(nations, [
-        nations[0],
-        nations[2],
-      ]);
+      const presenter = new NationsCheckboxPresenter(
+        nations,
+        [nations[0], nations[2]],
+        i18nService,
+      );
 
-      expect(presenter.checkboxArgs()).toEqual([
+      expect(presenter.checkboxArgs()).resolves.toEqual([
         {
-          text: 'nations.england',
+          text: 'England',
           value: 'GB-ENG',
           checked: true,
         },
         {
-          text: 'nations.scotland',
+          text: 'Scotland',
           value: 'GB-SCT',
           checked: false,
         },
         {
-          text: 'nations.wales',
+          text: 'Wales',
           value: 'GB-WLS',
           checked: true,
         },
         {
-          text: 'nations.northernIreland',
+          text: 'Northern Ireland',
           value: 'GB-NIR',
           checked: false,
         },

--- a/src/nations/nations-checkbox.presenter.spec.ts
+++ b/src/nations/nations-checkbox.presenter.spec.ts
@@ -1,0 +1,64 @@
+import { Nation } from './nation';
+import { NationsCheckboxPresenter } from './nations-checkbox.presenter';
+
+describe('NationsCheckboxPresenter', () => {
+  describe('checkboxArgs', () => {
+    it('should return unchecked checkbox arguments when called with one argument', () => {
+      const presenter = new NationsCheckboxPresenter(Nation.all());
+
+      expect(presenter.checkboxArgs()).toEqual([
+        {
+          text: 'nations.england',
+          value: 'GB-ENG',
+          checked: false,
+        },
+        {
+          text: 'nations.scotland',
+          value: 'GB-SCT',
+          checked: false,
+        },
+        {
+          text: 'nations.wales',
+          value: 'GB-WLS',
+          checked: false,
+        },
+        {
+          text: 'nations.northernIreland',
+          value: 'GB-NIR',
+          checked: false,
+        },
+      ]);
+    });
+
+    it('should return some checked checkbox arguments when called with two arguments', () => {
+      const nations = Nation.all();
+      const presenter = new NationsCheckboxPresenter(nations, [
+        nations[0],
+        nations[2],
+      ]);
+
+      expect(presenter.checkboxArgs()).toEqual([
+        {
+          text: 'nations.england',
+          value: 'GB-ENG',
+          checked: true,
+        },
+        {
+          text: 'nations.scotland',
+          value: 'GB-SCT',
+          checked: false,
+        },
+        {
+          text: 'nations.wales',
+          value: 'GB-WLS',
+          checked: true,
+        },
+        {
+          text: 'nations.northernIreland',
+          value: 'GB-NIR',
+          checked: false,
+        },
+      ]);
+    });
+  });
+});

--- a/src/nations/nations-checkbox.presenter.ts
+++ b/src/nations/nations-checkbox.presenter.ts
@@ -1,19 +1,23 @@
+import { I18nService } from 'nestjs-i18n';
 import { CheckboxArgs } from '../common/interfaces/checkbox-args.interface';
 import { Nation } from './nation';
 
 export class NationsCheckboxPresenter {
   constructor(
     private readonly allNations: Nation[],
-    private readonly checkedNations: Nation[] = [],
+    private readonly checkedNations: Nation[],
+    private readonly i18nService: I18nService,
   ) {}
 
-  checkboxArgs(): CheckboxArgs[] {
-    return this.allNations.map((nation) => ({
-      text: nation.name,
-      value: nation.code,
-      checked: !!this.checkedNations.find(
-        (checkedNation) => checkedNation.code === nation.code,
-      ),
-    }));
+  async checkboxArgs(): Promise<CheckboxArgs[]> {
+    return Promise.all(
+      this.allNations.map(async (nation) => ({
+        text: await nation.translatedName(this.i18nService),
+        value: nation.code,
+        checked: !!this.checkedNations.find(
+          (checkedNation) => checkedNation.code === nation.code,
+        ),
+      })),
+    );
   }
 }

--- a/src/nations/nations-checkbox.presenter.ts
+++ b/src/nations/nations-checkbox.presenter.ts
@@ -1,0 +1,19 @@
+import { CheckboxArgs } from '../common/interfaces/checkbox-args.interface';
+import { Nation } from './nation';
+
+export class NationsCheckboxPresenter {
+  constructor(
+    private readonly allNations: Nation[],
+    private readonly checkedNations: Nation[] = [],
+  ) {}
+
+  checkboxArgs(): CheckboxArgs[] {
+    return this.allNations.map((nation) => ({
+      text: nation.name,
+      value: nation.code,
+      checked: !!this.checkedNations.find(
+        (checkedNation) => checkedNation.code === nation.code,
+      ),
+    }));
+  }
+}

--- a/src/professions/admin/add-profession/interfaces/top-level-details.template.ts
+++ b/src/professions/admin/add-profession/interfaces/top-level-details.template.ts
@@ -1,4 +1,4 @@
-import { CheckboxArgs } from './checkboxArgs';
+import { CheckboxArgs } from '../../../../common/interfaces/checkbox-args.interface';
 
 export interface TopLevelDetailsTemplate {
   name: string | null;

--- a/src/professions/admin/add-profession/top-level-information.controller.spec.ts
+++ b/src/professions/admin/add-profession/top-level-information.controller.spec.ts
@@ -1,6 +1,7 @@
 import { DeepMocked, createMock } from '@golevelup/ts-jest';
 import { TestingModule, Test } from '@nestjs/testing';
 import { Response } from 'express';
+import { I18nService } from 'nestjs-i18n';
 import { IndustriesService } from '../../../industries/industries.service';
 import { Industry } from '../../../industries/industry.entity';
 import { Profession } from '../../profession.entity';
@@ -13,6 +14,7 @@ describe('TopLevelInformationController', () => {
   let industriesService: DeepMocked<IndustriesService>;
   let response: DeepMocked<Response>;
   let profession: DeepMocked<Profession>;
+  let i18nService: DeepMocked<I18nService>;
 
   const healthIndustry = new Industry('industries.health');
   healthIndustry.id = 'health-uuid';
@@ -35,11 +37,33 @@ describe('TopLevelInformationController', () => {
       find: async () => profession,
     });
 
+    i18nService = createMock<I18nService>();
+
+    i18nService.translate.mockImplementation(async (text) => {
+      switch (text) {
+        case 'industries.health':
+          return 'Health';
+        case 'industries.constructionAndEngineering':
+          return 'Construction & Engineering';
+        case 'nations.england':
+          return 'England';
+        case 'nations.scotland':
+          return 'Scotland';
+        case 'nations.wales':
+          return 'Wales';
+        case 'nations.northernIreland':
+          return 'Northern Ireland';
+        default:
+          return '';
+      }
+    });
+
     const module: TestingModule = await Test.createTestingModule({
       controllers: [TopLevelInformationController],
       providers: [
         { provide: IndustriesService, useValue: industriesService },
         { provide: ProfessionsService, useValue: professionsService },
+        { provide: I18nService, useValue: i18nService },
       ],
     }).compile();
 
@@ -65,34 +89,34 @@ describe('TopLevelInformationController', () => {
           name: null,
           industriesCheckboxArgs: [
             {
-              text: 'industries.health',
+              text: 'Health',
               value: 'health-uuid',
               checked: false,
             },
             {
-              text: 'industries.constructionAndEngineering',
+              text: 'Construction & Engineering',
               value: 'construction-uuid',
               checked: false,
             },
           ],
           nationsCheckboxArgs: [
             {
-              text: 'nations.england',
+              text: 'England',
               value: 'GB-ENG',
               checked: false,
             },
             {
-              text: 'nations.scotland',
+              text: 'Scotland',
               value: 'GB-SCT',
               checked: false,
             },
             {
-              text: 'nations.wales',
+              text: 'Wales',
               value: 'GB-WLS',
               checked: false,
             },
             {
-              text: 'nations.northernIreland',
+              text: 'Northern Ireland',
               value: 'GB-NIR',
               checked: false,
             },
@@ -129,34 +153,34 @@ describe('TopLevelInformationController', () => {
           name: 'Example Profession',
           industriesCheckboxArgs: [
             {
-              text: 'industries.health',
+              text: 'Health',
               value: 'health-uuid',
               checked: true,
             },
             {
-              text: 'industries.constructionAndEngineering',
+              text: 'Construction & Engineering',
               value: 'construction-uuid',
               checked: false,
             },
           ],
           nationsCheckboxArgs: [
             {
-              text: 'nations.england',
+              text: 'England',
               value: 'GB-ENG',
               checked: true,
             },
             {
-              text: 'nations.scotland',
+              text: 'Scotland',
               value: 'GB-SCT',
               checked: true,
             },
             {
-              text: 'nations.wales',
+              text: 'Wales',
               value: 'GB-WLS',
               checked: false,
             },
             {
-              text: 'nations.northernIreland',
+              text: 'Northern Ireland',
               value: 'GB-NIR',
               checked: false,
             },

--- a/src/professions/admin/add-profession/top-level-information.controller.ts
+++ b/src/professions/admin/add-profession/top-level-information.controller.ts
@@ -8,6 +8,8 @@ import {
   Res,
 } from '@nestjs/common';
 import { Response } from 'express';
+import { IndustriesCheckboxPresenter } from '../../../industries/industries-checkbox.presenter';
+import { NationsCheckboxPresenter } from '../../../nations/nations-checkbox.presenter';
 import { Validator } from '../../../helpers/validator';
 import { IndustriesService } from '../../../industries/industries.service';
 import { Nation } from '../../../nations/nation';
@@ -34,29 +36,17 @@ export class TopLevelInformationController {
 
     const industries = await this.industriesService.all();
 
-    const industriesCheckboxArgs = industries.map((industry) => {
-      const hasSelectedIndustry = !!(profession.industries || []).find(
-        (selectedIndustry) => industry.id === selectedIndustry.id,
-      );
+    const industriesCheckboxArgs = new IndustriesCheckboxPresenter(
+      industries,
+      profession.industries || [],
+    ).checkboxArgs();
 
-      return {
-        text: industry.name,
-        value: industry.id,
-        checked: hasSelectedIndustry,
-      };
-    });
-
-    const nationsCheckboxArgs = Nation.all().map((nation) => {
-      const hasSelectedNation = (profession.occupationLocations || []).includes(
-        nation.code,
-      );
-
-      return {
-        text: nation.name,
-        value: nation.code,
-        checked: hasSelectedNation,
-      };
-    });
+    const nationsCheckboxArgs = new NationsCheckboxPresenter(
+      Nation.all(),
+      (profession.occupationLocations || []).map((nationCode) =>
+        Nation.find(nationCode),
+      ),
+    ).checkboxArgs();
 
     return {
       name: profession.name,

--- a/src/professions/admin/add-profession/top-level-information.controller.ts
+++ b/src/professions/admin/add-profession/top-level-information.controller.ts
@@ -18,12 +18,14 @@ import { Profession } from '../../profession.entity';
 import { ProfessionsService } from '../../professions.service';
 import { TopLevelDetailsDto } from './dto/top-level-details.dto';
 import { TopLevelDetailsTemplate } from './interfaces/top-level-details.template';
+import { I18nService } from 'nestjs-i18n';
 
 @Controller('admin/professions')
 export class TopLevelInformationController {
   constructor(
     private readonly professionsService: ProfessionsService,
     private readonly industriesService: IndustriesService,
+    private readonly i18nService: I18nService,
   ) {}
 
   @Get('/:id/top-level-information/edit')
@@ -36,16 +38,18 @@ export class TopLevelInformationController {
 
     const industries = await this.industriesService.all();
 
-    const industriesCheckboxArgs = new IndustriesCheckboxPresenter(
+    const industriesCheckboxArgs = await new IndustriesCheckboxPresenter(
       industries,
       profession.industries || [],
+      this.i18nService,
     ).checkboxArgs();
 
-    const nationsCheckboxArgs = new NationsCheckboxPresenter(
+    const nationsCheckboxArgs = await new NationsCheckboxPresenter(
       Nation.all(),
       (profession.occupationLocations || []).map((nationCode) =>
         Nation.find(nationCode),
       ),
+      this.i18nService,
     ).checkboxArgs();
 
     return {

--- a/src/professions/professions.seeder.ts
+++ b/src/professions/professions.seeder.ts
@@ -20,6 +20,7 @@ type SeedProfession = {
   qualification: string;
   reservedActivities: string[];
   legislations: string[];
+  confirmed: boolean;
 };
 
 @Injectable()
@@ -43,7 +44,7 @@ export class ProfessionsSeeder implements Seeder {
     const professions = await Promise.all(
       professionsData.map(async (profession) => {
         const industries = await this.industriesRepository.find({
-          where: { name: In(profession.industries) },
+          where: { name: In(profession.industries || []) },
         });
 
         const qualification = await this.qualificationsRepository.findOne({
@@ -51,7 +52,7 @@ export class ProfessionsSeeder implements Seeder {
         });
 
         const legislations: Array<Legislation> = await Promise.all(
-          profession.legislations.map(async (legislation) => {
+          (profession.legislations || []).map(async (legislation) => {
             return this.legislationsRepository.findOne({
               where: { name: legislation },
             });
@@ -69,6 +70,7 @@ export class ProfessionsSeeder implements Seeder {
           qualification,
           profession.reservedActivities,
           legislations,
+          profession.confirmed,
         );
       }),
     );

--- a/src/professions/professions.service.spec.ts
+++ b/src/professions/professions.service.spec.ts
@@ -92,6 +92,16 @@ describe('Profession', () => {
     });
   });
 
+  describe('allConfirmed', () => {
+    it('should return all confirmed Professions', async () => {
+      const repoSpy = jest.spyOn(repo, 'find');
+      const professions = await service.allConfirmed();
+
+      expect(professions).toEqual(professionArray);
+      expect(repoSpy).toHaveBeenCalledWith({ where: { confirmed: true } });
+    });
+  });
+
   describe('find', () => {
     it('should return a Profession', async () => {
       const repoSpy = jest.spyOn(repo, 'findOne');

--- a/src/professions/professions.service.ts
+++ b/src/professions/professions.service.ts
@@ -17,6 +17,10 @@ export class ProfessionsService {
     return this.repository.find();
   }
 
+  allConfirmed(): Promise<Profession[]> {
+    return this.repository.find({ where: { confirmed: true } });
+  }
+
   find(id: string): Promise<Profession> {
     return this.repository.findOne(id);
   }

--- a/src/professions/search/dto/filter.dto.ts
+++ b/src/professions/search/dto/filter.dto.ts
@@ -1,5 +1,5 @@
 export class FilterDto {
   keywords = '';
-  industries: string[] | string = [];
-  nations: string[] | string = [];
+  industries: string[] = [];
+  nations: string[] = [];
 }

--- a/src/professions/search/helpers/filter.helper.spec.ts
+++ b/src/professions/search/helpers/filter.helper.spec.ts
@@ -47,6 +47,23 @@ describe('FilterHelper', () => {
       expect(results).toEqual([exampleProfessions[0], exampleProfessions[2]]);
     });
 
+    it('keywords are case insensitive', () => {
+      const exampleProfessions = [
+        new Profession('Trademark Attorny'),
+        new Profession('Chartered Accountant'),
+      ];
+
+      const filterHelper = new FilterHelper(exampleProfessions);
+
+      const results = filterHelper.filter({
+        keywords: 'aTtOrNy',
+        industries: [],
+        nations: [],
+      });
+
+      expect(results).toEqual([exampleProfessions[0]]);
+    });
+
     it('can filter professions by nations', () => {
       const exampleProfessions = [
         createProfessionWithNations('GB-NIR'),

--- a/src/professions/search/helpers/filter.helper.spec.ts
+++ b/src/professions/search/helpers/filter.helper.spec.ts
@@ -1,0 +1,168 @@
+import { randomUUID } from 'crypto';
+import { Industry } from '../../../industries/industry.entity';
+import { Nation } from '../../../nations/nation';
+import { Profession } from '../../../professions/profession.entity';
+import { FilterHelper } from './filter.helper';
+
+describe('FilterHelper', () => {
+  describe('filter', () => {
+    it('returns all professions when given an empty filter', () => {
+      const exampleProfessions = [
+        createProfession('Example 1', ['GB-ENG'], ['education', 'law']),
+        createProfession('Example 1', ['GB-SCT'], ['construction']),
+        createProfession(
+          'Example 3',
+          ['GB-WLS', 'GB-NIR'],
+          ['education', 'finance'],
+        ),
+      ];
+
+      const filterHelper = new FilterHelper(exampleProfessions);
+
+      const results = filterHelper.filter({
+        keywords: '',
+        industries: [],
+        nations: [],
+      });
+
+      expect(results).toEqual(exampleProfessions);
+    });
+
+    it('can filter professions by keywords', () => {
+      const exampleProfessions = [
+        new Profession('Trademark Attorny'),
+        new Profession('Chartered Accountant'),
+        new Profession('Secondary School Teacher'),
+      ];
+
+      const filterHelper = new FilterHelper(exampleProfessions);
+
+      const results = filterHelper.filter({
+        // Test a complete and incomplete word match
+        keywords: 'Attorny    condar',
+        industries: [],
+        nations: [],
+      });
+
+      expect(results).toEqual([exampleProfessions[0], exampleProfessions[2]]);
+    });
+
+    it('can filter professions by nations', () => {
+      const exampleProfessions = [
+        createProfessionWithNations('GB-NIR'),
+        createProfessionWithNations('GB-NIR', 'GB-SCT'),
+        createProfessionWithNations('GB-WLS'),
+        createProfessionWithNations('GB-ENG'),
+      ];
+
+      const filterHelper = new FilterHelper(exampleProfessions);
+
+      const results = filterHelper.filter({
+        keywords: '',
+        industries: [],
+        nations: [
+          new Nation('nations.england', 'GB-ENG'),
+          new Nation('nations.northernIreland', 'GB-NIR'),
+        ],
+      });
+
+      expect(results).toEqual([
+        exampleProfessions[0],
+        exampleProfessions[1],
+        exampleProfessions[3],
+      ]);
+    });
+
+    it('can filter professions by industry', () => {
+      const exampleProfessions = [
+        createProfessionWithIndustries('finance'),
+        createProfessionWithIndustries('health'),
+        createProfessionWithIndustries('law'),
+        createProfessionWithIndustries('law', 'education'),
+      ];
+
+      const filterHelper = new FilterHelper(exampleProfessions);
+
+      const results = filterHelper.filter({
+        keywords: '',
+        industries: [
+          createIndustryWithId('education'),
+          createIndustryWithId('finance'),
+        ],
+        nations: [],
+      });
+
+      expect(results).toEqual([exampleProfessions[0], exampleProfessions[3]]);
+    });
+
+    it('can filter by multiple criteria', () => {
+      const exampleProfessions = [
+        // Won't match on nation
+        createProfession('Secondary School Teacher', ['GB-SCT'], ['education']),
+        // Won't match on industry
+        createProfession('Bricklaying Teacher', ['GB-NIR'], ['construction']),
+        // Won't match on keyword
+        createProfession(
+          'Leagal Training Facilitator',
+          ['GB-WLS', 'GB-NIR'],
+          ['education', 'law'],
+        ),
+        // Will match on all
+        createProfession(
+          'Primary School Teacher',
+          ['GB-NIR', 'GB-ENG'],
+          ['education'],
+        ),
+      ];
+
+      const filterHelper = new FilterHelper(exampleProfessions);
+
+      const results = filterHelper.filter({
+        keywords: 'Teacher',
+        industries: [createIndustryWithId('education')],
+        nations: [new Nation('nations.northernIreland', 'GB-NIR')],
+      });
+
+      expect(results).toEqual([exampleProfessions[3]]);
+    });
+  });
+});
+
+function createProfessionWithNations(...nationCodes: string[]): Profession {
+  const profession = new Profession(randomUUID());
+  profession.occupationLocations = nationCodes;
+
+  return profession;
+}
+
+function createProfessionWithIndustries(
+  ...industryNames: string[]
+): Profession {
+  const profession = new Profession(randomUUID());
+  const industries = industryNames.map((name) => createIndustryWithId(name));
+
+  profession.industries = industries;
+
+  return profession;
+}
+
+function createProfession(
+  name: string,
+  nationCodes: string[],
+  industryNames: string[],
+): Profession {
+  const profession = new Profession(name);
+  const industries = industryNames.map((name) => createIndustryWithId(name));
+
+  profession.occupationLocations = nationCodes;
+  profession.industries = industries;
+
+  return profession;
+}
+
+function createIndustryWithId(industryId: string): Industry {
+  const industry = new Industry(industryId);
+  industry.id = industryId;
+
+  return industry;
+}

--- a/src/professions/search/helpers/filter.helper.ts
+++ b/src/professions/search/helpers/filter.helper.ts
@@ -88,13 +88,18 @@ export class FilterHelper {
   }
 
   private getSearchTerms(filterInput: FilterInput): string[] {
-    return filterInput.keywords.split(' ').filter((term) => term !== '');
+    return filterInput.keywords
+      .toLowerCase()
+      .split(' ')
+      .filter((term) => term !== '');
   }
 
   private matchesKeywords(
     profession: Profession,
     searchTerms: string[],
   ): boolean {
-    return searchTerms.some((term) => profession.name.includes(term));
+    return searchTerms.some((term) =>
+      profession.name.toLowerCase().includes(term),
+    );
   }
 }

--- a/src/professions/search/helpers/filter.helper.ts
+++ b/src/professions/search/helpers/filter.helper.ts
@@ -1,0 +1,100 @@
+import { Industry } from '../../../industries/industry.entity';
+import { Profession } from '../../../professions/profession.entity';
+import { FilterInput } from '../interfaces/filter-input.interface';
+
+export class FilterHelper {
+  constructor(private readonly allProfessions: Profession[]) {}
+
+  filter(filterInput: FilterInput): Profession[] {
+    const unfilteredProfessions = this.allProfessions;
+
+    const nationFilteredProfessions = this.filterByNation(
+      filterInput,
+      unfilteredProfessions,
+    );
+
+    const industryFilteredProfessions = this.filterByIndustry(
+      filterInput,
+      nationFilteredProfessions,
+    );
+
+    const keywordFilteredProfessions = this.filterByKeyword(
+      filterInput,
+      industryFilteredProfessions,
+    );
+
+    return keywordFilteredProfessions;
+  }
+
+  private filterByNation(
+    filterInput: FilterInput,
+    professions: Profession[],
+  ): Profession[] {
+    if (filterInput.nations.length === 0) {
+      return professions;
+    } else {
+      const filterNationCodes = filterInput.nations.map(
+        (nation) => nation.code,
+      );
+
+      return professions.filter((profession) =>
+        this.isNationOverlap(profession.occupationLocations, filterNationCodes),
+      );
+    }
+  }
+
+  private filterByIndustry(
+    filterInput: FilterInput,
+    professions: Profession[],
+  ): Profession[] {
+    if (filterInput.industries.length == 0) {
+      return professions;
+    } else {
+      return professions.filter((profession) =>
+        this.isIndustryOverlap(profession.industries, filterInput.industries),
+      );
+    }
+  }
+
+  private filterByKeyword(
+    filterInput: FilterInput,
+    professions: Profession[],
+  ): Profession[] {
+    const searchTerms = this.getSearchTerms(filterInput);
+
+    if (searchTerms.length === 0) {
+      return professions;
+    } else {
+      return professions.filter((profession) =>
+        this.matchesKeywords(profession, searchTerms),
+      );
+    }
+  }
+
+  private isNationOverlap(
+    nationCodes1: string[],
+    nationCodes2: string[],
+  ): boolean {
+    return nationCodes1.some((code) => nationCodes2.includes(code));
+  }
+
+  private isIndustryOverlap(
+    industries1: Industry[],
+    industries2: Industry[],
+  ): boolean {
+    return industries1.some((industry1) => {
+      return industries2.some((industry2) => industry1.id == industry2.id);
+    });
+  }
+
+  private getSearchTerms(filterInput: FilterInput): string[] {
+    return filterInput.keywords.split(' ').filter((term) => term !== '');
+  }
+
+  private matchesKeywords(
+    profession: Profession,
+    searchTerms: string[],
+  ): boolean {
+    return searchTerms.some((term) => profession.name.includes(term));
+  }
+}

--- a/src/professions/search/interfaces/filter-input.interface.ts
+++ b/src/professions/search/interfaces/filter-input.interface.ts
@@ -1,0 +1,8 @@
+import { Industry } from '../../../industries/industry.entity';
+import { Nation } from '../../../nations/nation';
+
+export interface FilterInput {
+  nations: Nation[];
+  industries: Industry[];
+  keywords: string;
+}

--- a/src/professions/search/interfaces/index-template.interface.ts
+++ b/src/professions/search/interfaces/index-template.interface.ts
@@ -1,11 +1,9 @@
 export interface IndexTemplate {
   professions: {
     name: string;
-    nations: string[];
+    slug: string;
+    nations: string;
     industries: string[];
-    qualification: {
-      level: string;
-    };
   }[];
 
   filters: {

--- a/src/professions/search/interfaces/index-template.interface.ts
+++ b/src/professions/search/interfaces/index-template.interface.ts
@@ -14,13 +14,13 @@ export interface IndexTemplate {
     keywords: string;
   };
 
-  nationsOptionSelectArgs: {
+  nationsCheckboxArgs: {
     text: string;
     value: string;
     checked: boolean;
   }[];
 
-  industriesOptionSelectArgs: {
+  industriesCheckboxArgs: {
     text: string;
     value: string;
     checked: boolean;

--- a/src/professions/search/interfaces/profession-search-result-template.interface.ts
+++ b/src/professions/search/interfaces/profession-search-result-template.interface.ts
@@ -1,0 +1,6 @@
+export interface ProfessionSearchResultTemplate {
+  name: string;
+  slug: string;
+  nations: string;
+  industries: string[];
+}

--- a/src/professions/search/profession-search-result.presenter.spec.ts
+++ b/src/professions/search/profession-search-result.presenter.spec.ts
@@ -1,0 +1,89 @@
+import { createMock, DeepMocked } from '@golevelup/ts-jest';
+import { I18nService } from 'nestjs-i18n';
+import { Industry } from '../../industries/industry.entity';
+import { Profession } from '../profession.entity';
+import { ProfessionSearchResultPresenter } from './profession-search-result.presenter';
+
+describe('ProfessionSearchResultPresenter', () => {
+  let i18nService: DeepMocked<I18nService>;
+
+  beforeEach(() => {
+    i18nService = createMock<I18nService>();
+
+    i18nService.translate.mockImplementation(async (text) => {
+      switch (text) {
+        case 'industries.health':
+          return 'Health';
+        case 'industries.law':
+          return 'Law';
+        case 'nations.england':
+          return 'England';
+        case 'nations.scotland':
+          return 'Scotland';
+        case 'nations.wales':
+          return 'Wales';
+        case 'nations.northernIreland':
+          return 'Northern Ireland';
+        case 'app.unitedKingdom':
+          return 'United Kingdom';
+        default:
+          return '';
+      }
+    });
+  });
+
+  describe('present', () => {
+    it('Returns a ProfessionSearchResultTemplate', async () => {
+      const exampleProfession = new Profession(
+        'Example Profession',
+        '',
+        'example-profession',
+      );
+      exampleProfession.occupationLocations = ['GB-ENG', 'GB-WLS'];
+      exampleProfession.industries = [
+        new Industry('industries.health'),
+        new Industry('industries.law'),
+      ];
+
+      const result = await new ProfessionSearchResultPresenter(
+        exampleProfession,
+      ).present(i18nService);
+
+      expect(result).toEqual({
+        name: 'Example Profession',
+        slug: 'example-profession',
+        nations: 'England, Wales',
+        industries: ['Health', 'Law'],
+      });
+    });
+
+    it('Collapses four nations into "United Kingdom"', async () => {
+      const exampleProfession = new Profession(
+        'Example Profession',
+        '',
+        'example-profession',
+      );
+      exampleProfession.occupationLocations = [
+        'GB-WLS',
+        'GB-SCT',
+        'GB-ENG',
+        'GB-NIR',
+      ];
+      exampleProfession.industries = [
+        new Industry('industries.health'),
+        new Industry('industries.law'),
+      ];
+
+      const result = await new ProfessionSearchResultPresenter(
+        exampleProfession,
+      ).present(i18nService);
+
+      expect(result).toEqual({
+        name: 'Example Profession',
+        slug: 'example-profession',
+        nations: 'United Kingdom',
+        industries: ['Health', 'Law'],
+      });
+    });
+  });
+});

--- a/src/professions/search/profession-search-result.presenter.ts
+++ b/src/professions/search/profession-search-result.presenter.ts
@@ -1,0 +1,45 @@
+import { I18nService } from 'nestjs-i18n';
+import { Nation } from '../../nations/nation';
+import { Profession } from '../profession.entity';
+import { ProfessionSearchResultTemplate } from './interfaces/profession-search-result-template.interface';
+
+export class ProfessionSearchResultPresenter {
+  constructor(private readonly profession: Profession) {}
+
+  async present(
+    i18nService: I18nService,
+  ): Promise<ProfessionSearchResultTemplate> {
+    const nations = await this.getNations(i18nService);
+
+    const industries = await Promise.all(
+      this.profession.industries.map(
+        async (industry) => await i18nService.translate(industry.name),
+      ),
+    );
+
+    return {
+      name: this.profession.name,
+      slug: this.profession.slug,
+      nations,
+      industries,
+    };
+  }
+
+  private async getNations(i18nService: I18nService): Promise<string> {
+    if (
+      Nation.all().every((nation) =>
+        this.profession.occupationLocations.includes(nation.code),
+      )
+    ) {
+      return i18nService.translate('app.unitedKingdom');
+    } else {
+      const translatedNations = await Promise.all(
+        this.profession.occupationLocations.map((code) =>
+          Nation.find(code).translatedName(i18nService),
+        ),
+      );
+
+      return translatedNations.join(', ');
+    }
+  }
+}

--- a/src/professions/search/search.controller.spec.ts
+++ b/src/professions/search/search.controller.spec.ts
@@ -50,7 +50,7 @@ describe('SearchController', () => {
     industriesService = createMock<IndustriesService>();
     i18nService = createMock<I18nService>();
 
-    professionsService.all.mockImplementation(async () => {
+    professionsService.allConfirmed.mockImplementation(async () => {
       return [exampleProfession1, exampleProfession2];
     });
 
@@ -124,6 +124,25 @@ describe('SearchController', () => {
         ],
         backLink: referrer,
       });
+    });
+
+    it('should request only complete professions from `ProfessionsService`', async () => {
+      const request = createMockRequest(
+        'http://example.com/some/path',
+        'example.com',
+      );
+
+      await controller.create(
+        {
+          keywords: '',
+          industries: [],
+          nations: 'GB-SCT',
+        },
+        request,
+      );
+
+      expect(professionsService.allConfirmed).toHaveBeenCalled();
+      expect(professionsService.all).not.toHaveBeenCalled();
     });
   });
 

--- a/src/professions/search/search.controller.spec.ts
+++ b/src/professions/search/search.controller.spec.ts
@@ -2,14 +2,15 @@ import { createMock, DeepMocked } from '@golevelup/ts-jest';
 import { Test, TestingModule } from '@nestjs/testing';
 import { Request } from 'express';
 import { I18nService } from 'nestjs-i18n';
+import { Nation } from '../../nations/nation';
 import { createMockRequest } from '../../common/create-mock-request';
 import { IndustriesService } from '../../industries/industries.service';
 import { Industry } from '../../industries/industry.entity';
 import { Profession } from '../profession.entity';
 
 import { ProfessionsService } from '../professions.service';
-import { IndexTemplate } from './interfaces/index-template.interface';
 import { SearchController } from './search.controller';
+import { SearchPresenter } from './search.presenter';
 
 const referrer = 'http://example.com/some/path';
 const host = 'example.com';
@@ -22,6 +23,12 @@ exampleIndustry2.id = 'example-industry-2';
 
 const exampleIndustry3 = new Industry('industries.example3');
 exampleIndustry3.id = 'example-industry-3';
+
+const exampleIndustries = [
+  exampleIndustry1,
+  exampleIndustry2,
+  exampleIndustry3,
+];
 
 const exampleProfession1 = new Profession(
   'Secondary School Teacher',
@@ -63,7 +70,7 @@ describe('SearchController', () => {
     });
 
     industriesService.all.mockImplementation(async () => {
-      return [exampleIndustry1, exampleIndustry2, exampleIndustry3];
+      return exampleIndustries;
     });
 
     i18nService.translate.mockImplementation(async (text) => {
@@ -76,10 +83,12 @@ describe('SearchController', () => {
           return 'Example industry 3';
         case 'nations.england':
           return 'England';
-        case 'nations.wales':
-          return 'Wales';
         case 'nations.scotland':
           return 'Scotland';
+        case 'nations.wales':
+          return 'Wales';
+        case 'nations.northernIreland':
+          return 'Northern Ireland';
         default:
           return '';
       }
@@ -111,24 +120,18 @@ describe('SearchController', () => {
     it('should return populated template params', async () => {
       const result = await controller.index(request);
 
-      expect(result).toMatchObject({
-        ...createNationsOptionsSelectArgs(),
-        ...createIndustriesOptionsSelectArgs(),
-        filters: {
+      const expected = await new SearchPresenter(
+        {
           keywords: '',
-          nations: [],
           industries: [],
+          nations: [],
         },
-        professions: [
-          {
-            name: exampleProfession1.name,
-          },
-          {
-            name: exampleProfession2.name,
-          },
-        ],
-        backLink: referrer,
-      });
+        Nation.all(),
+        exampleIndustries,
+        [exampleProfession1, exampleProfession2],
+      ).present(i18nService, request);
+
+      expect(result).toEqual(expected);
     });
 
     it('should request only complete professions from `ProfessionsService`', async () => {
@@ -162,18 +165,21 @@ describe('SearchController', () => {
         request,
       );
 
-      expect(result).toMatchObject({
-        ...createNationsOptionsSelectArgs('GB-SCT'),
-        ...createIndustriesOptionsSelectArgs(
-          'example-industry-1',
-          'example-industry-2',
-        ),
-        filters: {
+      const allNations = Nation.all();
+      const scotland = Nation.find('GB-SCT');
+
+      const expected = await new SearchPresenter(
+        {
           keywords: 'example search',
-          nations: ['nations.scotland'],
-          industries: ['industries.example1', 'industries.example2'],
+          industries: [exampleIndustry1, exampleIndustry2],
+          nations: [scotland],
         },
-      });
+        allNations,
+        exampleIndustries,
+        [],
+      ).present(i18nService, request);
+
+      expect(result).toEqual(expected);
     });
 
     it('should return filtered professions when searching by nation', async () => {
@@ -186,9 +192,21 @@ describe('SearchController', () => {
         request,
       );
 
-      expect(result.professions).toMatchObject([
-        { name: 'Trademark Attorny' },
-      ]);
+      const allNations = Nation.all();
+      const wales = Nation.find('GB-WLS');
+
+      const expected = await new SearchPresenter(
+        {
+          keywords: '',
+          industries: [],
+          nations: [wales],
+        },
+        allNations,
+        exampleIndustries,
+        [exampleProfession2],
+      ).present(i18nService, request);
+
+      expect(result).toEqual(expected);
     });
 
     it('should return filtered professions when searching by industry', async () => {
@@ -201,9 +219,18 @@ describe('SearchController', () => {
         request,
       );
 
-      expect(result.professions).toMatchObject([
-        { name: 'Secondary School Teacher' },
-      ]);
+      const expected = await new SearchPresenter(
+        {
+          keywords: '',
+          industries: [exampleIndustry1],
+          nations: [],
+        },
+        Nation.all(),
+        exampleIndustries,
+        [exampleProfession1],
+      ).present(i18nService, request);
+
+      expect(result).toEqual(expected);
     });
 
     it('should return filtered professions when searching by keyword', async () => {
@@ -216,9 +243,18 @@ describe('SearchController', () => {
         request,
       );
 
-      expect(result.professions).toMatchObject([
-        { name: 'Trademark Attorny' },
-      ]);
+      const expected = await new SearchPresenter(
+        {
+          keywords: 'Trademark',
+          industries: [],
+          nations: [],
+        },
+        Nation.all(),
+        exampleIndustries,
+        [exampleProfession2],
+      ).present(i18nService, request);
+
+      expect(result).toEqual(expected);
     });
 
     it('should return unfiltered professions when no search parameters are specified', async () => {
@@ -231,67 +267,18 @@ describe('SearchController', () => {
         request,
       );
 
-      expect(result.professions).toMatchObject([
+      const expected = await new SearchPresenter(
         {
-          name: 'Secondary School Teacher',
+          keywords: '',
+          industries: [],
+          nations: [],
         },
-        {
-          name: 'Trademark Attorny',
-        },
-      ]);
+        Nation.all(),
+        exampleIndustries,
+        [exampleProfession1, exampleProfession2],
+      ).present(i18nService, request);
+
+      expect(result).toEqual(expected);
     });
   });
 });
-
-function createNationsOptionsSelectArgs(
-  ...args: string[]
-): Pick<IndexTemplate, 'nationsOptionSelectArgs'> {
-  return {
-    nationsOptionSelectArgs: [
-      {
-        text: 'nations.england',
-        value: 'GB-ENG',
-        checked: args.includes('GB-ENG'),
-      },
-      {
-        text: 'nations.scotland',
-        value: 'GB-SCT',
-        checked: args.includes('GB-SCT'),
-      },
-      {
-        text: 'nations.wales',
-        value: 'GB-WLS',
-        checked: args.includes('GB-WLS'),
-      },
-      {
-        text: 'nations.northernIreland',
-        value: 'GB-NIR',
-        checked: args.includes('GB-NIR'),
-      },
-    ],
-  };
-}
-
-function createIndustriesOptionsSelectArgs(
-  ...args: string[]
-): Pick<IndexTemplate, 'industriesOptionSelectArgs'> {
-  return {
-    industriesOptionSelectArgs: [
-      {
-        text: exampleIndustry1.name,
-        value: exampleIndustry1.id,
-        checked: args.includes(exampleIndustry1.id),
-      },
-      {
-        text: exampleIndustry2.name,
-        value: exampleIndustry2.id,
-        checked: args.includes(exampleIndustry2.id),
-      },
-      {
-        text: exampleIndustry3.name,
-        value: exampleIndustry3.id,
-        checked: args.includes(exampleIndustry3.id),
-      },
-    ],
-  };
-}

--- a/src/professions/search/search.controller.spec.ts
+++ b/src/professions/search/search.controller.spec.ts
@@ -144,7 +144,7 @@ describe('SearchController', () => {
         {
           keywords: '',
           industries: [],
-          nations: 'GB-SCT',
+          nations: [],
         },
         request,
       );
@@ -160,7 +160,7 @@ describe('SearchController', () => {
         {
           keywords: 'example search',
           industries: [exampleIndustry1.id, exampleIndustry2.id],
-          nations: 'GB-SCT',
+          nations: ['GB-SCT'],
         },
         request,
       );
@@ -187,7 +187,7 @@ describe('SearchController', () => {
         {
           keywords: '',
           industries: [],
-          nations: 'GB-WLS',
+          nations: ['GB-WLS'],
         },
         request,
       );

--- a/src/professions/search/search.controller.spec.ts
+++ b/src/professions/search/search.controller.spec.ts
@@ -1,5 +1,6 @@
 import { createMock, DeepMocked } from '@golevelup/ts-jest';
 import { Test, TestingModule } from '@nestjs/testing';
+import { Request } from 'express';
 import { I18nService } from 'nestjs-i18n';
 import { createMockRequest } from '../../common/create-mock-request';
 import { IndustriesService } from '../../industries/industries.service';
@@ -9,6 +10,9 @@ import { Profession } from '../profession.entity';
 import { ProfessionsService } from '../professions.service';
 import { IndexTemplate } from './interfaces/index-template.interface';
 import { SearchController } from './search.controller';
+
+const referrer = 'http://example.com/some/path';
+const host = 'example.com';
 
 const exampleIndustry1 = new Industry('industries.example1');
 exampleIndustry1.id = 'example-industry-1';
@@ -20,7 +24,7 @@ const exampleIndustry3 = new Industry('industries.example3');
 exampleIndustry3.id = 'example-industry-3';
 
 const exampleProfession1 = new Profession(
-  'Example Profession 1',
+  'Secondary School Teacher',
   '',
   null,
   '',
@@ -30,7 +34,7 @@ const exampleProfession1 = new Profession(
 );
 
 const exampleProfession2 = new Profession(
-  'Example Profession 2',
+  'Trademark Attorny',
   '',
   null,
   '',
@@ -40,12 +44,16 @@ const exampleProfession2 = new Profession(
 );
 
 describe('SearchController', () => {
+  let request: DeepMocked<Request>;
+
   let controller: SearchController;
   let professionsService: DeepMocked<ProfessionsService>;
   let industriesService: DeepMocked<IndustriesService>;
   let i18nService: DeepMocked<I18nService>;
 
   beforeEach(async () => {
+    request = createMockRequest(referrer, host);
+
     professionsService = createMock<ProfessionsService>();
     industriesService = createMock<IndustriesService>();
     i18nService = createMock<I18nService>();
@@ -101,9 +109,6 @@ describe('SearchController', () => {
 
   describe('index', () => {
     it('should return populated template params', async () => {
-      const referrer = 'http://example.com/some/path';
-      const request = createMockRequest(referrer, 'example.com');
-
       const result = await controller.index(request);
 
       expect(result).toMatchObject({
@@ -148,11 +153,6 @@ describe('SearchController', () => {
 
   describe('create', () => {
     it('should return template params populated with provided search filters', async () => {
-      const request = createMockRequest(
-        'http://example.com/some/path',
-        'example.com',
-      );
-
       const result = await controller.create(
         {
           keywords: 'example search',
@@ -174,6 +174,71 @@ describe('SearchController', () => {
           industries: ['industries.example1', 'industries.example2'],
         },
       });
+    });
+
+    it('should return filtered professions when searching by nation', async () => {
+      const result = await controller.create(
+        {
+          keywords: '',
+          industries: [],
+          nations: 'GB-WLS',
+        },
+        request,
+      );
+
+      expect(result.professions).toMatchObject([
+        { name: 'Trademark Attorny' },
+      ]);
+    });
+
+    it('should return filtered professions when searching by industry', async () => {
+      const result = await controller.create(
+        {
+          keywords: '',
+          industries: [exampleIndustry1.id],
+          nations: [],
+        },
+        request,
+      );
+
+      expect(result.professions).toMatchObject([
+        { name: 'Secondary School Teacher' },
+      ]);
+    });
+
+    it('should return filtered professions when searching by keyword', async () => {
+      const result = await controller.create(
+        {
+          keywords: 'Trademark',
+          industries: [],
+          nations: [],
+        },
+        request,
+      );
+
+      expect(result.professions).toMatchObject([
+        { name: 'Trademark Attorny' },
+      ]);
+    });
+
+    it('should return unfiltered professions when no search parameters are specified', async () => {
+      const result = await controller.create(
+        {
+          keywords: '',
+          industries: [],
+          nations: [],
+        },
+        request,
+      );
+
+      expect(result.professions).toMatchObject([
+        {
+          name: 'Secondary School Teacher',
+        },
+        {
+          name: 'Trademark Attorny',
+        },
+      ]);
     });
   });
 });

--- a/src/professions/search/search.controller.ts
+++ b/src/professions/search/search.controller.ts
@@ -62,20 +62,11 @@ export class SearchController {
     allNations: Nation[],
     allIndustries: Industry[],
   ): FilterInput {
-    // Where a single option is selected, NestJS gives us a string rather than
-    // a single element array
-    const filterIndustryIds =
-      typeof filter.industries === 'string'
-        ? [filter.industries]
-        : filter.industries;
-    const filterNationCodes =
-      typeof filter.nations === 'string' ? [filter.nations] : filter.nations;
-
     const nations = allNations.filter((nation) =>
-      filterNationCodes.includes(nation.code),
+      filter.nations.includes(nation.code),
     );
     const industries = allIndustries.filter((industry) =>
-      filterIndustryIds.includes(industry.id),
+      filter.industries.includes(industry.id),
     );
 
     return { nations, industries, keywords: filter.keywords };

--- a/src/professions/search/search.controller.ts
+++ b/src/professions/search/search.controller.ts
@@ -8,6 +8,8 @@ import { Nation } from '../../nations/nation';
 import { Profession } from '../profession.entity';
 import { ProfessionsService } from '../professions.service';
 import { FilterDto } from './dto/filter.dto';
+import { FilterHelper } from './helpers/filter.helper';
+import { FilterInput } from './interfaces/filter-input.interface';
 import { IndexTemplate } from './interfaces/index-template.interface';
 
 @Controller('professions/search')
@@ -49,9 +51,8 @@ export class SearchController {
 
     const filterInput = this.getFilterInput(filter, allNations, allIndustries);
 
-    const filterProfessions = this.getFilteredProfessions(
+    const filterProfessions = new FilterHelper(allProfessions).filter(
       filterInput,
-      allProfessions,
     );
 
     return this.presentResults(
@@ -84,13 +85,6 @@ export class SearchController {
     );
 
     return { nations, industries, keywords: filter.keywords };
-  }
-
-  private getFilteredProfessions(
-    filterInput: FilterInput,
-    allProfessions: Profession[],
-  ): Profession[] {
-    return allProfessions;
   }
 
   private async presentResults(
@@ -141,9 +135,3 @@ export class SearchController {
     };
   }
 }
-
-type FilterInput = {
-  nations: Nation[];
-  industries: Industry[];
-  keywords: string;
-};

--- a/src/professions/search/search.controller.ts
+++ b/src/professions/search/search.controller.ts
@@ -2,8 +2,10 @@ import { Body, Controller, Get, Post, Render, Req } from '@nestjs/common';
 import { Request } from 'express';
 import { I18nService } from 'nestjs-i18n';
 import { backLink } from '../../common/utils';
+import { Industry } from '../../industries/industry.entity';
 import { IndustriesService } from '../../industries/industries.service';
 import { Nation } from '../../nations/nation';
+import { Profession } from '../profession.entity';
 import { ProfessionsService } from '../professions.service';
 import { FilterDto } from './dto/filter.dto';
 import { IndexTemplate } from './interfaces/index-template.interface';
@@ -40,42 +42,77 @@ export class SearchController {
   private async createSearchResults(
     filter: FilterDto,
   ): Promise<Omit<IndexTemplate, 'backLink'>> {
-    // Where a single option is selected, NestJS gives us a string rather than
-    // a single element array
-    if (typeof filter.industries === 'string') {
-      filter.industries = [filter.industries];
-    }
-
-    if (typeof filter.nations === 'string') {
-      filter.nations = [filter.nations];
-    }
-
     const allNations = Nation.all();
     const allIndustries = await this.industriesService.all();
 
     const allProfessions = await this.professionsService.allConfirmed();
 
-    const filterNations = allNations.filter((nation) =>
-      filter.nations.includes(nation.code),
-    );
-    const filterIndustries = allIndustries.filter((industry) =>
-      filter.industries.includes(industry.id),
+    const filterInput = this.getFilterInput(filter, allNations, allIndustries);
+
+    const filterProfessions = this.getFilteredProfessions(
+      filterInput,
+      allProfessions,
     );
 
+    return this.presentResults(
+      filterInput,
+      allNations,
+      allIndustries,
+      filterProfessions,
+    );
+  }
+
+  private getFilterInput(
+    filter: FilterDto,
+    allNations: Nation[],
+    allIndustries: Industry[],
+  ): FilterInput {
+    // Where a single option is selected, NestJS gives us a string rather than
+    // a single element array
+    const filterIndustryIds =
+      typeof filter.industries === 'string'
+        ? [filter.industries]
+        : filter.industries;
+    const filterNationCodes =
+      typeof filter.nations === 'string' ? [filter.nations] : filter.nations;
+
+    const nations = allNations.filter((nation) =>
+      filterNationCodes.includes(nation.code),
+    );
+    const industries = allIndustries.filter((industry) =>
+      filterIndustryIds.includes(industry.id),
+    );
+
+    return { nations, industries, keywords: filter.keywords };
+  }
+
+  private getFilteredProfessions(
+    filterInput: FilterInput,
+    allProfessions: Profession[],
+  ): Profession[] {
+    return allProfessions;
+  }
+
+  private async presentResults(
+    filterInput: FilterInput,
+    allNations: Nation[],
+    allIndustries: Industry[],
+    filteredProfessions: Profession[],
+  ): Promise<Omit<IndexTemplate, 'backLink'>> {
     const nationsOptionSelectArgs = allNations.map((nation) => ({
       text: nation.name,
       value: nation.code,
-      checked: filterNations.includes(nation),
+      checked: filterInput.nations.includes(nation),
     }));
 
     const industriesOptionSelectArgs = allIndustries.map((industry) => ({
       text: industry.name,
       value: industry.id,
-      checked: filterIndustries.includes(industry),
+      checked: filterInput.industries.includes(industry),
     }));
 
     const displayProfessions = await Promise.all(
-      allProfessions.map(async (profession) => {
+      filteredProfessions.map(async (profession) => {
         const nations = await Promise.all(
           profession.occupationLocations.map(async (code) =>
             Nation.find(code).translatedName(this.i18nService),
@@ -97,10 +134,16 @@ export class SearchController {
       nationsOptionSelectArgs,
       industriesOptionSelectArgs,
       filters: {
-        keywords: filter.keywords,
-        nations: filterNations.map((nation) => nation.name),
-        industries: filterIndustries.map((industry) => industry.name),
+        keywords: filterInput.keywords,
+        nations: filterInput.nations.map((nation) => nation.name),
+        industries: filterInput.industries.map((industry) => industry.name),
       },
     };
   }
 }
+
+type FilterInput = {
+  nations: Nation[];
+  industries: Industry[];
+  keywords: string;
+};

--- a/src/professions/search/search.controller.ts
+++ b/src/professions/search/search.controller.ts
@@ -1,16 +1,15 @@
 import { Body, Controller, Get, Post, Render, Req } from '@nestjs/common';
 import { Request } from 'express';
 import { I18nService } from 'nestjs-i18n';
-import { backLink } from '../../common/utils';
 import { Industry } from '../../industries/industry.entity';
 import { IndustriesService } from '../../industries/industries.service';
 import { Nation } from '../../nations/nation';
-import { Profession } from '../profession.entity';
 import { ProfessionsService } from '../professions.service';
 import { FilterDto } from './dto/filter.dto';
 import { FilterHelper } from './helpers/filter.helper';
 import { FilterInput } from './interfaces/filter-input.interface';
 import { IndexTemplate } from './interfaces/index-template.interface';
+import { SearchPresenter } from './search.presenter';
 
 @Controller('professions/search')
 export class SearchController {
@@ -23,10 +22,7 @@ export class SearchController {
   @Get()
   @Render('professions/search/index')
   async index(@Req() request: Request): Promise<IndexTemplate> {
-    return {
-      ...(await this.createSearchResults(new FilterDto())),
-      backLink: backLink(request),
-    };
+    return this.createSearchResults(new FilterDto(), request);
   }
 
   @Post()
@@ -35,15 +31,13 @@ export class SearchController {
     @Body() filter: FilterDto,
     @Req() request: Request,
   ): Promise<IndexTemplate> {
-    return {
-      ...(await this.createSearchResults(filter)),
-      backLink: backLink(request),
-    };
+    return this.createSearchResults(filter, request);
   }
 
   private async createSearchResults(
     filter: FilterDto,
-  ): Promise<Omit<IndexTemplate, 'backLink'>> {
+    request: Request,
+  ): Promise<IndexTemplate> {
     const allNations = Nation.all();
     const allIndustries = await this.industriesService.all();
 
@@ -51,16 +45,16 @@ export class SearchController {
 
     const filterInput = this.getFilterInput(filter, allNations, allIndustries);
 
-    const filterProfessions = new FilterHelper(allProfessions).filter(
+    const filteredProfessions = new FilterHelper(allProfessions).filter(
       filterInput,
     );
 
-    return this.presentResults(
+    return new SearchPresenter(
       filterInput,
       allNations,
       allIndustries,
-      filterProfessions,
-    );
+      filteredProfessions,
+    ).present(this.i18nService, request);
   }
 
   private getFilterInput(
@@ -85,53 +79,5 @@ export class SearchController {
     );
 
     return { nations, industries, keywords: filter.keywords };
-  }
-
-  private async presentResults(
-    filterInput: FilterInput,
-    allNations: Nation[],
-    allIndustries: Industry[],
-    filteredProfessions: Profession[],
-  ): Promise<Omit<IndexTemplate, 'backLink'>> {
-    const nationsOptionSelectArgs = allNations.map((nation) => ({
-      text: nation.name,
-      value: nation.code,
-      checked: filterInput.nations.includes(nation),
-    }));
-
-    const industriesOptionSelectArgs = allIndustries.map((industry) => ({
-      text: industry.name,
-      value: industry.id,
-      checked: filterInput.industries.includes(industry),
-    }));
-
-    const displayProfessions = await Promise.all(
-      filteredProfessions.map(async (profession) => {
-        const nations = await Promise.all(
-          profession.occupationLocations.map(async (code) =>
-            Nation.find(code).translatedName(this.i18nService),
-          ),
-        );
-
-        const industries = await Promise.all(
-          profession.industries.map(
-            async (industry) => await this.i18nService.translate(industry.name),
-          ),
-        );
-
-        return { ...profession, nations, industries };
-      }),
-    );
-
-    return {
-      professions: displayProfessions,
-      nationsOptionSelectArgs,
-      industriesOptionSelectArgs,
-      filters: {
-        keywords: filterInput.keywords,
-        nations: filterInput.nations.map((nation) => nation.name),
-        industries: filterInput.industries.map((industry) => industry.name),
-      },
-    };
   }
 }

--- a/src/professions/search/search.controller.ts
+++ b/src/professions/search/search.controller.ts
@@ -53,7 +53,7 @@ export class SearchController {
     const allNations = Nation.all();
     const allIndustries = await this.industriesService.all();
 
-    const allProfessions = await this.professionsService.all();
+    const allProfessions = await this.professionsService.allConfirmed();
 
     const filterNations = Nation.all().filter((nation) =>
       filter.nations.includes(nation.code),

--- a/src/professions/search/search.controller.ts
+++ b/src/professions/search/search.controller.ts
@@ -55,7 +55,7 @@ export class SearchController {
 
     const allProfessions = await this.professionsService.allConfirmed();
 
-    const filterNations = Nation.all().filter((nation) =>
+    const filterNations = allNations.filter((nation) =>
       filter.nations.includes(nation.code),
     );
     const filterIndustries = allIndustries.filter((industry) =>

--- a/src/professions/search/search.presenter.spec.ts
+++ b/src/professions/search/search.presenter.spec.ts
@@ -1,0 +1,130 @@
+import { createMock, DeepMocked } from '@golevelup/ts-jest';
+import { Request } from 'express';
+import { I18nService } from 'nestjs-i18n';
+import { createMockRequest } from '../../common/create-mock-request';
+import { Nation } from '../../nations/nation';
+import { Industry } from '../../industries/industry.entity';
+import { Profession } from '../profession.entity';
+import { FilterInput } from './interfaces/filter-input.interface';
+import { SearchPresenter } from './search.presenter';
+import { IndustriesCheckboxPresenter } from '../../industries/industries-checkbox.presenter';
+import { NationsCheckboxPresenter } from '../../nations/nations-checkbox.presenter';
+
+const exampleIndustry1 = new Industry('industries.example1');
+exampleIndustry1.id = 'example-industry-1';
+
+const exampleIndustry2 = new Industry('industries.example2');
+exampleIndustry2.id = 'example-industry-2';
+
+const exampleIndustry3 = new Industry('industries.example3');
+exampleIndustry3.id = 'example-industry-3';
+
+const exampleProfession1 = new Profession(
+  'Example Profession 1',
+  '',
+  null,
+  '',
+  ['GB-ENG'],
+  '',
+  [exampleIndustry1],
+);
+
+const exampleProfession2 = new Profession(
+  'Example Profession 2',
+  '',
+  null,
+  '',
+  ['GB-SCT', 'GB-WLS'],
+  '',
+  [exampleIndustry2, exampleIndustry3],
+);
+
+const exampleIndustries = [
+  exampleIndustry1,
+  exampleIndustry2,
+  exampleIndustry3,
+];
+
+describe('SearchPresenter', () => {
+  let request: DeepMocked<Request>;
+  let i18nService: DeepMocked<I18nService>;
+  let nations: Nation[];
+
+  beforeEach(() => {
+    request = createMockRequest('http://example.com/some/path', 'example.com');
+    i18nService = createMock<I18nService>();
+
+    i18nService.translate.mockImplementation(async (text) => {
+      switch (text) {
+        case 'industries.example1':
+          return 'Example industry 1';
+        case 'industries.example2':
+          return 'Example industry 2';
+        case 'industries.example3':
+          return 'Example industry 3';
+        case 'nations.england':
+          return 'England';
+        case 'nations.wales':
+          return 'Wales';
+        case 'nations.scotland':
+          return 'Scotland';
+        case 'nations.northernIreland':
+          return 'Northern Ireland';
+        default:
+          return '';
+      }
+    });
+
+    nations = Nation.all();
+  });
+
+  describe('present', () => {
+    it('should return a IndexTemplate', async () => {
+      const filterInput: FilterInput = {
+        nations: [nations[0]],
+        industries: [exampleIndustry2],
+        keywords: 'Example Keywords',
+      };
+
+      const presenter = new SearchPresenter(
+        filterInput,
+        nations,
+        exampleIndustries,
+        [exampleProfession1, exampleProfession2],
+      );
+
+      const result = await presenter.present(i18nService, request);
+
+      const industriesCheckboxArgs = new IndustriesCheckboxPresenter(
+        exampleIndustries,
+        [exampleIndustry2],
+      ).checkboxArgs();
+
+      const nationsCheckboxArgs = new NationsCheckboxPresenter(Nation.all(), [
+        Nation.find('GB-ENG'),
+      ]).checkboxArgs();
+
+      expect(result).toMatchObject({
+        filters: {
+          industries: ['industries.example2'],
+          keywords: 'Example Keywords',
+          nations: ['nations.england'],
+        },
+        industriesCheckboxArgs,
+        nationsCheckboxArgs,
+        professions: [
+          {
+            name: 'Example Profession 1',
+            industries: ['Example industry 1'],
+            nations: ['England'],
+          },
+          {
+            name: 'Example Profession 2',
+            industries: ['Example industry 2', 'Example industry 3'],
+            nations: ['Scotland', 'Wales'],
+          },
+        ],
+      });
+    });
+  });
+});

--- a/src/professions/search/search.presenter.spec.ts
+++ b/src/professions/search/search.presenter.spec.ts
@@ -128,5 +128,48 @@ describe('SearchPresenter', () => {
         ],
       });
     });
+
+    it('should sort the search results alphabetically', async () => {
+      const filterInput: FilterInput = {
+        nations: [],
+        industries: [],
+        keywords: '',
+      };
+
+      const professionA = new Profession('A');
+      professionA.occupationLocations = [];
+      professionA.industries = [];
+
+      const professionB = new Profession('B');
+      professionB.occupationLocations = [];
+      professionB.industries = [];
+
+      const professionC = new Profession('C');
+      professionC.occupationLocations = [];
+      professionC.industries = [];
+
+      const presenter = new SearchPresenter(
+        filterInput,
+        nations,
+        exampleIndustries,
+        [professionC, professionA, professionB],
+      );
+
+      const result = await presenter.present(i18nService, request);
+
+      expect(result).toMatchObject({
+        professions: [
+          await new ProfessionSearchResultPresenter(professionA).present(
+            i18nService,
+          ),
+          await new ProfessionSearchResultPresenter(professionB).present(
+            i18nService,
+          ),
+          await new ProfessionSearchResultPresenter(professionC).present(
+            i18nService,
+          ),
+        ],
+      });
+    });
   });
 });

--- a/src/professions/search/search.presenter.spec.ts
+++ b/src/professions/search/search.presenter.spec.ts
@@ -9,6 +9,7 @@ import { FilterInput } from './interfaces/filter-input.interface';
 import { SearchPresenter } from './search.presenter';
 import { IndustriesCheckboxPresenter } from '../../industries/industries-checkbox.presenter';
 import { NationsCheckboxPresenter } from '../../nations/nations-checkbox.presenter';
+import { ProfessionSearchResultPresenter } from './profession-search-result.presenter';
 
 const exampleIndustry1 = new Industry('industries.example1');
 exampleIndustry1.id = 'example-industry-1';
@@ -118,16 +119,12 @@ describe('SearchPresenter', () => {
         industriesCheckboxArgs,
         nationsCheckboxArgs,
         professions: [
-          {
-            name: 'Example Profession 1',
-            industries: ['Example industry 1'],
-            nations: 'England',
-          },
-          {
-            name: 'Example Profession 2',
-            industries: ['Example industry 2', 'Example industry 3'],
-            nations: 'Scotland, Wales',
-          },
+          await new ProfessionSearchResultPresenter(exampleProfession1).present(
+            i18nService,
+          ),
+          await new ProfessionSearchResultPresenter(exampleProfession2).present(
+            i18nService,
+          ),
         ],
       });
     });

--- a/src/professions/search/search.presenter.spec.ts
+++ b/src/professions/search/search.presenter.spec.ts
@@ -64,10 +64,10 @@ describe('SearchPresenter', () => {
           return 'Example industry 3';
         case 'nations.england':
           return 'England';
-        case 'nations.wales':
-          return 'Wales';
         case 'nations.scotland':
           return 'Scotland';
+        case 'nations.wales':
+          return 'Wales';
         case 'nations.northernIreland':
           return 'Northern Ireland';
         default:
@@ -95,14 +95,17 @@ describe('SearchPresenter', () => {
 
       const result = await presenter.present(i18nService, request);
 
-      const industriesCheckboxArgs = new IndustriesCheckboxPresenter(
+      const industriesCheckboxArgs = await new IndustriesCheckboxPresenter(
         exampleIndustries,
         [exampleIndustry2],
+        i18nService,
       ).checkboxArgs();
 
-      const nationsCheckboxArgs = new NationsCheckboxPresenter(Nation.all(), [
-        Nation.find('GB-ENG'),
-      ]).checkboxArgs();
+      const nationsCheckboxArgs = await new NationsCheckboxPresenter(
+        Nation.all(),
+        [Nation.find('GB-ENG')],
+        i18nService,
+      ).checkboxArgs();
 
       expect(result).toMatchObject({
         filters: {

--- a/src/professions/search/search.presenter.spec.ts
+++ b/src/professions/search/search.presenter.spec.ts
@@ -70,6 +70,8 @@ describe('SearchPresenter', () => {
           return 'Wales';
         case 'nations.northernIreland':
           return 'Northern Ireland';
+        case 'app.unitedKingdom':
+          return 'United Kingdom';
         default:
           return '';
       }
@@ -119,12 +121,12 @@ describe('SearchPresenter', () => {
           {
             name: 'Example Profession 1',
             industries: ['Example industry 1'],
-            nations: ['England'],
+            nations: 'England',
           },
           {
             name: 'Example Profession 2',
             industries: ['Example industry 2', 'Example industry 3'],
-            nations: ['Scotland', 'Wales'],
+            nations: 'Scotland, Wales',
           },
         ],
       });

--- a/src/professions/search/search.presenter.ts
+++ b/src/professions/search/search.presenter.ts
@@ -21,14 +21,16 @@ export class SearchPresenter {
     i18nService: I18nService,
     request: Request,
   ): Promise<IndexTemplate> {
-    const nationsCheckboxArgs = new NationsCheckboxPresenter(
+    const nationsCheckboxArgs = await new NationsCheckboxPresenter(
       this.allNations,
       this.filterInput.nations,
+      i18nService,
     ).checkboxArgs();
 
-    const industriesCheckboxArgs = new IndustriesCheckboxPresenter(
+    const industriesCheckboxArgs = await new IndustriesCheckboxPresenter(
       this.allIndustries,
       this.filterInput.industries,
+      i18nService,
     ).checkboxArgs();
 
     const displayProfessions = await Promise.all(

--- a/src/professions/search/search.presenter.ts
+++ b/src/professions/search/search.presenter.ts
@@ -35,11 +35,7 @@ export class SearchPresenter {
 
     const displayProfessions = await Promise.all(
       this.filteredProfessions.map(async (profession) => {
-        const nations = await Promise.all(
-          profession.occupationLocations.map(async (code) =>
-            Nation.find(code).translatedName(i18nService),
-          ),
-        );
+        const nations = await this.getNations(profession, i18nService);
 
         const industries = await Promise.all(
           profession.industries.map(
@@ -47,7 +43,12 @@ export class SearchPresenter {
           ),
         );
 
-        return { ...profession, nations, industries };
+        return {
+          name: profession.name,
+          slug: profession.slug,
+          nations,
+          industries,
+        };
       }),
     );
 
@@ -64,5 +65,18 @@ export class SearchPresenter {
       },
       backLink: backLink(request),
     };
+  }
+
+  private async getNations(
+    profession: Profession,
+    i18nService: I18nService,
+  ): Promise<string> {
+    const translatedNations = await Promise.all(
+      profession.occupationLocations.map(async (code) =>
+        Nation.find(code).translatedName(i18nService),
+      ),
+    );
+
+    return translatedNations.join(', ');
   }
 }

--- a/src/professions/search/search.presenter.ts
+++ b/src/professions/search/search.presenter.ts
@@ -8,6 +8,7 @@ import { NationsCheckboxPresenter } from '../../nations/nations-checkbox.present
 import { Profession } from '../profession.entity';
 import { FilterInput } from './interfaces/filter-input.interface';
 import { IndexTemplate } from './interfaces/index-template.interface';
+import { ProfessionSearchResultPresenter } from './profession-search-result.presenter';
 
 export class SearchPresenter {
   constructor(
@@ -34,22 +35,9 @@ export class SearchPresenter {
     ).checkboxArgs();
 
     const displayProfessions = await Promise.all(
-      this.filteredProfessions.map(async (profession) => {
-        const nations = await this.getNations(profession, i18nService);
-
-        const industries = await Promise.all(
-          profession.industries.map(
-            async (industry) => await i18nService.translate(industry.name),
-          ),
-        );
-
-        return {
-          name: profession.name,
-          slug: profession.slug,
-          nations,
-          industries,
-        };
-      }),
+      this.filteredProfessions.map(async (profession) =>
+        new ProfessionSearchResultPresenter(profession).present(i18nService),
+      ),
     );
 
     return {
@@ -65,18 +53,5 @@ export class SearchPresenter {
       },
       backLink: backLink(request),
     };
-  }
-
-  private async getNations(
-    profession: Profession,
-    i18nService: I18nService,
-  ): Promise<string> {
-    const translatedNations = await Promise.all(
-      profession.occupationLocations.map(async (code) =>
-        Nation.find(code).translatedName(i18nService),
-      ),
-    );
-
-    return translatedNations.join(', ');
   }
 }

--- a/src/professions/search/search.presenter.ts
+++ b/src/professions/search/search.presenter.ts
@@ -40,6 +40,16 @@ export class SearchPresenter {
       ),
     );
 
+    displayProfessions.sort((profession1, profession2) => {
+      if (profession1.name < profession2.name) {
+        return -1;
+      } else if (profession1.name > profession2.name) {
+        return 1;
+      } else {
+        return 0;
+      }
+    });
+
     return {
       professions: displayProfessions,
       nationsCheckboxArgs,

--- a/src/professions/search/search.presenter.ts
+++ b/src/professions/search/search.presenter.ts
@@ -1,0 +1,66 @@
+import { Request } from 'express';
+import { I18nService } from 'nestjs-i18n';
+import { backLink } from '../../common/utils';
+import { IndustriesCheckboxPresenter } from '../../industries/industries-checkbox.presenter';
+import { Industry } from '../../industries/industry.entity';
+import { Nation } from '../../nations/nation';
+import { NationsCheckboxPresenter } from '../../nations/nations-checkbox.presenter';
+import { Profession } from '../profession.entity';
+import { FilterInput } from './interfaces/filter-input.interface';
+import { IndexTemplate } from './interfaces/index-template.interface';
+
+export class SearchPresenter {
+  constructor(
+    private readonly filterInput: FilterInput,
+    private readonly allNations: Nation[],
+    private readonly allIndustries: Industry[],
+    private readonly filteredProfessions: Profession[],
+  ) {}
+
+  async present(
+    i18nService: I18nService,
+    request: Request,
+  ): Promise<IndexTemplate> {
+    const nationsCheckboxArgs = new NationsCheckboxPresenter(
+      this.allNations,
+      this.filterInput.nations,
+    ).checkboxArgs();
+
+    const industriesCheckboxArgs = new IndustriesCheckboxPresenter(
+      this.allIndustries,
+      this.filterInput.industries,
+    ).checkboxArgs();
+
+    const displayProfessions = await Promise.all(
+      this.filteredProfessions.map(async (profession) => {
+        const nations = await Promise.all(
+          profession.occupationLocations.map(async (code) =>
+            Nation.find(code).translatedName(i18nService),
+          ),
+        );
+
+        const industries = await Promise.all(
+          profession.industries.map(
+            async (industry) => await i18nService.translate(industry.name),
+          ),
+        );
+
+        return { ...profession, nations, industries };
+      }),
+    );
+
+    return {
+      professions: displayProfessions,
+      nationsCheckboxArgs,
+      industriesCheckboxArgs,
+      filters: {
+        keywords: this.filterInput.keywords,
+        nations: this.filterInput.nations.map((nation) => nation.name),
+        industries: this.filterInput.industries.map(
+          (industry) => industry.name,
+        ),
+      },
+      backLink: backLink(request),
+    };
+  }
+}

--- a/views/professions/admin/add-profession/top-level-information.njk
+++ b/views/professions/admin/add-profession/top-level-information.njk
@@ -46,7 +46,7 @@
                 hint: {
                   text: ("professions.form.checkboxes.hint" | t)
                 },
-                items: nationsCheckboxArgs | tOptionSelect
+                items: nationsCheckboxArgs
               })
             }}
 
@@ -64,7 +64,7 @@
                 hint: {
                   text: ("professions.form.checkboxes.hint" | t)
                 },
-                items: industriesCheckboxArgs | tOptionSelect
+                items: industriesCheckboxArgs
               })
             }}
 

--- a/views/professions/search/index.njk
+++ b/views/professions/search/index.njk
@@ -40,7 +40,7 @@
           }) }}
 
           {{ govukCheckboxes({
-            name: "nations",
+            name: "nations[]",
             classes: "govuk-checkboxes--small rpr-listing__filter",
             fieldset: {
               legend: {
@@ -56,7 +56,7 @@
           }) }}
 
           {{ govukCheckboxes({
-            name: "industries",
+            name: "industries[]",
             classes: "govuk-checkboxes--small rpr-listing__filter",
             fieldset: {
               legend: {

--- a/views/professions/search/index.njk
+++ b/views/professions/search/index.njk
@@ -52,7 +52,7 @@
             hint: {
               text: "search.form.nations.hint" | t
             },
-            items: nationsCheckboxArgs | tOptionSelect
+            items: nationsCheckboxArgs
           }) }}
 
           {{ govukCheckboxes({
@@ -68,7 +68,7 @@
             hint: {
               text: ""
             },
-            items: industriesCheckboxArgs | tOptionSelect
+            items: industriesCheckboxArgs
           }) }}
 
           {{ govukButton({

--- a/views/professions/search/index.njk
+++ b/views/professions/search/index.njk
@@ -82,7 +82,6 @@
 
     </div>
 
-
     <div class="govuk-grid-column-two-thirds">
 
       {% if filters.keywords %}
@@ -105,76 +104,56 @@
         </p>
       {% endif %}
       
-      <p class="govuk-body-m"><span class="govuk-!-font-size-36 govuk-!-font-weight-bold">{{ professions.length }}</span> {{ "profession" if (professions.count === 1) else "professions" }} found.</p>
+      <p class="govuk-body-m">
+        <span class="govuk-!-font-size-36 govuk-!-font-weight-bold">{{ professions.length }}</span> {{ ("search.foundSingular" | t) if (professions.length === 1) else ("search.foundPlural" | t) }}
+      </p>
 
       <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
-      <div class="rpr-listing__profession-container">
+      {% for profession in professions %}
 
-        {% for profession in professions %}
+        {% set industriesHtml %}
+          {% for industry in profession.industries %}
+            <p class="govuk-body-m">{{ industry }}</p>
+          {% endfor %}
+        {% endset %}
+
+        <div class="rpr-listing__profession-container">
           <h2>
-            <a class="govuk-link govuk-heading-l rpr-listing__profession-title" href="/professions/{{ profession.slug }}">{{profession.name}}</a>
+            <a class="govuk-link govuk-heading-l rpr-listing__profession-title" href="/professions/{{ profession.slug }}">{{profession.name}}<br>
+              <span class="govuk-caption-l">{{ profession.nations }}</span></a>
           </h2>
-
-
-          {% set nationsHtml %}
-            {% for nation in profession.nations %}
-              <p class="govuk-body-m">{{ nation }}</p>
-            {% endfor %}
-          {% endset %}
-
-          {% set industriesHtml %}
-            {% for industry in profession.industries %}
-              <p class="govuk-body-m">{{ industry }}</p>
-            {% endfor %}
-          {% endset %}
-
-          {{ govukSummaryList({
-            classes: 'govuk-summary-list--no-border rpr-listing__profession-summary-list',
-            rows: [
-              {
-                key: {
-                  text: ("search.profession.regulatedAuthority" | t)
+      
+            {{ govukSummaryList({
+              classes: 'govuk-summary-list--no-border rpr-listing__profession-summary-list',
+              rows: [
+                {
+                  key: {
+                    text: ("search.profession.regulators" | t)
+                  },
+                  value: {
+                    html: "Placeholder regulators"
+                  }
                 },
-                value: {
-                  text: "Placeholder authority"
+                {
+                  key: {
+                    text: ("search.profession.industry" | t)
+                  },
+                  value: {
+                    html: industriesHtml | safe
+                  }
                 }
-              },
-              {
-                key: {
-                  text: ("search.profession.nations" | t)
-                },
-                value: {
-                  text: nationsHtml | safe
-                }
-              },
-              {
-                key: {
-                  text: ("search.profession.industry" | t)
-                },
-                value: {
-                  html: industriesHtml | safe
-                }
-              },
-              {
-                key: {
-                  text: ("search.profession.qualificationLevel" | t)
-                },
-                value: {
-                  text: profession.qualification.level
-                }
-              }
-            ]
-          }) }}
+              ]
+            }) }}
 
           {% if not loop.last %}
               <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
           {% endif %}
 
-        {% endfor %}
+        </div>
 
-      </div>
-  
+      {% endfor %}
+
     </div>
 
   </div>

--- a/views/professions/search/index.njk
+++ b/views/professions/search/index.njk
@@ -52,7 +52,7 @@
             hint: {
               text: "search.form.nations.hint" | t
             },
-            items: nationsOptionSelectArgs | tOptionSelect
+            items: nationsCheckboxArgs | tOptionSelect
           }) }}
 
           {{ govukCheckboxes({
@@ -68,7 +68,7 @@
             hint: {
               text: ""
             },
-            items: industriesOptionSelectArgs | tOptionSelect
+            items: industriesCheckboxArgs | tOptionSelect
           }) }}
 
           {{ govukButton({


### PR DESCRIPTION
This PR implements working professions filters on top of the existing "all professions" page. This also updates the design of the page to match the latest prototype [here](https://rpr-prototype.herokuapp.com/beta-sprint-3/public-facing-v1/selected-service).

The bulk of the filtering logic is implemented in `FilterHelper`, and presentation is handled by a number of new presenter classes, with `SearchPresenter` ultimately responsible for wrangling results into the correct form for the Nunjucks template.

The `NationsCheckboxPresenter` and `IndustriesCheckboxPresenter` are re-used by `TopLevelInformationController`.