### PR TITLE
Fix prod deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,7 +32,7 @@ jobs:
   deploy_to_production:
     needs: build_and_push_to_dockerhub
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/tags/release'
+    if: startsWith(github.ref, 'refs/tags/release')
     env:
       TF_VAR_docker_tag: ${{ needs.build_and_push_to_dockerhub.outputs.docker_tag }}
       TF_VAR_docker_username: ${{ secrets.DOCKER_USERNAME }}


### PR DESCRIPTION
We were only matching against a tag name (`'refs/tags/release'`) rather than checking if that's what the tag starts with. This meant that the first step was running, but the deploy wasn't.