### PR TITLE
Add a profession backlinks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - New screen for selecting a regulatory authority when creating a new profession
 - Seed users at deploy time
 - New screen for inputting reserved activities and a description of the regulation when creating a new profession
+- Add functional backlinks to Add a profession journey
 
 ### Changed
 

--- a/src/professions/admin/add-profession/check-your-answers.controller.spec.ts
+++ b/src/professions/admin/add-profession/check-your-answers.controller.spec.ts
@@ -1,6 +1,8 @@
 import { DeepMocked, createMock } from '@golevelup/ts-jest';
 import { TestingModule, Test } from '@nestjs/testing';
+import { Request } from 'express';
 import { I18nService } from 'nestjs-i18n';
+import { createMockRequest } from '../../../common/create-mock-request';
 import industryFactory from '../../../testutils/factories/industry';
 import organisationFactory from '../../../testutils/factories/organisation';
 import professionFactory from '../../../testutils/factories/profession';
@@ -48,6 +50,11 @@ describe('CheckYourAnswersController', () => {
   describe('view', () => {
     describe('when a Profession has been created with the persisted ID', () => {
       it('fetches the draft Profession from the persisted ID, and renders the answers on the page', async () => {
+        const request: Request = createMockRequest(
+          'http://example.com/some/path',
+          'example.com',
+        );
+
         i18nService.translate.mockImplementation(async (text) => {
           switch (text) {
             case 'industries.construction':
@@ -59,7 +66,7 @@ describe('CheckYourAnswersController', () => {
           }
         });
 
-        const templateParams = await controller.show('profession-id');
+        const templateParams = await controller.show(request, 'profession-id');
         expect(templateParams.name).toEqual('Gas Safe Engineer');
         expect(templateParams.nations).toEqual(['England']);
         expect(templateParams.industries).toEqual([

--- a/src/professions/admin/add-profession/check-your-answers.controller.ts
+++ b/src/professions/admin/add-profession/check-your-answers.controller.ts
@@ -1,5 +1,7 @@
-import { Controller, Get, Param, Render } from '@nestjs/common';
+import { Controller, Get, Param, Render, Req } from '@nestjs/common';
+import { Request } from 'express';
 import { I18nService } from 'nestjs-i18n';
+import { backLink } from '../../../common/utils';
 
 import { Nation } from '../../../nations/nation';
 import { ProfessionsService } from '../../professions.service';
@@ -14,7 +16,10 @@ export class CheckYourAnswersController {
 
   @Get(':id/check-your-answers')
   @Render('professions/admin/add-profession/check-your-answers')
-  async show(@Param('id') id: string): Promise<CheckYourAnswersTemplate> {
+  async show(
+    @Req() req: Request,
+    @Param('id') id: string,
+  ): Promise<CheckYourAnswersTemplate> {
     const draftProfession = await this.professionsService.find(id);
 
     if (!draftProfession) {
@@ -42,6 +47,7 @@ export class CheckYourAnswersController {
       mandatoryRegistration: draftProfession.mandatoryRegistration,
       description: draftProfession.description,
       reservedActivities: draftProfession.reservedActivities,
+      backLink: backLink(req),
     };
   }
 }

--- a/src/professions/admin/add-profession/interfaces/check-your-answers.template.ts
+++ b/src/professions/admin/add-profession/interfaces/check-your-answers.template.ts
@@ -7,4 +7,5 @@ export interface CheckYourAnswersTemplate {
   mandatoryRegistration: string;
   reservedActivities: string;
   description: string;
+  backLink: string;
 }

--- a/src/professions/admin/add-profession/interfaces/regulated-activities.template.ts
+++ b/src/professions/admin/add-profession/interfaces/regulated-activities.template.ts
@@ -2,5 +2,6 @@ export interface RegulatedActivitiesTemplate {
   reservedActivities: string;
   regulationDescription: string;
   change: boolean;
+  backLink: string;
   errors: object | undefined;
 }

--- a/src/professions/admin/add-profession/interfaces/regulatory-body.template.ts
+++ b/src/professions/admin/add-profession/interfaces/regulatory-body.template.ts
@@ -5,5 +5,6 @@ export interface RegulatoryBodyTemplate {
   regulatedAuthoritiesSelectArgs: SelectItemArgs[];
   mandatoryRegistrationRadioButtonArgs: RadioButtonArgs[];
   change: boolean;
+  backLink: string;
   errors: object | undefined;
 }

--- a/src/professions/admin/add-profession/interfaces/top-level-details.template.ts
+++ b/src/professions/admin/add-profession/interfaces/top-level-details.template.ts
@@ -5,5 +5,6 @@ export interface TopLevelDetailsTemplate {
   industriesCheckboxArgs: CheckboxArgs[];
   nationsCheckboxArgs: CheckboxArgs[];
   change: boolean;
+  backLink: string;
   errors: object | undefined;
 }

--- a/src/professions/admin/add-profession/regulated-activities.controller.spec.ts
+++ b/src/professions/admin/add-profession/regulated-activities.controller.spec.ts
@@ -46,13 +46,51 @@ describe(RegulatedActivitiesController, () => {
 
       expect(response.render).toHaveBeenCalledWith(
         'professions/admin/add-profession/regulated-activities',
-        {
+        expect.objectContaining({
           reservedActivities: 'Example reserved activities',
           regulationDescription: 'A description of the profession',
-          change: false,
-          errors: undefined,
-        },
+        }),
       );
+    });
+
+    describe('back links', () => {
+      describe('when the "Change" query param is false', () => {
+        it('links back to the previous page in the journey', async () => {
+          const profession = professionFactory.build({
+            id: 'profession-id',
+          });
+
+          professionsService.find.mockImplementation(async () => profession);
+
+          await controller.edit(response, 'profession-id', false);
+
+          expect(response.render).toHaveBeenCalledWith(
+            'professions/admin/add-profession/regulated-activities',
+            expect.objectContaining({
+              backLink: '/admin/professions/profession-id/regulatory-body/edit',
+            }),
+          );
+        });
+      });
+
+      describe('when the "Change" query param is true', () => {
+        it('links back to the Check your Answers page', async () => {
+          const profession = professionFactory.build({
+            id: 'profession-id',
+          });
+
+          professionsService.find.mockImplementation(async () => profession);
+
+          await controller.edit(response, 'profession-id', true);
+
+          expect(response.render).toHaveBeenCalledWith(
+            'professions/admin/add-profession/regulated-activities',
+            expect.objectContaining({
+              backLink: '/admin/professions/profession-id/check-your-answers',
+            }),
+          );
+        });
+      });
     });
   });
 

--- a/src/professions/admin/add-profession/regulated-activities.controller.ts
+++ b/src/professions/admin/add-profession/regulated-activities.controller.ts
@@ -24,6 +24,7 @@ export class RegulatedActivitiesController {
       profession.reservedActivities,
       profession.description,
       change,
+      this.backLink(change, id),
     );
   }
 
@@ -57,6 +58,7 @@ export class RegulatedActivitiesController {
           regulatedActivitiesAnswers,
         ),
         regulatedActivitiesAnswers.change,
+        this.backLink(regulatedActivitiesAnswers.change, id),
         errors,
       );
     }
@@ -84,12 +86,14 @@ export class RegulatedActivitiesController {
     reservedActivities: string | null,
     regulationDescription: string | null,
     change: boolean,
+    backLink: string,
     errors: object | undefined = undefined,
   ): Promise<void> {
     const templateArgs: RegulatedActivitiesTemplate = {
       reservedActivities,
       regulationDescription,
       change,
+      backLink,
       errors,
     };
 
@@ -111,5 +115,11 @@ export class RegulatedActivitiesController {
     regulatedActivitiesDto: RegulatedActivitiesDto,
   ) {
     return regulatedActivitiesDto.description || profession.description;
+  }
+
+  private backLink(change: boolean, id: string) {
+    return change
+      ? `/admin/professions/${id}/check-your-answers`
+      : `/admin/professions/${id}/regulatory-body/edit`;
   }
 }

--- a/src/professions/admin/add-profession/regulatory-body.controller.spec.ts
+++ b/src/professions/admin/add-profession/regulatory-body.controller.spec.ts
@@ -97,14 +97,12 @@ describe(RegulatoryBodyController, () => {
 
         expect(response.render).toHaveBeenCalledWith(
           'professions/admin/add-profession/regulatory-body',
-          {
+          expect.objectContaining({
             regulatedAuthoritiesSelectArgs:
               regulatedAuthoritiesSelectPresenter.selectArgs(),
             mandatoryRegistrationRadioButtonArgs:
               await mandatoryRegistrationRadioButtonsPresenter.radioButtonArgs(),
-            change: false,
-            errors: undefined,
-          },
+          }),
         );
         expect(organisationsService.all).toHaveBeenCalled();
       });
@@ -136,14 +134,12 @@ describe(RegulatoryBodyController, () => {
 
         expect(response.render).toHaveBeenCalledWith(
           'professions/admin/add-profession/regulatory-body',
-          {
+          expect.objectContaining({
             regulatedAuthoritiesSelectArgs:
               regulatedAuthoritiesSelectPresenterWithSelectedOrganisation.selectArgs(),
             mandatoryRegistrationRadioButtonArgs:
               await mandatoryRegistrationRadioButtonsPresenterWithSelectedValue.radioButtonArgs(),
-            change: false,
-            errors: undefined,
-          },
+          }),
         );
 
         expect(organisationsService.all).toHaveBeenCalled();
@@ -322,80 +318,119 @@ describe(RegulatoryBodyController, () => {
     });
 
     describe('the "change" query param', () => {
-      it('redirects to check your answers when true', async () => {
-        const profession = professionFactory.build({ id: 'profession-id' });
+      describe('when set to true', () => {
+        it('redirects to check your answers on submit', async () => {
+          const profession = professionFactory.build({ id: 'profession-id' });
 
-        professionsService.find.mockImplementation(async () => profession);
+          professionsService.find.mockImplementation(async () => profession);
 
-        const regulatoryBodyDtoWithChangeParam = {
-          regulatoryBody: 'example-org-id',
-          mandatoryRegistration: MandatoryRegistration.Voluntary,
-          change: true,
-        };
-
-        const organisation = organisationFactory.build();
-
-        organisationsService.find.mockImplementationOnce(
-          async () => organisation,
-        );
-
-        await controller.update(
-          response,
-          'profession-id',
-          regulatoryBodyDtoWithChangeParam,
-        );
-
-        expect(professionsService.save).toHaveBeenCalledWith(
-          expect.objectContaining({
-            id: 'profession-id',
-            organisation: organisation,
+          const regulatoryBodyDtoWithChangeParam = {
+            regulatoryBody: 'example-org-id',
             mandatoryRegistration: MandatoryRegistration.Voluntary,
-            occupationLocations: profession.occupationLocations,
-            industries: profession.industries,
-          }),
-        );
+            change: true,
+          };
 
-        expect(response.redirect).toHaveBeenCalledWith(
-          '/admin/professions/profession-id/check-your-answers',
-        );
+          const organisation = organisationFactory.build();
+
+          organisationsService.find.mockImplementationOnce(
+            async () => organisation,
+          );
+
+          await controller.update(
+            response,
+            'profession-id',
+            regulatoryBodyDtoWithChangeParam,
+          );
+
+          expect(professionsService.save).toHaveBeenCalledWith(
+            expect.objectContaining({
+              id: 'profession-id',
+              organisation: organisation,
+              mandatoryRegistration: MandatoryRegistration.Voluntary,
+              occupationLocations: profession.occupationLocations,
+              industries: profession.industries,
+            }),
+          );
+
+          expect(response.redirect).toHaveBeenCalledWith(
+            '/admin/professions/profession-id/check-your-answers',
+          );
+        });
+
+        it('sets the back link to point to check your answers', async () => {
+          const profession = professionFactory.build({
+            id: 'profession-id',
+          });
+
+          professionsService.find.mockImplementation(async () => profession);
+
+          await controller.edit(response, 'profession-id', true);
+
+          expect(response.render).toHaveBeenCalledWith(
+            'professions/admin/add-profession/regulatory-body',
+            expect.objectContaining({
+              backLink: '/admin/professions/profession-id/check-your-answers',
+            }),
+          );
+        });
       });
 
-      it('continues to the next step in the journey when false or missing', async () => {
-        const profession = professionFactory.build({ id: 'profession-id' });
+      describe('when false or missing', () => {
+        it('continues to the next step in the journey', async () => {
+          const profession = professionFactory.build({ id: 'profession-id' });
 
-        professionsService.find.mockImplementation(async () => profession);
+          professionsService.find.mockImplementation(async () => profession);
 
-        const regulatoryBodyDtoWithFalseChangeParam = {
-          regulatoryBody: 'example-org-id',
-          mandatoryRegistration: MandatoryRegistration.Voluntary,
-          change: false,
-        };
-
-        const organisation = organisationFactory.build();
-
-        organisationsService.find.mockImplementationOnce(
-          async () => organisation,
-        );
-
-        await controller.update(
-          response,
-          'profession-id',
-          regulatoryBodyDtoWithFalseChangeParam,
-        );
-
-        expect(professionsService.save).toHaveBeenCalledWith(
-          expect.objectContaining({
-            id: 'profession-id',
-            organisation: organisation,
+          const regulatoryBodyDtoWithFalseChangeParam = {
+            regulatoryBody: 'example-org-id',
             mandatoryRegistration: MandatoryRegistration.Voluntary,
-            occupationLocations: profession.occupationLocations,
-            industries: profession.industries,
-          }),
-        );
+            change: false,
+          };
 
-        expect(response.redirect).toHaveBeenCalledWith(
-          '/admin/professions/profession-id/regulated-activities/edit',
-        );
+          const organisation = organisationFactory.build();
+
+          organisationsService.find.mockImplementationOnce(
+            async () => organisation,
+          );
+
+          await controller.update(
+            response,
+            'profession-id',
+            regulatoryBodyDtoWithFalseChangeParam,
+          );
+
+          expect(professionsService.save).toHaveBeenCalledWith(
+            expect.objectContaining({
+              id: 'profession-id',
+              organisation: organisation,
+              mandatoryRegistration: MandatoryRegistration.Voluntary,
+              occupationLocations: profession.occupationLocations,
+              industries: profession.industries,
+            }),
+          );
+
+          expect(response.redirect).toHaveBeenCalledWith(
+            '/admin/professions/profession-id/regulated-activities/edit',
+          );
+        });
+
+        it('sets the back link to point to the previous step in the journey', async () => {
+          const profession = professionFactory.build({
+            id: 'profession-id',
+          });
+
+          professionsService.find.mockImplementation(async () => profession);
+
+          await controller.edit(response, 'profession-id', false);
+
+          expect(response.render).toHaveBeenCalledWith(
+            'professions/admin/add-profession/regulatory-body',
+            expect.objectContaining({
+              backLink:
+                '/admin/professions/profession-id/top-level-information/edit',
+            }),
+          );
+        });
       });
     });
   });

--- a/src/professions/admin/add-profession/regulatory-body.controller.ts
+++ b/src/professions/admin/add-profession/regulatory-body.controller.ts
@@ -37,6 +37,7 @@ export class RegulatoryBodyController {
       profession.organisation,
       selectedMandatoryRegistration,
       change,
+      this.backLink(change, id),
       errors,
     );
   }
@@ -67,6 +68,7 @@ export class RegulatoryBodyController {
           regulatoryBodyDto,
         ),
         regulatoryBodyDto.change,
+        this.backLink(regulatoryBodyDto.change, id),
         errors,
       );
     }
@@ -102,6 +104,7 @@ export class RegulatoryBodyController {
     selectedRegulatoryAuthority: Organisation | null,
     mandatoryRegistration: MandatoryRegistration | null,
     change: boolean,
+    backLink: string,
     errors: object | undefined = undefined,
   ): Promise<void> {
     const regulatedAuthorities = await this.organisationsService.all();
@@ -122,6 +125,7 @@ export class RegulatoryBodyController {
       regulatedAuthoritiesSelectArgs,
       mandatoryRegistrationRadioButtonArgs,
       change,
+      backLink,
       errors,
     };
 
@@ -149,5 +153,11 @@ export class RegulatoryBodyController {
       profession.mandatoryRegistration;
 
     return selectedMandatoryRegistration as MandatoryRegistration;
+  }
+
+  private backLink(change: boolean, id: string) {
+    return change
+      ? `/admin/professions/${id}/check-your-answers`
+      : `/admin/professions/${id}/top-level-information/edit`;
   }
 }

--- a/src/professions/admin/add-profession/top-level-information.controller.ts
+++ b/src/professions/admin/add-profession/top-level-information.controller.ts
@@ -36,6 +36,7 @@ export class TopLevelInformationController {
       profession.industries || [],
       profession.occupationLocations || [],
       change,
+      this.backLink(change, id),
       errors,
     );
   }
@@ -67,6 +68,7 @@ export class TopLevelInformationController {
           topLevelDetailsDto,
         ),
         topLevelDetailsDto.change,
+        this.backLink(topLevelDetailsDto.change, id),
         errors,
       );
     }
@@ -101,6 +103,7 @@ export class TopLevelInformationController {
     selectedIndustries: Industry[],
     selectedNations: string[],
     change: boolean,
+    backLink: string,
     errors: object | undefined = undefined,
   ): Promise<void> {
     const industries = await this.industriesService.all();
@@ -122,6 +125,7 @@ export class TopLevelInformationController {
       industriesCheckboxArgs,
       nationsCheckboxArgs,
       change,
+      backLink,
       errors,
     };
 
@@ -145,5 +149,11 @@ export class TopLevelInformationController {
     topLevelDetailsDto: TopLevelDetailsDto,
   ): string[] {
     return topLevelDetailsDto.nations || profession.occupationLocations || [];
+  }
+
+  private backLink(change: boolean, id: string) {
+    return change
+      ? `/admin/professions/${id}/check-your-answers`
+      : '/admin/professions/add-profession';
   }
 }

--- a/views/professions/admin/add-profession/check-your-answers.njk
+++ b/views/professions/admin/add-profession/check-your-answers.njk
@@ -5,7 +5,7 @@
 {% block content %}
 
   <div class="govuk-width-container">
-    <a href="#" class="govuk-back-link">{{ ("app.back" | t) }}</a>
+    <a href="{{backLink}}" class="govuk-back-link">{{ ("app.back" | t) }}</a>
 
     <main class="govuk-main-wrapper">
 

--- a/views/professions/admin/add-profession/regulated-activities.njk
+++ b/views/professions/admin/add-profession/regulated-activities.njk
@@ -5,7 +5,7 @@
 
 {% block content %}
 
-  <a href="#" class="govuk-back-link">{{ ('app.back' | t) }}</a>
+  <a href="{{backLink}}" class="govuk-back-link">{{ ('app.back' | t) }}</a>
 
   {% include "../../../shared/_errors.njk" %}
 

--- a/views/professions/admin/add-profession/regulatory-body.njk
+++ b/views/professions/admin/add-profession/regulatory-body.njk
@@ -6,7 +6,7 @@
 
 {% block content %}
 
-  <a href="#" class="govuk-back-link">{{ ('app.back' | t) }}</a>
+  <a href="{{backLink}}" class="govuk-back-link">{{ ('app.back' | t) }}</a>
 
   {% include "../../../shared/_errors.njk" %}
 

--- a/views/professions/admin/add-profession/top-level-information.njk
+++ b/views/professions/admin/add-profession/top-level-information.njk
@@ -7,7 +7,7 @@
 {% block content %}
 
   <div class="govuk-width-container">
-    <a href="#" class="govuk-back-link">{{ ('app.back' | t) }}</a>
+    <a href="{{backLink}}" class="govuk-back-link">{{ ('app.back' | t) }}</a>
 
     {% include "../../../shared/_errors.njk" %}
 


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR

Adds working backlinks to the Add a profession journey. These mostly don't use the backlinks helper as this leads to broken journeys when trying to go back to a previous form page is submitted successfully after previously submitting with an error. After resubmitting the form successfully but trying to go back, the page would 404 as it would by trying to visit the `post` URL.

I've had to fallback on this behaviour for the "Check your answers" page for now, as determining the different routes e.g. appending `edit` and possibly a `change=true` query param feels like it could be a timesink for the value it might add. We may want to either remove the back link on this page (as the "change" links would likely be the thing users click to go to other pages in the journey) or make it go back to the last page in the journey (currently the "reserved activities" page).
