### PR TITLE
Add a service owner boolean to a user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 - Add more granular database fields for storing the duration of a qualification
+- Add a service owner boolean to a user
 
 ### Changed
 

--- a/cypress/integration/admin/user/create-new-user.spec.ts
+++ b/cypress/integration/admin/user/create-new-user.spec.ts
@@ -27,6 +27,7 @@ describe('Creating a new user', () => {
       cy.get('input[name="email"]').type('name@example.com');
       cy.get('button').click();
 
+      cy.get('input[name="serviceOwner"][value="1"]').check();
       cy.get('[type="checkbox"]').check('admin');
 
       cy.get('button').click();
@@ -35,6 +36,9 @@ describe('Creating a new user', () => {
       cy.get('body').should('contain', 'name@example.com');
       cy.translate('users.form.label.admin').then((adminLabel) => {
         cy.get('body').should('contain', adminLabel);
+      });
+      cy.translate('app.boolean.true').then((isServiceOwner) => {
+        cy.get('body').should('contain', isServiceOwner);
       });
 
       cy.get('button').click();
@@ -69,6 +73,7 @@ describe('Creating a new user', () => {
       cy.get('input[name="email"]').type('name2@example.com');
       cy.get('button').click();
 
+      cy.get('input[name="serviceOwner"][value="1"]').check();
       cy.get('[type="checkbox"]').check('admin');
 
       cy.get('button').click();
@@ -80,9 +85,10 @@ describe('Creating a new user', () => {
 
       cy.get('body').should('contain', 'name3@example.com');
 
-      cy.get('a[href*="roles/edit?change=true"]').click();
+      cy.get('a[href*="roles/edit?change=true"]').first().click();
 
       cy.get('[type="checkbox"]').check('editor');
+      cy.get('input[name="serviceOwner"][value="0"]').check();
       cy.get('button').click();
 
       cy.translate('users.form.label.admin').then((adminLabel) => {
@@ -91,6 +97,14 @@ describe('Creating a new user', () => {
 
       cy.translate('users.form.label.editor').then((editorLabel) => {
         cy.get('body').should('contain', editorLabel);
+      });
+
+      cy.translate('app.boolean.false').then((isServiceOwner) => {
+        cy.get('body').should('not.contain', isServiceOwner);
+      });
+
+      cy.translate('app.boolean.true').then((isServiceOwner) => {
+        cy.get('body').should('contain', isServiceOwner);
       });
 
       cy.get('button').click();

--- a/seeds/development/users.json
+++ b/seeds/development/users.json
@@ -4,13 +4,15 @@
     "name": "beis-rpr",
     "externalIdentifier": "auth0|61a0f8d2d6e3f3006b5b722e",
     "roles": ["admin"],
-    "confirmed": true
+    "confirmed": true,
+    "serviceOwner": true
   },
   {
     "email": "beis-rpr+editor@dxw.com",
     "name": "Editor",
     "externalIdentifier": "auth0|61a8b60ecf6b7100741ab726",
     "roles": ["editor"],
-    "confirmed": true
+    "confirmed": true,
+    "serviceOwner": false
   }
 ]

--- a/seeds/prod/users.json
+++ b/seeds/prod/users.json
@@ -4,13 +4,15 @@
     "name": "beis-rpr",
     "externalIdentifier": "auth0|61d42ee720680d00696f52e3",
     "roles": ["admin"],
-    "confirmed": true
+    "confirmed": true,
+    "serviceOwner": true
   },
   {
     "email": "beis-rpr+editor@dxw.com",
     "name": "Editor",
     "externalIdentifier": "auth0|61d42f3e91488b0069f2fe05",
     "roles": ["editor"],
-    "confirmed": true
+    "confirmed": true,
+    "serviceOwner": false
   }
 ]

--- a/seeds/staging/users.json
+++ b/seeds/staging/users.json
@@ -4,13 +4,15 @@
     "name": "beis-rpr",
     "externalIdentifier": "auth0|61d421ae91488b0069f2fbf1",
     "roles": ["admin"],
-    "confirmed": true
+    "confirmed": true,
+    "serviceOwner": true
   },
   {
     "email": "beis-rpr+editor@dxw.com",
     "name": "Editor",
     "externalIdentifier": "auth0|61d4220c20680d00696f50a1",
     "roles": ["editor"],
-    "confirmed": true
+    "confirmed": true,
+    "serviceOwner": false
   }
 ]

--- a/seeds/test/users.json
+++ b/seeds/test/users.json
@@ -4,13 +4,15 @@
     "name": "beis-rpr",
     "externalIdentifier": "auth0|61a0f8d2d6e3f3006b5b722e",
     "roles": ["admin"],
-    "confirmed": true
+    "confirmed": true,
+    "serviceOwner": true
   },
   {
     "email": "beis-rpr+editor@dxw.com",
     "name": "Editor",
     "externalIdentifier": "auth0|61a8b60ecf6b7100741ab726",
     "roles": ["editor"],
-    "confirmed": true
+    "confirmed": true,
+    "serviceOwner": false
   }
 ]

--- a/src/db/migrate/1641828821055-AddServiceOwnerBooleanToUser.ts
+++ b/src/db/migrate/1641828821055-AddServiceOwnerBooleanToUser.ts
@@ -1,0 +1,17 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddServiceOwnerBooleanToUser1641828821055
+  implements MigrationInterface
+{
+  name = 'AddServiceOwnerBooleanToUser1641828821055';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "users" ADD "serviceOwner" boolean NOT NULL DEFAULT false`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "users" DROP COLUMN "serviceOwner"`);
+  }
+}

--- a/src/i18n/en/app.json
+++ b/src/i18n/en/app.json
@@ -14,6 +14,10 @@
   "backToDashboard": "Back to the dashboard",
   "yes": "Yes",
   "no": "No",
+  "boolean": {
+    "true": "Yes",
+    "false": "No"
+  },
   "unitedKingdom": "United Kingdom",
   "phase": {
     "beta": {

--- a/src/i18n/en/users.json
+++ b/src/i18n/en/users.json
@@ -5,11 +5,13 @@
       "email": "Email address",
       "roles": "What roles apply to this user?",
       "admin": "Administrator",
-      "editor": "Editor"
+      "editor": "Editor",
+      "serviceOwner": "Is this user a service owner?"
     },
     "hint": {
       "name": "For example, Clare Jones.",
-      "email": "For example, clarejones@beis.gov.uk."
+      "email": "For example, clarejones@beis.gov.uk.",
+      "serviceOwner": "Service owners can access all content across organisations"
     },
     "button": {
       "add": "Add a new user",
@@ -19,6 +21,12 @@
     "errors": {
       "email": {
         "alreadyExists": "A user with this email address already exists"
+      },
+      "serviceOwner": {
+        "empty": "You must select if a user is a service owner"
+      },
+      "roles": {
+        "empty": "You must select at least one role"
       }
     },
     "headings": {

--- a/src/professions/admin/professions.controller.spec.ts
+++ b/src/professions/admin/professions.controller.spec.ts
@@ -8,7 +8,7 @@ import { IndustriesService } from '../../industries/industries.service';
 import { Nation } from '../../nations/nation';
 import { Organisation } from '../../organisations/organisation.entity';
 import { OrganisationsService } from '../../organisations/organisations.service';
-import { User, UserRole } from '../../users/user.entity';
+import { User } from '../../users/user.entity';
 import { FilterInput } from '../interfaces/filter-input.interface';
 import { Profession } from '../profession.entity';
 import { ProfessionsService } from '../professions.service';
@@ -125,10 +125,10 @@ describe('ProfessionsController', () => {
   });
 
   describe('index', () => {
-    describe('when the user is an admin', () => {
+    describe('when the user is a service owner', () => {
       beforeEach(() => {
         request['appSession'].user = createMock<User>({
-          roles: [UserRole.Admin],
+          serviceOwner: true,
         });
       });
 
@@ -238,10 +238,10 @@ describe('ProfessionsController', () => {
       });
     });
 
-    describe('when the user is not an admin', () => {
+    describe('when the user is not a service owner', () => {
       beforeEach(() => {
         request['appSession'].user = createMock<User>({
-          roles: [UserRole.Editor],
+          serviceOwner: false,
         });
       });
 

--- a/src/professions/admin/professions.controller.ts
+++ b/src/professions/admin/professions.controller.ts
@@ -13,7 +13,7 @@ import {
   ProfessionsPresenterView,
 } from './professions.presenter';
 import { AuthenticationGuard } from '../../common/authentication.guard';
-import { User, UserRole } from '../../users/user.entity';
+import { User } from '../../users/user.entity';
 import { FilterDto } from './dto/filter.dto';
 import { OrganisationsService } from '../../organisations/organisations.service';
 import { Organisation } from '../../organisations/organisation.entity';
@@ -49,15 +49,15 @@ export class ProfessionsController {
 
     const user = request['appSession'].user as User;
 
-    const overview = user.roles.includes(UserRole.Admin);
+    const showAllOrgs = user.serviceOwner;
 
-    const view: ProfessionsPresenterView = overview
+    const view: ProfessionsPresenterView = showAllOrgs
       ? 'overview'
       : 'single-organisation';
 
     // Once the user has an organisation, we will want to use that here for
     // non-admin users
-    const userOrganisaiton = overview ? null : allOrganisations[0];
+    const userOrganisation = showAllOrgs ? null : allOrganisations[0];
 
     const filterInput = this.getFilterInput(
       filter,
@@ -66,8 +66,8 @@ export class ProfessionsController {
       allIndustries,
     );
 
-    if (userOrganisaiton !== null) {
-      filterInput.organisations = [userOrganisaiton];
+    if (userOrganisation !== null) {
+      filterInput.organisations = [userOrganisation];
     }
 
     const filteredProfessions = new FilterHelper(allProfessions).filter(
@@ -76,7 +76,7 @@ export class ProfessionsController {
 
     return new ProfessionsPresenter(
       filterInput,
-      userOrganisaiton,
+      userOrganisation,
       allNations,
       allOrganisations,
       allIndustries,

--- a/src/testutils/factories/user.ts
+++ b/src/testutils/factories/user.ts
@@ -7,6 +7,7 @@ export default Factory.define<User>(({ sequence }) => ({
   name: 'Example User',
   roles: [UserRole.Admin],
   externalIdentifier: 'extid|1234567',
+  serviceOwner: false,
   confirmed: false,
   created_at: new Date(),
   updated_at: new Date(),

--- a/src/users/roles/dto/roles.dto.ts
+++ b/src/users/roles/dto/roles.dto.ts
@@ -1,9 +1,18 @@
 import { IsNotEmpty } from 'class-validator';
+import { Type } from 'class-transformer';
 import { UserRole } from '../../user.entity';
 
 export class RolesDto {
-  @IsNotEmpty()
+  @IsNotEmpty({
+    message: 'users.form.errors.roles.empty',
+  })
   roles: Array<UserRole>;
+
+  @Type(() => Boolean)
+  @IsNotEmpty({
+    message: 'users.form.errors.serviceOwner.empty',
+  })
+  serviceOwner: boolean;
 
   change: boolean;
 }

--- a/src/users/roles/roles.controller.spec.ts
+++ b/src/users/roles/roles.controller.spec.ts
@@ -76,6 +76,7 @@ describe('RolesController', () => {
     it('should redirect to confirm and update if the DTO is valid', async () => {
       const rolesDto = {
         roles: [UserRole.Admin],
+        serviceOwner: true,
         change: true,
       };
       await controller.create(rolesDto, 'user-uuid', res);

--- a/src/users/user.entity.ts
+++ b/src/users/user.entity.ts
@@ -49,6 +49,9 @@ export class User {
   updated_at: Date;
 
   @Column({ default: false })
+  serviceOwner: boolean;
+
+  @Column({ default: false })
   confirmed: boolean;
 
   constructor(
@@ -56,12 +59,14 @@ export class User {
     name?: string,
     externalIdentifier?: string,
     roles?: UserRole[],
+    serviceOwner?: boolean,
     confirmed?: boolean,
   ) {
     this.email = email || '';
     this.name = name || '';
     this.externalIdentifier = externalIdentifier || null;
     this.roles = roles || [];
+    this.serviceOwner = serviceOwner || false;
     this.confirmed = confirmed || false;
   }
 }

--- a/src/users/users.seeder.ts
+++ b/src/users/users.seeder.ts
@@ -13,6 +13,7 @@ type SeedUser = {
   name: string;
   externalIdentifier: string;
   roles: string[];
+  serviceOwner: boolean;
   confirmed: boolean;
 };
 
@@ -34,6 +35,7 @@ export class UsersSeeder implements Seeder {
         user.name,
         user.externalIdentifier,
         roles,
+        user.serviceOwner,
         user.confirmed,
       );
     });

--- a/views/users/_summary.njk
+++ b/views/users/_summary.njk
@@ -39,6 +39,23 @@
       },
       {
         key: {
+          text: ("users.form.label.serviceOwner" | t)
+        },
+        value: {
+          text: (("app.boolean." + serviceOwner) | t)
+        },
+        actions: {
+          items: [
+            {
+              href: "/admin/users/" + id + "/roles/edit?change=true",
+              text: ("app.change" | t),
+              visuallyHiddenText: ("users.form.label.roles" | t)
+            }
+          ]
+        }
+      },
+      {
+        key: {
           text: ("users.form.label.roles" | t)
         },
         value: {

--- a/views/users/roles/edit.njk
+++ b/views/users/roles/edit.njk
@@ -2,6 +2,7 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
 
 {% block content %}
 
@@ -14,7 +15,7 @@
         href: backLink
       }) }}
     {% endif %}
-    
+
     {% include "../../shared/_errors.njk" %}
 
     <span class="govuk-caption-xl">{{ "users.form.headings.main" | t }}</span>
@@ -23,6 +24,31 @@
     <form method="post" action="./">
 
       <input type="hidden" name="change" value="{{ change }}" />
+
+      {{ govukRadios({
+        classes: "govuk-radios--inline",
+        name: "serviceOwner",
+        fieldset: {
+          legend: {
+            text: ("users.form.label.serviceOwner" | t),
+            isPageHeading: false,
+            classes: "govuk-fieldset__legend--l"
+          }
+        },
+        hint: {
+          text: ("users.form.hint.serviceOwner" | t)
+        },
+        items: [
+          {
+            value: 1,
+            text: ("app.yes" | t)
+          },
+          {
+            value: 0,
+            text: ("app.no" | t)
+          }
+        ]
+      }) }}
 
       {% set roleItems = [] %}
       {% for role in roles %}


### PR DESCRIPTION
This adds a new `serviceOwner` boolean to a user, allowing us to specify if a user can see content for all organisations, or just their organisation.

## Screnshots of UI changes

![image](https://user-images.githubusercontent.com/109774/148915029-d02a3af1-7252-4303-bebb-afb2b044b023.png)
