### PR TITLE
Ignore testutils when building production to stop factory files from failing the build

### DIFF
--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -7,6 +7,7 @@
     "dist",
     "**/*spec.ts",
     "src/common/create-mock-request.ts",
+    "src/testutils*",
     "./ormconfig.ts"
   ]
 }


### PR DESCRIPTION
# Changes in this PR

#92's introduction of Fishery as a dev dependency causes the build to fail, as the production environment doesn't build dev dependencies, so it doesn't know what `Fishery` is. We ignore all `spec` files to get around this issue in tests, but because these factories' filenames don't end in `.spec`, the production build is trying to build them and failing.

Here's the failing build: https://github.com/UKGovernmentBEIS/regulated-professions-register/runs/4729842793?check_suite_focus=true
