### PR TITLE
Make regulated activities strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,5 +20,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Create draft Professions in the database, rather than using session storage when adding a new profession
 - Fix bug where submitting invalid top level details on a new Profession caused the page to hang
 - Add functionality to "change" links on Check your answers when creating a new Profession
+- Update Regulated Activities to represent free text, rather than a list of items
 
 [unreleased]: https://github.com/UKGovernmentBEIS/regulated-professions-register/compare/release...HEAD

--- a/seeds/development/professions.json
+++ b/seeds/development/professions.json
@@ -8,12 +8,7 @@
     "regulationType": "Reserves of activities",
     "industries": ["industries.law"],
     "qualification": "DSE - Diploma (post-secondary education), including Annex II (ex 92/51, Annex C,D) , Art. 11 c",
-    "reservedActivities": [
-      "The exercise of a right of audience.",
-      "The conduct of litigation.",
-      "Reserved instrument activities.",
-      "The administration of oaths."
-    ],
+    "reservedActivities": "England and Wales: the exercise of a right of audience; the conduct of litigation; reserved instrument activities; probate activities; the administration of oaths (see section 12 Legal Services Act 2007).",
     "legislations": ["The Trade Marks Act 1994", "Legal Services Act 2007"],
     "mandatoryRegistration": "voluntary",
     "confirmed": true
@@ -27,7 +22,7 @@
     "regulationType": "N/A",
     "industries": ["industries.education"],
     "qualification": "PS3 - Diploma of post-secondary level (3-4 years) , Art. 11 d",
-    "reservedActivities": ["No information submitted"],
+    "reservedActivities": "No information submitted",
     "legislations": [
       "The Education (School Teachers' Qualifications) (England) Regulations 2003/1662 (as amended)",
       "The Education (Induction Arrangements for School Teachers) (England) Regulations 2012/1115 (as amended)"

--- a/src/db/migrate/1641381089306-DeprecateReservedActivitiesField.ts
+++ b/src/db/migrate/1641381089306-DeprecateReservedActivitiesField.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class DeprecateReservedActivitiesField1641381089306
+  implements MigrationInterface
+{
+  name = 'DeprecateReservedActivitiesField1641381089306';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "professions" RENAME COLUMN "reservedActivities" TO "reservedActivitiesDeprecated"`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "professions" RENAME COLUMN "reservedActivitiesDeprecated" TO "reservedActivities"`,
+    );
+  }
+}

--- a/src/db/migrate/1641381772481-AddStringReservedActivities.ts
+++ b/src/db/migrate/1641381772481-AddStringReservedActivities.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddStringReservedActivities1641381772481
+  implements MigrationInterface
+{
+  name = 'AddStringReservedActivities1641381772481';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "professions" ADD "reservedActivities" character varying`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "professions" DROP COLUMN "reservedActivities"`,
+    );
+  }
+}

--- a/src/db/migrate/1641384303747-RemoveDeprecatedReservedActivities.ts
+++ b/src/db/migrate/1641384303747-RemoveDeprecatedReservedActivities.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class RemoveDeprecatedReservedActivities1641384303747
+  implements MigrationInterface
+{
+  name = 'RemoveDeprecatedReservedActivities1641384303747';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "professions" DROP COLUMN "reservedActivitiesDeprecated"`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "professions" ADD "reservedActivitiesDeprecated" text array`,
+    );
+  }
+}

--- a/src/professions/profession.entity.ts
+++ b/src/professions/profession.entity.ts
@@ -57,7 +57,7 @@ export class Profession {
   qualification: Qualification;
 
   @Column('text', { array: true, nullable: true })
-  reservedActivities: string[];
+  reservedActivitiesDeprecated: string[];
 
   @ManyToMany(() => Legislation, {
     eager: true,
@@ -110,7 +110,7 @@ export class Profession {
     this.mandatoryRegistration = mandatoryRegistration || null;
     this.industries = industries || null;
     this.qualification = qualification || null;
-    this.reservedActivities = reservedActivities || null;
+    this.reservedActivitiesDeprecated = reservedActivities || null;
     this.legislations = legislations || null;
     this.organisation = organisation || null;
     this.confirmed = confirmed || false;

--- a/src/professions/profession.entity.ts
+++ b/src/professions/profession.entity.ts
@@ -56,6 +56,9 @@ export class Profession {
   })
   qualification: Qualification;
 
+  @Column({ nullable: true })
+  reservedActivities: string;
+
   @Column('text', { array: true, nullable: true })
   reservedActivitiesDeprecated: string[];
 
@@ -96,7 +99,7 @@ export class Profession {
     mandatoryRegistration?: MandatoryRegistration,
     industries?: Industry[],
     qualification?: Qualification,
-    reservedActivities?: string[],
+    reservedActivities?: string,
     legislations?: Legislation[],
     organisation?: Organisation,
     confirmed?: boolean,
@@ -110,7 +113,7 @@ export class Profession {
     this.mandatoryRegistration = mandatoryRegistration || null;
     this.industries = industries || null;
     this.qualification = qualification || null;
-    this.reservedActivitiesDeprecated = reservedActivities || null;
+    this.reservedActivities = reservedActivities || null;
     this.legislations = legislations || null;
     this.organisation = organisation || null;
     this.confirmed = confirmed || false;

--- a/src/professions/profession.entity.ts
+++ b/src/professions/profession.entity.ts
@@ -59,9 +59,6 @@ export class Profession {
   @Column({ nullable: true })
   reservedActivities: string;
 
-  @Column('text', { array: true, nullable: true })
-  reservedActivitiesDeprecated: string[];
-
   @ManyToMany(() => Legislation, {
     eager: true,
   })

--- a/src/professions/professions.seeder.ts
+++ b/src/professions/professions.seeder.ts
@@ -19,7 +19,7 @@ type SeedProfession = {
   regulationType: string;
   industries: string[];
   qualification: string;
-  reservedActivities: string[];
+  reservedActivities: string;
   legislations: string[];
   mandatoryRegistration: MandatoryRegistration;
   confirmed: boolean;

--- a/src/professions/professions.service.spec.ts
+++ b/src/professions/professions.service.spec.ts
@@ -18,9 +18,7 @@ const profession = new Profession(
   MandatoryRegistration.Voluntary,
   [new Industry('Construction & Engineering')],
   new Qualification('ATT - Attestation of competence , Art. 11 a'),
-  [
-    'Gas Safe Register is the official list of gas engineers in the UK, Isle of Man and Guernsey. To work on gas appliances and installations you must be on the gas safe register. The register exists to protect the public from unsafe gas work (EN)',
-  ],
+  'Gas Safe Register is the official list of gas engineers in the UK, Isle of Man and Guernsey. To work on gas appliances and installations you must be on the gas safe register. The register exists to protect the public from unsafe gas work (EN)',
 );
 const professionArray = [
   profession,
@@ -36,10 +34,7 @@ const professionArray = [
     new Qualification(
       'PS3 - Diploma of post-secondary level (3-4 years) , Art. 11 d',
     ),
-    [
-      'England, must be registered with the Health and Care Professions Council (HCPC)',
-      'Northern Ireland, must be registered with the Northern Ireland Social Care Council (NISCC)',
-    ],
+    'England, must be registered with the Health and Care Professions Council (HCPC); Northern Ireland, must be registered with the Northern Ireland Social Care Council (NISCC)',
   ),
 ];
 

--- a/views/professions/show.njk
+++ b/views/professions/show.njk
@@ -119,11 +119,6 @@
         <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
         <h2 class="govuk-heading-m rpr-details__section-title">{{ "professions.show.regulatedActivities.heading" | t }}</h2>
-
-        {% set escapedActivites = [] %}
-        {% for activity in profession.reservedActivities %}
-          {% set escapedActivites = (escapedActivites.push(activity | escape), escapedActivites) %}
-        {% endfor %}
         
         {{ govukSummaryList({
           classes: 'govuk-summary-list--no-border',
@@ -133,7 +128,7 @@
                 text: ("professions.show.regulatedActivities.reservedActivities" | t)
               },
               value: {
-                html: ["<ul class=\"govuk-list\"><li>", (escapedActivites | join("</li><li>")), "</li></ul>"] | join
+                text: profession.reservedActivities
               }
             },
             {


### PR DESCRIPTION
# Changes in this PR

Updates Regulated Activities field on Professions to represent free text, rather than an array of strings, as we'd previously designed it. This matches the latest designs for adding a Profession, which includes a textarea for adding this information. In the long term, we may want to iterate on this to provide more structured data that will be easier to display to users, but for now this will work with the dataset we want to import.