### PR TITLE
(1950) Add page for selecting a regulatory body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - A landing page for public and admin users
 - Send confirmation email to users once created
 - Add Bull to run background tasks
+- New screen for selecting a regulatory authority when creating a new profession
 
 ### Changed
 

--- a/cypress/integration/admin/professions/add-a-profession.spec.ts
+++ b/cypress/integration/admin/professions/add-a-profession.spec.ts
@@ -24,6 +24,15 @@ describe('Adding a new profession', () => {
       cy.get('button').contains(buttonText).click();
     });
 
+    cy.translate('professions.form.headings.regulatoryBody').then((heading) => {
+      cy.get('body').should('contain', heading);
+    });
+    cy.get('select[name="regulatoryBody"]').select('Department for Education');
+    cy.get('input[name="mandatoryRegistration"][value="mandatory"]').check();
+    cy.translate('app.continue').then((buttonText) => {
+      cy.get('button').contains(buttonText).click();
+    });
+
     cy.translate('professions.form.headings.checkAnswers').then((heading) => {
       cy.get('body').should('contain', heading);
     });
@@ -33,6 +42,12 @@ describe('Adding a new profession', () => {
       cy.get('body').should('contain', england);
     });
     cy.get('body').should('contain', 'Construction & Engineering');
+    cy.get('body').should('contain', 'Department for Education');
+    cy.translate(
+      'professions.form.radioButtons.mandatoryRegistration.mandatory',
+    ).then((mandatoryRegistration) => {
+      cy.get('body').should('contain', mandatoryRegistration);
+    });
 
     cy.translate('professions.form.button.create').then((buttonText) => {
       cy.get('button').contains(buttonText).click();

--- a/seeds/organisations.json
+++ b/seeds/organisations.json
@@ -1,0 +1,42 @@
+[
+  {
+    "name": "Council of Registered Gas Installers",
+    "alternateName": "",
+    "address": "123 Fake Street, London, EC1 1AB",
+    "url": "www.corgi-gas-safety.com",
+    "email": "gas@example.com",
+    "contactUrl": "gas@example.com/contact-us",
+    "telephone": "+44 0123 456789",
+    "fax": "+44 0123 456780"
+  },
+  {
+    "name": "Department for Education",
+    "alternateName": "",
+    "address": "123 Example Street, London, EC1 1AB",
+    "url": "https://www.gov.uk/guidance/early-years-qualifications-finder#overseas-qualifications",
+    "email": "dfe@example.com",
+    "contactUrl": "def@example.com/contact-us",
+    "telephone": "+44 0123 456789",
+    "fax": "+44 0123 456780"
+  },
+  {
+    "name": "Law Society of England and Wales",
+    "alternateName": "",
+    "address": "456 Example Street, London, EC1 1AB",
+    "url": "www.lawsociety.org.uk",
+    "email": "law@example.com",
+    "contactUrl": "law@example.com/contact-us",
+    "telephone": "+44 0123 456789",
+    "fax": "+44 0123 456780"
+  },
+  {
+    "name": "General Medical Council",
+    "alternateName": "",
+    "address": "456 Fake Street, London, EC1 1AB",
+    "url": "www.gmc.com",
+    "email": "gmc@example.com",
+    "contactUrl": "gmc@example.com/contact-us",
+    "telephone": "+44 0123 456789",
+    "fax": "+44 0123 456780"
+  }
+]

--- a/seeds/professions.json
+++ b/seeds/professions.json
@@ -15,6 +15,7 @@
       "The administration of oaths."
     ],
     "legislations": ["The Trade Marks Act 1994", "Legal Services Act 2007"],
+    "mandatoryRegistration": "voluntary",
     "confirmed": true
   },
   {
@@ -31,6 +32,7 @@
       "The Education (School Teachers' Qualifications) (England) Regulations 2003/1662 (as amended)",
       "The Education (Induction Arrangements for School Teachers) (England) Regulations 2012/1115 (as amended)"
     ],
+    "mandatoryRegistration": "mandatory",
     "confirmed": true
   },
   {

--- a/src/common/interfaces/radio-button-args.interface.ts
+++ b/src/common/interfaces/radio-button-args.interface.ts
@@ -1,0 +1,5 @@
+export interface RadioButtonArgs {
+  text: string;
+  value: string;
+  checked: boolean;
+}

--- a/src/common/interfaces/select-item-args.interface.ts
+++ b/src/common/interfaces/select-item-args.interface.ts
@@ -1,0 +1,5 @@
+export interface SelectItemArgs {
+  value: string;
+  text: string;
+  selected: boolean;
+}

--- a/src/db/migrate/1640263118080-AddOrganisationAndProfessionRelationship.ts
+++ b/src/db/migrate/1640263118080-AddOrganisationAndProfessionRelationship.ts
@@ -1,0 +1,25 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddOrganisationAndProfessionRelationship1640263118080
+  implements MigrationInterface
+{
+  name = 'AddOrganisationAndProfessionRelationship1640263118080';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "professions" ADD "organisationId" uuid`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "professions" ADD CONSTRAINT "FK_a1a8fd6782014089dbab4a5118f" FOREIGN KEY ("organisationId") REFERENCES "organisations"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "professions" DROP CONSTRAINT "FK_a1a8fd6782014089dbab4a5118f"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "professions" DROP COLUMN "organisationId"`,
+    );
+  }
+}

--- a/src/db/migrate/1641296064917-AddMandatoryRegistrationToProfession.ts
+++ b/src/db/migrate/1641296064917-AddMandatoryRegistrationToProfession.ts
@@ -1,0 +1,25 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddMandatoryRegistrationToProfession1641296064917
+  implements MigrationInterface
+{
+  name = 'AddMandatoryRegistrationToProfession1641296064917';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TYPE "public"."professions_mandatoryregistration_enum" AS ENUM('mandatory', 'voluntary', 'unknown')`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "professions" ADD "mandatoryRegistration" "public"."professions_mandatoryregistration_enum"`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "professions" DROP COLUMN "mandatoryRegistration"`,
+    );
+    await queryRunner.query(
+      `DROP TYPE "public"."professions_mandatoryregistration_enum"`,
+    );
+  }
+}

--- a/src/i18n/en/professions.json
+++ b/src/i18n/en/professions.json
@@ -73,5 +73,10 @@
       "nationalLegislation": "National legislation",
       "legislationLink": "Legislation link"
     }
+  },
+  "mandatoryRegistration": {
+    "mandatory": "Mandatory",
+    "voluntary": "Voluntary",
+    "unknown": "Unknown"
   }
 }

--- a/src/i18n/en/professions.json
+++ b/src/i18n/en/professions.json
@@ -14,6 +14,14 @@
         "industry": "Industry / sector"
       }
     },
+    "radioButtons": {
+      "hint": "Select one option.",
+      "mandatoryRegistration": {
+        "mandatory": "Mandatory",
+        "voluntary": "Voluntary",
+        "unknown": "Unknown"
+      }
+    },
     "checkboxes": {
       "hint": "Select all that apply."
     },

--- a/src/i18n/en/professions.json
+++ b/src/i18n/en/professions.json
@@ -3,6 +3,7 @@
     "headings": {
       "main": "Add a new profession",
       "topLevelInformation": "Top level information",
+      "regulatoryBody": "Regulatory / professional bodies",
       "checkAnswers": "Check your answers",
       "confirmation": "New profession created"
     },
@@ -12,6 +13,10 @@
         "name": "Name of regulated profession",
         "nations": "In which nation(s) is this profession regulated?",
         "industry": "Industry / sector"
+      },
+      "regulatoryBody": {
+        "regulatedAuthority": "Which body regulates this profession?",
+        "mandatoryRegistration": "Is registration mandatory with professional bodies?"
       }
     },
     "radioButtons": {

--- a/src/organisations/organisation.entity.ts
+++ b/src/organisations/organisation.entity.ts
@@ -3,8 +3,6 @@ import {
   Entity,
   PrimaryGeneratedColumn,
   Column,
-  ManyToMany,
-  JoinTable,
   CreateDateColumn,
   UpdateDateColumn,
   OneToMany,

--- a/src/organisations/organisation.entity.ts
+++ b/src/organisations/organisation.entity.ts
@@ -7,6 +7,7 @@ import {
   JoinTable,
   CreateDateColumn,
   UpdateDateColumn,
+  OneToMany,
 } from 'typeorm';
 
 @Entity({ name: 'organisations' })
@@ -38,8 +39,7 @@ export class Organisation {
   @Column({ nullable: true })
   fax: string;
 
-  @ManyToMany(() => Profession)
-  @JoinTable()
+  @OneToMany(() => Profession, (profession) => profession.organisation)
   professions: Profession[];
 
   @CreateDateColumn({

--- a/src/organisations/organisations.seeder.ts
+++ b/src/organisations/organisations.seeder.ts
@@ -1,0 +1,54 @@
+import { Injectable } from '@nestjs/common';
+import { Repository } from 'typeorm';
+
+import { Seeder } from 'nestjs-seeder';
+import { InjectRepository } from '@nestjs/typeorm';
+
+import { Organisation } from '../organisations/organisation.entity';
+
+type SeedOrganisation = {
+  name: string;
+  alternateName: string;
+  address: string;
+  url: string;
+  email: string;
+  contactUrl: string;
+  telephone: string;
+  fax: string;
+};
+
+@Injectable()
+export class OrganisationsSeeder implements Seeder {
+  constructor(
+    @InjectRepository(Organisation)
+    private readonly organisationsRepository: Repository<Organisation>,
+  ) {}
+
+  async seed(): Promise<any> {
+    /* eslint-disable @typescript-eslint/no-var-requires */
+    const organisationsData =
+      require('../../seeds/organisations.json') as SeedOrganisation[];
+
+    const organisations = await Promise.all(
+      organisationsData.map(async (organisation) => {
+        return new Organisation(
+          organisation.name,
+          organisation.alternateName,
+          organisation.address,
+          organisation.url,
+          organisation.email,
+          organisation.contactUrl,
+          organisation.telephone,
+          organisation.fax,
+          null,
+        );
+      }),
+    );
+
+    return this.organisationsRepository.save(organisations);
+  }
+
+  async drop(): Promise<any> {
+    await this.organisationsRepository.delete({});
+  }
+}

--- a/src/professions/admin/add-profession/check-your-answers.controller.spec.ts
+++ b/src/professions/admin/add-profession/check-your-answers.controller.spec.ts
@@ -2,7 +2,8 @@ import { DeepMocked, createMock } from '@golevelup/ts-jest';
 import { TestingModule, Test } from '@nestjs/testing';
 import { I18nService } from 'nestjs-i18n';
 import { Industry } from '../../../industries/industry.entity';
-import { Profession } from '../../profession.entity';
+import { Organisation } from '../../../organisations/organisation.entity';
+import { MandatoryRegistration, Profession } from '../../profession.entity';
 import { ProfessionsService } from '../../professions.service';
 import { CheckYourAnswersController } from './check-your-answers.controller';
 
@@ -18,6 +19,10 @@ describe('CheckYourAnswersController', () => {
       name: 'Gas Safe Engineer',
       occupationLocations: ['GB-ENG'],
       industries: [new Industry('industries.construction')],
+      organisation: createMock<Organisation>({
+        name: 'Council of Gas Registered Engineers',
+      }),
+      mandatoryRegistration: MandatoryRegistration.Voluntary,
     });
 
     professionsService = createMock<ProfessionsService>({
@@ -58,6 +63,12 @@ describe('CheckYourAnswersController', () => {
         expect(templateParams.industries).toEqual([
           'Construction & Engineering',
         ]);
+        expect(templateParams.organisation).toEqual(
+          'Council of Gas Registered Engineers',
+        );
+        expect(templateParams.mandatoryRegistration).toEqual(
+          MandatoryRegistration.Voluntary,
+        );
         expect(professionsService.find).toHaveBeenCalledWith('profession-id');
       });
     });

--- a/src/professions/admin/add-profession/check-your-answers.controller.ts
+++ b/src/professions/admin/add-profession/check-your-answers.controller.ts
@@ -38,6 +38,8 @@ export class CheckYourAnswersController {
       name: draftProfession.name,
       nations: selectedNations,
       industries: industryNames,
+      organisation: draftProfession.organisation.name,
+      mandatoryRegistration: draftProfession.mandatoryRegistration,
     };
   }
 }

--- a/src/professions/admin/add-profession/dto/regulatory-body.dto.ts
+++ b/src/professions/admin/add-profession/dto/regulatory-body.dto.ts
@@ -1,0 +1,10 @@
+import { IsNotEmpty } from 'class-validator';
+import { MandatoryRegistration } from '../../../profession.entity';
+
+export class RegulatoryBodyDto {
+  @IsNotEmpty()
+  regulatoryBody: string;
+
+  @IsNotEmpty()
+  mandatoryRegistration: MandatoryRegistration;
+}

--- a/src/professions/admin/add-profession/dto/regulatory-body.dto.ts
+++ b/src/professions/admin/add-profession/dto/regulatory-body.dto.ts
@@ -7,4 +7,6 @@ export class RegulatoryBodyDto {
 
   @IsNotEmpty()
   mandatoryRegistration: MandatoryRegistration;
+
+  change: boolean;
 }

--- a/src/professions/admin/add-profession/interfaces/check-your-answers.template.ts
+++ b/src/professions/admin/add-profession/interfaces/check-your-answers.template.ts
@@ -3,4 +3,6 @@ export interface CheckYourAnswersTemplate {
   nations: string[];
   industries: string[];
   professionId: string;
+  organisation: string;
+  mandatoryRegistration: string;
 }

--- a/src/professions/admin/add-profession/interfaces/regulatory-body.template.ts
+++ b/src/professions/admin/add-profession/interfaces/regulatory-body.template.ts
@@ -1,0 +1,8 @@
+import { RadioButtonArgs } from '../../../../common/interfaces/radio-button-args.interface';
+import { SelectItemArgs } from '../../../../common/interfaces/select-item-args.interface';
+
+export interface RegulatoryBodyTemplate {
+  regulatedAuthoritiesSelectArgs: SelectItemArgs[];
+  mandatoryRegistrationRadioButtonArgs: RadioButtonArgs[];
+  errors: object | undefined;
+}

--- a/src/professions/admin/add-profession/interfaces/regulatory-body.template.ts
+++ b/src/professions/admin/add-profession/interfaces/regulatory-body.template.ts
@@ -4,5 +4,6 @@ import { SelectItemArgs } from '../../../../common/interfaces/select-item-args.i
 export interface RegulatoryBodyTemplate {
   regulatedAuthoritiesSelectArgs: SelectItemArgs[];
   mandatoryRegistrationRadioButtonArgs: RadioButtonArgs[];
+  change: boolean;
   errors: object | undefined;
 }

--- a/src/professions/admin/add-profession/regulatory-body.controller.spec.ts
+++ b/src/professions/admin/add-profession/regulatory-body.controller.spec.ts
@@ -1,0 +1,152 @@
+import { DeepMocked, createMock } from '@golevelup/ts-jest';
+import { TestingModule, Test } from '@nestjs/testing';
+import { Response } from 'express';
+import { I18nService } from 'nestjs-i18n';
+import { Organisation } from '../../../organisations/organisation.entity';
+import { OrganisationsService } from '../../../organisations/organisations.service';
+import { MandatoryRegistration, Profession } from '../../profession.entity';
+import { ProfessionsService } from '../../professions.service';
+import { MandatoryRegistrationRadioButtonsPresenter } from '../mandatory-registration-radio-buttons-presenter';
+import { RegulatedAuthoritiesSelectPresenter } from '../regulated-authorities-select-presenter';
+import { RegulatoryBodyController } from './regulatory-body.controller';
+
+describe(RegulatoryBodyController, () => {
+  let controller: RegulatoryBodyController;
+  let professionsService: DeepMocked<ProfessionsService>;
+  let organisationsService: DeepMocked<OrganisationsService>;
+  let response: DeepMocked<Response>;
+  let profession: DeepMocked<Profession>;
+  let i18nService: DeepMocked<I18nService>;
+
+  const organisation1 = createMock<Organisation>({
+    name: 'Organisation 1',
+    id: 'org-1-id',
+  });
+  const organisation2 = createMock<Organisation>({
+    name: 'Organisation 2',
+    id: 'org-2-id',
+  });
+
+  beforeEach(async () => {
+    profession = createMock<Profession>({
+      id: 'profession-id',
+      industries: null,
+      occupationLocations: null,
+    });
+
+    professionsService = createMock<ProfessionsService>({
+      find: async () => profession,
+    });
+
+    organisationsService = createMock<OrganisationsService>({
+      find: async () => organisation1,
+    });
+
+    i18nService = createMock<I18nService>();
+
+    i18nService.translate.mockImplementation(async (text) => {
+      switch (text) {
+        case 'professions.form.radioButtons.mandatoryRegistration.mandatory':
+          return 'Mandatory';
+        case 'professions.form.radioButtons.mandatoryRegistration.voluntary':
+          return 'Voluntary';
+        case 'professions.form.radioButtons.mandatoryRegistration.unknown':
+          return 'Unknown';
+        default:
+          return text;
+      }
+    });
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [RegulatoryBodyController],
+      providers: [
+        { provide: ProfessionsService, useValue: professionsService },
+        { provide: OrganisationsService, useValue: organisationsService },
+        { provide: I18nService, useValue: i18nService },
+      ],
+    }).compile();
+
+    organisationsService.all.mockImplementation(async () => [
+      organisation1,
+      organisation2,
+    ]);
+    response = createMock<Response>();
+
+    controller = module.get<RegulatoryBodyController>(RegulatoryBodyController);
+  });
+
+  describe('edit', () => {
+    describe('when editing a just-created, blank Profession', () => {
+      it('should render a list of Organisations to be displayed in a Select, alongside Radio Buttons with mandatory registration values with none of them selected', async () => {
+        professionsService.find.mockImplementation(async () => profession);
+        const regulatedAuthoritiesSelectPresenter =
+          new RegulatedAuthoritiesSelectPresenter(
+            [organisation1, organisation2],
+            null,
+          );
+
+        const mandatoryRegistrationRadioButtonsPresenter =
+          new MandatoryRegistrationRadioButtonsPresenter(null, i18nService);
+
+        await controller.edit(response, 'profession-id');
+
+        expect(response.render).toHaveBeenCalledWith(
+          'professions/admin/add-profession/regulatory-body',
+          {
+            regulatedAuthoritiesSelectArgs:
+              regulatedAuthoritiesSelectPresenter.selectArgs(),
+            mandatoryRegistrationRadioButtonArgs:
+              await mandatoryRegistrationRadioButtonsPresenter.radioButtonArgs(),
+            errors: undefined,
+          },
+        );
+        expect(organisationsService.all).toHaveBeenCalled();
+      });
+    });
+
+    describe('when an existing Profession is found', () => {
+      const existingProfession = createMock<Profession>({
+        id: 'profession-id',
+        organisation: organisation1,
+        mandatoryRegistration: MandatoryRegistration.Mandatory,
+      });
+
+      it('should pre-select the Organisation from the Select and the mandatory registration in the radio buttons', async () => {
+        professionsService.find.mockImplementation(
+          async () => existingProfession,
+        );
+
+        const regulatedAuthoritiesSelectPresenterWithSelectedOrganisation =
+          new RegulatedAuthoritiesSelectPresenter(
+            [organisation1, organisation2],
+            organisation1,
+          );
+
+        const mandatoryRegistrationRadioButtonsPresenterWithSelectedValue =
+          new MandatoryRegistrationRadioButtonsPresenter(
+            MandatoryRegistration.Mandatory,
+            i18nService,
+          );
+
+        await controller.edit(response, 'profession-id');
+
+        expect(response.render).toHaveBeenCalledWith(
+          'professions/admin/add-profession/regulatory-body',
+          {
+            regulatedAuthoritiesSelectArgs:
+              regulatedAuthoritiesSelectPresenterWithSelectedOrganisation.selectArgs(),
+            mandatoryRegistrationRadioButtonArgs:
+              await mandatoryRegistrationRadioButtonsPresenterWithSelectedValue.radioButtonArgs(),
+            errors: undefined,
+          },
+        );
+
+        expect(organisationsService.all).toHaveBeenCalled();
+      });
+    });
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+});

--- a/src/professions/admin/add-profession/regulatory-body.controller.ts
+++ b/src/professions/admin/add-profession/regulatory-body.controller.ts
@@ -24,6 +24,7 @@ export class RegulatoryBodyController {
   async edit(
     @Res() res: Response,
     @Param('id') id: string,
+    @Query('change') change: boolean,
     errors: object | undefined = undefined,
   ): Promise<void> {
     const profession = await this.professionsService.find(id);
@@ -35,6 +36,7 @@ export class RegulatoryBodyController {
       res,
       profession.organisation,
       selectedMandatoryRegistration,
+      change,
       errors,
     );
   }
@@ -64,6 +66,7 @@ export class RegulatoryBodyController {
           profession,
           regulatoryBodyDto,
         ),
+        regulatoryBodyDto.change,
         errors,
       );
     }
@@ -87,6 +90,11 @@ export class RegulatoryBodyController {
 
     await this.professionsService.save(updated);
 
+    if (regulatoryBodyDto.change) {
+      return res.redirect(`/admin/professions/${id}/check-your-answers`);
+    }
+
+    // This will be a different page once the next page in the journey is added
     return res.redirect(`/admin/professions/${id}/check-your-answers`);
   }
 
@@ -94,6 +102,7 @@ export class RegulatoryBodyController {
     res: Response,
     selectedRegulatoryAuthority: Organisation | null,
     mandatoryRegistration: MandatoryRegistration | null,
+    change: boolean,
     errors: object | undefined = undefined,
   ): Promise<void> {
     const regulatedAuthorities = await this.organisationsService.all();
@@ -113,6 +122,7 @@ export class RegulatoryBodyController {
     const templateArgs: RegulatoryBodyTemplate = {
       regulatedAuthoritiesSelectArgs,
       mandatoryRegistrationRadioButtonArgs,
+      change,
       errors,
     };
 

--- a/src/professions/admin/add-profession/regulatory-body.controller.ts
+++ b/src/professions/admin/add-profession/regulatory-body.controller.ts
@@ -1,0 +1,75 @@
+import { Controller, Get, Param, Post, Query, Res } from '@nestjs/common';
+import { Response } from 'express';
+import { ProfessionsService } from '../../professions.service';
+import { I18nService } from 'nestjs-i18n';
+import { OrganisationsService } from '../../../organisations/organisations.service';
+import { RegulatoryBodyTemplate } from './interfaces/regulatory-body.template';
+import { RegulatedAuthoritiesSelectPresenter } from '../regulated-authorities-select-presenter';
+import { MandatoryRegistration } from '../../profession.entity';
+import { Organisation } from '../../../organisations/organisation.entity';
+import { MandatoryRegistrationRadioButtonsPresenter } from '../mandatory-registration-radio-buttons-presenter';
+
+@Controller('admin/professions')
+export class RegulatoryBodyController {
+  constructor(
+    private readonly organisationsService: OrganisationsService,
+    private readonly professionsService: ProfessionsService,
+    private readonly i18nService: I18nService,
+  ) {}
+
+  @Get('/:id/regulatory-body/edit')
+  async edit(
+    @Res() res: Response,
+    @Param('id') id: string,
+    errors: object | undefined = undefined,
+  ): Promise<void> {
+    const profession = await this.professionsService.find(id);
+
+    const selectedMandatoryRegistration: MandatoryRegistration =
+      profession.mandatoryRegistration as MandatoryRegistration;
+
+    return this.renderForm(
+      res,
+      profession.organisation,
+      selectedMandatoryRegistration,
+      errors,
+    );
+  }
+
+  @Post('/:id/regulatory-body')
+  async update(@Res() res: Response, @Param('id') id: string): Promise<void> {
+    return res.redirect(`/admin/professions/${id}/check-your-answers`);
+  }
+
+  private async renderForm(
+    res: Response,
+    selectedRegulatoryAuthority: Organisation | null,
+    mandatoryRegistration: MandatoryRegistration | null,
+    errors: object | undefined = undefined,
+  ): Promise<void> {
+    const regulatedAuthorities = await this.organisationsService.all();
+
+    const regulatedAuthoritiesSelectArgs =
+      new RegulatedAuthoritiesSelectPresenter(
+        regulatedAuthorities,
+        selectedRegulatoryAuthority,
+      ).selectArgs();
+
+    const mandatoryRegistrationRadioButtonArgs =
+      await new MandatoryRegistrationRadioButtonsPresenter(
+        mandatoryRegistration,
+        this.i18nService,
+      ).radioButtonArgs();
+
+    const templateArgs: RegulatoryBodyTemplate = {
+      regulatedAuthoritiesSelectArgs,
+      mandatoryRegistrationRadioButtonArgs,
+      errors,
+    };
+
+    return res.render(
+      'professions/admin/add-profession/regulatory-body',
+      templateArgs,
+    );
+  }
+}

--- a/src/professions/admin/add-profession/regulatory-body.controller.ts
+++ b/src/professions/admin/add-profession/regulatory-body.controller.ts
@@ -1,13 +1,16 @@
-import { Controller, Get, Param, Post, Query, Res } from '@nestjs/common';
+import { Body, Controller, Get, Param, Post, Query, Res } from '@nestjs/common';
 import { Response } from 'express';
 import { ProfessionsService } from '../../professions.service';
 import { I18nService } from 'nestjs-i18n';
 import { OrganisationsService } from '../../../organisations/organisations.service';
 import { RegulatoryBodyTemplate } from './interfaces/regulatory-body.template';
 import { RegulatedAuthoritiesSelectPresenter } from '../regulated-authorities-select-presenter';
-import { MandatoryRegistration } from '../../profession.entity';
+import { MandatoryRegistration, Profession } from '../../profession.entity';
 import { Organisation } from '../../../organisations/organisation.entity';
 import { MandatoryRegistrationRadioButtonsPresenter } from '../mandatory-registration-radio-buttons-presenter';
+import { Validator } from '../../../helpers/validator';
+import { RegulatoryBodyDto } from './dto/regulatory-body.dto';
+import { ValidationFailedError } from '../../../validation/validation-failed.error';
 
 @Controller('admin/professions')
 export class RegulatoryBodyController {
@@ -37,7 +40,53 @@ export class RegulatoryBodyController {
   }
 
   @Post('/:id/regulatory-body')
-  async update(@Res() res: Response, @Param('id') id: string): Promise<void> {
+  async update(
+    @Res() res: Response,
+    @Param('id') id: string,
+    @Body() regulatoryBodyDto,
+  ): Promise<void> {
+    const validator = await Validator.validate(
+      RegulatoryBodyDto,
+      regulatoryBodyDto,
+    );
+
+    const profession = await this.professionsService.find(id);
+
+    if (!validator.valid()) {
+      const errors = new ValidationFailedError(validator.errors).fullMessages();
+      return this.renderForm(
+        res,
+        await this.getSelectedOrganisationFromDtoThenProfession(
+          profession,
+          regulatoryBodyDto,
+        ),
+        this.getSelectedMandatoryRegistrationFromDtoThenProfession(
+          profession,
+          regulatoryBodyDto,
+        ),
+        errors,
+      );
+    }
+
+    const regulatoryBodyAnswers: RegulatoryBodyDto = regulatoryBodyDto;
+
+    const organisation = await this.organisationsService.find(
+      regulatoryBodyAnswers.regulatoryBody,
+    );
+
+    const selectedMandatoryRegistration: MandatoryRegistration =
+      regulatoryBodyDto.mandatoryRegistration as MandatoryRegistration;
+
+    const updated: Profession = {
+      ...profession,
+      ...{
+        organisation: organisation,
+        mandatoryRegistration: selectedMandatoryRegistration,
+      },
+    };
+
+    await this.professionsService.save(updated);
+
     return res.redirect(`/admin/professions/${id}/check-your-answers`);
   }
 
@@ -71,5 +120,25 @@ export class RegulatoryBodyController {
       'professions/admin/add-profession/regulatory-body',
       templateArgs,
     );
+  }
+
+  async getSelectedOrganisationFromDtoThenProfession(
+    profession: Profession,
+    regulatoryBodyDto: RegulatoryBodyDto,
+  ): Promise<Organisation> {
+    return regulatoryBodyDto.regulatoryBody
+      ? await this.organisationsService.find(regulatoryBodyDto.regulatoryBody)
+      : profession.organisation;
+  }
+
+  getSelectedMandatoryRegistrationFromDtoThenProfession(
+    profession: Profession,
+    regulatoryBodyDto: RegulatoryBodyDto,
+  ): MandatoryRegistration {
+    const selectedMandatoryRegistration =
+      regulatoryBodyDto.mandatoryRegistration ||
+      profession.mandatoryRegistration;
+
+    return selectedMandatoryRegistration as MandatoryRegistration;
   }
 }

--- a/src/professions/admin/add-profession/top-level-information.controller.spec.ts
+++ b/src/professions/admin/add-profession/top-level-information.controller.spec.ts
@@ -203,7 +203,7 @@ describe('TopLevelInformationController', () => {
 
   describe('update', () => {
     describe('when all required parameters are entered', () => {
-      it('updates the Profession and redirects to the Check your answers page', async () => {
+      it('updates the Profession and redirects to the next page in the journey', async () => {
         const topLevelDetailsDto = {
           name: 'Gas Safe Engineer',
           nations: ['GB-ENG'],
@@ -222,7 +222,7 @@ describe('TopLevelInformationController', () => {
         });
 
         expect(response.redirect).toHaveBeenCalledWith(
-          '/admin/professions/profession-id/check-your-answers',
+          '/admin/professions/profession-id/regulatory-body/edit',
         );
       });
     });
@@ -463,7 +463,7 @@ describe('TopLevelInformationController', () => {
         );
 
         expect(response.redirect).toHaveBeenCalledWith(
-          '/admin/professions/profession-id/check-your-answers',
+          '/admin/professions/profession-id/regulatory-body/edit',
         );
       });
     });

--- a/src/professions/admin/add-profession/top-level-information.controller.spec.ts
+++ b/src/professions/admin/add-profession/top-level-information.controller.spec.ts
@@ -142,6 +142,7 @@ describe('TopLevelInformationController', () => {
         null,
         ['GB-ENG', 'GB-SCT'],
         null,
+        null,
         [selectedIndustry],
       );
       existingProfession.id = 'profession-id';
@@ -253,6 +254,7 @@ describe('TopLevelInformationController', () => {
           null,
           ['GB-ENG', 'GB-SCT'],
           null,
+          null,
           [industry],
         );
 
@@ -329,6 +331,7 @@ describe('TopLevelInformationController', () => {
           null,
           ['GB-ENG', 'GB-SCT'],
           null,
+          null,
           [new Industry('industries.health')],
         );
 
@@ -399,6 +402,7 @@ describe('TopLevelInformationController', () => {
           null,
           ['GB-ENG', 'GB-SCT'],
           null,
+          null,
           [constructionIndustry],
         );
         existingProfession.id = 'profession-id';
@@ -434,6 +438,7 @@ describe('TopLevelInformationController', () => {
           null,
           null,
           ['GB-ENG', 'GB-SCT'],
+          null,
           null,
           [constructionIndustry],
         );

--- a/src/professions/admin/add-profession/top-level-information.controller.ts
+++ b/src/professions/admin/add-profession/top-level-information.controller.ts
@@ -92,8 +92,7 @@ export class TopLevelInformationController {
       return res.redirect(`/admin/professions/${id}/check-your-answers`);
     }
 
-    // This will be the next page in the journey, but for now is the same as above
-    return res.redirect(`/admin/professions/${id}/check-your-answers`);
+    return res.redirect(`/admin/professions/${id}/regulatory-body/edit`);
   }
 
   private async renderForm(

--- a/src/professions/admin/mandatory-registration-radio-buttons-presenter.spec.ts
+++ b/src/professions/admin/mandatory-registration-radio-buttons-presenter.spec.ts
@@ -1,0 +1,77 @@
+import { createMock, DeepMocked } from '@golevelup/ts-jest';
+import { I18nService } from 'nestjs-i18n';
+import { MandatoryRegistration } from '../profession.entity';
+import { MandatoryRegistrationRadioButtonsPresenter } from './mandatory-registration-radio-buttons-presenter';
+
+describe(MandatoryRegistrationRadioButtonsPresenter, () => {
+  let i18nService: DeepMocked<I18nService>;
+
+  beforeEach(async () => {
+    i18nService = createMock<I18nService>();
+
+    i18nService.translate.mockImplementation(async (text) => {
+      switch (text) {
+        case 'professions.form.radioButtons.mandatoryRegistration.mandatory':
+          return 'Mandatory';
+        case 'professions.form.radioButtons.mandatoryRegistration.voluntary':
+          return 'Voluntary';
+        case 'professions.form.radioButtons.mandatoryRegistration.unknown':
+          return 'Unknown';
+        default:
+          return '';
+      }
+    });
+  });
+
+  describe('radioButtonArgs', () => {
+    it('should return translated values with unchecked radio buttons when called with a null Mandatory Registration value', async () => {
+      const presenter = new MandatoryRegistrationRadioButtonsPresenter(
+        null,
+        i18nService,
+      );
+
+      await expect(presenter.radioButtonArgs()).resolves.toEqual([
+        {
+          text: 'Mandatory',
+          value: MandatoryRegistration.Mandatory,
+          checked: false,
+        },
+        {
+          text: 'Voluntary',
+          value: MandatoryRegistration.Voluntary,
+          checked: false,
+        },
+        {
+          text: 'Unknown',
+          value: MandatoryRegistration.Unknown,
+          checked: false,
+        },
+      ]);
+    });
+
+    it('should pre-check the relevant radio button for a matching Mandatory Registration value', async () => {
+      const presenter = new MandatoryRegistrationRadioButtonsPresenter(
+        MandatoryRegistration.Mandatory,
+        i18nService,
+      );
+
+      await expect(presenter.radioButtonArgs()).resolves.toEqual([
+        {
+          text: 'Mandatory',
+          value: MandatoryRegistration.Mandatory,
+          checked: true,
+        },
+        {
+          text: 'Voluntary',
+          value: MandatoryRegistration.Voluntary,
+          checked: false,
+        },
+        {
+          text: 'Unknown',
+          value: MandatoryRegistration.Unknown,
+          checked: false,
+        },
+      ]);
+    });
+  });
+});

--- a/src/professions/admin/mandatory-registration-radio-buttons-presenter.ts
+++ b/src/professions/admin/mandatory-registration-radio-buttons-presenter.ts
@@ -1,0 +1,36 @@
+import { I18nService } from 'nestjs-i18n';
+import { RadioButtonArgs } from '../../common/interfaces/radio-button-args.interface';
+import { MandatoryRegistration } from '../profession.entity';
+
+export class MandatoryRegistrationRadioButtonsPresenter {
+  constructor(
+    private readonly mandatoryRegistration: MandatoryRegistration | null,
+    private readonly i18nService: I18nService,
+  ) {}
+
+  async radioButtonArgs(): Promise<RadioButtonArgs[]> {
+    return [
+      {
+        value: MandatoryRegistration.Mandatory,
+        text: await this.i18nService.translate(
+          'professions.form.radioButtons.mandatoryRegistration.mandatory',
+        ),
+        checked: this.mandatoryRegistration === MandatoryRegistration.Mandatory,
+      },
+      {
+        value: MandatoryRegistration.Voluntary,
+        text: await this.i18nService.translate(
+          'professions.form.radioButtons.mandatoryRegistration.voluntary',
+        ),
+        checked: this.mandatoryRegistration === MandatoryRegistration.Voluntary,
+      },
+      {
+        value: MandatoryRegistration.Unknown,
+        text: await this.i18nService.translate(
+          'professions.form.radioButtons.mandatoryRegistration.unknown',
+        ),
+        checked: this.mandatoryRegistration === MandatoryRegistration.Unknown,
+      },
+    ];
+  }
+}

--- a/src/professions/admin/regulated-authorities-select-presenter.spec.ts
+++ b/src/professions/admin/regulated-authorities-select-presenter.spec.ts
@@ -1,0 +1,51 @@
+import { Organisation } from '../../organisations/organisation.entity';
+import { RegulatedAuthoritiesSelectPresenter } from './regulated-authorities-select-presenter';
+
+describe(RegulatedAuthoritiesSelectPresenter, () => {
+  const exampleOrganisation1 = new Organisation('Example Organisation 1');
+  exampleOrganisation1.id = 'org1-id';
+  const exampleOrganisation2 = new Organisation('Example Organisation 2');
+  exampleOrganisation2.id = 'org2-id';
+
+  describe('selectArgs', () => {
+    it('should return no selected item when called with an empty list of selected Organisations', async () => {
+      const presenter = new RegulatedAuthoritiesSelectPresenter(
+        [exampleOrganisation1, exampleOrganisation2],
+        null,
+      );
+
+      expect(presenter.selectArgs()).toEqual([
+        {
+          text: 'Example Organisation 1',
+          value: 'org1-id',
+          selected: false,
+        },
+        {
+          text: 'Example Organisation 2',
+          value: 'org2-id',
+          selected: false,
+        },
+      ]);
+    });
+
+    it('should return some checked checkbox arguments when called with a non-empty list of Nations', async () => {
+      const presenter = new RegulatedAuthoritiesSelectPresenter(
+        [exampleOrganisation1, exampleOrganisation2],
+        exampleOrganisation1,
+      );
+
+      expect(presenter.selectArgs()).toEqual([
+        {
+          text: 'Example Organisation 1',
+          value: 'org1-id',
+          selected: true,
+        },
+        {
+          text: 'Example Organisation 2',
+          value: 'org2-id',
+          selected: false,
+        },
+      ]);
+    });
+  });
+});

--- a/src/professions/admin/regulated-authorities-select-presenter.ts
+++ b/src/professions/admin/regulated-authorities-select-presenter.ts
@@ -1,0 +1,19 @@
+import { SelectItemArgs } from '../../common/interfaces/select-item-args.interface';
+import { Organisation } from '../../organisations/organisation.entity';
+
+export class RegulatedAuthoritiesSelectPresenter {
+  constructor(
+    private readonly allOrganisations: Organisation[],
+    private readonly selectedOrganisation: Organisation | null,
+  ) {}
+
+  selectArgs(): SelectItemArgs[] {
+    return this.allOrganisations.map((organisation) => ({
+      text: organisation.name,
+      value: organisation.id,
+      selected: this.selectedOrganisation
+        ? this.selectedOrganisation.id === organisation.id
+        : false,
+    }));
+  }
+}

--- a/src/professions/profession.entity.ts
+++ b/src/professions/profession.entity.ts
@@ -14,6 +14,12 @@ import {
 import { Industry } from '../industries/industry.entity';
 import { Organisation } from '../organisations/organisation.entity';
 
+export enum MandatoryRegistration {
+  Mandatory = 'mandatory',
+  Voluntary = 'voluntary',
+  Unknown = 'unknown',
+}
+
 @Entity({ name: 'professions' })
 export class Profession {
   @PrimaryGeneratedColumn('uuid')
@@ -37,6 +43,9 @@ export class Profession {
 
   @Column({ nullable: true })
   regulationType: string;
+
+  @Column({ nullable: true, type: 'enum', enum: MandatoryRegistration })
+  mandatoryRegistration: MandatoryRegistration;
 
   @ManyToMany(() => Industry, { nullable: true, eager: true })
   @JoinTable()
@@ -84,6 +93,7 @@ export class Profession {
     description?: string,
     occupationLocations?: string[],
     regulationType?: string,
+    mandatoryRegistration?: MandatoryRegistration,
     industries?: Industry[],
     qualification?: Qualification,
     reservedActivities?: string[],
@@ -97,6 +107,7 @@ export class Profession {
     this.description = description || null;
     this.occupationLocations = occupationLocations || null;
     this.regulationType = regulationType || null;
+    this.mandatoryRegistration = mandatoryRegistration || null;
     this.industries = industries || null;
     this.qualification = qualification || null;
     this.reservedActivities = reservedActivities || null;

--- a/src/professions/profession.entity.ts
+++ b/src/professions/profession.entity.ts
@@ -12,6 +12,7 @@ import {
   UpdateDateColumn,
 } from 'typeorm';
 import { Industry } from '../industries/industry.entity';
+import { Organisation } from '../organisations/organisation.entity';
 
 @Entity({ name: 'professions' })
 export class Profession {
@@ -55,6 +56,11 @@ export class Profession {
   @JoinTable()
   legislations: Legislation[];
 
+  @ManyToOne(() => Organisation, (organisation) => organisation.professions, {
+    eager: true,
+  })
+  organisation: Organisation;
+
   @Column({ default: false })
   confirmed: boolean;
 
@@ -82,6 +88,7 @@ export class Profession {
     qualification?: Qualification,
     reservedActivities?: string[],
     legislations?: Legislation[],
+    organisation?: Organisation,
     confirmed?: boolean,
   ) {
     this.name = name || null;
@@ -94,6 +101,7 @@ export class Profession {
     this.qualification = qualification || null;
     this.reservedActivities = reservedActivities || null;
     this.legislations = legislations || null;
+    this.organisation = organisation || null;
     this.confirmed = confirmed || false;
   }
 }

--- a/src/professions/professions.controller.spec.ts
+++ b/src/professions/professions.controller.spec.ts
@@ -17,6 +17,7 @@ const exampleProfession = new Profession(
   '',
   ['GB-ENG'],
   '',
+  null,
   [industry],
 );
 exampleProfession.id = 'profession-id';

--- a/src/professions/professions.module.ts
+++ b/src/professions/professions.module.ts
@@ -9,17 +9,22 @@ import { Industry } from '../industries/industry.entity';
 import { CheckYourAnswersController } from './admin/add-profession/check-your-answers.controller';
 import { ConfirmationController } from './admin/add-profession/confirmation.controller';
 import { SearchController } from './search/search.controller';
+import { RegulatoryBodyController } from './admin/add-profession/regulatory-body.controller';
+import { Organisation } from '../organisations/organisation.entity';
+import { OrganisationsService } from '../organisations/organisations.service';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([Profession]),
     TypeOrmModule.forFeature([Industry]),
+    TypeOrmModule.forFeature([Organisation]),
   ],
-  providers: [ProfessionsService, IndustriesService],
+  providers: [ProfessionsService, IndustriesService, OrganisationsService],
   controllers: [
     SearchController,
     ProfessionsController,
     TopLevelInformationController,
+    RegulatoryBodyController,
     CheckYourAnswersController,
     ConfirmationController,
   ],

--- a/src/professions/professions.seeder.ts
+++ b/src/professions/professions.seeder.ts
@@ -70,6 +70,7 @@ export class ProfessionsSeeder implements Seeder {
           qualification,
           profession.reservedActivities,
           legislations,
+          null,
           profession.confirmed,
         );
       }),

--- a/src/professions/professions.seeder.ts
+++ b/src/professions/professions.seeder.ts
@@ -4,7 +4,7 @@ import { In, Repository } from 'typeorm';
 import { Seeder } from 'nestjs-seeder';
 import { InjectRepository } from '@nestjs/typeorm';
 
-import { Profession } from './profession.entity';
+import { MandatoryRegistration, Profession } from './profession.entity';
 import { Industry } from 'src/industries/industry.entity';
 import { Qualification } from 'src/qualifications/qualification.entity';
 import { Legislation } from 'src/legislations/legislation.entity';
@@ -20,6 +20,7 @@ type SeedProfession = {
   qualification: string;
   reservedActivities: string[];
   legislations: string[];
+  mandatoryRegistration: MandatoryRegistration;
   confirmed: boolean;
 };
 
@@ -66,6 +67,7 @@ export class ProfessionsSeeder implements Seeder {
           profession.description,
           profession.occupationLocations,
           profession.regulationType,
+          profession.mandatoryRegistration,
           industries,
           qualification,
           profession.reservedActivities,

--- a/src/professions/professions.service.spec.ts
+++ b/src/professions/professions.service.spec.ts
@@ -5,7 +5,7 @@ import { Connection, EntityManager, QueryRunner, Repository } from 'typeorm';
 
 import { Industry } from '../industries/industry.entity';
 import { Qualification } from '../qualifications/qualification.entity';
-import { Profession } from './profession.entity';
+import { MandatoryRegistration, Profession } from './profession.entity';
 import { ProfessionsService } from './professions.service';
 
 const profession = new Profession(
@@ -15,6 +15,7 @@ const profession = new Profession(
   'Gas installers work on gas appliances and installations.',
   ['GB-ENG', 'GB-SCT', 'GB-WLS', 'GB-NIR'],
   'Reserves of activities',
+  MandatoryRegistration.Voluntary,
   [new Industry('Construction & Engineering')],
   new Qualification('ATT - Attestation of competence , Art. 11 a'),
   [
@@ -30,6 +31,7 @@ const professionArray = [
     'Social workers are trained to: make assessments, taking account of a range of factors',
     ['GB-ENG'],
     'Protected title',
+    MandatoryRegistration.Mandatory,
     [new Industry('Health')],
     new Qualification(
       'PS3 - Diploma of post-secondary level (3-4 years) , Art. 11 d',
@@ -161,6 +163,7 @@ describe('Profession', () => {
             null,
             null,
             null,
+            null,
             true,
           );
 
@@ -197,6 +200,7 @@ describe('Profession', () => {
               '',
               null,
               '',
+              null,
               null,
               null,
               null,
@@ -255,6 +259,7 @@ describe('Profession', () => {
               null,
               null,
               null,
+              null,
               true,
             ),
           );
@@ -288,6 +293,7 @@ describe('Profession', () => {
               '',
               null,
               '',
+              null,
               null,
               null,
               null,

--- a/src/professions/professions.service.spec.ts
+++ b/src/professions/professions.service.spec.ts
@@ -160,6 +160,7 @@ describe('Profession', () => {
             null,
             null,
             null,
+            null,
             true,
           );
 
@@ -196,6 +197,7 @@ describe('Profession', () => {
               '',
               null,
               '',
+              null,
               null,
               null,
               null,
@@ -252,6 +254,7 @@ describe('Profession', () => {
               null,
               null,
               null,
+              null,
               true,
             ),
           );
@@ -285,6 +288,7 @@ describe('Profession', () => {
               '',
               null,
               '',
+              null,
               null,
               null,
               null,

--- a/src/professions/professions.service.ts
+++ b/src/professions/professions.service.ts
@@ -29,8 +29,8 @@ export class ProfessionsService {
     return this.repository.findOne({ where: { slug } });
   }
 
-  async save(user: Profession): Promise<Profession> {
-    return this.repository.save(user);
+  async save(profession: Profession): Promise<Profession> {
+    return this.repository.save(profession);
   }
 
   async confirm(profession: Profession): Promise<Profession> {

--- a/src/professions/search/search.controller.spec.ts
+++ b/src/professions/search/search.controller.spec.ts
@@ -37,6 +37,7 @@ const exampleProfession1 = new Profession(
   '',
   ['GB-ENG'],
   '',
+  null,
   [exampleIndustry1],
 );
 
@@ -47,6 +48,7 @@ const exampleProfession2 = new Profession(
   '',
   ['GB-SCT', 'GB-WLS'],
   '',
+  null,
   [exampleIndustry2, exampleIndustry3],
 );
 

--- a/src/professions/search/search.presenter.spec.ts
+++ b/src/professions/search/search.presenter.spec.ts
@@ -27,6 +27,7 @@ const exampleProfession1 = new Profession(
   '',
   ['GB-ENG'],
   '',
+  null,
   [exampleIndustry1],
 );
 
@@ -37,6 +38,7 @@ const exampleProfession2 = new Profession(
   '',
   ['GB-SCT', 'GB-WLS'],
   '',
+  null,
   [exampleIndustry2, exampleIndustry3],
 );
 

--- a/src/seeder.ts
+++ b/src/seeder.ts
@@ -16,6 +16,8 @@ import { Profession } from './professions/profession.entity';
 import { QualificationsSeeder } from './qualifications/qualifications.seeder';
 import { LegislationsSeeder } from './legislations/legislations.seeder';
 import { ProfessionsSeeder } from './professions/professions.seeder';
+import { OrganisationsSeeder } from './organisations/organisations.seeder';
+import { Organisation } from './organisations/organisation.entity';
 
 seeder({
   imports: [
@@ -35,6 +37,7 @@ seeder({
       Qualification,
       Legislation,
       Profession,
+      Organisation,
     ]),
   ],
 }).run([
@@ -43,4 +46,5 @@ seeder({
   QualificationsSeeder,
   LegislationsSeeder,
   ProfessionsSeeder,
+  OrganisationsSeeder,
 ]);

--- a/views/professions/admin/add-profession/check-your-answers.njk
+++ b/views/professions/admin/add-profession/check-your-answers.njk
@@ -15,6 +15,8 @@
           <h1 class="govuk-heading-l">{{ ("professions.form.headings.checkAnswers" | t) }}</h1>
 
           <form method="post" action="confirmation">
+            <h2 class="govuk-heading-m">{{ ("professions.form.headings.topLevelInformation" | t) }}</h2>
+
             {% set selectedNationsSummaryListHtml %}
               <ul>
                 {% for nation in nations %}
@@ -80,6 +82,49 @@
                           href: "/admin/professions/" + professionId +"/top-level-information/edit?change=true",
                           text: ("app.change" | t),
                           visuallyHiddenText: ("professions.form.label.topLevelInformation.industry" | t)
+                        }
+                      ]
+                    }
+                  }
+                ]
+              })
+            }}
+
+            <h2 class="govuk-heading-m">{{ ("professions.form.headings.regulatoryBody" | t) }}</h2>
+
+            {{
+              govukSummaryList({
+                rows: [
+                  {
+                    key: {
+                      text: ("professions.form.label.regulatoryBody.regulatedAuthority" | t)
+                    },
+                    value: {
+                      text: organisation
+                    },
+                    actions: {
+                      items: [
+                        {
+                          href: "/admin/professions/" + professionId +"/regulatory-body/edit",
+                          text: ("app.change" | t),
+                          visuallyHiddenText: ("professions.form.label.regulatoryBody.regulatedAuthority" | t)
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    key: {
+                      text: ("professions.form.label.regulatoryBody.mandatoryRegistration" | t)
+                    },
+                    value: {
+                      text: ("professions.mandatoryRegistration." + mandatoryRegistration) | t
+                    },
+                    actions: {
+                      items: [
+                        {
+                          href: "/admin/professions/" + professionId + "/regulatory-body/edit",
+                          text: ("app.change" | t),
+                          visuallyHiddenText: ("professions.form.label.regulatoryBody.mandatoryRegistration" | t)
                         }
                       ]
                     }

--- a/views/professions/admin/add-profession/check-your-answers.njk
+++ b/views/professions/admin/add-profession/check-your-answers.njk
@@ -105,7 +105,7 @@
                     actions: {
                       items: [
                         {
-                          href: "/admin/professions/" + professionId +"/regulatory-body/edit",
+                          href: "/admin/professions/" + professionId +"/regulatory-body/edit?change=true",
                           text: ("app.change" | t),
                           visuallyHiddenText: ("professions.form.label.regulatoryBody.regulatedAuthority" | t)
                         }
@@ -122,7 +122,7 @@
                     actions: {
                       items: [
                         {
-                          href: "/admin/professions/" + professionId + "/regulatory-body/edit",
+                          href: "/admin/professions/" + professionId + "/regulatory-body/edit?change=true",
                           text: ("app.change" | t),
                           visuallyHiddenText: ("professions.form.label.regulatoryBody.mandatoryRegistration" | t)
                         }

--- a/views/professions/admin/add-profession/regulatory-body.njk
+++ b/views/professions/admin/add-profession/regulatory-body.njk
@@ -18,19 +18,36 @@
       <form method="post" action="./">
         <input type="hidden" name="change" value="{{ change }}" />
 
-          <form method="post" action="./">
-            {{
-              govukSelect({
-                label: {
-                  text: ("professions.form.label.regulatoryBody.regulatedAuthority" | t),
-                  classes: "govuk-label--m",
-                  isPageHeading: false
-                },
-                id: "regulatory-body",
-                name: "regulatoryBody",
-                items: regulatedAuthoritiesSelectArgs
-              })
-            }}
+        {{
+          govukSelect({
+            label: {
+              text: ("professions.form.label.regulatoryBody.regulatedAuthority" | t),
+              classes: "govuk-label--m",
+              isPageHeading: false
+            },
+            id: "regulatory-body",
+            name: "regulatoryBody",
+            items: regulatedAuthoritiesSelectArgs
+          })
+        }}
+
+        {{
+          govukRadios({
+            id: "mandatory-registration",
+            name: "mandatoryRegistration",
+            fieldset: {
+              legend: {
+                text: ("professions.form.label.regulatoryBody.mandatoryRegistration" | t),
+                isPageHeading: false,
+                classes: "govuk-fieldset__legend--m"
+              }
+            },
+            hint: {
+              text: ("professions.form.radioButtons.hint" | t)
+            },
+            items: mandatoryRegistrationRadioButtonArgs
+          })
+        }}
 
         {{
           govukButton({

--- a/views/professions/admin/add-profession/regulatory-body.njk
+++ b/views/professions/admin/add-profession/regulatory-body.njk
@@ -1,0 +1,47 @@
+{% extends "base.njk" %}
+{% from "govuk/components/input/macro.njk" import govukInput %}
+{% from "govuk/components/select/macro.njk" import govukSelect %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% block content %}
+
+  <a href="#" class="govuk-back-link">{{ ('app.back' | t) }}</a>
+
+  {% include "../../../shared/_errors.njk" %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-l">{{ ("professions.form.headings.regulatoryBody" | t) }}</h1>
+
+      <form method="post" action="./">
+        <input type="hidden" name="change" value="{{ change }}" />
+
+          <form method="post" action="./">
+            {{
+              govukSelect({
+                label: {
+                  text: ("professions.form.label.regulatoryBody.regulatedAuthority" | t),
+                  classes: "govuk-label--m",
+                  isPageHeading: false
+                },
+                id: "regulatory-body",
+                name: "regulatoryBody",
+                items: regulatedAuthoritiesSelectArgs
+              })
+            }}
+
+        {{
+          govukButton({
+            id: "submit-button",
+            type: "Submit",
+            text: ("app.continue" | t)
+          })
+        }}
+      </form>
+
+    </div>
+  </div>
+
+{% endblock %}


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR

- Adds a screen for selecting a regulatory body when adding a new profession.
- Adds seeds for Organisations, currently not linked to any professions.
- Adds regulatory body data to check your answers page.

## Screenshots of UI changes

### After

#### Add regulatory / professional bodies

![image](https://user-images.githubusercontent.com/19826940/147283816-75f4a3de-36cd-4968-ac87-18338991c486.png)

#### Check your answers

![image](https://user-images.githubusercontent.com/19826940/147283792-15750a60-33bd-46aa-b06f-465e8dd72923.png)
