### PR TITLE
Make `methodToObtain` enum values nullable to fix staging deployment

### DIFF
--- a/seeds/test/qualifications.json
+++ b/seeds/test/qualifications.json
@@ -18,7 +18,7 @@
     "otherMethodToObtain": "",
     "commonPathToObtain": "generalOrVocationalPostSecondaryEducation",
     "otherCommonPathToObtain": "",
-    "educationDuration": " 3.5 Year",
+    "educationDuration": "3.5 Year",
     "educationDurationYears": 3,
     "educationDurationMonths": 6,
     "educationDurationDays": 0,

--- a/src/db/migrate/1641834068149-AddEnumMethodToObtainValues.ts
+++ b/src/db/migrate/1641834068149-AddEnumMethodToObtainValues.ts
@@ -10,7 +10,7 @@ export class AddEnumMethodToObtainValues1641834068149
       `CREATE TYPE "public"."qualifications_methodtoobtain_enum" AS ENUM('generalSecondaryEducation', 'generalOrVocationalPostSecondaryEducation', 'generalPostSecondaryEducationMandatoryVocational', 'vocationalPostSecondaryEducation', 'degreeLevel', 'others')`,
     );
     await queryRunner.query(
-      `ALTER TABLE "qualifications" ADD "methodToObtain" "public"."qualifications_methodtoobtain_enum" NOT NULL`,
+      `ALTER TABLE "qualifications" ADD "methodToObtain" "public"."qualifications_methodtoobtain_enum"`,
     );
     await queryRunner.query(
       `ALTER TABLE "qualifications" ADD "otherMethodToObtain" character varying`,
@@ -19,7 +19,7 @@ export class AddEnumMethodToObtainValues1641834068149
       `CREATE TYPE "public"."qualifications_commonpathtoobtain_enum" AS ENUM('generalSecondaryEducation', 'generalOrVocationalPostSecondaryEducation', 'generalPostSecondaryEducationMandatoryVocational', 'vocationalPostSecondaryEducation', 'degreeLevel', 'others')`,
     );
     await queryRunner.query(
-      `ALTER TABLE "qualifications" ADD "commonPathToObtain" "public"."qualifications_commonpathtoobtain_enum" NOT NULL`,
+      `ALTER TABLE "qualifications" ADD "commonPathToObtain" "public"."qualifications_commonpathtoobtain_enum"`,
     );
     await queryRunner.query(
       `ALTER TABLE "qualifications" ADD "otherCommonPathToObtain" character varying`,

--- a/src/qualifications/qualification.entity.ts
+++ b/src/qualifications/qualification.entity.ts
@@ -23,13 +23,13 @@ export class Qualification {
   @Column()
   level: string;
 
-  @Column({ type: 'enum', enum: MethodToObtain })
+  @Column({ type: 'enum', enum: MethodToObtain, nullable: true })
   methodToObtain: MethodToObtain;
 
   @Column({ nullable: true })
   otherMethodToObtain: string;
 
-  @Column({ type: 'enum', enum: MethodToObtain })
+  @Column({ type: 'enum', enum: MethodToObtain, nullable: true })
   commonPathToObtain: MethodToObtain;
 
   @Column({ nullable: true })


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR
Update migration to make `methodToObtain` enum values nullable

There's an issue with staging deployments where the migrations fail due
to this field being null in the database at the time of migration. We
believe this is an issue tied to using an `enum` value for a field in
the DB (which is why we've never had issues creating new non-nullable
fields up until now) - we always need to make these nullable or provide
a default value. In this case, a default value didn't seem sensible.

We'll catch `null` values at code level, rather than database level, so
this shouldn't be a huge issue for us.

I'm editing the existing migration here, which is something we shouldn't
normally do, but if we don't, the migrations won't able to get past this
one successfully.