### PR TITLE
Fix invalid profession submit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,5 +14,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - Create draft Professions in the database, rather than using session storage when adding a new profession
+- Fix bug where submitting invalid top level details on a new Profession caused the page to hang
 
 [unreleased]: https://github.com/UKGovernmentBEIS/regulated-professions-register/compare/release...HEAD

--- a/src/industries/industries-checkbox.presenter.ts
+++ b/src/industries/industries-checkbox.presenter.ts
@@ -4,14 +4,13 @@ import { Industry } from './industry.entity';
 
 export class IndustriesCheckboxPresenter {
   constructor(
-    private readonly allIndustires: Industry[],
+    private readonly allIndustries: Industry[],
     private readonly checkedIndustries: Industry[],
     private readonly i18nService: I18nService,
   ) {}
-
   async checkboxArgs(): Promise<CheckboxArgs[]> {
     return Promise.all(
-      this.allIndustires.map(async (industry) => ({
+      this.allIndustries.map(async (industry) => ({
         text: await this.i18nService.translate(industry.name),
         value: industry.id,
         checked: !!this.checkedIndustries.find(


### PR DESCRIPTION
# Changes in this PR

There was an issue here where the page would hang on submitting without
a required field, due to there not being a `@Render` decorator on the
`edit` function. I've extracted the rendering functionality into its own
function, and tweaked it the logic for what to display.

The tests are a bit complex, and there might be a better way to handle
this, but here's what the new logic does:
- If there's a blank Profession (i.e. we've just landed on the page)
  persist user input even if one or more fields are missing, so they
  don't have to re-type their answers.
- If there's already a filled-in Profession, e.g. the user is editing
  after already completing this step, render those answers on the page,
  but if a new answer is submitted and a required field is missing,
  render the new values in the form, rather than the older ones on the
  Profession.
