### PR TITLE
(1971) Add change links to "Add a profession"'s "check your answers" page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,5 +15,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Create draft Professions in the database, rather than using session storage when adding a new profession
 - Fix bug where submitting invalid top level details on a new Profession caused the page to hang
+- Add functionality to "change" links on Check your answers when creating a new Profession
 
 [unreleased]: https://github.com/UKGovernmentBEIS/regulated-professions-register/compare/release...HEAD

--- a/src/professions/admin/add-profession/dto/top-level-details.dto.ts
+++ b/src/professions/admin/add-profession/dto/top-level-details.dto.ts
@@ -9,4 +9,6 @@ export class TopLevelDetailsDto {
 
   @IsNotEmpty()
   industries: string[];
+
+  change: boolean;
 }

--- a/src/professions/admin/add-profession/interfaces/top-level-details.template.ts
+++ b/src/professions/admin/add-profession/interfaces/top-level-details.template.ts
@@ -4,5 +4,6 @@ export interface TopLevelDetailsTemplate {
   name: string | null;
   industriesCheckboxArgs: CheckboxArgs[];
   nationsCheckboxArgs: CheckboxArgs[];
+  change: boolean;
   errors: object | undefined;
 }

--- a/src/professions/admin/add-profession/top-level-information.controller.spec.ts
+++ b/src/professions/admin/add-profession/top-level-information.controller.spec.ts
@@ -83,7 +83,7 @@ describe('TopLevelInformationController', () => {
       it('should fetch all Industries and Nations to be displayed in an option select, with none of them checked', async () => {
         professionsService.find.mockImplementation(async () => blankProfession);
 
-        await controller.edit(response, 'profession-id');
+        await controller.edit(response, 'profession-id', false);
 
         expect(response.render).toHaveBeenCalledWith(
           'professions/admin/add-profession/top-level-information',
@@ -123,6 +123,7 @@ describe('TopLevelInformationController', () => {
                 checked: false,
               },
             ],
+            change: false,
             errors: undefined,
           },
         );
@@ -150,7 +151,7 @@ describe('TopLevelInformationController', () => {
           async () => existingProfession,
         );
 
-        await controller.edit(response, 'profession-id');
+        await controller.edit(response, 'profession-id', false);
 
         expect(response.render).toHaveBeenCalledWith(
           'professions/admin/add-profession/top-level-information',
@@ -190,6 +191,7 @@ describe('TopLevelInformationController', () => {
                 checked: false,
               },
             ],
+            change: false,
             errors: undefined,
           },
         );
@@ -264,6 +266,7 @@ describe('TopLevelInformationController', () => {
               name: 'Example Profession',
               nations: ['GB-ENG'],
               industries: ['construction-uuid'],
+              change: false,
             };
 
             industriesService.findByIds.mockResolvedValue([
@@ -285,6 +288,7 @@ describe('TopLevelInformationController', () => {
               name: 'Gas Safe Engineer',
               nations: ['GB-ENG'],
               industries: null,
+              change: false,
             };
 
             await expect(
@@ -304,6 +308,7 @@ describe('TopLevelInformationController', () => {
               name: 'Gas Safe Engineer',
               nations: ['GB-ENG'],
               industries: undefined,
+              change: false,
             };
 
             await expect(
@@ -333,6 +338,7 @@ describe('TopLevelInformationController', () => {
               name: 'Gas Safe Engineer',
               nations: ['GB-NIR'],
               industries: ['construction-uuid'],
+              change: false,
             };
 
             expect(
@@ -350,6 +356,7 @@ describe('TopLevelInformationController', () => {
               name: 'Gas Safe Engineer',
               nations: undefined,
               industries: ['construction-uuid'],
+              change: false,
             };
 
             expect(
@@ -369,6 +376,7 @@ describe('TopLevelInformationController', () => {
               name: 'Gas Safe Engineer',
               nations: undefined,
               industries: ['construction-uuid'],
+              change: false,
             };
 
             expect(
@@ -379,6 +387,79 @@ describe('TopLevelInformationController', () => {
             ).toEqual([]);
           });
         });
+      });
+    });
+
+    describe('the "change" query param', () => {
+      it('redirects to check your answers when true', async () => {
+        const existingProfession = new Profession(
+          'Example Profession',
+          null,
+          null,
+          null,
+          ['GB-ENG', 'GB-SCT'],
+          null,
+          [constructionIndustry],
+        );
+        existingProfession.id = 'profession-id';
+
+        professionsService.find.mockImplementation(
+          async () => existingProfession,
+        );
+
+        const topLevelDetailsDtoWithChangeParam = {
+          name: 'A new profession',
+          nations: ['GB-ENG'],
+          industries: ['construction-uuid'],
+          change: true,
+        };
+
+        industriesService.findByIds.mockResolvedValue([constructionIndustry]);
+
+        await controller.update(
+          topLevelDetailsDtoWithChangeParam,
+          response,
+          'profession-id',
+        );
+
+        expect(response.redirect).toHaveBeenCalledWith(
+          '/admin/professions/profession-id/check-your-answers',
+        );
+      });
+
+      it('continues to the next step in the journey when false', async () => {
+        const existingProfession = new Profession(
+          'Example Profession',
+          null,
+          null,
+          null,
+          ['GB-ENG', 'GB-SCT'],
+          null,
+          [constructionIndustry],
+        );
+        existingProfession.id = 'profession-id';
+
+        professionsService.find.mockImplementation(
+          async () => existingProfession,
+        );
+
+        const topLevelDetailsDtoWithoutChangeParam = {
+          name: 'A new profession',
+          nations: ['GB-ENG'],
+          industries: ['construction-uuid'],
+        };
+
+        industriesService.findByIds.mockResolvedValue([constructionIndustry]);
+
+        await controller.update(
+          topLevelDetailsDtoWithoutChangeParam,
+          response,
+          'profession-id',
+        );
+
+        expect(response.redirect).toHaveBeenCalledWith(
+          '/admin/professions/profession-id/check-your-answers',
+        );
       });
     });
   });

--- a/src/professions/admin/add-profession/top-level-information.controller.ts
+++ b/src/professions/admin/add-profession/top-level-information.controller.ts
@@ -11,6 +11,7 @@ import { ProfessionsService } from '../../professions.service';
 import { TopLevelDetailsDto } from './dto/top-level-details.dto';
 import { I18nService } from 'nestjs-i18n';
 import { Industry } from '../../../industries/industry.entity';
+import { TopLevelDetailsTemplate } from './interfaces/top-level-details.template';
 
 @Controller('admin/professions')
 export class TopLevelInformationController {
@@ -117,15 +118,17 @@ export class TopLevelInformationController {
       this.i18nService,
     ).checkboxArgs();
 
+    const templateArgs: TopLevelDetailsTemplate = {
+      name,
+      industriesCheckboxArgs,
+      nationsCheckboxArgs,
+      change,
+      errors,
+    };
+
     return res.render(
       'professions/admin/add-profession/top-level-information',
-      {
-        name,
-        industriesCheckboxArgs,
-        nationsCheckboxArgs,
-        change,
-        errors,
-      },
+      templateArgs,
     );
   }
 

--- a/src/professions/admin/add-profession/top-level-information.controller.ts
+++ b/src/professions/admin/add-profession/top-level-information.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Get, Param, Post, Res } from '@nestjs/common';
+import { Body, Controller, Get, Param, Post, Query, Res } from '@nestjs/common';
 import { Response } from 'express';
 import { IndustriesCheckboxPresenter } from '../../../industries/industries-checkbox.presenter';
 import { NationsCheckboxPresenter } from '../../../nations/nations-checkbox.presenter';
@@ -24,6 +24,7 @@ export class TopLevelInformationController {
   async edit(
     @Res() res: Response,
     @Param('id') id: string,
+    @Query('change') change: boolean,
     errors: object | undefined = undefined,
   ): Promise<void> {
     const profession = await this.professionsService.find(id);
@@ -33,6 +34,7 @@ export class TopLevelInformationController {
       profession.name,
       profession.industries || [],
       profession.occupationLocations || [],
+      change,
       errors,
     );
   }
@@ -63,6 +65,7 @@ export class TopLevelInformationController {
           profession,
           topLevelDetailsDto,
         ),
+        topLevelDetailsDto.change,
         errors,
       );
     }
@@ -84,6 +87,11 @@ export class TopLevelInformationController {
 
     await this.professionsService.save(updated);
 
+    if (topLevelDetailsDto.change) {
+      return res.redirect(`/admin/professions/${id}/check-your-answers`);
+    }
+
+    // This will be the next page in the journey, but for now is the same as above
     return res.redirect(`/admin/professions/${id}/check-your-answers`);
   }
 
@@ -92,6 +100,7 @@ export class TopLevelInformationController {
     name: string,
     selectedIndustries: Industry[],
     selectedNations: string[],
+    change: boolean,
     errors: object | undefined = undefined,
   ): Promise<void> {
     const industries = await this.industriesService.all();
@@ -114,6 +123,7 @@ export class TopLevelInformationController {
         name,
         industriesCheckboxArgs,
         nationsCheckboxArgs,
+        change,
         errors,
       },
     );

--- a/views/professions/admin/add-profession/check-your-answers.njk
+++ b/views/professions/admin/add-profession/check-your-answers.njk
@@ -43,7 +43,7 @@
                     actions: {
                       items: [
                         {
-                          href: "#",
+                          href: "/admin/professions/" + professionId +"/top-level-information/edit?change=true",
                           text: ("app.change" | t),
                           visuallyHiddenText: ("professions.form.label.topLevelInformation.name" | t)
                         }
@@ -60,7 +60,7 @@
                     actions: {
                       items: [
                         {
-                          href: "#",
+                          href: "/admin/professions/" + professionId +"/top-level-information/edit?change=true",
                           text: ("app.change" | t),
                           visuallyHiddenText: ("professions.form.label.topLevelInformation.nation" | t)
                         }
@@ -77,7 +77,7 @@
                     actions: {
                       items: [
                         {
-                          href: "#",
+                          href: "/admin/professions/" + professionId +"/top-level-information/edit?change=true",
                           text: ("app.change" | t),
                           visuallyHiddenText: ("professions.form.label.topLevelInformation.industry" | t)
                         }

--- a/views/professions/admin/add-profession/top-level-information.njk
+++ b/views/professions/admin/add-profession/top-level-information.njk
@@ -19,6 +19,8 @@
           <h1 class="govuk-heading-l">{{ ("professions.form.headings.topLevelInformation" | t) }}</h1>
 
           <form method="post" action="./">
+            <input type="hidden" name="change" value="{{ change }}" />
+
             {{
               govukInput({
                 label: {


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR

Adds functionality for "change" links on the Check your answers page when adding a new profession.

