### PR TITLE
Require users to be logged in to be able to create a new profession

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - No longer display previous values on a profession when rendering form errors
 - Use enums for storing methods to obtain and common paths to obtain a qualification
+- Require users to be logged in to be able to add a profession
 
 ## [release-001] - 2022-01-10
 

--- a/cypress/integration/admin/professions/add-a-profession.spec.ts
+++ b/cypress/integration/admin/professions/add-a-profession.spec.ts
@@ -1,8 +1,10 @@
 describe('Adding a new profession', () => {
   it('I can add a new profession', () => {
-    cy.visit('/admin/professions/add-profession');
+    cy.loginAuth0('admin');
 
-    cy.translate('app.start').then((buttonText) => {
+    cy.visit('/admin/professions');
+
+    cy.translate('professions.admin.addButtonLabel').then((buttonText) => {
       cy.get('button').contains(buttonText).click();
     });
 

--- a/src/professions/admin/add-profession/check-your-answers.controller.ts
+++ b/src/professions/admin/add-profession/check-your-answers.controller.ts
@@ -1,12 +1,14 @@
-import { Controller, Get, Param, Render, Req } from '@nestjs/common';
+import { Controller, Get, Param, Render, Req, UseGuards } from '@nestjs/common';
 import { Request } from 'express';
 import { I18nService } from 'nestjs-i18n';
+import { AuthenticationGuard } from '../../../common/authentication.guard';
 import { backLink } from '../../../common/utils';
 
 import { Nation } from '../../../nations/nation';
 import { ProfessionsService } from '../../professions.service';
 import { CheckYourAnswersTemplate } from './interfaces/check-your-answers.template';
 
+@UseGuards(AuthenticationGuard)
 @Controller('admin/professions')
 export class CheckYourAnswersController {
   constructor(

--- a/src/professions/admin/add-profession/confirmation.controller.ts
+++ b/src/professions/admin/add-profession/confirmation.controller.ts
@@ -1,9 +1,19 @@
-import { Controller, Get, Param, Post, Render, Res } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Param,
+  Post,
+  Render,
+  Res,
+  UseGuards,
+} from '@nestjs/common';
 import { Response } from 'express';
+import { AuthenticationGuard } from '../../../common/authentication.guard';
 
 import { ProfessionsService } from '../../professions.service';
 import { ConfirmationTemplate } from './interfaces/confirmation.template';
 
+@UseGuards(AuthenticationGuard)
 @Controller('admin/professions')
 export class ConfirmationController {
   constructor(private professionsService: ProfessionsService) {}

--- a/src/professions/admin/add-profession/regulated-activities.controller.ts
+++ b/src/professions/admin/add-profession/regulated-activities.controller.ts
@@ -1,5 +1,15 @@
-import { Controller, Get, Res, Param, Post, Body, Query } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Res,
+  Param,
+  Post,
+  Body,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
 import { Response } from 'express';
+import { AuthenticationGuard } from '../../../common/authentication.guard';
 import { Validator } from '../../../helpers/validator';
 import { ValidationFailedError } from '../../../validation/validation-failed.error';
 import { Profession } from '../../profession.entity';
@@ -7,6 +17,7 @@ import { ProfessionsService } from '../../professions.service';
 import { RegulatedActivitiesDto } from './dto/regulated-activities.dto';
 import { RegulatedActivitiesTemplate } from './interfaces/regulated-activities.template';
 
+@UseGuards(AuthenticationGuard)
 @Controller('admin/professions')
 export class RegulatedActivitiesController {
   constructor(private readonly professionsService: ProfessionsService) {}

--- a/src/professions/admin/add-profession/regulatory-body.controller.ts
+++ b/src/professions/admin/add-profession/regulatory-body.controller.ts
@@ -1,4 +1,13 @@
-import { Body, Controller, Get, Param, Post, Query, Res } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  Post,
+  Query,
+  Res,
+  UseGuards,
+} from '@nestjs/common';
 import { Response } from 'express';
 import { ProfessionsService } from '../../professions.service';
 import { I18nService } from 'nestjs-i18n';
@@ -11,7 +20,9 @@ import { MandatoryRegistrationRadioButtonsPresenter } from '../mandatory-registr
 import { Validator } from '../../../helpers/validator';
 import { RegulatoryBodyDto } from './dto/regulatory-body.dto';
 import { ValidationFailedError } from '../../../validation/validation-failed.error';
+import { AuthenticationGuard } from '../../../common/authentication.guard';
 
+@UseGuards(AuthenticationGuard)
 @Controller('admin/professions')
 export class RegulatoryBodyController {
   constructor(

--- a/src/professions/admin/add-profession/top-level-information.controller.spec.ts
+++ b/src/professions/admin/add-profession/top-level-information.controller.spec.ts
@@ -347,7 +347,7 @@ describe('TopLevelInformationController', () => {
         expect(response.render).toHaveBeenCalledWith(
           'professions/admin/add-profession/top-level-information',
           expect.objectContaining({
-            backLink: '/admin/professions/add-profession',
+            backLink: '/admin/professions',
           }),
         );
       });

--- a/src/professions/admin/add-profession/top-level-information.controller.ts
+++ b/src/professions/admin/add-profession/top-level-information.controller.ts
@@ -1,4 +1,13 @@
-import { Body, Controller, Get, Param, Post, Query, Res } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  Post,
+  Query,
+  Res,
+  UseGuards,
+} from '@nestjs/common';
 import { Response } from 'express';
 import { IndustriesCheckboxPresenter } from '../../../industries/industries-checkbox.presenter';
 import { NationsCheckboxPresenter } from '../../../nations/nations-checkbox.presenter';
@@ -12,7 +21,9 @@ import { TopLevelDetailsDto } from './dto/top-level-details.dto';
 import { I18nService } from 'nestjs-i18n';
 import { Industry } from '../../../industries/industry.entity';
 import { TopLevelDetailsTemplate } from './interfaces/top-level-details.template';
+import { AuthenticationGuard } from '../../../common/authentication.guard';
 
+@UseGuards(AuthenticationGuard)
 @Controller('admin/professions')
 export class TopLevelInformationController {
   constructor(

--- a/src/professions/admin/add-profession/top-level-information.controller.ts
+++ b/src/professions/admin/add-profession/top-level-information.controller.ts
@@ -132,6 +132,6 @@ export class TopLevelInformationController {
   private backLink(change: boolean, id: string) {
     return change
       ? `/admin/professions/${id}/check-your-answers`
-      : '/admin/professions/add-profession';
+      : '/admin/professions';
   }
 }

--- a/src/professions/admin/professions.controller.spec.ts
+++ b/src/professions/admin/professions.controller.spec.ts
@@ -1,6 +1,6 @@
 import { createMock, DeepMocked } from '@golevelup/ts-jest';
 import { Test } from '@nestjs/testing';
-import { Request } from 'express';
+import { Request, Response } from 'express';
 import { I18nService } from 'nestjs-i18n';
 import { createMockI18nService } from '../../testutils/create-mock-i18n-service';
 import { createMockRequest } from '../../testutils/create-mock-request';
@@ -120,8 +120,27 @@ describe('ProfessionsController', () => {
     controller = module.get<ProfessionsController>(ProfessionsController);
   });
 
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
   it('should be defined', () => {
     expect(controller).toBeDefined();
+  });
+
+  describe('create', () => {
+    it('should create a Profession and redirect', async () => {
+      const res = createMock<Response>();
+
+      professionsService.save.mockResolvedValue(profession1);
+
+      await controller.create(res);
+
+      expect(professionsService.save).toHaveBeenCalled();
+      expect(res.redirect).toHaveBeenCalledWith(
+        `/admin/professions/${profession1.id}/top-level-information/edit`,
+      );
+    });
   });
 
   describe('index', () => {

--- a/src/professions/admin/professions.controller.ts
+++ b/src/professions/admin/professions.controller.ts
@@ -28,6 +28,7 @@ import { OrganisationsService } from '../../organisations/organisations.service'
 import { Organisation } from '../../organisations/organisation.entity';
 import { Profession } from '../profession.entity';
 
+@UseGuards(AuthenticationGuard)
 @Controller('admin/professions')
 export class ProfessionsController {
   constructor(
@@ -47,7 +48,6 @@ export class ProfessionsController {
   }
 
   @Get()
-  @UseGuards(AuthenticationGuard)
   @Render('professions/admin/index')
   async index(
     @Req() request: Request,

--- a/src/professions/admin/professions.controller.ts
+++ b/src/professions/admin/professions.controller.ts
@@ -1,5 +1,14 @@
-import { Controller, Get, Query, Render, Req, UseGuards } from '@nestjs/common';
-import { Request } from 'express';
+import {
+  Controller,
+  Get,
+  Post,
+  Query,
+  Render,
+  Req,
+  Res,
+  UseGuards,
+} from '@nestjs/common';
+import { Request, Response } from 'express';
 import { I18nService } from 'nestjs-i18n';
 import { Industry } from '../../industries/industry.entity';
 import { IndustriesService } from '../../industries/industries.service';
@@ -17,6 +26,7 @@ import { User } from '../../users/user.entity';
 import { FilterDto } from './dto/filter.dto';
 import { OrganisationsService } from '../../organisations/organisations.service';
 import { Organisation } from '../../organisations/organisation.entity';
+import { Profession } from '../profession.entity';
 
 @Controller('admin/professions')
 export class ProfessionsController {
@@ -26,6 +36,15 @@ export class ProfessionsController {
     private readonly industriesService: IndustriesService,
     private readonly i18Service: I18nService,
   ) {}
+
+  @Post()
+  async create(@Res() res: Response): Promise<void> {
+    const profession = await this.professionsService.save(new Profession());
+
+    res.redirect(
+      `/admin/professions/${profession.id}/top-level-information/edit`,
+    );
+  }
 
   @Get()
   @UseGuards(AuthenticationGuard)

--- a/src/professions/professions.controller.spec.ts
+++ b/src/professions/professions.controller.spec.ts
@@ -1,7 +1,6 @@
 import { createMock, DeepMocked } from '@golevelup/ts-jest';
 import { NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
-import { Response } from 'express';
 import { I18nService } from 'nestjs-i18n';
 import industryFactory from '../testutils/factories/industry';
 import professionFactory from '../testutils/factories/profession';
@@ -46,25 +45,6 @@ describe('ProfessionsController', () => {
 
   it('should be defined', () => {
     expect(controller).toBeDefined();
-  });
-
-  describe('new', () => {
-    it('should return an empty object', () => {
-      expect(controller.new()).toEqual({});
-    });
-  });
-
-  describe('create', () => {
-    it('should create a Profession and redirect', async () => {
-      const res = createMock<Response>();
-
-      await controller.create(res);
-
-      expect(professionsService.save).toHaveBeenCalled();
-      expect(res.redirect).toHaveBeenCalledWith(
-        `/admin/professions/${exampleProfession.id}/top-level-information/edit`,
-      );
-    });
   });
 
   describe('show', () => {

--- a/src/professions/professions.controller.ts
+++ b/src/professions/professions.controller.ts
@@ -3,15 +3,11 @@ import {
   Get,
   NotFoundException,
   Param,
-  Post,
   Render,
-  Res,
 } from '@nestjs/common';
-import { Response } from 'express';
 import { I18nService } from 'nestjs-i18n';
 import { Nation } from '../nations/nation';
 import { ShowTemplate } from './interfaces/show-template.interface';
-import { Profession } from './profession.entity';
 import { ProfessionsService } from './professions.service';
 
 @Controller()
@@ -20,21 +16,6 @@ export class ProfessionsController {
     private professionsService: ProfessionsService,
     private readonly i18nService: I18nService,
   ) {}
-
-  @Get('admin/professions/add-profession')
-  @Render('professions/admin/add-profession/new')
-  new(): Record<string, any> {
-    return {};
-  }
-
-  @Post('admin/professions')
-  async create(@Res() res: Response): Promise<void> {
-    const profession = await this.professionsService.save(new Profession());
-
-    res.redirect(
-      `/admin/professions/${profession.id}/top-level-information/edit`,
-    );
-  }
 
   @Get('/professions/:slug')
   @Render('professions/show')

--- a/views/professions/admin/index.njk
+++ b/views/professions/admin/index.njk
@@ -28,7 +28,7 @@
       <h2 class="govuk-heading-l">{{ "professions.admin.addHeading" | t }} </h2>
       
       <p class="govuk-body-m">{{ "professions.admin.addText" | t }}</p>
-      <form action="/admin/professions/add-profession/" method="get" class="form">
+      <form action="/admin/professions" method="post" class="form">
         {{ govukButton({
           text: "professions.admin.addButtonLabel" | t
         }) }}


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR

Require users to be logged in to be able to add professions. This was left off to make things easier in develop, but now we've got the guards etc in place, it feels easy to add in now.

This also removes the "start" page for adding a profession, as there doesn't really seem to be a need for it.

## Screenshots of UI changes

### Before (removed screen)

![image](https://user-images.githubusercontent.com/19826940/148943136-412ef300-67fc-49bb-83c8-df350bd9c6ec.png)

### After (clicking the button here takes you straight to "top level details):

![image](https://user-images.githubusercontent.com/19826940/148943094-c8ad9105-de21-42ed-be29-7a42d13e15ac.png)

![image](https://user-images.githubusercontent.com/19826940/148943196-583d8f47-0c30-4731-92bc-cd5bd69087f7.png)

