### PR TITLE
Improve errors in Add a profession journey

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,5 +24,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add functionality to "change" links on Check your answers when creating a new Profession
 - Update Regulated Activities to represent free text, rather than a list of items
 - Fix links in error messages when adding a new profession
+- Make validation errors more human readable
 
 [unreleased]: https://github.com/UKGovernmentBEIS/regulated-professions-register/compare/release...HEAD

--- a/src/config/nunjucks.config.ts
+++ b/src/config/nunjucks.config.ts
@@ -42,5 +42,29 @@ export const nunjucksConfig = async (
     true,
   );
 
+  env.addFilter(
+    'tError',
+    async (...args) => {
+      const callback = args.pop();
+      const error = args[0];
+
+      if (!error) {
+        callback(null);
+        return;
+      }
+
+      const personalisation = args.length < 2 ? {} : args[1];
+      try {
+        const result = {
+          text: await i18nHelper.translate(error.text, personalisation),
+        };
+        callback(null, result);
+      } catch (error) {
+        callback(error);
+      }
+    },
+    true,
+  );
+
   return env;
 };

--- a/src/i18n/en/professions.json
+++ b/src/i18n/en/professions.json
@@ -61,6 +61,26 @@
         "emailNotification": "We have sent you a confirmation email.",
         "next": "What happens next?"
       }
+    },
+    "errors": {
+      "name": {
+        "empty": "Enter the name of the regulated profession"
+      },
+      "nations": {
+        "empty": "Select at least one nation"
+      },
+      "industries": {
+        "empty": "Select at least one industry"
+      },
+      "mandatoryRegistration": {
+        "empty": "Select whether registration with the regulatory authority is mandatory"
+      },
+      "reservedActivities": {
+        "empty": "Enter reserved activities"
+      },
+      "description": {
+        "empty": "Enter a description of the regulation / reserved activities"
+      }
     }
   },
   "show": {

--- a/src/professions/admin/add-profession/dto/regulated-activities.dto.ts
+++ b/src/professions/admin/add-profession/dto/regulated-activities.dto.ts
@@ -1,10 +1,12 @@
 import { IsNotEmpty } from 'class-validator';
 
 export class RegulatedActivitiesDto {
-  @IsNotEmpty()
+  @IsNotEmpty({ message: 'professions.form.errors.reservedActivities.empty' })
   activities: string;
 
-  @IsNotEmpty()
+  @IsNotEmpty({
+    message: 'professions.form.errors.description.empty',
+  })
   description: string;
 
   change: boolean;

--- a/src/professions/admin/add-profession/dto/regulatory-body.dto.ts
+++ b/src/professions/admin/add-profession/dto/regulatory-body.dto.ts
@@ -5,7 +5,9 @@ export class RegulatoryBodyDto {
   @IsNotEmpty()
   regulatoryBody: string;
 
-  @IsNotEmpty()
+  @IsNotEmpty({
+    message: 'professions.form.errors.mandatoryRegistration.empty',
+  })
   mandatoryRegistration: MandatoryRegistration;
 
   change: boolean;

--- a/src/professions/admin/add-profession/dto/top-level-details.dto.ts
+++ b/src/professions/admin/add-profession/dto/top-level-details.dto.ts
@@ -1,13 +1,13 @@
 import { IsNotEmpty } from 'class-validator';
 
 export class TopLevelDetailsDto {
-  @IsNotEmpty()
+  @IsNotEmpty({ message: 'professions.form.errors.name.empty' })
   name: string;
 
-  @IsNotEmpty()
+  @IsNotEmpty({ message: 'professions.form.errors.nations.empty' })
   nations: string[];
 
-  @IsNotEmpty()
+  @IsNotEmpty({ message: 'professions.form.errors.industries.empty' })
   industries: string[];
 
   change: boolean;

--- a/src/professions/admin/add-profession/regulated-activities.controller.spec.ts
+++ b/src/professions/admin/add-profession/regulated-activities.controller.spec.ts
@@ -188,7 +188,7 @@ describe(RegulatedActivitiesController, () => {
             reservedActivities: 'Example reserved activities',
             errors: {
               description: {
-                text: 'description should not be empty',
+                text: 'professions.form.errors.description.empty',
               },
             },
           }),

--- a/src/professions/admin/add-profession/regulatory-body.controller.spec.ts
+++ b/src/professions/admin/add-profession/regulatory-body.controller.spec.ts
@@ -209,7 +209,7 @@ describe(RegulatoryBodyController, () => {
           expect.objectContaining({
             errors: {
               mandatoryRegistration: {
-                text: 'mandatoryRegistration should not be empty',
+                text: 'professions.form.errors.mandatoryRegistration.empty',
               },
             },
           }),

--- a/views/professions/admin/add-profession/regulated-activities.njk
+++ b/views/professions/admin/add-profession/regulated-activities.njk
@@ -35,7 +35,7 @@
             name: "activities",
             value: reservedActivities,
             rows: "7",
-            errorMessage: errors.activities
+            errorMessage: errors.activities | tError
           })
         }}
 
@@ -50,7 +50,7 @@
             name: "description",
             value: regulationDescription,
             rows: "7",
-            errorMessage: errors.description
+            errorMessage: errors.description | tError
           })
         }}
 

--- a/views/professions/admin/add-profession/regulated-activities.njk
+++ b/views/professions/admin/add-profession/regulated-activities.njk
@@ -34,7 +34,8 @@
             id: "activities",
             name: "activities",
             value: reservedActivities,
-            rows: "7"
+            rows: "7",
+            errorMessage: errors.activities
           })
         }}
 
@@ -48,7 +49,8 @@
             id: "description",
             name: "description",
             value: regulationDescription,
-            rows: "7"
+            rows: "7",
+            errorMessage: errors.description
           })
         }}
 

--- a/views/professions/admin/add-profession/regulatory-body.njk
+++ b/views/professions/admin/add-profession/regulatory-body.njk
@@ -46,7 +46,7 @@
               text: ("professions.form.radioButtons.hint" | t)
             },
             items: mandatoryRegistrationRadioButtonArgs,
-            errorMessage: errors.mandatoryRegistration
+            errorMessage: errors.mandatoryRegistration | tError
           })
         }}
 

--- a/views/professions/admin/add-profession/regulatory-body.njk
+++ b/views/professions/admin/add-profession/regulatory-body.njk
@@ -45,7 +45,8 @@
             hint: {
               text: ("professions.form.radioButtons.hint" | t)
             },
-            items: mandatoryRegistrationRadioButtonArgs
+            items: mandatoryRegistrationRadioButtonArgs,
+            errorMessage: errors.mandatoryRegistration
           })
         }}
 

--- a/views/professions/admin/add-profession/top-level-information.njk
+++ b/views/professions/admin/add-profession/top-level-information.njk
@@ -30,7 +30,8 @@
                 },
                 id: "name",
                 name: "name",
-                value: name
+                value: name,
+                errorMessage: errors.name
               })
             }}
 
@@ -48,7 +49,8 @@
                 hint: {
                   text: ("professions.form.checkboxes.hint" | t)
                 },
-                items: nationsCheckboxArgs
+                items: nationsCheckboxArgs,
+                errorMessage: errors.nations
               })
             }}
 
@@ -66,7 +68,8 @@
                 hint: {
                   text: ("professions.form.checkboxes.hint" | t)
                 },
-                items: industriesCheckboxArgs
+                items: industriesCheckboxArgs,
+                errorMessage: errors.industries
               })
             }}
 

--- a/views/professions/admin/add-profession/top-level-information.njk
+++ b/views/professions/admin/add-profession/top-level-information.njk
@@ -31,7 +31,7 @@
                 id: "name",
                 name: "name",
                 value: name,
-                errorMessage: errors.name
+                errorMessage: errors.name | tError
               })
             }}
 
@@ -50,7 +50,7 @@
                   text: ("professions.form.checkboxes.hint" | t)
                 },
                 items: nationsCheckboxArgs,
-                errorMessage: errors.nations
+                errorMessage: errors.nations | tError
               })
             }}
 
@@ -69,7 +69,7 @@
                   text: ("professions.form.checkboxes.hint" | t)
                 },
                 items: industriesCheckboxArgs,
-                errorMessage: errors.industries
+                errorMessage: errors.industries | tError
               })
             }}
 

--- a/views/shared/_errors.njk
+++ b/views/shared/_errors.njk
@@ -7,7 +7,7 @@
     <ul class="govuk-list govuk-error-summary__list">
     {% for target, message in errors %}
       <li>
-        <a href="#{{ target }}">{{ message.text }}</a>
+        <a href="#{{ target }}">{{ message.text | t }}</a>
       </li>
     {% endfor %}
     </ul>


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR

- Fixes missing error highlighting on form fields when there's a validation error.
- Adds custom user-friendly error messages, rather than the standard `x should not be empty` default that comes from `class-validator`

**Note**:This is currently only being done for Professions at the moment, as there's an issue with translating errors when we have multiple error messages we want to show for a single field (e.g. trying to create a user with an invalid and missing email address) that I've spent a lot of time on today but would like to park until we have some more time to iron this out. It may be worth us listing multiple errors separately, rather than joining them with commas, as this feels a bit off to me.

## Screenshots of UI changes

### Before

![image](https://user-images.githubusercontent.com/19826940/148560156-f928b9ed-52bb-4d87-8e73-e929419780d4.png)

### After

![image](https://user-images.githubusercontent.com/19826940/148560305-4ceee73f-9f74-4b66-b0de-b5a950df79b2.png)

