### PR TITLE
Add `slug` to `Organisation` entity

### DIFF
--- a/seeds/development/organisations.json
+++ b/seeds/development/organisations.json
@@ -2,6 +2,7 @@
   {
     "name": "Department for Education",
     "alternateName": "",
+    "slug": "department-for-education",
     "address": "123 Example Street, London, EC1 1AB",
     "url": "https://www.gov.uk/guidance/early-years-qualifications-finder#overseas-qualifications",
     "email": "dfe@example.com",
@@ -12,6 +13,7 @@
   {
     "name": "Council of Registered Gas Installers",
     "alternateName": "",
+    "slug": "council-of-registered-gas-installers",
     "address": "123 Fake Street, London, EC1 1AB",
     "url": "www.corgi-gas-safety.com",
     "email": "gas@example.com",
@@ -22,6 +24,7 @@
   {
     "name": "Law Society of England and Wales",
     "alternateName": "",
+    "slug": "law-society-of-england-and-wales",
     "address": "456 Example Street, London, EC1 1AB",
     "url": "www.lawsociety.org.uk",
     "email": "law@example.com",
@@ -32,6 +35,7 @@
   {
     "name": "General Medical Council",
     "alternateName": "",
+    "slug": "general-medical-council",
     "address": "456 Fake Street, London, EC1 1AB",
     "url": "www.gmc.com",
     "email": "gmc@example.com",

--- a/seeds/test/organisations.json
+++ b/seeds/test/organisations.json
@@ -2,6 +2,7 @@
   {
     "name": "Department for Education",
     "alternateName": "",
+    "slug": "department-for-education",
     "address": "123 Example Street, London, EC1 1AB",
     "url": "https://www.gov.uk/guidance/early-years-qualifications-finder#overseas-qualifications",
     "email": "dfe@example.com",
@@ -12,6 +13,7 @@
   {
     "name": "Council of Registered Gas Installers",
     "alternateName": "",
+    "slug": "council-of-registered-gas-installers",
     "address": "123 Fake Street, London, EC1 1AB",
     "url": "www.corgi-gas-safety.com",
     "email": "gas@example.com",
@@ -22,6 +24,7 @@
   {
     "name": "Law Society of England and Wales",
     "alternateName": "",
+    "slug": "law-society-of-england-and-wales",
     "address": "456 Example Street, London, EC1 1AB",
     "url": "www.lawsociety.org.uk",
     "email": "law@example.com",
@@ -32,6 +35,7 @@
   {
     "name": "General Medical Council",
     "alternateName": "",
+    "slug": "general-medical-council",
     "address": "456 Fake Street, London, EC1 1AB",
     "url": "www.gmc.com",
     "email": "gmc@example.com",

--- a/src/db/migrate/1641839765019-AddSlugToOrganisation.ts
+++ b/src/db/migrate/1641839765019-AddSlugToOrganisation.ts
@@ -1,0 +1,21 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddSlugToOrganisation1641839765019 implements MigrationInterface {
+  name = 'AddSlugToOrganisation1641839765019';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "organisations" ADD "slug" character varying`,
+    );
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX "IDX_33e00528c843c238825895273b" ON "organisations" ("slug") WHERE "slug" IS NOT NULL`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_33e00528c843c238825895273b"`,
+    );
+    await queryRunner.query(`ALTER TABLE "organisations" DROP COLUMN "slug"`);
+  }
+}

--- a/src/organisations/organisation.entity.ts
+++ b/src/organisations/organisation.entity.ts
@@ -6,6 +6,7 @@ import {
   CreateDateColumn,
   UpdateDateColumn,
   OneToMany,
+  Index,
 } from 'typeorm';
 
 @Entity({ name: 'organisations' })
@@ -18,6 +19,10 @@ export class Organisation {
 
   @Column({ nullable: true })
   alternateName: string;
+
+  @Index({ unique: true, where: '"slug" IS NOT NULL' })
+  @Column({ nullable: true })
+  slug: string;
 
   @Column()
   address: string;
@@ -56,6 +61,7 @@ export class Organisation {
   constructor(
     name?: string,
     alternateName?: string,
+    slug?: string,
     address?: string,
     url?: string,
     email?: string,
@@ -66,6 +72,7 @@ export class Organisation {
   ) {
     this.name = name || '';
     this.alternateName = alternateName || '';
+    this.slug = slug || '';
     this.address = address || '';
     this.url = url || '';
     this.email = email || '';

--- a/src/organisations/organisations.seeder.ts
+++ b/src/organisations/organisations.seeder.ts
@@ -10,6 +10,7 @@ import { InjectData } from '../common/decorators/seeds.decorator';
 type SeedOrganisation = {
   name: string;
   alternateName: string;
+  slug: string;
   address: string;
   url: string;
   email: string;
@@ -34,6 +35,7 @@ export class OrganisationsSeeder implements Seeder {
         return new Organisation(
           organisation.name,
           organisation.alternateName,
+          organisation.slug,
           organisation.address,
           organisation.url,
           organisation.email,

--- a/src/testutils/factories/organisation.ts
+++ b/src/testutils/factories/organisation.ts
@@ -5,6 +5,7 @@ export default Factory.define<Organisation>(({ sequence }) => ({
   id: sequence.toString(),
   name: 'Example Organisation',
   alternateName: 'Alternate Organisation Name',
+  slug: 'example-slug',
   address: '123 Fake Street, London, AB1 2AB, England',
   url: 'https://www.example-org.com',
   email: 'hello@example-org.com',


### PR DESCRIPTION
# Changes in this PR

This PR adds a `slug` field to the `Organisation` entity, for use in the public-facing regulatory authority search journey. This mirrors the use of slugs in professions 