### PR TITLE
Update data types for "method to obtain" and "duration" of qualifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- Add more granular database fields for storing the duration of a qualification
+
 ### Changed
 
 - No longer display previous values on a profession when rendering form errors
+- Use enums for storing methods to obtain and common paths to obtain a qualification
 
 ## [release-001] - 2022-01-10
 

--- a/seeds/development/qualifications.json
+++ b/seeds/development/qualifications.json
@@ -1,15 +1,19 @@
 [
   {
     "level": "DSE - Diploma (post-secondary education), including Annex II (ex 92/51, Annex C,D) , Art. 11 c",
-    "methodToObtain": "Vocational post-secondary education level",
-    "commonPathToObtain": "Vocational post-secondary education level",
+    "methodToObtain": "generalSecondaryEducation",
+    "otherMethodToObtain": "",
+    "commonPathToObtain": "generalSecondaryEducation",
+    "otherCommonPathToObtain": "",
     "educationDuration": " 5.0 Year",
     "mandatoryProfessionalExperience": true
   },
   {
     "level": "PS3 - Diploma of post-secondary level (3-4 years) , Art. 11 d",
-    "methodToObtain": "No information submitted",
-    "commonPathToObtain": "No information submitted",
+    "methodToObtain": "generalOrVocationalPostSecondaryEducation",
+    "otherMethodToObtain": "",
+    "commonPathToObtain": "generalOrVocationalPostSecondaryEducation",
+    "otherCommonPathToObtain": "",
     "educationDuration": "No information submitted",
     "mandatoryProfessionalExperience": true
   }

--- a/seeds/development/qualifications.json
+++ b/seeds/development/qualifications.json
@@ -6,6 +6,10 @@
     "commonPathToObtain": "generalSecondaryEducation",
     "otherCommonPathToObtain": "",
     "educationDuration": " 5.0 Year",
+    "educationDurationYears": 5,
+    "educationDurationMonths": 0,
+    "educationDurationDays": 0,
+    "educationDurationHours": 0,
     "mandatoryProfessionalExperience": true
   },
   {
@@ -14,7 +18,11 @@
     "otherMethodToObtain": "",
     "commonPathToObtain": "generalOrVocationalPostSecondaryEducation",
     "otherCommonPathToObtain": "",
-    "educationDuration": "No information submitted",
+    "educationDuration": "3.5 Year",
+    "educationDurationYears": 3,
+    "educationDurationMonths": 6,
+    "educationDurationDays": 0,
+    "educationDurationHours": 0,
     "mandatoryProfessionalExperience": true
   }
 ]

--- a/seeds/staging/qualifications.json
+++ b/seeds/staging/qualifications.json
@@ -1,15 +1,19 @@
 [
   {
     "level": "DSE - Diploma (post-secondary education), including Annex II (ex 92/51, Annex C,D) , Art. 11 c",
-    "methodToObtain": "Vocational post-secondary education level",
-    "commonPathToObtain": "Vocational post-secondary education level",
+    "methodToObtain": "generalSecondaryEducation",
+    "otherMethodToObtain": "",
+    "commonPathToObtain": "generalSecondaryEducation",
+    "otherCommonPathToObtain": "",
     "educationDuration": " 5.0 Year",
     "mandatoryProfessionalExperience": true
   },
   {
     "level": "PS3 - Diploma of post-secondary level (3-4 years) , Art. 11 d",
-    "methodToObtain": "No information submitted",
-    "commonPathToObtain": "No information submitted",
+    "methodToObtain": "generalOrVocationalPostSecondaryEducation",
+    "otherMethodToObtain": "",
+    "commonPathToObtain": "generalOrVocationalPostSecondaryEducation",
+    "otherCommonPathToObtain": "",
     "educationDuration": "No information submitted",
     "mandatoryProfessionalExperience": true
   }

--- a/seeds/staging/qualifications.json
+++ b/seeds/staging/qualifications.json
@@ -6,6 +6,10 @@
     "commonPathToObtain": "generalSecondaryEducation",
     "otherCommonPathToObtain": "",
     "educationDuration": " 5.0 Year",
+    "educationDurationYears": 5,
+    "educationDurationMonths": 0,
+    "educationDurationDays": 0,
+    "educationDurationHours": 0,
     "mandatoryProfessionalExperience": true
   },
   {
@@ -14,7 +18,11 @@
     "otherMethodToObtain": "",
     "commonPathToObtain": "generalOrVocationalPostSecondaryEducation",
     "otherCommonPathToObtain": "",
-    "educationDuration": "No information submitted",
+    "educationDuration": "3.5 Year",
+    "educationDurationYears": 3,
+    "educationDurationMonths": 6,
+    "educationDurationDays": 0,
+    "educationDurationHours": 0,
     "mandatoryProfessionalExperience": true
   }
 ]

--- a/seeds/test/qualifications.json
+++ b/seeds/test/qualifications.json
@@ -1,15 +1,19 @@
 [
   {
     "level": "DSE - Diploma (post-secondary education), including Annex II (ex 92/51, Annex C,D) , Art. 11 c",
-    "methodToObtain": "Vocational post-secondary education level",
-    "commonPathToObtain": "Vocational post-secondary education level",
+    "methodToObtain": "generalSecondaryEducation",
+    "otherMethodToObtain": "",
+    "commonPathToObtain": "generalSecondaryEducation",
+    "otherCommonPathToObtain": "",
     "educationDuration": " 5.0 Year",
     "mandatoryProfessionalExperience": true
   },
   {
     "level": "PS3 - Diploma of post-secondary level (3-4 years) , Art. 11 d",
-    "methodToObtain": "No information submitted",
-    "commonPathToObtain": "No information submitted",
+    "methodToObtain": "generalOrVocationalPostSecondaryEducation",
+    "otherMethodToObtain": "",
+    "commonPathToObtain": "generalOrVocationalPostSecondaryEducation",
+    "otherCommonPathToObtain": "",
     "educationDuration": "No information submitted",
     "mandatoryProfessionalExperience": true
   }

--- a/seeds/test/qualifications.json
+++ b/seeds/test/qualifications.json
@@ -6,6 +6,10 @@
     "commonPathToObtain": "generalSecondaryEducation",
     "otherCommonPathToObtain": "",
     "educationDuration": " 5.0 Year",
+    "educationDurationYears": 5,
+    "educationDurationMonths": 0,
+    "educationDurationDays": 0,
+    "educationDurationHours": 0,
     "mandatoryProfessionalExperience": true
   },
   {
@@ -14,7 +18,11 @@
     "otherMethodToObtain": "",
     "commonPathToObtain": "generalOrVocationalPostSecondaryEducation",
     "otherCommonPathToObtain": "",
-    "educationDuration": "No information submitted",
+    "educationDuration": " 3.5 Year",
+    "educationDurationYears": 3,
+    "educationDurationMonths": 6,
+    "educationDurationDays": 0,
+    "educationDurationHours": 0,
     "mandatoryProfessionalExperience": true
   }
 ]

--- a/src/db/migrate/1641833300694-DeprecateMethodToObtainValues.ts
+++ b/src/db/migrate/1641833300694-DeprecateMethodToObtainValues.ts
@@ -1,0 +1,37 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class deprecateMethodToObtainValues1641833300694
+  implements MigrationInterface
+{
+  name = 'deprecateMethodToObtainValues1641833300694';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "qualifications" RENAME COLUMN "methodToObtain" TO "methodToObtainDeprecated"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "qualifications" ALTER COLUMN "methodToObtainDeprecated" DROP NOT NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "qualifications" RENAME COLUMN "commonPathToObtain" TO "commonPathToObtainDeprecated"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "qualifications" ALTER COLUMN "commonPathToObtainDeprecated" DROP NOT NULL`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "qualifications" ALTER COLUMN "commonPathToObtainDeprecated" SET NOT NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "qualifications" RENAME COLUMN "commonPathToObtainDeprecated" TO "commonPathToObtain"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "qualifications" ALTER COLUMN "methodToObtainDeprecated" SET NOT NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "qualifications" RENAME COLUMN "methodToObtainDeprecated" TO "methodToObtain"`,
+    );
+  }
+}

--- a/src/db/migrate/1641834068149-AddEnumMethodToObtainValues.ts
+++ b/src/db/migrate/1641834068149-AddEnumMethodToObtainValues.ts
@@ -1,0 +1,49 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddEnumMethodToObtainValues1641834068149
+  implements MigrationInterface
+{
+  name = 'AddEnumMethodToObtainValues1641834068149';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TYPE "public"."qualifications_methodtoobtain_enum" AS ENUM('generalSecondaryEducation', 'generalOrVocationalPostSecondaryEducation', 'generalPostSecondaryEducationMandatoryVocational', 'vocationalPostSecondaryEducation', 'degreeLevel', 'others')`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "qualifications" ADD "methodToObtain" "public"."qualifications_methodtoobtain_enum" NOT NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "qualifications" ADD "otherMethodToObtain" character varying`,
+    );
+    await queryRunner.query(
+      `CREATE TYPE "public"."qualifications_commonpathtoobtain_enum" AS ENUM('generalSecondaryEducation', 'generalOrVocationalPostSecondaryEducation', 'generalPostSecondaryEducationMandatoryVocational', 'vocationalPostSecondaryEducation', 'degreeLevel', 'others')`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "qualifications" ADD "commonPathToObtain" "public"."qualifications_commonpathtoobtain_enum" NOT NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "qualifications" ADD "otherCommonPathToObtain" character varying`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "qualifications" DROP COLUMN "otherCommonPathToObtain"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "qualifications" DROP COLUMN "commonPathToObtain"`,
+    );
+    await queryRunner.query(
+      `DROP TYPE "public"."qualifications_commonpathtoobtain_enum"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "qualifications" DROP COLUMN "otherMethodToObtain"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "qualifications" DROP COLUMN "methodToObtain"`,
+    );
+    await queryRunner.query(
+      `DROP TYPE "public"."qualifications_methodtoobtain_enum"`,
+    );
+  }
+}

--- a/src/db/migrate/1641834350530-RemoveDeprecatedMethodsToObtain.ts
+++ b/src/db/migrate/1641834350530-RemoveDeprecatedMethodsToObtain.ts
@@ -1,0 +1,25 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class RemoveDeprecatedMethodsToObtain1641834350530
+  implements MigrationInterface
+{
+  name = 'RemoveDeprecatedMethodsToObtain1641834350530';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "qualifications" DROP COLUMN "methodToObtainDeprecated"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "qualifications" DROP COLUMN "commonPathToObtainDeprecated"`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "qualifications" ADD "commonPathToObtainDeprecated" character varying`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "qualifications" ADD "methodToObtainDeprecated" character varying`,
+    );
+  }
+}

--- a/src/db/migrate/1641834876892-AddGranularEducationDurations.ts
+++ b/src/db/migrate/1641834876892-AddGranularEducationDurations.ts
@@ -1,0 +1,37 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddGranularEducationDurations1641834876892
+  implements MigrationInterface
+{
+  name = 'AddGranularEducationDurations1641834876892';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "qualifications" ADD "educationDurationYears" integer NOT NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "qualifications" ADD "educationDurationMonths" integer NOT NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "qualifications" ADD "educationDurationDays" integer NOT NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "qualifications" ADD "educationDurationHours" integer NOT NULL`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "qualifications" DROP COLUMN "educationDurationHours"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "qualifications" DROP COLUMN "educationDurationDays"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "qualifications" DROP COLUMN "educationDurationMonths"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "qualifications" DROP COLUMN "educationDurationYears"`,
+    );
+  }
+}

--- a/src/qualifications/qualification.entity.ts
+++ b/src/qualifications/qualification.entity.ts
@@ -6,6 +6,15 @@ import {
   UpdateDateColumn,
 } from 'typeorm';
 
+export enum MethodToObtain {
+  GeneralSecondaryEducation = 'generalSecondaryEducation',
+  GeneralOrVocationalPostSecondaryEducation = 'generalOrVocationalPostSecondaryEducation',
+  GeneralPostSecondaryEducationMandatoryVocational = 'generalPostSecondaryEducationMandatoryVocational',
+  VocationalPostSecondaryEducation = 'vocationalPostSecondaryEducation',
+  DegreeLevel = 'degreeLevel',
+  Others = 'others',
+}
+
 @Entity({ name: 'qualifications' })
 export class Qualification {
   @PrimaryGeneratedColumn('uuid')
@@ -13,6 +22,18 @@ export class Qualification {
 
   @Column()
   level: string;
+
+  @Column({ type: 'enum', enum: MethodToObtain })
+  methodToObtain: MethodToObtain;
+
+  @Column({ nullable: true })
+  otherMethodToObtain: string;
+
+  @Column({ type: 'enum', enum: MethodToObtain })
+  commonPathToObtain: MethodToObtain;
+
+  @Column({ nullable: true })
+  otherCommonPathToObtain: string;
 
   @Column({ nullable: true })
   methodToObtainDeprecated: string;
@@ -41,14 +62,18 @@ export class Qualification {
 
   constructor(
     level?: string,
-    methodToObtain?: string,
-    commonPathToObtain?: string,
+    methodToObtain?: MethodToObtain,
+    otherMethodToObtain?: string,
+    commonPathToObtain?: MethodToObtain,
+    otherCommonPathToObtain?: string,
     educationDuration?: string,
     mandatoryProfessionalExperience?: boolean,
   ) {
     this.level = level || '';
-    this.methodToObtainDeprecated = methodToObtain || null;
-    this.commonPathToObtainDeprecated = commonPathToObtain || null;
+    this.methodToObtain = methodToObtain || undefined;
+    this.commonPathToObtain = commonPathToObtain || undefined;
+    this.otherMethodToObtain = otherMethodToObtain || '';
+    this.otherCommonPathToObtain = otherCommonPathToObtain || '';
     this.educationDuration = educationDuration || '';
     this.mandatoryProfessionalExperience =
       mandatoryProfessionalExperience || true;

--- a/src/qualifications/qualification.entity.ts
+++ b/src/qualifications/qualification.entity.ts
@@ -14,11 +14,11 @@ export class Qualification {
   @Column()
   level: string;
 
-  @Column()
-  methodToObtain: string;
+  @Column({ nullable: true })
+  methodToObtainDeprecated: string;
 
-  @Column()
-  commonPathToObtain: string;
+  @Column({ nullable: true })
+  commonPathToObtainDeprecated: string;
 
   @Column()
   educationDuration: string;
@@ -47,8 +47,8 @@ export class Qualification {
     mandatoryProfessionalExperience?: boolean,
   ) {
     this.level = level || '';
-    this.methodToObtain = methodToObtain || '';
-    this.commonPathToObtain = commonPathToObtain || '';
+    this.methodToObtainDeprecated = methodToObtain || null;
+    this.commonPathToObtainDeprecated = commonPathToObtain || null;
     this.educationDuration = educationDuration || '';
     this.mandatoryProfessionalExperience =
       mandatoryProfessionalExperience || true;

--- a/src/qualifications/qualification.entity.ts
+++ b/src/qualifications/qualification.entity.ts
@@ -39,6 +39,18 @@ export class Qualification {
   educationDuration: string;
 
   @Column()
+  educationDurationYears: number;
+
+  @Column()
+  educationDurationMonths: number;
+
+  @Column()
+  educationDurationDays: number;
+
+  @Column()
+  educationDurationHours: number;
+
+  @Column()
   mandatoryProfessionalExperience: boolean;
 
   @CreateDateColumn({
@@ -61,6 +73,10 @@ export class Qualification {
     commonPathToObtain?: MethodToObtain,
     otherCommonPathToObtain?: string,
     educationDuration?: string,
+    educationDurationYears?: number,
+    educationDurationMonths?: number,
+    educationDurationDays?: number,
+    educationDurationHours?: number,
     mandatoryProfessionalExperience?: boolean,
   ) {
     this.level = level || '';
@@ -69,6 +85,10 @@ export class Qualification {
     this.otherMethodToObtain = otherMethodToObtain || '';
     this.otherCommonPathToObtain = otherCommonPathToObtain || '';
     this.educationDuration = educationDuration || '';
+    this.educationDurationYears = educationDurationYears || 0;
+    this.educationDurationMonths = educationDurationMonths || 0;
+    this.educationDurationDays = educationDurationDays || 0;
+    this.educationDurationHours = educationDurationHours || 0;
     this.mandatoryProfessionalExperience =
       mandatoryProfessionalExperience || true;
   }

--- a/src/qualifications/qualification.entity.ts
+++ b/src/qualifications/qualification.entity.ts
@@ -35,12 +35,6 @@ export class Qualification {
   @Column({ nullable: true })
   otherCommonPathToObtain: string;
 
-  @Column({ nullable: true })
-  methodToObtainDeprecated: string;
-
-  @Column({ nullable: true })
-  commonPathToObtainDeprecated: string;
-
   @Column()
   educationDuration: string;
 

--- a/src/qualifications/qualifications.seeder.ts
+++ b/src/qualifications/qualifications.seeder.ts
@@ -14,6 +14,10 @@ type SeedQualification = {
   commonPathToObtain: MethodToObtain;
   otherCommonPathToObtain: MethodToObtain;
   educationDuration: string;
+  educationDurationYears: number;
+  educationDurationMonths: number;
+  educationDurationDays: number;
+  educationDurationHours: number;
   mandatoryProfessionalExperience: boolean;
 };
 
@@ -36,6 +40,10 @@ export class QualificationsSeeder implements Seeder {
         qualification.commonPathToObtain as MethodToObtain,
         qualification.otherCommonPathToObtain,
         qualification.educationDuration,
+        qualification.educationDurationYears,
+        qualification.educationDurationMonths,
+        qualification.educationDurationDays,
+        qualification.educationDurationHours,
         qualification.mandatoryProfessionalExperience,
       );
     });

--- a/src/qualifications/qualifications.seeder.ts
+++ b/src/qualifications/qualifications.seeder.ts
@@ -4,13 +4,15 @@ import { Repository } from 'typeorm';
 import { Seeder } from 'nestjs-seeder';
 import { InjectRepository } from '@nestjs/typeorm';
 
-import { Qualification } from './qualification.entity';
+import { MethodToObtain, Qualification } from './qualification.entity';
 import { InjectData } from '../common/decorators/seeds.decorator';
 
 type SeedQualification = {
   level: string;
-  methodToObtain: string;
-  commonPathToObtain: string;
+  methodToObtain: MethodToObtain;
+  otherMethodToObtain: string;
+  commonPathToObtain: MethodToObtain;
+  otherCommonPathToObtain: MethodToObtain;
   educationDuration: string;
   mandatoryProfessionalExperience: boolean;
 };
@@ -29,8 +31,10 @@ export class QualificationsSeeder implements Seeder {
     const qualifications = this.data.map((qualification) => {
       return new Qualification(
         qualification.level,
-        qualification.methodToObtain,
-        qualification.commonPathToObtain,
+        qualification.methodToObtain as MethodToObtain,
+        qualification.otherMethodToObtain,
+        qualification.commonPathToObtain as MethodToObtain,
+        qualification.otherCommonPathToObtain,
         qualification.educationDuration,
         qualification.mandatoryProfessionalExperience,
       );

--- a/src/qualifications/qualifications.service.spec.ts
+++ b/src/qualifications/qualifications.service.spec.ts
@@ -1,17 +1,12 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
+import qualificationFactory from '../testutils/factories/qualification';
 
 import { Qualification } from './qualification.entity';
 import { QualificationsService } from './qualifications.service';
 
-const qualification = new Qualification(
-  'ATT - Attestation of competence , Art. 11 a',
-  'Accredited Certification Scheme accredited by the United Kongdom Accrediation Service UKAS in accordance with ISO EN 17024 or an approprate National/Scottish Vocational Qualification at level 2',
-  'General secondary education',
-  '1 Year',
-  false,
-);
+const qualification = qualificationFactory.build();
 
 describe('Qualification service', () => {
   let service: QualificationsService;

--- a/src/testutils/factories/qualification.ts
+++ b/src/testutils/factories/qualification.ts
@@ -4,10 +4,10 @@ import { Qualification } from '../../qualifications/qualification.entity';
 export default Factory.define<Qualification>(({ sequence }) => ({
   id: sequence.toString(),
   level: 'Diploma from post-secondary level (more than 4 years)',
-  commonPathToObtain: 'General post-secondary education',
+  commonPathToObtainDeprecated: 'General post-secondary education',
   educationDuration: '1.0 Year',
   mandatoryProfessionalExperience: true,
-  methodToObtain: 'Vocational post-secondary education level',
+  methodToObtainDeprecated: 'Vocational post-secondary education level',
   created_at: new Date(),
   updated_at: new Date(),
 }));

--- a/src/testutils/factories/qualification.ts
+++ b/src/testutils/factories/qualification.ts
@@ -1,13 +1,21 @@
 import { Factory } from 'fishery';
-import { Qualification } from '../../qualifications/qualification.entity';
+import {
+  MethodToObtain,
+  Qualification,
+} from '../../qualifications/qualification.entity';
 
 export default Factory.define<Qualification>(({ sequence }) => ({
   id: sequence.toString(),
   level: 'Diploma from post-secondary level (more than 4 years)',
   commonPathToObtainDeprecated: 'General post-secondary education',
+  commonPathToObtain: MethodToObtain.GeneralSecondaryEducation,
+  otherCommonPathToObtain: '',
   educationDuration: '1.0 Year',
   mandatoryProfessionalExperience: true,
   methodToObtainDeprecated: 'Vocational post-secondary education level',
+  methodToObtain:
+    MethodToObtain.GeneralPostSecondaryEducationMandatoryVocational,
+  otherMethodToObtain: '',
   created_at: new Date(),
   updated_at: new Date(),
 }));

--- a/src/testutils/factories/qualification.ts
+++ b/src/testutils/factories/qualification.ts
@@ -11,6 +11,10 @@ export default Factory.define<Qualification>(({ sequence }) => ({
   commonPathToObtain: MethodToObtain.GeneralSecondaryEducation,
   otherCommonPathToObtain: '',
   educationDuration: '1.0 Year',
+  educationDurationYears: 1,
+  educationDurationMonths: 0,
+  educationDurationDays: 0,
+  educationDurationHours: 0,
   mandatoryProfessionalExperience: true,
   methodToObtainDeprecated: 'Vocational post-secondary education level',
   methodToObtain:


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR

Adds some database changes to pave the way for the new "Qualification Information" page, now that we know a bit more about how Qualifications should be structured:

- Uses enum fields for storing `methodToObtain` and `commonPathToObtain` values to give us consistency in responses. Adds a text `other` field for each of these, when a user needs to enter their own value.
- Adds additional, more granular `educationDurationX` fields, as the original string value wasn't really fit for purpose. We'll remove the old field when we start displaying these new fields in the service.
