### PR TITLE
(1991) Use Express Rollbar

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,6 @@
         "jwt-decode": "^3.1.2",
         "method-override": "^3.0.0",
         "nestjs-i18n": "^8.2.2",
-        "nestjs-rollbar": "^1.7.0",
         "nestjs-seeder": "^0.2.0",
         "notifications-node-client": "^5.1.0",
         "nunjucks": "^3.2.3",
@@ -5524,11 +5523,6 @@
       "resolved": "https://registry.npmjs.org/consola/-/consola-2.15.3.tgz",
       "integrity": "sha512-9vAdYbHj6x2fLKC4+oPH0kFzY/orMZyG2Aj+kNylHxKGJ/Ed4dpNyAQYwJOdqO4zdM7XpVHmyejQDcQHrnuXbw=="
     },
-    "node_modules/console-polyfill": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/console-polyfill/-/console-polyfill-0.3.0.tgz",
-      "integrity": "sha512-w+JSDZS7XML43Xnwo2x5O5vxB0ID7T5BdqDtyqT6uiCAX2kZAgcWxNaGqT97tZfSHzfOcvrfsDAodKcJ3UvnXQ=="
-    },
     "node_modules/constant-case": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-1.1.2.tgz",
@@ -6330,15 +6324,6 @@
       "integrity": "sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=",
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/decache": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/decache/-/decache-3.1.0.tgz",
-      "integrity": "sha1-T1A2+9ZYH8yXI3rDlUokS5U2wto=",
-      "optional": true,
-      "dependencies": {
-        "find": "^0.2.4"
       }
     },
     "node_modules/decimal.js": {
@@ -8016,15 +8001,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
-    "node_modules/find": {
-      "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/find/-/find-0.2.9.tgz",
-      "integrity": "sha1-S3Px/55WrZG3bnFkB/5f/mVUu4w=",
-      "optional": true,
-      "dependencies": {
-        "traverse-chain": "~0.1.0"
-      }
-    },
     "node_modules/find-cache-dir": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.2.tgz",
@@ -9068,11 +9044,6 @@
       "engines": {
         "node": ">= 0.10"
       }
-    },
-    "node_modules/is_js": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/is_js/-/is_js-0.9.0.tgz",
-      "integrity": "sha1-CrlFQFArp6+iTIVqqYVWFmnpxS0="
     },
     "node_modules/is-absolute-url": {
       "version": "3.0.3",
@@ -10620,7 +10591,8 @@
     "node_modules/json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+      "dev": true
     },
     "node_modules/json5": {
       "version": "2.2.0",
@@ -11598,17 +11570,6 @@
       "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==",
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/nestjs-rollbar": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/nestjs-rollbar/-/nestjs-rollbar-1.7.0.tgz",
-      "integrity": "sha512-5c92+VTA8KIXepwgfkNk67tXcLHe4dK/usHlWQR0+MmrmAOk6YH8WeqacetpB7XT4jkLyx+csvYDtKH+NIEkhg==",
-      "dependencies": {
-        "rollbar": "^2.22.0"
-      },
-      "peerDependencies": {
-        "@nestjs/common": "^8.0.0"
       }
     },
     "node_modules/nestjs-seeder": {
@@ -13632,14 +13593,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/request-ip": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/request-ip/-/request-ip-2.0.2.tgz",
-      "integrity": "sha1-3urm1K8hdoSX24zQX6NxQ/jxJX4=",
-      "dependencies": {
-        "is_js": "^0.9.0"
-      }
-    },
     "node_modules/request-progress": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-3.0.0.tgz",
@@ -14070,51 +14023,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/rollbar": {
-      "version": "2.24.0",
-      "resolved": "https://registry.npmjs.org/rollbar/-/rollbar-2.24.0.tgz",
-      "integrity": "sha512-cjAGDeTOUH5Bc4qzXlrp2D3eTO51adMWMxzOrr079t/nZidrO8ISBFM8SnazJVv5fOjIX5VbB/4a+gwbn9l4rw==",
-      "dependencies": {
-        "async": "~1.2.1",
-        "console-polyfill": "0.3.0",
-        "error-stack-parser": "^2.0.4",
-        "json-stringify-safe": "~5.0.0",
-        "lru-cache": "~2.2.1",
-        "request-ip": "~2.0.1",
-        "source-map": "^0.5.7",
-        "uuid": "3.0.x"
-      },
-      "optionalDependencies": {
-        "decache": "^3.0.5"
-      }
-    },
-    "node_modules/rollbar/node_modules/async": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/async/-/async-1.2.1.tgz",
-      "integrity": "sha1-pIFqF81f9RbfosdpikUzabl5DeA="
-    },
-    "node_modules/rollbar/node_modules/lru-cache": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.2.4.tgz",
-      "integrity": "sha1-bGWGGb7PFAMdDQtZSxYELOTcBj0="
-    },
-    "node_modules/rollbar/node_modules/source-map": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/rollbar/node_modules/uuid": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
-      "integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE=",
-      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
-      "bin": {
-        "uuid": "bin/uuid"
       }
     },
     "node_modules/run-async": {
@@ -15600,12 +15508,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/traverse-chain": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/traverse-chain/-/traverse-chain-0.1.0.tgz",
-      "integrity": "sha1-YdvC1Ttp/2CRoSoWj9fUMxB+QPE=",
-      "optional": true
     },
     "node_modules/tree-kill": {
       "version": "1.2.2",
@@ -21335,11 +21237,6 @@
       "resolved": "https://registry.npmjs.org/consola/-/consola-2.15.3.tgz",
       "integrity": "sha512-9vAdYbHj6x2fLKC4+oPH0kFzY/orMZyG2Aj+kNylHxKGJ/Ed4dpNyAQYwJOdqO4zdM7XpVHmyejQDcQHrnuXbw=="
     },
-    "console-polyfill": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/console-polyfill/-/console-polyfill-0.3.0.tgz",
-      "integrity": "sha512-w+JSDZS7XML43Xnwo2x5O5vxB0ID7T5BdqDtyqT6uiCAX2kZAgcWxNaGqT97tZfSHzfOcvrfsDAodKcJ3UvnXQ=="
-    },
     "constant-case": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-1.1.2.tgz",
@@ -21934,15 +21831,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/debuglog/-/debuglog-1.0.1.tgz",
       "integrity": "sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI="
-    },
-    "decache": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/decache/-/decache-3.1.0.tgz",
-      "integrity": "sha1-T1A2+9ZYH8yXI3rDlUokS5U2wto=",
-      "optional": true,
-      "requires": {
-        "find": "^0.2.4"
-      }
     },
     "decimal.js": {
       "version": "10.3.1",
@@ -23244,15 +23132,6 @@
         }
       }
     },
-    "find": {
-      "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/find/-/find-0.2.9.tgz",
-      "integrity": "sha1-S3Px/55WrZG3bnFkB/5f/mVUu4w=",
-      "optional": true,
-      "requires": {
-        "traverse-chain": "~0.1.0"
-      }
-    },
     "find-cache-dir": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.2.tgz",
@@ -24007,11 +23886,6 @@
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
       "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="
-    },
-    "is_js": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/is_js/-/is_js-0.9.0.tgz",
-      "integrity": "sha1-CrlFQFArp6+iTIVqqYVWFmnpxS0="
     },
     "is-absolute-url": {
       "version": "3.0.3",
@@ -25163,7 +25037,8 @@
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+      "dev": true
     },
     "json5": {
       "version": "2.2.0",
@@ -25950,14 +25825,6 @@
           "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
           "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA=="
         }
-      }
-    },
-    "nestjs-rollbar": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/nestjs-rollbar/-/nestjs-rollbar-1.7.0.tgz",
-      "integrity": "sha512-5c92+VTA8KIXepwgfkNk67tXcLHe4dK/usHlWQR0+MmrmAOk6YH8WeqacetpB7XT4jkLyx+csvYDtKH+NIEkhg==",
-      "requires": {
-        "rollbar": "^2.22.0"
       }
     },
     "nestjs-seeder": {
@@ -27393,14 +27260,6 @@
         }
       }
     },
-    "request-ip": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/request-ip/-/request-ip-2.0.2.tgz",
-      "integrity": "sha1-3urm1K8hdoSX24zQX6NxQ/jxJX4=",
-      "requires": {
-        "is_js": "^0.9.0"
-      }
-    },
     "request-progress": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-3.0.0.tgz",
@@ -27720,44 +27579,6 @@
       "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
       "requires": {
         "glob": "^7.1.3"
-      }
-    },
-    "rollbar": {
-      "version": "2.24.0",
-      "resolved": "https://registry.npmjs.org/rollbar/-/rollbar-2.24.0.tgz",
-      "integrity": "sha512-cjAGDeTOUH5Bc4qzXlrp2D3eTO51adMWMxzOrr079t/nZidrO8ISBFM8SnazJVv5fOjIX5VbB/4a+gwbn9l4rw==",
-      "requires": {
-        "async": "~1.2.1",
-        "console-polyfill": "0.3.0",
-        "decache": "^3.0.5",
-        "error-stack-parser": "^2.0.4",
-        "json-stringify-safe": "~5.0.0",
-        "lru-cache": "~2.2.1",
-        "request-ip": "~2.0.1",
-        "source-map": "^0.5.7",
-        "uuid": "3.0.x"
-      },
-      "dependencies": {
-        "async": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.2.1.tgz",
-          "integrity": "sha1-pIFqF81f9RbfosdpikUzabl5DeA="
-        },
-        "lru-cache": {
-          "version": "2.2.4",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.2.4.tgz",
-          "integrity": "sha1-bGWGGb7PFAMdDQtZSxYELOTcBj0="
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-        },
-        "uuid": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
-          "integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE="
-        }
       }
     },
     "run-async": {
@@ -28869,12 +28690,6 @@
       "requires": {
         "punycode": "^2.1.1"
       }
-    },
-    "traverse-chain": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/traverse-chain/-/traverse-chain-0.1.0.tgz",
-      "integrity": "sha1-YdvC1Ttp/2CRoSoWj9fUMxB+QPE=",
-      "optional": true
     },
     "tree-kill": {
       "version": "1.2.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "pg": "^8.7.1",
         "reflect-metadata": "^0.1.13",
         "rimraf": "^3.0.2",
+        "rollbar": "^2.24.0",
         "rxjs": "^7.4.0",
         "sass": "^1.43.4",
         "sass-loader": "^12.3.0",
@@ -5523,6 +5524,11 @@
       "resolved": "https://registry.npmjs.org/consola/-/consola-2.15.3.tgz",
       "integrity": "sha512-9vAdYbHj6x2fLKC4+oPH0kFzY/orMZyG2Aj+kNylHxKGJ/Ed4dpNyAQYwJOdqO4zdM7XpVHmyejQDcQHrnuXbw=="
     },
+    "node_modules/console-polyfill": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/console-polyfill/-/console-polyfill-0.3.0.tgz",
+      "integrity": "sha512-w+JSDZS7XML43Xnwo2x5O5vxB0ID7T5BdqDtyqT6uiCAX2kZAgcWxNaGqT97tZfSHzfOcvrfsDAodKcJ3UvnXQ=="
+    },
     "node_modules/constant-case": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-1.1.2.tgz",
@@ -6324,6 +6330,15 @@
       "integrity": "sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=",
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/decache": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/decache/-/decache-3.1.0.tgz",
+      "integrity": "sha1-T1A2+9ZYH8yXI3rDlUokS5U2wto=",
+      "optional": true,
+      "dependencies": {
+        "find": "^0.2.4"
       }
     },
     "node_modules/decimal.js": {
@@ -8001,6 +8016,15 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
+    "node_modules/find": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/find/-/find-0.2.9.tgz",
+      "integrity": "sha1-S3Px/55WrZG3bnFkB/5f/mVUu4w=",
+      "optional": true,
+      "dependencies": {
+        "traverse-chain": "~0.1.0"
+      }
+    },
     "node_modules/find-cache-dir": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.2.tgz",
@@ -9044,6 +9068,11 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/is_js": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/is_js/-/is_js-0.9.0.tgz",
+      "integrity": "sha1-CrlFQFArp6+iTIVqqYVWFmnpxS0="
     },
     "node_modules/is-absolute-url": {
       "version": "3.0.3",
@@ -10591,8 +10620,7 @@
     "node_modules/json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-      "dev": true
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
     "node_modules/json5": {
       "version": "2.2.0",
@@ -13593,6 +13621,14 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/request-ip": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/request-ip/-/request-ip-2.0.2.tgz",
+      "integrity": "sha1-3urm1K8hdoSX24zQX6NxQ/jxJX4=",
+      "dependencies": {
+        "is_js": "^0.9.0"
+      }
+    },
     "node_modules/request-progress": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-3.0.0.tgz",
@@ -14023,6 +14059,51 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rollbar": {
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/rollbar/-/rollbar-2.24.0.tgz",
+      "integrity": "sha512-cjAGDeTOUH5Bc4qzXlrp2D3eTO51adMWMxzOrr079t/nZidrO8ISBFM8SnazJVv5fOjIX5VbB/4a+gwbn9l4rw==",
+      "dependencies": {
+        "async": "~1.2.1",
+        "console-polyfill": "0.3.0",
+        "error-stack-parser": "^2.0.4",
+        "json-stringify-safe": "~5.0.0",
+        "lru-cache": "~2.2.1",
+        "request-ip": "~2.0.1",
+        "source-map": "^0.5.7",
+        "uuid": "3.0.x"
+      },
+      "optionalDependencies": {
+        "decache": "^3.0.5"
+      }
+    },
+    "node_modules/rollbar/node_modules/async": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/async/-/async-1.2.1.tgz",
+      "integrity": "sha1-pIFqF81f9RbfosdpikUzabl5DeA="
+    },
+    "node_modules/rollbar/node_modules/lru-cache": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.2.4.tgz",
+      "integrity": "sha1-bGWGGb7PFAMdDQtZSxYELOTcBj0="
+    },
+    "node_modules/rollbar/node_modules/source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rollbar/node_modules/uuid": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
+      "integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE=",
+      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "bin": {
+        "uuid": "bin/uuid"
       }
     },
     "node_modules/run-async": {
@@ -15508,6 +15589,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/traverse-chain": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/traverse-chain/-/traverse-chain-0.1.0.tgz",
+      "integrity": "sha1-YdvC1Ttp/2CRoSoWj9fUMxB+QPE=",
+      "optional": true
     },
     "node_modules/tree-kill": {
       "version": "1.2.2",
@@ -21237,6 +21324,11 @@
       "resolved": "https://registry.npmjs.org/consola/-/consola-2.15.3.tgz",
       "integrity": "sha512-9vAdYbHj6x2fLKC4+oPH0kFzY/orMZyG2Aj+kNylHxKGJ/Ed4dpNyAQYwJOdqO4zdM7XpVHmyejQDcQHrnuXbw=="
     },
+    "console-polyfill": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/console-polyfill/-/console-polyfill-0.3.0.tgz",
+      "integrity": "sha512-w+JSDZS7XML43Xnwo2x5O5vxB0ID7T5BdqDtyqT6uiCAX2kZAgcWxNaGqT97tZfSHzfOcvrfsDAodKcJ3UvnXQ=="
+    },
     "constant-case": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-1.1.2.tgz",
@@ -21831,6 +21923,15 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/debuglog/-/debuglog-1.0.1.tgz",
       "integrity": "sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI="
+    },
+    "decache": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/decache/-/decache-3.1.0.tgz",
+      "integrity": "sha1-T1A2+9ZYH8yXI3rDlUokS5U2wto=",
+      "optional": true,
+      "requires": {
+        "find": "^0.2.4"
+      }
     },
     "decimal.js": {
       "version": "10.3.1",
@@ -23132,6 +23233,15 @@
         }
       }
     },
+    "find": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/find/-/find-0.2.9.tgz",
+      "integrity": "sha1-S3Px/55WrZG3bnFkB/5f/mVUu4w=",
+      "optional": true,
+      "requires": {
+        "traverse-chain": "~0.1.0"
+      }
+    },
     "find-cache-dir": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.2.tgz",
@@ -23886,6 +23996,11 @@
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
       "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="
+    },
+    "is_js": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/is_js/-/is_js-0.9.0.tgz",
+      "integrity": "sha1-CrlFQFArp6+iTIVqqYVWFmnpxS0="
     },
     "is-absolute-url": {
       "version": "3.0.3",
@@ -25037,8 +25152,7 @@
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-      "dev": true
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
     "json5": {
       "version": "2.2.0",
@@ -27260,6 +27374,14 @@
         }
       }
     },
+    "request-ip": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/request-ip/-/request-ip-2.0.2.tgz",
+      "integrity": "sha1-3urm1K8hdoSX24zQX6NxQ/jxJX4=",
+      "requires": {
+        "is_js": "^0.9.0"
+      }
+    },
     "request-progress": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-3.0.0.tgz",
@@ -27579,6 +27701,44 @@
       "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
       "requires": {
         "glob": "^7.1.3"
+      }
+    },
+    "rollbar": {
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/rollbar/-/rollbar-2.24.0.tgz",
+      "integrity": "sha512-cjAGDeTOUH5Bc4qzXlrp2D3eTO51adMWMxzOrr079t/nZidrO8ISBFM8SnazJVv5fOjIX5VbB/4a+gwbn9l4rw==",
+      "requires": {
+        "async": "~1.2.1",
+        "console-polyfill": "0.3.0",
+        "decache": "^3.0.5",
+        "error-stack-parser": "^2.0.4",
+        "json-stringify-safe": "~5.0.0",
+        "lru-cache": "~2.2.1",
+        "request-ip": "~2.0.1",
+        "source-map": "^0.5.7",
+        "uuid": "3.0.x"
+      },
+      "dependencies": {
+        "async": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.2.1.tgz",
+          "integrity": "sha1-pIFqF81f9RbfosdpikUzabl5DeA="
+        },
+        "lru-cache": {
+          "version": "2.2.4",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.2.4.tgz",
+          "integrity": "sha1-bGWGGb7PFAMdDQtZSxYELOTcBj0="
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+        },
+        "uuid": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
+          "integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE="
+        }
       }
     },
     "run-async": {
@@ -28690,6 +28850,12 @@
       "requires": {
         "punycode": "^2.1.1"
       }
+    },
+    "traverse-chain": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/traverse-chain/-/traverse-chain-0.1.0.tgz",
+      "integrity": "sha1-YdvC1Ttp/2CRoSoWj9fUMxB+QPE=",
+      "optional": true
     },
     "tree-kill": {
       "version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "pg": "^8.7.1",
     "reflect-metadata": "^0.1.13",
     "rimraf": "^3.0.2",
+    "rollbar": "^2.24.0",
     "rxjs": "^7.4.0",
     "sass": "^1.43.4",
     "sass-loader": "^12.3.0",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "jwt-decode": "^3.1.2",
     "method-override": "^3.0.0",
     "nestjs-i18n": "^8.2.2",
-    "nestjs-rollbar": "^1.7.0",
     "nestjs-seeder": "^0.2.0",
     "notifications-node-client": "^5.1.0",
     "nunjucks": "^3.2.3",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -4,7 +4,6 @@ import { Module } from '@nestjs/common';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { I18nModule, I18nJsonParser } from 'nestjs-i18n';
 import { BullModule } from '@nestjs/bull';
-import { LoggerModule } from 'nestjs-rollbar';
 
 import * as path from 'path';
 
@@ -20,53 +19,41 @@ import { IndustriesModule } from './industries/industries.module';
 
 import dbConfiguration from './config/db.config';
 
-const imports = [
-  ConfigModule.forRoot({
-    isGlobal: true,
-    load: [dbConfiguration],
-  }),
-  TypeOrmModule.forRootAsync({
-    inject: [ConfigService],
-    useFactory: async (configService: ConfigService) => ({
-      ...(await configService.get('database')),
-    }),
-  }),
-  I18nModule.forRoot({
-    fallbackLanguage: 'en',
-    parser: I18nJsonParser,
-    parserOptions: {
-      path: path.join(__dirname, '/i18n/'),
-      watch: process.env.NODE_ENV === 'development',
-    },
-  }),
-  BullModule.forRoot({
-    redis: {
-      host: process.env.REDIS_HOST || 'localhost',
-      port: Number(process.env.REDIS_PORT || 6379),
-    },
-  }),
-  BullModule.registerQueue({
-    name: 'default',
-  }),
-  UsersModule,
-  ProfessionsModule,
-  LegislationsModule,
-  OrganisationsModule,
-  IndustriesModule,
-];
-
-// Only include Rollbar in production
-if (process.env['NODE_ENV'] === 'production') {
-  imports.push(
-    LoggerModule.forRoot({
-      accessToken: process.env['ROLLBAR_TOKEN'],
-      environment: process.env['ENVIRONMENT'],
-    }),
-  );
-}
-
 @Module({
-  imports: imports,
+  imports: [
+    ConfigModule.forRoot({
+      isGlobal: true,
+      load: [dbConfiguration],
+    }),
+    TypeOrmModule.forRootAsync({
+      inject: [ConfigService],
+      useFactory: async (configService: ConfigService) => ({
+        ...(await configService.get('database')),
+      }),
+    }),
+    I18nModule.forRoot({
+      fallbackLanguage: 'en',
+      parser: I18nJsonParser,
+      parserOptions: {
+        path: path.join(__dirname, '/i18n/'),
+        watch: process.env.NODE_ENV === 'development',
+      },
+    }),
+    BullModule.forRoot({
+      redis: {
+        host: process.env.REDIS_HOST || 'localhost',
+        port: Number(process.env.REDIS_PORT || 6379),
+      },
+    }),
+    BullModule.registerQueue({
+      name: 'default',
+    }),
+    UsersModule,
+    ProfessionsModule,
+    LegislationsModule,
+    OrganisationsModule,
+    IndustriesModule,
+  ],
   controllers: [AppController],
   providers: [AppService, MailerConsumer],
 })

--- a/src/common/mailer.consumer.spec.ts
+++ b/src/common/mailer.consumer.spec.ts
@@ -1,9 +1,13 @@
 import { MailerConsumer } from './mailer.consumer';
 import { NotifyClient } from 'notifications-node-client';
+import Rollbar from 'rollbar';
+
 import { createMock, DeepMocked } from '@golevelup/ts-jest';
 
 describe('MailerConsumer', () => {
   let notifyClient: DeepMocked<NotifyClient>;
+  let rollbarClient: DeepMocked<Rollbar>;
+
   let mailerConsumer: MailerConsumer;
 
   beforeEach(() => {
@@ -12,11 +16,24 @@ describe('MailerConsumer', () => {
         return {};
       }),
     });
+    rollbarClient = createMock<Rollbar>({
+      error: jest.fn(() => {
+        return {};
+      }),
+    });
     mailerConsumer = new MailerConsumer();
 
     const getClient = jest.spyOn(MailerConsumer.prototype as any, 'getClient');
+    const getRollbarClient = jest.spyOn(
+      MailerConsumer.prototype as any,
+      'getRollbarClient',
+    );
+
     getClient.mockImplementation(() => {
       return notifyClient;
+    });
+    getRollbarClient.mockImplementation(() => {
+      return rollbarClient;
     });
   });
 
@@ -42,6 +59,31 @@ describe('MailerConsumer', () => {
         },
         reference: null,
       },
+    );
+  });
+
+  it('sends an error to rollbar if it fails', async () => {
+    notifyClient.sendEmail.mockImplementation(() => {
+      throw new Error();
+    });
+
+    await expect(async () => {
+      await mailerConsumer.send({
+        data: {
+          templateID: '1234',
+          email: 'email@example.com',
+          personalisation: {
+            subject: 'foo',
+            body: 'bar',
+          },
+        },
+      });
+    }).rejects.toThrowError();
+
+    expect(rollbarClient.error).toHaveBeenCalledWith(
+      expect.any(Error),
+      {},
+      { templateID: '1234', email: 'email@example.com' },
     );
   });
 });

--- a/src/common/mailer.consumer.ts
+++ b/src/common/mailer.consumer.ts
@@ -1,20 +1,43 @@
 import { Processor, Process } from '@nestjs/bull';
 import { EmailMessage } from './interfaces/email-message';
 import { NotifyClient } from 'notifications-node-client';
+import Rollbar from 'rollbar';
 
 @Processor('default')
 export class MailerConsumer {
   @Process('mailer')
   async send(message: EmailMessage): Promise<void> {
     const client = this.getClient();
+    const rollbarClient = this.getRollbarClient();
 
-    await client.sendEmail(message.data.templateID, message.data.email, {
-      personalisation: message.data.personalisation,
-      reference: null,
-    });
+    try {
+      await client.sendEmail(message.data.templateID, message.data.email, {
+        personalisation: message.data.personalisation,
+        reference: null,
+      });
+    } catch (err) {
+      rollbarClient.error(
+        err,
+        {},
+        { templateID: message.data.templateID, email: message.data.email },
+      );
+      Promise.resolve();
+      throw err;
+    }
   }
 
   private getClient(): NotifyClient {
     return new NotifyClient(process.env['NOTIFY_API_KEY']);
+  }
+
+  private getRollbarClient(): Rollbar {
+    return new Rollbar({
+      accessToken: process.env['ROLLBAR_TOKEN'],
+      captureUncaught: true,
+      captureUnhandledRejections: true,
+      payload: {
+        environment: process.env['ENVIRONMENT'],
+      },
+    });
   }
 }


### PR DESCRIPTION
NestJS Rollbar doesn't catch all errors by default (you need to add decorators to each method). We can get round this by adding an ExceptionFilter, but we lose a bunch of useful information about where the error came from, so I've switched to using the Express version, which is more 'fire and forget' and allows us to have more useful info about where an error has come from.