### PR TITLE
(1992) Use Fishery for creating test objects

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -64,6 +64,7 @@
         "eslint": "^8.0.1",
         "eslint-config-prettier": "^8.3.0",
         "eslint-plugin-prettier": "^4.0.0",
+        "fishery": "^2.1.0",
         "jest": "^27.2.5",
         "prettier": "^2.3.2",
         "puppeteer": "^11.0.0",
@@ -9372,6 +9373,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/fishery": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fishery/-/fishery-2.1.0.tgz",
+      "integrity": "sha512-CGXNmOkth/Je/oIM5UqB4TKz2p9A/GrappTw8nEOCy50vqx18S51jp4OARRPfxofhSx3ihZwI6t3wh+SA5mz4A==",
+      "dev": true,
+      "dependencies": {
+        "lodash.mergewith": "^4.6.2"
+      }
+    },
     "node_modules/flat-cache": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
@@ -12475,6 +12485,12 @@
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "devOptional": true
+    },
+    "node_modules/lodash.mergewith": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
+      "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==",
+      "dev": true
     },
     "node_modules/lodash.once": {
       "version": "4.1.1",
@@ -26089,6 +26105,15 @@
         "path-exists": "^4.0.0"
       }
     },
+    "fishery": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fishery/-/fishery-2.1.0.tgz",
+      "integrity": "sha512-CGXNmOkth/Je/oIM5UqB4TKz2p9A/GrappTw8nEOCy50vqx18S51jp4OARRPfxofhSx3ihZwI6t3wh+SA5mz4A==",
+      "dev": true,
+      "requires": {
+        "lodash.mergewith": "^4.6.2"
+      }
+    },
     "flat-cache": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
@@ -28424,6 +28449,12 @@
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "devOptional": true
+    },
+    "lodash.mergewith": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
+      "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==",
+      "dev": true
     },
     "lodash.once": {
       "version": "4.1.1",

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "eslint": "^8.0.1",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-prettier": "^4.0.0",
+    "fishery": "^2.1.0",
     "jest": "^27.2.5",
     "prettier": "^2.3.2",
     "puppeteer": "^11.0.0",

--- a/src/industries/industries.service.spec.ts
+++ b/src/industries/industries.service.spec.ts
@@ -4,12 +4,13 @@ import { Repository } from 'typeorm';
 
 import { Industry } from './industry.entity';
 import { IndustriesService } from './industries.service';
+import industryFactory from '../testutils/factories/industry';
 
 describe('IndustriesService', () => {
   let service: IndustriesService;
   let repo: Repository<Industry>;
 
-  const industry = new Industry('finance');
+  const industry = industryFactory.build();
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -55,7 +56,7 @@ describe('IndustriesService', () => {
 
   describe('findByIds', () => {
     it('should return all Industries for the given IDs', async () => {
-      const shippingIndustry = new Industry('Shipping');
+      const shippingIndustry = industryFactory.build({ name: 'Shipping' });
       const repoSpy = jest
         .spyOn(repo, 'find')
         .mockResolvedValueOnce([industry, shippingIndustry]);

--- a/src/legislations/legislations.service.spec.ts
+++ b/src/legislations/legislations.service.spec.ts
@@ -1,21 +1,13 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
+import legislationFactory from '../testutils/factories/legislation';
 
 import { Legislation } from './legislation.entity';
 import { LegislationsService } from './legislations.service';
 
-const legislation = new Legislation(
-  'Gas Safety (Installation and Use ) Regulations 1998',
-  'http://www.legislation.gov.uk/uksi/1998/2451/made',
-);
-const legislationArray = [
-  legislation,
-  new Legislation(
-    'Health and Social Work Professions Order 2001.',
-    'http://www.hcpc-uk.org/aboutus/legislation/',
-  ),
-];
+const legislation = legislationFactory.build();
+const legislationArray = legislationFactory.buildList(2);
 
 describe('LegislationsService', () => {
   let service: LegislationsService;

--- a/src/organisations/organisations.service.spec.ts
+++ b/src/organisations/organisations.service.spec.ts
@@ -1,6 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
+import organisationFactory from '../testutils/factories/organisation';
 import { Organisation } from './organisation.entity';
 import { OrganisationsService } from './organisations.service';
 
@@ -8,17 +9,7 @@ describe('OrganisationsService', () => {
   let service: OrganisationsService;
   let repo: Repository<Organisation>;
 
-  const organisation = new Organisation(
-    'Department of Business, Energy and Industrial Strategy',
-    'BEIS',
-    '123 Fake Street',
-    'www.beis.gov.uk',
-    'beis@example.com',
-    'contact-us.example.com',
-    '0123456789',
-    '0123456780',
-    [],
-  );
+  const organisation = organisationFactory.build();
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({

--- a/src/professions/admin/add-profession/check-your-answers.controller.spec.ts
+++ b/src/professions/admin/add-profession/check-your-answers.controller.spec.ts
@@ -1,9 +1,10 @@
 import { DeepMocked, createMock } from '@golevelup/ts-jest';
 import { TestingModule, Test } from '@nestjs/testing';
 import { I18nService } from 'nestjs-i18n';
-import { Industry } from '../../../industries/industry.entity';
-import { Organisation } from '../../../organisations/organisation.entity';
-import { MandatoryRegistration, Profession } from '../../profession.entity';
+import industryFactory from '../../../testutils/factories/industry';
+import organisationFactory from '../../../testutils/factories/organisation';
+import professionFactory from '../../../testutils/factories/profession';
+import { MandatoryRegistration } from '../../profession.entity';
 import { ProfessionsService } from '../../professions.service';
 import { CheckYourAnswersController } from './check-your-answers.controller';
 
@@ -11,15 +12,14 @@ describe('CheckYourAnswersController', () => {
   let controller: CheckYourAnswersController;
   let professionsService: DeepMocked<ProfessionsService>;
   let i18nService: DeepMocked<I18nService>;
-  let profession: DeepMocked<Profession>;
 
   beforeEach(async () => {
-    profession = createMock<Profession>({
+    const profession = professionFactory.build({
       id: 'profession-id',
       name: 'Gas Safe Engineer',
       occupationLocations: ['GB-ENG'],
-      industries: [new Industry('industries.construction')],
-      organisation: createMock<Organisation>({
+      industries: [industryFactory.build({ name: 'industries.construction' })],
+      organisation: organisationFactory.build({
         name: 'Council of Gas Registered Engineers',
       }),
       mandatoryRegistration: MandatoryRegistration.Voluntary,

--- a/src/professions/admin/add-profession/confirmation.controller.spec.ts
+++ b/src/professions/admin/add-profession/confirmation.controller.spec.ts
@@ -1,8 +1,6 @@
 import { DeepMocked, createMock } from '@golevelup/ts-jest';
 import { TestingModule, Test } from '@nestjs/testing';
 import { Response } from 'express';
-import { IndustriesService } from '../../../industries/industries.service';
-import { Industry } from '../../../industries/industry.entity';
 import professionFactory from '../../../testutils/factories/profession';
 import { Profession } from '../../profession.entity';
 import { ProfessionsService } from '../../professions.service';
@@ -11,7 +9,6 @@ import { ConfirmationController } from './confirmation.controller';
 describe('ConfirmationController', () => {
   let controller: ConfirmationController;
   let professionsService: DeepMocked<ProfessionsService>;
-  let industriesService: DeepMocked<IndustriesService>;
   let profession: Profession;
 
   beforeEach(async () => {
@@ -24,13 +21,11 @@ describe('ConfirmationController', () => {
       find: async () => profession,
       save: async () => profession,
     });
-    industriesService = createMock<IndustriesService>();
 
     const module: TestingModule = await Test.createTestingModule({
       controllers: [ConfirmationController],
       providers: [
         { provide: ProfessionsService, useValue: professionsService },
-        { provide: IndustriesService, useValue: industriesService },
       ],
     }).compile();
 

--- a/src/professions/admin/add-profession/confirmation.controller.spec.ts
+++ b/src/professions/admin/add-profession/confirmation.controller.spec.ts
@@ -3,6 +3,7 @@ import { TestingModule, Test } from '@nestjs/testing';
 import { Response } from 'express';
 import { IndustriesService } from '../../../industries/industries.service';
 import { Industry } from '../../../industries/industry.entity';
+import professionFactory from '../../../testutils/factories/profession';
 import { Profession } from '../../profession.entity';
 import { ProfessionsService } from '../../professions.service';
 import { ConfirmationController } from './confirmation.controller';
@@ -11,14 +12,12 @@ describe('ConfirmationController', () => {
   let controller: ConfirmationController;
   let professionsService: DeepMocked<ProfessionsService>;
   let industriesService: DeepMocked<IndustriesService>;
-  let profession: DeepMocked<Profession>;
+  let profession: Profession;
 
   beforeEach(async () => {
-    profession = createMock<Profession>({
+    profession = professionFactory.build({
       id: 'profession-id',
       name: 'Gas Safe Engineer',
-      occupationLocations: ['GB-ENG'],
-      industries: [new Industry('industries.construction')],
     });
 
     professionsService = createMock<ProfessionsService>({

--- a/src/professions/admin/add-profession/regulated-activities.controller.spec.ts
+++ b/src/professions/admin/add-profession/regulated-activities.controller.spec.ts
@@ -1,7 +1,7 @@
 import { createMock, DeepMocked } from '@golevelup/ts-jest';
 import { Test, TestingModule } from '@nestjs/testing';
 import { Response } from 'express';
-import { Profession } from '../../profession.entity';
+import professionFactory from '../../../testutils/factories/profession';
 import { ProfessionsService } from '../../professions.service';
 import { RegulatedActivitiesDto } from './dto/regulated-activities.dto';
 import { RegulatedActivitiesController } from './regulated-activities.controller';
@@ -10,9 +10,10 @@ describe(RegulatedActivitiesController, () => {
   let controller: RegulatedActivitiesController;
   let professionsService: DeepMocked<ProfessionsService>;
   let response: DeepMocked<Response>;
-  let profession: DeepMocked<Profession>;
 
   beforeEach(async () => {
+    const profession = professionFactory.build();
+
     professionsService = createMock<ProfessionsService>({
       find: async () => profession,
     });
@@ -33,11 +34,13 @@ describe(RegulatedActivitiesController, () => {
 
   describe('edit', () => {
     it('should render the regulated activities page, passing in any values on the Profession that have already been set', async () => {
-      profession = createMock<Profession>({
+      const profession = professionFactory.build({
         id: 'profession-id',
         reservedActivities: 'Example reserved activities',
         description: 'A description of the profession',
       });
+
+      professionsService.find.mockImplementation(async () => profession);
 
       await controller.edit(response, 'profession-id', false);
 
@@ -57,6 +60,10 @@ describe(RegulatedActivitiesController, () => {
     describe('when all required parameters are entered', () => {
       describe('when the "Change" query param is false', () => {
         it('updates the Profession and redirects to the next page in the journey', async () => {
+          const profession = professionFactory.build({ id: 'profession-id' });
+
+          professionsService.find.mockImplementation(async () => profession);
+
           const regulatedActivitiesDto: RegulatedActivitiesDto = {
             activities: 'Example reserved activities',
             description: 'A description of the profession',
@@ -69,11 +76,13 @@ describe(RegulatedActivitiesController, () => {
             regulatedActivitiesDto,
           );
 
-          expect(professionsService.save).toHaveBeenCalledWith({
-            id: 'profession-id',
-            description: 'A description of the profession',
-            reservedActivities: 'Example reserved activities',
-          });
+          expect(professionsService.save).toHaveBeenCalledWith(
+            expect.objectContaining({
+              id: 'profession-id',
+              description: 'A description of the profession',
+              reservedActivities: 'Example reserved activities',
+            }),
+          );
 
           // This will be the Qualification information page in future
           expect(response.redirect).toHaveBeenCalledWith(
@@ -84,6 +93,10 @@ describe(RegulatedActivitiesController, () => {
 
       describe('when the "Change" query param is true', () => {
         it('updates the Profession and redirects to the Check your answers page', async () => {
+          const profession = professionFactory.build({ id: 'profession-id' });
+
+          professionsService.find.mockImplementation(async () => profession);
+
           const regulatedActivitiesDto: RegulatedActivitiesDto = {
             activities: 'Example reserved activities',
             description: 'A description of the profession',
@@ -96,11 +109,13 @@ describe(RegulatedActivitiesController, () => {
             regulatedActivitiesDto,
           );
 
-          expect(professionsService.save).toHaveBeenCalledWith({
-            id: 'profession-id',
-            description: 'A description of the profession',
-            reservedActivities: 'Example reserved activities',
-          });
+          expect(professionsService.save).toHaveBeenCalledWith(
+            expect.objectContaining({
+              id: 'profession-id',
+              description: 'A description of the profession',
+              reservedActivities: 'Example reserved activities',
+            }),
+          );
 
           expect(response.redirect).toHaveBeenCalledWith(
             '/admin/professions/profession-id/check-your-answers',
@@ -111,6 +126,10 @@ describe(RegulatedActivitiesController, () => {
 
     describe('when required parameters are not entered', () => {
       it('does not update the profession, and re-renders the regulated activities form page with errors', async () => {
+        const profession = professionFactory.build();
+
+        professionsService.find.mockImplementation(async () => profession);
+
         const regulatedActivitiesDto: RegulatedActivitiesDto = {
           activities: 'Example reserved activities',
           description: undefined,
@@ -142,7 +161,7 @@ describe(RegulatedActivitiesController, () => {
     describe('getPreviouslyEnteredReservedActivitiesFromDtoThenProfession', () => {
       describe('when there is an existing Profession with ReservedActivities and new params are submitted', () => {
         it('returns the dto value, over the Profession', () => {
-          profession = createMock<Profession>({
+          const profession = professionFactory.build({
             reservedActivities: 'Older reserved activities',
           });
 
@@ -164,7 +183,7 @@ describe(RegulatedActivitiesController, () => {
 
       describe('when there is an existing Profession with ReservedActivities and empty params are submitted', () => {
         it('returns the Profession value, not overwriting it', () => {
-          profession = createMock<Profession>({
+          const profession = professionFactory.build({
             reservedActivities: 'Older reserved activities',
           });
 
@@ -188,7 +207,7 @@ describe(RegulatedActivitiesController, () => {
     describe('getPreviouslyEnteredDescriptionFromDtoThenProfession ', () => {
       describe('when there is an existing Profession with a Description and new params are submitted', () => {
         it('returns the dto value, over the Profession', () => {
-          profession = createMock<Profession>({
+          const profession = professionFactory.build({
             description: 'Older description',
           });
 
@@ -209,7 +228,7 @@ describe(RegulatedActivitiesController, () => {
 
       describe('when there is an existing Profession with Description and empty params are submitted', () => {
         it('returns the Profession value, not overwriting it', () => {
-          profession = createMock<Profession>({
+          const profession = professionFactory.build({
             description: 'Older description',
           });
 

--- a/src/professions/professions.controller.spec.ts
+++ b/src/professions/professions.controller.spec.ts
@@ -3,24 +3,19 @@ import { NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { Response } from 'express';
 import { I18nService } from 'nestjs-i18n';
-import { Industry } from '../industries/industry.entity';
-import { Profession } from './profession.entity';
+import industryFactory from '../testutils/factories/industry';
+import professionFactory from '../testutils/factories/profession';
 
 import { ProfessionsController } from './professions.controller';
 import { ProfessionsService } from './professions.service';
 
-const industry = new Industry('industries.example');
-const exampleProfession = new Profession(
-  'Example Profession',
-  '',
-  null,
-  '',
-  ['GB-ENG'],
-  '',
-  null,
-  [industry],
-);
-exampleProfession.id = 'profession-id';
+const industry = industryFactory.build({ name: 'industries.example' });
+const exampleProfession = professionFactory.build({
+  id: 'profession-id',
+  name: 'Example Profession',
+  occupationLocations: ['GB-ENG'],
+  industries: [industry],
+});
 
 describe('ProfessionsController', () => {
   let controller: ProfessionsController;

--- a/src/testutils/factories/industry.ts
+++ b/src/testutils/factories/industry.ts
@@ -1,0 +1,9 @@
+import { Industry } from '../../industries/industry.entity';
+import { Factory } from 'fishery';
+
+export default Factory.define<Industry>(({ sequence }) => ({
+  id: sequence.toString(),
+  name: 'Example industry',
+  created_at: new Date(),
+  updated_at: new Date(),
+}));

--- a/src/testutils/factories/legislation.ts
+++ b/src/testutils/factories/legislation.ts
@@ -1,0 +1,10 @@
+import { Factory } from 'fishery';
+import { Legislation } from '../../legislations/legislation.entity';
+
+export default Factory.define<Legislation>(({ sequence }) => ({
+  id: sequence.toString(),
+  name: 'Example legislation',
+  url: 'https://www.legislation.example.com',
+  created_at: new Date(),
+  updated_at: new Date(),
+}));

--- a/src/testutils/factories/organisation.ts
+++ b/src/testutils/factories/organisation.ts
@@ -1,0 +1,17 @@
+import { Factory } from 'fishery';
+import { Organisation } from '../../organisations/organisation.entity';
+
+export default Factory.define<Organisation>(({ sequence }) => ({
+  id: sequence.toString(),
+  name: 'Example Organisation',
+  alternateName: 'Alternate Organisation Name',
+  address: '123 Fake Street, London, AB1 2AB, England',
+  url: 'https://www.example-org.com',
+  email: 'hello@example-org.com',
+  contactUrl: 'https://www.example-org.com/contact-us',
+  telephone: '+441234567890',
+  fax: '+441234567891',
+  professions: undefined,
+  created_at: new Date(),
+  updated_at: new Date(),
+}));

--- a/src/testutils/factories/profession.ts
+++ b/src/testutils/factories/profession.ts
@@ -7,7 +7,28 @@ import industryFactory from './industry';
 import legislation from './legislation';
 import qualificationFactory from './qualification';
 
-export default Factory.define<Profession>(({ sequence }) => ({
+class ProfessionFactory extends Factory<Profession> {
+  justCreated(id: string) {
+    return this.params({
+      id: id,
+      name: undefined,
+      alternateName: undefined,
+      slug: undefined,
+      description: undefined,
+      occupationLocations: undefined,
+      regulationType: undefined,
+      mandatoryRegistration: undefined,
+      industries: undefined,
+      qualification: undefined,
+      confirmed: undefined,
+      legislations: undefined,
+      organisation: undefined,
+      reservedActivities: undefined,
+    });
+  }
+}
+
+export default ProfessionFactory.define(({ sequence }) => ({
   id: sequence.toString(),
   name: 'Example Profession',
   alternateName: 'Alternate profession name',

--- a/src/testutils/factories/profession.ts
+++ b/src/testutils/factories/profession.ts
@@ -1,0 +1,30 @@
+import { Factory } from 'fishery';
+import {
+  MandatoryRegistration,
+  Profession,
+} from '../../professions/profession.entity';
+import industryFactory from './industry';
+import legislation from './legislation';
+import qualificationFactory from './qualification';
+
+export default Factory.define<Profession>(({ sequence }) => ({
+  id: sequence.toString(),
+  name: 'Example Profession',
+  alternateName: 'Alternate profession name',
+  slug: 'example-slug',
+  description:
+    'A description of the profession that will be displayed to users',
+  occupationLocations: ['GB-ENG'],
+  regulationType: 'Reserves of activities',
+  mandatoryRegistration: MandatoryRegistration.Mandatory,
+  industries: [
+    industryFactory.build({ name: 'Example industry', id: 'example-industry' }),
+  ],
+  qualification: qualificationFactory.build(),
+  confirmed: false,
+  created_at: new Date(),
+  legislations: [legislation.build()],
+  organisation: undefined,
+  reservedActivities: 'Stuff',
+  updated_at: new Date(),
+}));

--- a/src/testutils/factories/qualification.ts
+++ b/src/testutils/factories/qualification.ts
@@ -1,0 +1,13 @@
+import { Factory } from 'fishery';
+import { Qualification } from '../../qualifications/qualification.entity';
+
+export default Factory.define<Qualification>(({ sequence }) => ({
+  id: sequence.toString(),
+  level: 'Diploma from post-secondary level (more than 4 years)',
+  commonPathToObtain: 'General post-secondary education',
+  educationDuration: '1.0 Year',
+  mandatoryProfessionalExperience: true,
+  methodToObtain: 'Vocational post-secondary education level',
+  created_at: new Date(),
+  updated_at: new Date(),
+}));

--- a/src/testutils/factories/user.ts
+++ b/src/testutils/factories/user.ts
@@ -1,0 +1,13 @@
+import { Factory } from 'fishery';
+import { User, UserRole } from '../../users/user.entity';
+
+export default Factory.define<User>(({ sequence }) => ({
+  id: sequence.toString(),
+  email: 'user@example.com',
+  name: 'Example User',
+  roles: [UserRole.Admin],
+  externalIdentifier: 'extid|1234567',
+  confirmed: false,
+  created_at: new Date(),
+  updated_at: new Date(),
+}));

--- a/src/users/roles/roles.controller.spec.ts
+++ b/src/users/roles/roles.controller.spec.ts
@@ -5,6 +5,7 @@ import { RolesController } from './roles.controller';
 import { createMock, DeepMocked } from '@golevelup/ts-jest';
 import { Request, Response } from 'express';
 import { createMockRequest } from '../../common/create-mock-request';
+import userFactory from '../../testutils/factories/user';
 
 describe('RolesController', () => {
   let controller: RolesController;
@@ -12,7 +13,7 @@ describe('RolesController', () => {
   let user: User;
 
   beforeEach(async () => {
-    user = createMock<User>({
+    user = userFactory.build({
       id: 'user-uuid',
     });
 
@@ -79,10 +80,12 @@ describe('RolesController', () => {
       };
       await controller.create(rolesDto, 'user-uuid', res);
 
-      expect(usersService.save).toHaveBeenCalledWith({
-        id: 'user-uuid',
-        rolesDto,
-      });
+      expect(usersService.save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: 'user-uuid',
+          ...rolesDto,
+        }),
+      );
       expect(res.redirect).toHaveBeenCalledWith(
         `/admin/users/user-uuid/confirm`,
       );

--- a/src/users/user.mailer.spec.ts
+++ b/src/users/user.mailer.spec.ts
@@ -3,9 +3,13 @@ import { Queue } from 'bull';
 import { getQueueToken } from '@nestjs/bull';
 
 import { UserMailer } from './user.mailer';
-import { User } from './user.entity';
+import userFactory from '../testutils/factories/user';
 
-const user = new User('email@example.com', 'name', '212121');
+const user = userFactory.build({
+  email: 'email@example.com',
+  name: 'name',
+  externalIdentifier: '212121',
+});
 
 describe('UserMailer', () => {
   let service: UserMailer;

--- a/src/users/user.presenter.spec.ts
+++ b/src/users/user.presenter.spec.ts
@@ -1,12 +1,13 @@
 import { createMock, DeepMocked } from '@golevelup/ts-jest';
 import { I18nService } from 'nestjs-i18n';
+import userFactory from '../testutils/factories/user';
 
-import { User, UserRole } from './user.entity';
+import { UserRole } from './user.entity';
 import { UserPresenter } from './user.presenter';
 
 describe('UserPresenter', () => {
   const roles: UserRole[] = [UserRole.Admin];
-  const user: DeepMocked<User> = createMock<User>({
+  const user = userFactory.build({
     id: 'some-uuid-string',
     email: 'email@example.com',
     name: 'name',
@@ -62,7 +63,7 @@ describe('UserPresenter', () => {
 
     describe('when there are multiple roles', () => {
       const roles: UserRole[] = [UserRole.Admin, UserRole.Editor];
-      const user: DeepMocked<User> = createMock<User>({
+      const user = userFactory.build({
         id: 'some-uuid-string',
         name: 'name',
         email: 'email@example.com',

--- a/src/users/users.controller.spec.ts
+++ b/src/users/users.controller.spec.ts
@@ -10,6 +10,7 @@ import { User, UserRole } from './user.entity';
 import { UsersPresenter } from './users.presenter';
 import { UserPresenter } from './user.presenter';
 import { UserMailer } from './user.mailer';
+import userFactory from '../testutils/factories/user';
 
 const name = 'Example Name';
 const email = 'name@example.com';
@@ -26,7 +27,7 @@ describe('UsersController', () => {
   let user: User;
 
   beforeEach(async () => {
-    user = createMock<User>({
+    user = userFactory.build({
       id: 'user-uuid',
       name: name,
       email: email,
@@ -158,13 +159,15 @@ describe('UsersController', () => {
       expect(externalUserCreationService.createExternalUser).toBeCalledWith(
         email,
       );
-      expect(usersService.save).toBeCalledWith({
-        name,
-        email,
-        externalIdentifier,
-        roles,
-        confirmed: true,
-      });
+      expect(usersService.save).toBeCalledWith(
+        expect.objectContaining({
+          name,
+          email,
+          externalIdentifier,
+          roles,
+          confirmed: true,
+        }),
+      );
       expect(userMailer.confirmation).toBeCalledWith(
         user,
         'http://example.org',
@@ -204,13 +207,15 @@ describe('UsersController', () => {
 
       await controller.complete(res, user.id);
 
-      expect(usersService.attemptAdd).toBeCalledWith({
-        name,
-        email,
-        externalIdentifier,
-        roles,
-        confirmed: true,
-      });
+      expect(usersService.attemptAdd).toBeCalledWith(
+        expect.objectContaining({
+          name,
+          email,
+          externalIdentifier,
+          roles,
+          confirmed: true,
+        }),
+      );
       expect(res.redirect).toBeCalledWith('done');
     });
 

--- a/src/users/users.presenter.spec.ts
+++ b/src/users/users.presenter.spec.ts
@@ -1,35 +1,20 @@
 import { createMock, DeepMocked } from '@golevelup/ts-jest';
 import { I18nService } from 'nestjs-i18n';
+import userFactory from '../testutils/factories/user';
 
-import { User } from './user.entity';
 import { UsersPresenter } from './users.presenter';
 
-const users = [
-  createMock<User>({
-    id: 'some-uuid-string',
-    name: 'name',
-    email: 'email@example.com',
-    externalIdentifier: '212121',
-  }),
-  createMock<User>({
-    id: 'some-other-uuid-string',
-    name: 'name2',
-    email: 'emai2l@example.com',
-    externalIdentifier: '12345',
-  }),
-];
-
 describe('UsersPresenter', () => {
-  let presenter: UsersPresenter;
   let i18nService: DeepMocked<I18nService>;
 
   beforeEach(() => {
     i18nService = createMock<I18nService>();
-    presenter = new UsersPresenter(users, i18nService);
   });
 
   describe('tableRows', () => {
     it('returns an array of table rows', () => {
+      const users = userFactory.buildList(2);
+      const presenter = new UsersPresenter(users, i18nService);
       const rows = presenter.tableRows();
 
       expect(rows.length).toEqual(2);

--- a/src/users/users.service.spec.ts
+++ b/src/users/users.service.spec.ts
@@ -2,12 +2,13 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { Connection, Repository, SelectQueryBuilder } from 'typeorm';
 import { createMock, DeepMocked } from '@golevelup/ts-jest';
+import userFactory from '../testutils/factories/user';
 
 import { User } from './user.entity';
 import { UsersService } from './users.service';
 
-const user = new User('email@example.com', 'name', '212121');
-const userArray = [user, new User('email2@example.com', 'name2', '1234')];
+const user = userFactory.build();
+const userArray = userFactory.buildList(2);
 
 describe('UsersService', () => {
   let service: UsersService;


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR

Adds "Fishery" package which gives us factories for creating objects to use in tests, rather than the combination of normal objects and mocks that we've had up until now. This takes a lot of boilerplate out of test setup and provides a consistent approach to testing.

I've updated the majority of the tests in the codebase, using factories for:
- Organisations
- Professions
- Users
- Legislations
- Industries

The one area I've left untouched is the Search functionality tests, as I know they're currently being worked on and I don't want to cause issues with merge conflicts. We can incorporate these new factory objects into those tests as a separate piece of work once both branches are merged in.

Apologies for the sheer number of commits, most of them are very small!
