### PR TITLE
Get Redis options from URL

### DIFF
--- a/src/config/redis.config.spec.ts
+++ b/src/config/redis.config.spec.ts
@@ -27,7 +27,12 @@ describe('redisConfiguration', () => {
       process.env['VCAP_SERVICES'] = JSON.stringify(vcap_json);
 
       expect(redisConfiguration()).toEqual({
-        redis: 'rediss://:password@host:6379',
+        redis: {
+          port: 6379,
+          host: 'host',
+          password: 'password',
+          tls: {},
+        },
       });
     });
   });
@@ -37,7 +42,10 @@ describe('redisConfiguration', () => {
 
     it('should get the Redis configuration from the REDIS_URI environment variable', () => {
       expect(redisConfiguration()).toEqual({
-        redis: 'redis://localhost:6379',
+        redis: {
+          port: 6379,
+          host: 'localhost',
+        },
       });
     });
   });


### PR DESCRIPTION
It seems that we can't pass the URL in directly, as that leads to it being ignored (see https://github.com/OptimalBits/bull/issues/1338), so we need to parse the individual parts from the url and pass them in as an `IORedis.RedisOptions` object.