### PR TITLE
(1983) Add screen for adding Regulated Activities to a profession

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add Bull to run background tasks
 - New screen for selecting a regulatory authority when creating a new profession
 - Seed users at deploy time
+- New screen for inputting reserved activities and a description of the regulation when creating a new profession
 
 ### Changed
 

--- a/cypress/integration/admin/professions/add-a-profession.spec.ts
+++ b/cypress/integration/admin/professions/add-a-profession.spec.ts
@@ -33,6 +33,16 @@ describe('Adding a new profession', () => {
       cy.get('button').contains(buttonText).click();
     });
 
+    cy.translate('professions.form.headings.regulatedActivities').then(
+      (heading) => {
+        cy.get('body').should('contain', heading);
+      },
+    );
+
+    cy.translate('app.continue').then((buttonText) => {
+      cy.get('button').contains(buttonText).click();
+    });
+
     cy.translate('professions.form.headings.checkAnswers').then((heading) => {
       cy.get('body').should('contain', heading);
     });

--- a/cypress/integration/admin/professions/add-a-profession.spec.ts
+++ b/cypress/integration/admin/professions/add-a-profession.spec.ts
@@ -39,6 +39,11 @@ describe('Adding a new profession', () => {
       },
     );
 
+    cy.get('textarea[name="activities"]').type('An example activity');
+    cy.get('textarea[name="description"]').type(
+      'A description of the regulation',
+    );
+
     cy.translate('app.continue').then((buttonText) => {
       cy.get('button').contains(buttonText).click();
     });

--- a/cypress/integration/admin/professions/add-a-profession.spec.ts
+++ b/cypress/integration/admin/professions/add-a-profession.spec.ts
@@ -63,6 +63,8 @@ describe('Adding a new profession', () => {
     ).then((mandatoryRegistration) => {
       cy.get('body').should('contain', mandatoryRegistration);
     });
+    cy.get('body').should('contain', 'An example activity');
+    cy.get('body').should('contain', 'A description of the regulation');
 
     cy.translate('professions.form.button.create').then((buttonText) => {
       cy.get('button').contains(buttonText).click();

--- a/src/i18n/en/professions.json
+++ b/src/i18n/en/professions.json
@@ -5,7 +5,8 @@
       "topLevelInformation": "Top level information",
       "regulatoryBody": "Regulatory / professional bodies",
       "checkAnswers": "Check your answers",
-      "confirmation": "New profession created"
+      "confirmation": "New profession created",
+      "regulatedActivities": "Regulated activities"
     },
     "description": "Use this section of the site to add a new profession",
     "label": {
@@ -17,6 +18,16 @@
       "regulatoryBody": {
         "regulatedAuthority": "Which body regulates this profession?",
         "mandatoryRegistration": "Is registration mandatory with professional bodies?"
+      },
+      "regulatedActivities": {
+        "activities": "Reserved activities",
+        "description": "Description of activities / regulation description"
+      }
+    },
+    "details": {
+      "regulatedActivities": {
+        "summaryText": "What are reserved activities?",
+        "text": "Reserved activities means a form of regulating a profession where the access to a professional activity or group of professional activities is reserved, directly or indirectly, by virtue of legislative, regulatory or administrative provisions to members of a regulated profession holding a specific professional qualification, including where the activity is shared with other regulated professions."
       }
     },
     "radioButtons": {

--- a/src/professions/admin/add-profession/check-your-answers.controller.spec.ts
+++ b/src/professions/admin/add-profession/check-your-answers.controller.spec.ts
@@ -23,6 +23,8 @@ describe('CheckYourAnswersController', () => {
         name: 'Council of Gas Registered Engineers',
       }),
       mandatoryRegistration: MandatoryRegistration.Voluntary,
+      description: 'A description of the regulation',
+      reservedActivities: 'Some reserved activities',
     });
 
     professionsService = createMock<ProfessionsService>({
@@ -68,6 +70,12 @@ describe('CheckYourAnswersController', () => {
         );
         expect(templateParams.mandatoryRegistration).toEqual(
           MandatoryRegistration.Voluntary,
+        );
+        expect(templateParams.reservedActivities).toEqual(
+          'Some reserved activities',
+        );
+        expect(templateParams.description).toEqual(
+          'A description of the regulation',
         );
         expect(professionsService.find).toHaveBeenCalledWith('profession-id');
       });

--- a/src/professions/admin/add-profession/check-your-answers.controller.ts
+++ b/src/professions/admin/add-profession/check-your-answers.controller.ts
@@ -40,6 +40,8 @@ export class CheckYourAnswersController {
       industries: industryNames,
       organisation: draftProfession.organisation.name,
       mandatoryRegistration: draftProfession.mandatoryRegistration,
+      description: draftProfession.description,
+      reservedActivities: draftProfession.reservedActivities,
     };
   }
 }

--- a/src/professions/admin/add-profession/dto/regulated-activities.dto.ts
+++ b/src/professions/admin/add-profession/dto/regulated-activities.dto.ts
@@ -6,4 +6,6 @@ export class RegulatedActivitiesDto {
 
   @IsNotEmpty()
   description: string;
+
+  change: boolean;
 }

--- a/src/professions/admin/add-profession/dto/regulated-activities.dto.ts
+++ b/src/professions/admin/add-profession/dto/regulated-activities.dto.ts
@@ -1,0 +1,9 @@
+import { IsNotEmpty } from 'class-validator';
+
+export class RegulatedActivitiesDto {
+  @IsNotEmpty()
+  activities: string;
+
+  @IsNotEmpty()
+  description: string;
+}

--- a/src/professions/admin/add-profession/interfaces/check-your-answers.template.ts
+++ b/src/professions/admin/add-profession/interfaces/check-your-answers.template.ts
@@ -5,4 +5,6 @@ export interface CheckYourAnswersTemplate {
   professionId: string;
   organisation: string;
   mandatoryRegistration: string;
+  reservedActivities: string;
+  description: string;
 }

--- a/src/professions/admin/add-profession/interfaces/regulated-activities.template.ts
+++ b/src/professions/admin/add-profession/interfaces/regulated-activities.template.ts
@@ -1,4 +1,5 @@
 export interface RegulatedActivitiesTemplate {
   reservedActivities: string;
   regulationDescription: string;
+  errors: object | undefined;
 }

--- a/src/professions/admin/add-profession/interfaces/regulated-activities.template.ts
+++ b/src/professions/admin/add-profession/interfaces/regulated-activities.template.ts
@@ -1,5 +1,6 @@
 export interface RegulatedActivitiesTemplate {
   reservedActivities: string;
   regulationDescription: string;
+  change: boolean;
   errors: object | undefined;
 }

--- a/src/professions/admin/add-profession/interfaces/regulated-activities.template.ts
+++ b/src/professions/admin/add-profession/interfaces/regulated-activities.template.ts
@@ -1,0 +1,4 @@
+export interface RegulatedActivitiesTemplate {
+  reservedActivities: string;
+  regulationDescription: string;
+}

--- a/src/professions/admin/add-profession/regulated-activities.controller.spec.ts
+++ b/src/professions/admin/add-profession/regulated-activities.controller.spec.ts
@@ -39,13 +39,14 @@ describe(RegulatedActivitiesController, () => {
         description: 'A description of the profession',
       });
 
-      await controller.edit(response, 'profession-id');
+      await controller.edit(response, 'profession-id', false);
 
       expect(response.render).toHaveBeenCalledWith(
         'professions/admin/add-profession/regulated-activities',
         {
           reservedActivities: 'Example reserved activities',
           regulationDescription: 'A description of the profession',
+          change: false,
           errors: undefined,
         },
       );
@@ -54,27 +55,57 @@ describe(RegulatedActivitiesController, () => {
 
   describe('update', () => {
     describe('when all required parameters are entered', () => {
-      it('updates the Profession and redirects to the next page in the journey', async () => {
-        const regulatedActivitiesDto: RegulatedActivitiesDto = {
-          activities: 'Example reserved activities',
-          description: 'A description of the profession',
-        };
+      describe('when the "Change" query param is false', () => {
+        it('updates the Profession and redirects to the next page in the journey', async () => {
+          const regulatedActivitiesDto: RegulatedActivitiesDto = {
+            activities: 'Example reserved activities',
+            description: 'A description of the profession',
+            change: false,
+          };
 
-        await controller.update(
-          response,
-          'profession-id',
-          regulatedActivitiesDto,
-        );
+          await controller.update(
+            response,
+            'profession-id',
+            regulatedActivitiesDto,
+          );
 
-        expect(professionsService.save).toHaveBeenCalledWith({
-          id: 'profession-id',
-          description: 'A description of the profession',
-          reservedActivities: 'Example reserved activities',
+          expect(professionsService.save).toHaveBeenCalledWith({
+            id: 'profession-id',
+            description: 'A description of the profession',
+            reservedActivities: 'Example reserved activities',
+          });
+
+          // This will be the Qualification information page in future
+          expect(response.redirect).toHaveBeenCalledWith(
+            '/admin/professions/profession-id/check-your-answers',
+          );
         });
+      });
 
-        expect(response.redirect).toHaveBeenCalledWith(
-          '/admin/professions/profession-id/check-your-answers',
-        );
+      describe('when the "Change" query param is true', () => {
+        it('updates the Profession and redirects to the Check your answers page', async () => {
+          const regulatedActivitiesDto: RegulatedActivitiesDto = {
+            activities: 'Example reserved activities',
+            description: 'A description of the profession',
+            change: true,
+          };
+
+          await controller.update(
+            response,
+            'profession-id',
+            regulatedActivitiesDto,
+          );
+
+          expect(professionsService.save).toHaveBeenCalledWith({
+            id: 'profession-id',
+            description: 'A description of the profession',
+            reservedActivities: 'Example reserved activities',
+          });
+
+          expect(response.redirect).toHaveBeenCalledWith(
+            '/admin/professions/profession-id/check-your-answers',
+          );
+        });
       });
     });
 
@@ -83,6 +114,7 @@ describe(RegulatedActivitiesController, () => {
         const regulatedActivitiesDto: RegulatedActivitiesDto = {
           activities: 'Example reserved activities',
           description: undefined,
+          change: false,
         };
 
         await controller.update(
@@ -118,6 +150,7 @@ describe(RegulatedActivitiesController, () => {
             {
               activities: 'Newer reserved activities',
               description: undefined,
+              change: false,
             };
 
           expect(
@@ -139,6 +172,7 @@ describe(RegulatedActivitiesController, () => {
             {
               activities: undefined,
               description: 'Example description',
+              change: false,
             };
 
           expect(
@@ -161,6 +195,7 @@ describe(RegulatedActivitiesController, () => {
           const regulatoryBodyDtoWithNewDescription: RegulatedActivitiesDto = {
             description: 'Newer description',
             activities: undefined,
+            change: false,
           };
 
           expect(
@@ -182,6 +217,7 @@ describe(RegulatedActivitiesController, () => {
             {
               description: undefined,
               activities: undefined,
+              change: false,
             };
 
           expect(

--- a/src/professions/admin/add-profession/regulated-activities.controller.spec.ts
+++ b/src/professions/admin/add-profession/regulated-activities.controller.spec.ts
@@ -1,0 +1,67 @@
+import { createMock, DeepMocked } from '@golevelup/ts-jest';
+import { Test, TestingModule } from '@nestjs/testing';
+import { Response } from 'express';
+import { Profession } from '../../profession.entity';
+import { ProfessionsService } from '../../professions.service';
+import { RegulatedActivitiesController } from './regulated-activities.controller';
+
+describe(RegulatedActivitiesController, () => {
+  let controller: RegulatedActivitiesController;
+  let professionsService: DeepMocked<ProfessionsService>;
+  let response: DeepMocked<Response>;
+  let profession: DeepMocked<Profession>;
+
+  beforeEach(async () => {
+    professionsService = createMock<ProfessionsService>({
+      find: async () => profession,
+    });
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [RegulatedActivitiesController],
+      providers: [
+        { provide: ProfessionsService, useValue: professionsService },
+      ],
+    }).compile();
+
+    response = createMock<Response>();
+
+    controller = module.get<RegulatedActivitiesController>(
+      RegulatedActivitiesController,
+    );
+  });
+
+  describe('edit', () => {
+    it('should render the regulated activities page, passing in any values on the Profession that have already been set', async () => {
+      profession = createMock<Profession>({
+        id: 'profession-id',
+        reservedActivities: 'Example reserved activities',
+        description: 'A description of the profession',
+      });
+
+      await controller.edit(response, 'profession-id');
+
+      expect(response.render).toHaveBeenCalledWith(
+        'professions/admin/add-profession/regulated-activities',
+        {
+          reservedActivities: 'Example reserved activities',
+          regulationDescription: 'A description of the profession',
+          errors: undefined,
+        },
+      );
+    });
+  });
+
+  describe('update', () => {
+    it('redirects to the "Check your answers" page', async () => {
+      await controller.update(response, 'profession-id');
+
+      expect(response.redirect).toHaveBeenCalledWith(
+        '/admin/professions/profession-id/check-your-answers',
+      );
+    });
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+});

--- a/src/professions/admin/add-profession/regulated-activities.controller.ts
+++ b/src/professions/admin/add-profession/regulated-activities.controller.ts
@@ -1,0 +1,29 @@
+import { Controller, Get, Res, Param, Post } from '@nestjs/common';
+import { Response } from 'express';
+import { ProfessionsService } from '../../professions.service';
+import { RegulatedActivitiesTemplate } from './interfaces/regulated-activities.template';
+
+@Controller('admin/professions')
+export class RegulatedActivitiesController {
+  constructor(private readonly professionsService: ProfessionsService) {}
+
+  @Get('/:id/regulated-activities/edit')
+  async edit(@Res() res: Response, @Param('id') id: string): Promise<void> {
+    const profession = await this.professionsService.find(id);
+
+    const templateArgs: RegulatedActivitiesTemplate = {
+      reservedActivities: profession.reservedActivities,
+      regulationDescription: profession.description,
+    };
+
+    return res.render(
+      'professions/admin/add-profession/regulated-activities',
+      templateArgs,
+    );
+  }
+
+  @Post('/:id/regulated-activities')
+  async update(@Res() res: Response, @Param('id') id: string): Promise<void> {
+    return res.redirect(`/admin/professions/${id}/check-your-answers`);
+  }
+}

--- a/src/professions/admin/add-profession/regulated-activities.controller.ts
+++ b/src/professions/admin/add-profession/regulated-activities.controller.ts
@@ -1,6 +1,10 @@
-import { Controller, Get, Res, Param, Post } from '@nestjs/common';
+import { Controller, Get, Res, Param, Post, Body } from '@nestjs/common';
 import { Response } from 'express';
+import { Validator } from '../../../helpers/validator';
+import { ValidationFailedError } from '../../../validation/validation-failed.error';
+import { Profession } from '../../profession.entity';
 import { ProfessionsService } from '../../professions.service';
+import { RegulatedActivitiesDto } from './dto/regulated-activities.dto';
 import { RegulatedActivitiesTemplate } from './interfaces/regulated-activities.template';
 
 @Controller('admin/professions')
@@ -11,9 +15,65 @@ export class RegulatedActivitiesController {
   async edit(@Res() res: Response, @Param('id') id: string): Promise<void> {
     const profession = await this.professionsService.find(id);
 
+    this.renderForm(res, profession.reservedActivities, profession.description);
+  }
+
+  @Post('/:id/regulated-activities')
+  async update(
+    @Res() res: Response,
+    @Param('id') id: string,
+    @Body() regulatedActivitiesDto,
+  ): Promise<void> {
+    const validator = await Validator.validate(
+      RegulatedActivitiesDto,
+      regulatedActivitiesDto,
+    );
+
+    const profession = await this.professionsService.find(id);
+
+    const regulatedActivitiesAnswers: RegulatedActivitiesDto =
+      regulatedActivitiesDto;
+
+    if (!validator.valid()) {
+      const errors = new ValidationFailedError(validator.errors).fullMessages();
+
+      return this.renderForm(
+        res,
+        this.getPreviouslyEnteredReservedActivitiesFromDtoThenProfession(
+          profession,
+          regulatedActivitiesAnswers,
+        ),
+        this.getPreviouslyEnteredDescriptionFromDtoThenProfession(
+          profession,
+          regulatedActivitiesAnswers,
+        ),
+        errors,
+      );
+    }
+
+    const updated: Profession = {
+      ...profession,
+      ...{
+        reservedActivities: regulatedActivitiesAnswers.activities,
+        description: regulatedActivitiesAnswers.description,
+      },
+    };
+
+    await this.professionsService.save(updated);
+
+    return res.redirect(`/admin/professions/${id}/check-your-answers`);
+  }
+
+  private async renderForm(
+    res: Response,
+    reservedActivities: string | null,
+    regulationDescription: string | null,
+    errors: object | undefined = undefined,
+  ): Promise<void> {
     const templateArgs: RegulatedActivitiesTemplate = {
-      reservedActivities: profession.reservedActivities,
-      regulationDescription: profession.description,
+      reservedActivities,
+      regulationDescription,
+      errors: errors,
     };
 
     return res.render(
@@ -22,8 +82,17 @@ export class RegulatedActivitiesController {
     );
   }
 
-  @Post('/:id/regulated-activities')
-  async update(@Res() res: Response, @Param('id') id: string): Promise<void> {
-    return res.redirect(`/admin/professions/${id}/check-your-answers`);
+  getPreviouslyEnteredReservedActivitiesFromDtoThenProfession(
+    profession: Profession,
+    regulatedActivitiesDto: RegulatedActivitiesDto,
+  ) {
+    return regulatedActivitiesDto.activities || profession.reservedActivities;
+  }
+
+  getPreviouslyEnteredDescriptionFromDtoThenProfession(
+    profession: Profession,
+    regulatedActivitiesDto: RegulatedActivitiesDto,
+  ) {
+    return regulatedActivitiesDto.description || profession.description;
   }
 }

--- a/src/professions/admin/add-profession/regulatory-body.controller.spec.ts
+++ b/src/professions/admin/add-profession/regulatory-body.controller.spec.ts
@@ -175,7 +175,7 @@ describe(RegulatoryBodyController, () => {
         });
 
         expect(response.redirect).toHaveBeenCalledWith(
-          '/admin/professions/profession-id/check-your-answers',
+          '/admin/professions/profession-id/regulated-activities/edit',
         );
       });
     });
@@ -370,7 +370,7 @@ describe(RegulatoryBodyController, () => {
         });
 
         expect(response.redirect).toHaveBeenCalledWith(
-          '/admin/professions/profession-id/check-your-answers',
+          '/admin/professions/profession-id/regulated-activities/edit',
         );
       });
     });

--- a/src/professions/admin/add-profession/regulatory-body.controller.ts
+++ b/src/professions/admin/add-profession/regulatory-body.controller.ts
@@ -94,8 +94,7 @@ export class RegulatoryBodyController {
       return res.redirect(`/admin/professions/${id}/check-your-answers`);
     }
 
-    // This will be a different page once the next page in the journey is added
-    return res.redirect(`/admin/professions/${id}/check-your-answers`);
+    return res.redirect(`/admin/professions/${id}/regulated-activities/edit`);
   }
 
   private async renderForm(

--- a/src/professions/professions.module.ts
+++ b/src/professions/professions.module.ts
@@ -12,6 +12,7 @@ import { SearchController } from './search/search.controller';
 import { RegulatoryBodyController } from './admin/add-profession/regulatory-body.controller';
 import { Organisation } from '../organisations/organisation.entity';
 import { OrganisationsService } from '../organisations/organisations.service';
+import { RegulatedActivitiesController } from './admin/add-profession/regulated-activities.controller';
 
 @Module({
   imports: [
@@ -25,6 +26,7 @@ import { OrganisationsService } from '../organisations/organisations.service';
     ProfessionsController,
     TopLevelInformationController,
     RegulatoryBodyController,
+    RegulatedActivitiesController,
     CheckYourAnswersController,
     ConfirmationController,
   ],

--- a/views/professions/admin/add-profession/check-your-answers.njk
+++ b/views/professions/admin/add-profession/check-your-answers.njk
@@ -148,7 +148,7 @@
                     actions: {
                       items: [
                         {
-                          href: "/admin/professions/" + professionId + "/regulated-activities/edit",
+                          href: "/admin/professions/" + professionId + "/regulated-activities/edit?change=true",
                           text: ("app.change" | t),
                           visuallyHiddenText: ("professions.form.label.regulatedActivities.activities" | t)
                         }
@@ -165,7 +165,7 @@
                     actions: {
                       items: [
                         {
-                          href: "/admin/professions/" + professionId + "/regulated-activities/edit",
+                          href: "/admin/professions/" + professionId + "/regulated-activities/edit?change=true",
                           text: ("app.change" | t),
                           visuallyHiddenText: ("professions.form.label.regulatedActivities.description" | t)
                         }

--- a/views/professions/admin/add-profession/check-your-answers.njk
+++ b/views/professions/admin/add-profession/check-your-answers.njk
@@ -132,6 +132,50 @@
                 ]
               })
             }}
+
+            <h2 class="govuk-heading-m">{{ ("professions.form.headings.regulatedActivities" | t) }}</h2>
+
+            {{
+              govukSummaryList({
+                rows: [
+                  {
+                    key: {
+                      text: ("professions.form.label.regulatedActivities.activities" | t)
+                    },
+                    value: {
+                      text: reservedActivities
+                    },
+                    actions: {
+                      items: [
+                        {
+                          href: "/admin/professions/" + professionId + "/regulated-activities/edit",
+                          text: ("app.change" | t),
+                          visuallyHiddenText: ("professions.form.label.regulatedActivities.activities" | t)
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    key: {
+                      text: ("professions.form.label.regulatedActivities.description" | t)
+                    },
+                    value: {
+                      text: description
+                    },
+                    actions: {
+                      items: [
+                        {
+                          href: "/admin/professions/" + professionId + "/regulated-activities/edit",
+                          text: ("app.change" | t),
+                          visuallyHiddenText: ("professions.form.label.regulatedActivities.description" | t)
+                        }
+                      ]
+                    }
+                  }
+                ]
+              })
+            }}
+
             {{
               govukButton({
                 id: "submit-button",

--- a/views/professions/admin/add-profession/regulated-activities.njk
+++ b/views/professions/admin/add-profession/regulated-activities.njk
@@ -1,0 +1,66 @@
+{% extends "base.njk" %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/textarea/macro.njk" import govukTextarea %}
+{% from "govuk/components/details/macro.njk" import govukDetails %}
+
+{% block content %}
+
+  <a href="#" class="govuk-back-link">{{ ('app.back' | t) }}</a>
+
+  {% include "../../../shared/_errors.njk" %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-l">{{ ("professions.form.headings.regulatedActivities" | t) }}</h1>
+
+      <form method="post" action="./">
+
+        {{
+          govukDetails({
+            summaryText: ("professions.form.details.regulatedActivities.summaryText" | t),
+            text: ("professions.form.details.regulatedActivities.text" | t)
+          })
+        }}
+
+        {{
+          govukTextarea({
+            label: {
+              text: ("professions.form.label.regulatedActivities.activities" | t),
+              classes: "govuk-label--m",
+              isPageHeading: false
+            },
+            id: "activities",
+            name: "activities",
+            value: reservedActivities,
+            rows: "7"
+          })
+        }}
+
+        {{
+          govukTextarea({
+            label: {
+              text: ("professions.form.label.regulatedActivities.description" | t),
+              classes: "govuk-label--m",
+              isPageHeading: false
+            },
+            id: "description",
+            name: "description",
+            value: regulationDescription,
+            rows: "7"
+          })
+        }}
+
+        {{
+          govukButton({
+            id: "submit-button",
+            type: "Submit",
+            text: ("app.continue" | t)
+          })
+        }}
+      </form>
+
+    </div>
+  </div>
+
+{% endblock %}

--- a/views/professions/admin/add-profession/regulated-activities.njk
+++ b/views/professions/admin/add-profession/regulated-activities.njk
@@ -15,6 +15,7 @@
       <h1 class="govuk-heading-l">{{ ("professions.form.headings.regulatedActivities" | t) }}</h1>
 
       <form method="post" action="./">
+        <input type="hidden" name="change" value="{{ change }}" />
 
         {{
           govukDetails({


### PR DESCRIPTION
# Changes in this PR

Adds new Regulated Activities screen with textareas for entering regulated activities and descriptions for a Profession, with functional changelinks.

I'm not 100% sure the content on this page is all that clear, but this is something we can iterate on with user testing and content design, once we have that support.

## Screenshots of UI changes

### Regulated activities

![image](https://user-images.githubusercontent.com/19826940/148263224-9e06781f-01d4-439e-ac53-b794502bb3b7.png)

### Check your answers

![image](https://user-images.githubusercontent.com/19826940/148263181-68a0201f-a2b3-4b8c-ae0b-9ee84df089bc.png)

