### PR TITLE
Upload screenshots and videos when a test fails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,24 @@ jobs:
         run: script/ci/cibuild
 
       - name: Test
+        id: test
         run: script/ci/test
+
+      - name: Upload end-to-end-test screenshots
+        if: failure() && steps.Test.outcome == 'failure'
+        uses: actions/upload-artifact@v2
+        with:
+          name: end-to-end-test-screenshots
+          path: cypress/screenshots/
+          retention-days: 14
+
+      - name: Upload end-to-end-test videos
+        if: failure() && steps.Test.outcome == 'failure'
+        uses: actions/upload-artifact@v2
+        with:
+          name: end-to-end-test-videos
+          path: cypress/videos/
+          retention-days: 14
 
       - if: always() && steps.cache-docker.outputs.cache-hit != 'true'
         name: Prepare Docker cache

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -30,6 +30,9 @@ services:
       REDIS_URI: redis://redis:6379
     networks:
       - test
+    volumes:
+      - ./cypress/screenshots:/srv/app/cypress/screenshots:Z
+      - ./cypress/videos:/srv/app/cypress/videos:Z
 
   test-db:
     image: postgres


### PR DESCRIPTION
This uploads the videos and screenshots of failing Cypress tests if they fail in CI. We can then download them and review them from the Github Actions Artifacts section i.e:

![image](https://user-images.githubusercontent.com/109774/148388977-ac0ec920-eba5-4354-b023-0e688290fb7a.png)

I've had this branch hanging round for ages, and I've just had to use it again, so thought it'd be useful.

