### PR TITLE
Make new education duration fields nullable

### DIFF
--- a/src/db/migrate/1641834876892-AddGranularEducationDurations.ts
+++ b/src/db/migrate/1641834876892-AddGranularEducationDurations.ts
@@ -7,16 +7,16 @@ export class AddGranularEducationDurations1641834876892
 
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(
-      `ALTER TABLE "qualifications" ADD "educationDurationYears" integer NOT NULL`,
+      `ALTER TABLE "qualifications" ADD "educationDurationYears" integer`,
     );
     await queryRunner.query(
-      `ALTER TABLE "qualifications" ADD "educationDurationMonths" integer NOT NULL`,
+      `ALTER TABLE "qualifications" ADD "educationDurationMonths" integer`,
     );
     await queryRunner.query(
-      `ALTER TABLE "qualifications" ADD "educationDurationDays" integer NOT NULL`,
+      `ALTER TABLE "qualifications" ADD "educationDurationDays" integer`,
     );
     await queryRunner.query(
-      `ALTER TABLE "qualifications" ADD "educationDurationHours" integer NOT NULL`,
+      `ALTER TABLE "qualifications" ADD "educationDurationHours" integer`,
     );
   }
 

--- a/src/qualifications/qualification.entity.ts
+++ b/src/qualifications/qualification.entity.ts
@@ -38,16 +38,16 @@ export class Qualification {
   @Column()
   educationDuration: string;
 
-  @Column()
+  @Column({ nullable: true })
   educationDurationYears: number;
 
-  @Column()
+  @Column({ nullable: true })
   educationDurationMonths: number;
 
-  @Column()
+  @Column({ nullable: true })
   educationDurationDays: number;
 
-  @Column()
+  @Column({ nullable: true })
   educationDurationHours: number;
 
   @Column()


### PR DESCRIPTION

<!-- Do you need to update the changelog? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR

This adds a similar to the one added in #106 to fix DB migrations that seem to fail on deployments to staging. We believe we need to do this because we already have seeded data for a qualification in the DB, which is why it's never happened with adding brand new entities.