### PR TITLE
(1762) Define user permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Add more granular database fields for storing the duration of a qualification
 - Add a service owner boolean to a user
+- Define new user permissions
 
 ### Changed
 
 - No longer display previous values on a profession when rendering form errors
 - Use enums for storing methods to obtain and common paths to obtain a qualification
 - Require users to be logged in to be able to add a profession
+- Change roles to permissions
 
 ## [release-001] - 2022-01-10
 

--- a/cypress/integration/admin/professions/add-a-profession.spec.ts
+++ b/cypress/integration/admin/professions/add-a-profession.spec.ts
@@ -1,81 +1,114 @@
 describe('Adding a new profession', () => {
-  it('I can add a new profession', () => {
-    cy.loginAuth0('admin');
+  context('when I am not logged in', () => {
+    it('I am prompted to log in', () => {
+      cy.visit('/admin/professions');
+      cy.location('pathname').should('contain', 'login');
+    });
+  });
 
-    cy.visit('/admin/professions');
-
-    cy.translate('professions.admin.addButtonLabel').then((buttonText) => {
-      cy.get('button').contains(buttonText).click();
+  context('when I am logged in without the correct permissions', () => {
+    beforeEach(() => {
+      cy.loginAuth0('editor');
     });
 
-    cy.translate('professions.form.headings.topLevelInformation').then(
-      (heading) => {
+    it('does not allow me to add a profession', () => {
+      cy.visit('/admin/professions');
+
+      cy.translate('professions.admin.addButtonLabel').then((buttonText) => {
+        cy.get('button').contains(buttonText).click();
+      });
+
+      cy.translate('errors.forbidden.heading').then((errorMessage) => {
+        cy.get('body').should('contain', errorMessage);
+      });
+    });
+  });
+
+  context('when I am logged in with the correct permissions', () => {
+    beforeEach(() => {
+      cy.loginAuth0();
+    });
+
+    it('I can add a new profession', () => {
+      cy.visit('/admin/professions');
+
+      cy.translate('professions.admin.addButtonLabel').then((buttonText) => {
+        cy.get('button').contains(buttonText).click();
+      });
+
+      cy.translate('professions.form.headings.topLevelInformation').then(
+        (heading) => {
+          cy.get('body').should('contain', heading);
+        },
+      );
+
+      cy.get('input[name="name"]').type('Example Profession');
+      cy.get('[type="checkbox"]').check('GB-ENG');
+      cy.translate('industries.constructionAndEngineering').then(
+        (constructionAndEngineering) => {
+          cy.contains(constructionAndEngineering).click();
+        },
+      );
+
+      cy.translate('app.continue').then((buttonText) => {
+        cy.get('button').contains(buttonText).click();
+      });
+
+      cy.translate('professions.form.headings.regulatoryBody').then(
+        (heading) => {
+          cy.get('body').should('contain', heading);
+        },
+      );
+      cy.get('select[name="regulatoryBody"]').select(
+        'Department for Education',
+      );
+      cy.get('input[name="mandatoryRegistration"][value="mandatory"]').check();
+      cy.translate('app.continue').then((buttonText) => {
+        cy.get('button').contains(buttonText).click();
+      });
+
+      cy.translate('professions.form.headings.regulatedActivities').then(
+        (heading) => {
+          cy.get('body').should('contain', heading);
+        },
+      );
+
+      cy.get('textarea[name="activities"]').type('An example activity');
+      cy.get('textarea[name="description"]').type(
+        'A description of the regulation',
+      );
+
+      cy.translate('app.continue').then((buttonText) => {
+        cy.get('button').contains(buttonText).click();
+      });
+
+      cy.translate('professions.form.headings.checkAnswers').then((heading) => {
         cy.get('body').should('contain', heading);
-      },
-    );
+      });
 
-    cy.get('input[name="name"]').type('Example Profession');
-    cy.get('[type="checkbox"]').check('GB-ENG');
-    cy.translate('industries.constructionAndEngineering').then(
-      (constructionAndEngineering) => {
-        cy.contains(constructionAndEngineering).click();
-      },
-    );
+      cy.get('body').should('contain', 'Example Profession');
+      cy.translate('nations.england').then((england) => {
+        cy.get('body').should('contain', england);
+      });
+      cy.get('body').should('contain', 'Construction & Engineering');
+      cy.get('body').should('contain', 'Department for Education');
+      cy.translate(
+        'professions.form.radioButtons.mandatoryRegistration.mandatory',
+      ).then((mandatoryRegistration) => {
+        cy.get('body').should('contain', mandatoryRegistration);
+      });
+      cy.get('body').should('contain', 'An example activity');
+      cy.get('body').should('contain', 'A description of the regulation');
 
-    cy.translate('app.continue').then((buttonText) => {
-      cy.get('button').contains(buttonText).click();
-    });
+      cy.translate('professions.form.button.create').then((buttonText) => {
+        cy.get('button').contains(buttonText).click();
+      });
 
-    cy.translate('professions.form.headings.regulatoryBody').then((heading) => {
-      cy.get('body').should('contain', heading);
-    });
-    cy.get('select[name="regulatoryBody"]').select('Department for Education');
-    cy.get('input[name="mandatoryRegistration"][value="mandatory"]').check();
-    cy.translate('app.continue').then((buttonText) => {
-      cy.get('button').contains(buttonText).click();
-    });
-
-    cy.translate('professions.form.headings.regulatedActivities').then(
-      (heading) => {
-        cy.get('body').should('contain', heading);
-      },
-    );
-
-    cy.get('textarea[name="activities"]').type('An example activity');
-    cy.get('textarea[name="description"]').type(
-      'A description of the regulation',
-    );
-
-    cy.translate('app.continue').then((buttonText) => {
-      cy.get('button').contains(buttonText).click();
-    });
-
-    cy.translate('professions.form.headings.checkAnswers').then((heading) => {
-      cy.get('body').should('contain', heading);
-    });
-
-    cy.get('body').should('contain', 'Example Profession');
-    cy.translate('nations.england').then((england) => {
-      cy.get('body').should('contain', england);
-    });
-    cy.get('body').should('contain', 'Construction & Engineering');
-    cy.get('body').should('contain', 'Department for Education');
-    cy.translate(
-      'professions.form.radioButtons.mandatoryRegistration.mandatory',
-    ).then((mandatoryRegistration) => {
-      cy.get('body').should('contain', mandatoryRegistration);
-    });
-    cy.get('body').should('contain', 'An example activity');
-    cy.get('body').should('contain', 'A description of the regulation');
-
-    cy.translate('professions.form.button.create').then((buttonText) => {
-      cy.get('button').contains(buttonText).click();
-    });
-
-    cy.translate('professions.form.headings.confirmation').then((heading) => {
-      cy.get('body')
-        .should('contain', heading)
-        .should('contain', 'Example Profession');
+      cy.translate('professions.form.headings.confirmation').then((heading) => {
+        cy.get('body')
+          .should('contain', heading)
+          .should('contain', 'Example Profession');
+      });
     });
   });
 });

--- a/cypress/integration/admin/professions/add-a-profession.spec.ts
+++ b/cypress/integration/admin/professions/add-a-profession.spec.ts
@@ -15,11 +15,7 @@ describe('Adding a new profession', () => {
       cy.visit('/admin/professions');
 
       cy.translate('professions.admin.addButtonLabel').then((buttonText) => {
-        cy.get('button').contains(buttonText).click();
-      });
-
-      cy.translate('errors.forbidden.heading').then((errorMessage) => {
-        cy.get('body').should('contain', errorMessage);
+        cy.get('body').should('not.contain', buttonText);
       });
     });
   });

--- a/cypress/integration/admin/user/create-new-user.spec.ts
+++ b/cypress/integration/admin/user/create-new-user.spec.ts
@@ -28,14 +28,14 @@ describe('Creating a new user', () => {
       cy.get('button').click();
 
       cy.get('input[name="serviceOwner"][value="1"]').check();
-      cy.get('[type="checkbox"]').check('admin');
+      cy.get('[type="checkbox"]').check('createOrganisation');
 
       cy.get('button').click();
 
       cy.get('body').should('contain', 'Example Name');
       cy.get('body').should('contain', 'name@example.com');
-      cy.translate('users.form.label.admin').then((adminLabel) => {
-        cy.get('body').should('contain', adminLabel);
+      cy.translate('users.form.label.createOrganisation').then((label) => {
+        cy.get('body').should('contain', label);
       });
       cy.translate('app.boolean.true').then((isServiceOwner) => {
         cy.get('body').should('contain', isServiceOwner);
@@ -74,7 +74,7 @@ describe('Creating a new user', () => {
       cy.get('button').click();
 
       cy.get('input[name="serviceOwner"][value="1"]').check();
-      cy.get('[type="checkbox"]').check('admin');
+      cy.get('[type="checkbox"]').check('createOrganisation');
 
       cy.get('button').click();
 
@@ -85,18 +85,19 @@ describe('Creating a new user', () => {
 
       cy.get('body').should('contain', 'name3@example.com');
 
-      cy.get('a[href*="roles/edit?change=true"]').first().click();
+      cy.get('a[href*="permissions/edit?change=true"]').first().click();
 
-      cy.get('[type="checkbox"]').check('editor');
       cy.get('input[name="serviceOwner"][value="0"]').check();
+      cy.get('[type="checkbox"]').check('createUser');
+
       cy.get('button').click();
 
-      cy.translate('users.form.label.admin').then((adminLabel) => {
-        cy.get('body').should('not.contain', adminLabel);
+      cy.translate('users.form.label.createOrganisation').then((label) => {
+        cy.get('body').should('not.contain', label);
       });
 
-      cy.translate('users.form.label.editor').then((editorLabel) => {
-        cy.get('body').should('contain', editorLabel);
+      cy.translate('users.form.label.createUser').then((label) => {
+        cy.get('body').should('contain', label);
       });
 
       cy.translate('app.boolean.false').then((isServiceOwner) => {

--- a/cypress/integration/admin/user/create-new-user.spec.ts
+++ b/cypress/integration/admin/user/create-new-user.spec.ts
@@ -12,6 +12,12 @@ describe('Creating a new user', () => {
     });
 
     it('does not allow me to add a user', () => {
+      cy.visit('/admin');
+
+      cy.translate('users.headings.index').then((userLabel) => {
+        cy.get('body').should('not.contain', userLabel);
+      });
+
       cy.visit('/admin/users/new');
 
       cy.translate('errors.forbidden.heading').then((errorMessage) => {

--- a/cypress/integration/admin/user/create-new-user.spec.ts
+++ b/cypress/integration/admin/user/create-new-user.spec.ts
@@ -6,7 +6,21 @@ describe('Creating a new user', () => {
     });
   });
 
-  context('when I am logged in', () => {
+  context('when I am logged in without the correct permissions', () => {
+    beforeEach(() => {
+      cy.loginAuth0('editor');
+    });
+
+    it('does not allow me to add a user', () => {
+      cy.visit('/admin/users/new');
+
+      cy.translate('errors.forbidden.heading').then((errorMessage) => {
+        cy.get('body').should('contain', errorMessage);
+      });
+    });
+  });
+
+  context('when I am logged in with the correct permissions', () => {
     beforeEach(() => {
       cy.loginAuth0();
     });

--- a/cypress/integration/application.spec.ts
+++ b/cypress/integration/application.spec.ts
@@ -7,7 +7,7 @@ describe('/', () => {
     });
   });
 
-  context('when I am logged in as an admin', () => {
+  context('when I am logged in', () => {
     beforeEach(() => {
       cy.loginAuth0('admin');
       cy.visit('/admin');
@@ -19,38 +19,6 @@ describe('/', () => {
           cy.get('body').should('contain', welcomeMessage);
         },
       );
-    });
-
-    it('allows me to access the super admin area', () => {
-      cy.visit('/admin/superadmin');
-      cy.translate('app.superadmin', { name: 'beis-rpr' }).then(
-        (superadminMessage) => {
-          cy.get('body').should('contain', superadminMessage);
-        },
-      );
-    });
-  });
-
-  context('when I am logged in as an editor', () => {
-    beforeEach(() => {
-      cy.loginAuth0('editor');
-      cy.visit('/admin');
-    });
-
-    it('shows my username', () => {
-      cy.translate('app.welcome', { name: 'beis-rpr+editor' }).then(
-        (welcomeMessage) => {
-          cy.get('body').should('contain', welcomeMessage);
-        },
-      );
-    });
-
-    it('does not allow me to access the super admin area', () => {
-      cy.visit('/admin/superadmin');
-
-      cy.translate('errors.forbidden.heading').then((errorMessage) => {
-        cy.get('body').should('contain', errorMessage);
-      });
     });
   });
 });

--- a/seeds/development/users.json
+++ b/seeds/development/users.json
@@ -3,7 +3,18 @@
     "email": "beis-rpr@dxw.com",
     "name": "beis-rpr",
     "externalIdentifier": "auth0|61a0f8d2d6e3f3006b5b722e",
-    "roles": ["admin"],
+    "permissions": [
+      "createUser",
+      "editUser",
+      "deleteUser",
+      "createOrganisation",
+      "deleteOrganisation",
+      "createProfession",
+      "deleteprofession",
+      "uploadDecisionData",
+      "downloadDecisionData",
+      "viewDecisionData"
+    ],
     "confirmed": true,
     "serviceOwner": true
   },
@@ -11,7 +22,7 @@
     "email": "beis-rpr+editor@dxw.com",
     "name": "Editor",
     "externalIdentifier": "auth0|61a8b60ecf6b7100741ab726",
-    "roles": ["editor"],
+    "permissions": [],
     "confirmed": true,
     "serviceOwner": false
   }

--- a/seeds/prod/users.json
+++ b/seeds/prod/users.json
@@ -3,7 +3,18 @@
     "email": "beis-rpr@dxw.com",
     "name": "beis-rpr",
     "externalIdentifier": "auth0|61d42ee720680d00696f52e3",
-    "roles": ["admin"],
+    "permissions": [
+      "createUser",
+      "editUser",
+      "deleteUser",
+      "createOrganisation",
+      "deleteOrganisation",
+      "createProfession",
+      "deleteprofession",
+      "uploadDecisionData",
+      "downloadDecisionData",
+      "viewDecisionData"
+    ],
     "confirmed": true,
     "serviceOwner": true
   },
@@ -11,7 +22,7 @@
     "email": "beis-rpr+editor@dxw.com",
     "name": "Editor",
     "externalIdentifier": "auth0|61d42f3e91488b0069f2fe05",
-    "roles": ["editor"],
+    "permissions": [],
     "confirmed": true,
     "serviceOwner": false
   }

--- a/seeds/staging/users.json
+++ b/seeds/staging/users.json
@@ -3,7 +3,18 @@
     "email": "beis-rpr@dxw.com",
     "name": "beis-rpr",
     "externalIdentifier": "auth0|61d421ae91488b0069f2fbf1",
-    "roles": ["admin"],
+    "permissions": [
+      "createUser",
+      "editUser",
+      "deleteUser",
+      "createOrganisation",
+      "deleteOrganisation",
+      "createProfession",
+      "deleteprofession",
+      "uploadDecisionData",
+      "downloadDecisionData",
+      "viewDecisionData"
+    ],
     "confirmed": true,
     "serviceOwner": true
   },
@@ -11,7 +22,7 @@
     "email": "beis-rpr+editor@dxw.com",
     "name": "Editor",
     "externalIdentifier": "auth0|61d4220c20680d00696f50a1",
-    "roles": ["editor"],
+    "permissions": ["editor"],
     "confirmed": true,
     "serviceOwner": false
   }

--- a/seeds/test/users.json
+++ b/seeds/test/users.json
@@ -3,7 +3,18 @@
     "email": "beis-rpr@dxw.com",
     "name": "beis-rpr",
     "externalIdentifier": "auth0|61a0f8d2d6e3f3006b5b722e",
-    "roles": ["admin"],
+    "permissions": [
+      "createUser",
+      "editUser",
+      "deleteUser",
+      "createOrganisation",
+      "deleteOrganisation",
+      "createProfession",
+      "deleteprofession",
+      "uploadDecisionData",
+      "downloadDecisionData",
+      "viewDecisionData"
+    ],
     "confirmed": true,
     "serviceOwner": true
   },
@@ -11,7 +22,7 @@
     "email": "beis-rpr+editor@dxw.com",
     "name": "Editor",
     "externalIdentifier": "auth0|61a8b60ecf6b7100741ab726",
-    "roles": ["editor"],
+    "permissions": [],
     "confirmed": true,
     "serviceOwner": false
   }

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -10,9 +10,7 @@ import {
 } from '@nestjs/common';
 import { AppService } from './app.service';
 import { AuthenticationGuard } from './common/authentication.guard';
-import { Permissions } from './common/permissions.decorator';
 import { Request, Response } from 'express';
-import { UserPermission } from './users/user.entity';
 @Controller()
 export class AppController {
   constructor(private readonly appService: AppService) {}
@@ -49,15 +47,5 @@ export class AppController {
 
       res.redirect(path);
     }
-  }
-
-  @Get('/admin/superadmin')
-  @Permissions(UserPermission.CreateUser)
-  @UseGuards(AuthenticationGuard)
-  @Render('admin/superadmin')
-  superAdmin(@Req() req: Request): object {
-    return {
-      name: req.oidc.user.nickname,
-    };
   }
 }

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -10,9 +10,9 @@ import {
 } from '@nestjs/common';
 import { AppService } from './app.service';
 import { AuthenticationGuard } from './common/authentication.guard';
-import { Roles } from './common/roles.decorator';
+import { Permissions } from './common/permissions.decorator';
 import { Request, Response } from 'express';
-import { UserRole } from './users/user.entity';
+import { UserPermission } from './users/user.entity';
 @Controller()
 export class AppController {
   constructor(private readonly appService: AppService) {}
@@ -52,8 +52,8 @@ export class AppController {
   }
 
   @Get('/admin/superadmin')
+  @Permissions(UserPermission.CreateUser)
   @UseGuards(AuthenticationGuard)
-  @Roles(UserRole.Admin)
   @Render('admin/superadmin')
   superAdmin(@Req() req: Request): object {
     return {

--- a/src/common/authentication.guard.spec.ts
+++ b/src/common/authentication.guard.spec.ts
@@ -3,14 +3,14 @@ import { Reflector } from '@nestjs/core';
 
 import { createMock } from '@golevelup/ts-jest';
 import { AuthenticationGuard } from './authentication.guard';
-import { UserRole, User } from '../users/user.entity';
+import { UserPermission, User } from '../users/user.entity';
 
 describe('AuthenticationGuard', () => {
   let host: ExecutionContext;
   let oidc: any;
   let guard: AuthenticationGuard;
   let reflector: Reflector;
-  let roles: string[];
+  let permissions: string[];
   let user: User;
 
   beforeEach(() => {
@@ -28,7 +28,7 @@ describe('AuthenticationGuard', () => {
     });
     reflector = createMock<Reflector>({
       get: () => {
-        return roles;
+        return permissions;
       },
     });
 
@@ -46,28 +46,28 @@ describe('AuthenticationGuard', () => {
       expect(guard.canActivate(host)).toStrictEqual(true);
     });
 
-    describe('when roles are specified', () => {
+    describe('when permissions are specified', () => {
       beforeEach(() => {
-        roles = [UserRole.Admin];
+        permissions = [UserPermission.CreateUser];
       });
 
-      it('should return true when the user has the appropriate role', () => {
+      it('should return true when the user has the appropriate permission', () => {
         user = new User();
-        user.roles = [UserRole.Admin];
+        user.permissions = [UserPermission.CreateUser];
 
         expect(guard.canActivate(host)).toStrictEqual(true);
       });
 
-      it('should return false when the user does not have the appropriate role', () => {
+      it('should return false when the user does not have the appropriate permission', () => {
         user = new User();
-        user.roles = [UserRole.Editor];
+        user.permissions = [UserPermission.CreateOrganisation];
 
         expect(guard.canActivate(host)).toStrictEqual(false);
       });
 
-      it('should return false when the user has no roles', () => {
+      it('should return false when the user has no permissions', () => {
         user = new User();
-        user.roles = [];
+        user.permissions = [];
 
         expect(guard.canActivate(host)).toStrictEqual(false);
       });

--- a/src/common/global-locals.spec.ts
+++ b/src/common/global-locals.spec.ts
@@ -1,0 +1,51 @@
+import { globalLocals, RequestWithAppSession } from './global-locals';
+import { Response, NextFunction, Application } from 'express';
+import userFactory from '../testutils/factories/user';
+
+import { createMock, DeepMocked } from '@golevelup/ts-jest';
+
+const user = userFactory.build({
+  email: 'email@example.com',
+  name: 'name',
+  externalIdentifier: '212121',
+});
+
+describe('globalLocals', () => {
+  let request: DeepMocked<RequestWithAppSession>;
+  let response: DeepMocked<Response>;
+  let next: DeepMocked<NextFunction>;
+
+  beforeEach(() => {
+    request = createMock<RequestWithAppSession>();
+    response = createMock<Response>({
+      app: createMock<Application>({}),
+    });
+    next = createMock<NextFunction>(() => {
+      return true;
+    });
+  });
+
+  describe('when the request has a user', () => {
+    beforeEach(() => {
+      request.appSession = {
+        user: user,
+      };
+    });
+
+    it('sets the expected variables', () => {
+      globalLocals(request, response, next);
+
+      expect(response.app.locals.isLoggedin).toEqual(true);
+      expect(response.app.locals.user).toEqual(user);
+    });
+  });
+
+  describe('when the request does not have a user', () => {
+    it('sets the expected variables', () => {
+      globalLocals(request, response, next);
+
+      expect(response.app.locals.isLoggedin).toEqual(false);
+      expect(response.app.locals.user).toEqual(undefined);
+    });
+  });
+});

--- a/src/common/global-locals.ts
+++ b/src/common/global-locals.ts
@@ -1,0 +1,19 @@
+import { Request, Response, NextFunction } from 'express';
+import { User } from './../users/user.entity';
+
+export interface RequestWithAppSession extends Request {
+  appSession: any;
+}
+
+export function globalLocals(
+  req: RequestWithAppSession,
+  res: Response,
+  next: NextFunction,
+): void {
+  const user = req.appSession.user as User;
+
+  res.app.locals.isLoggedin = user !== undefined;
+  res.app.locals.user = user;
+
+  next();
+}

--- a/src/common/permissions.decorator.ts
+++ b/src/common/permissions.decorator.ts
@@ -1,0 +1,5 @@
+import { SetMetadata } from '@nestjs/common';
+import { UserPermission } from '../users/user.entity';
+
+export const Permissions = (...permissions: UserPermission[]) =>
+  SetMetadata('permissions', permissions);

--- a/src/common/roles.decorator.ts
+++ b/src/common/roles.decorator.ts
@@ -1,4 +1,0 @@
-import { SetMetadata } from '@nestjs/common';
-import { UserRole } from '../users/user.entity';
-
-export const Roles = (...roles: UserRole[]) => SetMetadata('roles', roles);

--- a/src/db/migrate/1640274620476-ChangeRolesToPermissions.ts
+++ b/src/db/migrate/1640274620476-ChangeRolesToPermissions.ts
@@ -1,0 +1,58 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class ChangeRolesToPermissions1640274620476
+  implements MigrationInterface
+{
+  name = 'ChangeRolesToPermissions1640274620476';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`UPDATE users SET roles = '{}' WHERE 1=1`);
+    await queryRunner.query(
+      `ALTER TABLE "users" RENAME COLUMN "roles" TO "permissions"`,
+    );
+    await queryRunner.query(
+      `ALTER TYPE "public"."users_roles_enum" RENAME TO "users_permissions_enum"`,
+    );
+    await queryRunner.query(
+      `ALTER TYPE "public"."users_permissions_enum" RENAME TO "users_permissions_enum_old"`,
+    );
+    await queryRunner.query(
+      `CREATE TYPE "public"."users_permissions_enum" AS ENUM('createUser', 'editUser', 'deleteUser', 'createOrganisation', 'deleteOrganisation', 'createProfession', 'deleteprofession', 'uploadDecisionData', 'downloadDecisionData', 'viewDecisionData')`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "users" ALTER COLUMN "permissions" DROP DEFAULT`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "users" ALTER COLUMN "permissions" TYPE "public"."users_permissions_enum"[] USING "permissions"::"text"::"public"."users_permissions_enum"[]`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "users" ALTER COLUMN "permissions" SET DEFAULT '{}'`,
+    );
+    await queryRunner.query(`DROP TYPE "public"."users_permissions_enum_old"`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TYPE "public"."users_permissions_enum_old" AS ENUM('admin', 'editor')`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "users" ALTER COLUMN "permissions" DROP DEFAULT`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "users" ALTER COLUMN "permissions" TYPE "public"."users_permissions_enum_old"[] USING "permissions"::"text"::"public"."users_permissions_enum_old"[]`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "users" ALTER COLUMN "permissions" SET DEFAULT '{}'`,
+    );
+    await queryRunner.query(`DROP TYPE "public"."users_permissions_enum"`);
+    await queryRunner.query(
+      `ALTER TYPE "public"."users_permissions_enum_old" RENAME TO "users_permissions_enum"`,
+    );
+    await queryRunner.query(
+      `ALTER TYPE "public"."users_permissions_enum" RENAME TO "users_roles_enum"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "users" RENAME COLUMN "permissions" TO "roles"`,
+    );
+  }
+}

--- a/src/i18n/en/app.json
+++ b/src/i18n/en/app.json
@@ -7,6 +7,7 @@
   "change": "Change",
   "start": "Start",
   "startButton": "Start now",
+  "logout": "Logout",
   "or": "Or",
   "errors": {
     "heading": "There is a problem"

--- a/src/i18n/en/organisations.json
+++ b/src/i18n/en/organisations.json
@@ -1,0 +1,5 @@
+{
+  "admin": {
+    "heading": "Regulatory authorities"
+  }
+}

--- a/src/i18n/en/users.json
+++ b/src/i18n/en/users.json
@@ -3,9 +3,17 @@
     "label": {
       "name": "Name",
       "email": "Email address",
-      "roles": "What roles apply to this user?",
-      "admin": "Administrator",
-      "editor": "Editor",
+      "permissions": "What permissions apply to this user?",
+      "createUser": "Create User",
+      "editUser": "Edit User",
+      "deleteUser": "Delete User",
+      "createOrganisation": "Create organisation",
+      "deleteOrganisation": "Delete organisation",
+      "createProfession": "Create profession",
+      "deleteprofession": "Delete profession",
+      "uploadDecisionData": "Upload decision data",
+      "downloadDecisionData": "Download decision data",
+      "viewDecisionData": "View decision data",
       "serviceOwner": "Is this user a service owner?"
     },
     "hint": {
@@ -33,7 +41,7 @@
       "main": "Creating RPR user",
       "checkAnswers": "Check your answers before creating this user",
       "personalDetails": "Personal details",
-      "roles": "Roles"
+      "permissions": "Permissions"
     },
     "delete": {
       "confirmMessage": "Are you sure you want to delete this user?",

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,6 +12,7 @@ import Rollbar from 'rollbar';
 import { AppModule } from './app.module';
 import { AuthenticationMidleware } from './middleware/authentication.middleware';
 import { nunjucksConfig } from './config/nunjucks.config';
+import { globalLocals } from './common/global-locals';
 
 import { ValidationFailedError } from './validation/validation-failed.error';
 import { HttpExceptionFilter } from './common/http-exception.filter';
@@ -71,6 +72,9 @@ async function bootstrap() {
     });
     app.use(rollbar.errorHandler());
   }
+
+  // Add global variables to the application to be used in the templates
+  app.use(globalLocals);
 
   await app.listen(process.env.PORT || 3000);
 }

--- a/src/professions/admin/add-profession/check-your-answers.controller.ts
+++ b/src/professions/admin/add-profession/check-your-answers.controller.ts
@@ -7,7 +7,8 @@ import { backLink } from '../../../common/utils';
 import { Nation } from '../../../nations/nation';
 import { ProfessionsService } from '../../professions.service';
 import { CheckYourAnswersTemplate } from './interfaces/check-your-answers.template';
-
+import { Permissions } from '../../../common/permissions.decorator';
+import { UserPermission } from '../../../users/user.entity';
 @UseGuards(AuthenticationGuard)
 @Controller('admin/professions')
 export class CheckYourAnswersController {
@@ -17,6 +18,7 @@ export class CheckYourAnswersController {
   ) {}
 
   @Get(':id/check-your-answers')
+  @Permissions(UserPermission.CreateProfession)
   @Render('professions/admin/add-profession/check-your-answers')
   async show(
     @Req() req: Request,

--- a/src/professions/admin/add-profession/confirmation.controller.ts
+++ b/src/professions/admin/add-profession/confirmation.controller.ts
@@ -9,16 +9,17 @@ import {
 } from '@nestjs/common';
 import { Response } from 'express';
 import { AuthenticationGuard } from '../../../common/authentication.guard';
-
 import { ProfessionsService } from '../../professions.service';
 import { ConfirmationTemplate } from './interfaces/confirmation.template';
-
+import { Permissions } from '../../../common/permissions.decorator';
+import { UserPermission } from '../../../users/user.entity';
 @UseGuards(AuthenticationGuard)
 @Controller('admin/professions')
 export class ConfirmationController {
   constructor(private professionsService: ProfessionsService) {}
 
   @Post('/:id/confirmation')
+  @Permissions(UserPermission.CreateProfession)
   async create(@Res() res: Response, @Param('id') id: string): Promise<void> {
     const profession = await this.professionsService.find(id);
 
@@ -28,6 +29,7 @@ export class ConfirmationController {
   }
 
   @Get('/:id/confirmation')
+  @Permissions(UserPermission.CreateProfession)
   @Render('professions/admin/add-profession/confirmation')
   async new(@Param('id') id: string): Promise<ConfirmationTemplate> {
     const profession = await this.professionsService.find(id);

--- a/src/professions/admin/add-profession/regulated-activities.controller.ts
+++ b/src/professions/admin/add-profession/regulated-activities.controller.ts
@@ -16,13 +16,15 @@ import { Profession } from '../../profession.entity';
 import { ProfessionsService } from '../../professions.service';
 import { RegulatedActivitiesDto } from './dto/regulated-activities.dto';
 import { RegulatedActivitiesTemplate } from './interfaces/regulated-activities.template';
-
+import { Permissions } from '../../../common/permissions.decorator';
+import { UserPermission } from '../../../users/user.entity';
 @UseGuards(AuthenticationGuard)
 @Controller('admin/professions')
 export class RegulatedActivitiesController {
   constructor(private readonly professionsService: ProfessionsService) {}
 
   @Get('/:id/regulated-activities/edit')
+  @Permissions(UserPermission.CreateProfession)
   async edit(
     @Res() res: Response,
     @Param('id') id: string,
@@ -40,6 +42,7 @@ export class RegulatedActivitiesController {
   }
 
   @Post('/:id/regulated-activities')
+  @Permissions(UserPermission.CreateProfession)
   async update(
     @Res() res: Response,
     @Param('id') id: string,

--- a/src/professions/admin/add-profession/regulatory-body.controller.ts
+++ b/src/professions/admin/add-profession/regulatory-body.controller.ts
@@ -9,6 +9,7 @@ import {
   UseGuards,
 } from '@nestjs/common';
 import { Response } from 'express';
+import { AuthenticationGuard } from '../../../common/authentication.guard';
 import { ProfessionsService } from '../../professions.service';
 import { I18nService } from 'nestjs-i18n';
 import { OrganisationsService } from '../../../organisations/organisations.service';
@@ -20,8 +21,8 @@ import { MandatoryRegistrationRadioButtonsPresenter } from '../mandatory-registr
 import { Validator } from '../../../helpers/validator';
 import { RegulatoryBodyDto } from './dto/regulatory-body.dto';
 import { ValidationFailedError } from '../../../validation/validation-failed.error';
-import { AuthenticationGuard } from '../../../common/authentication.guard';
-
+import { Permissions } from '../../../common/permissions.decorator';
+import { UserPermission } from '../../../users/user.entity';
 @UseGuards(AuthenticationGuard)
 @Controller('admin/professions')
 export class RegulatoryBodyController {
@@ -32,6 +33,7 @@ export class RegulatoryBodyController {
   ) {}
 
   @Get('/:id/regulatory-body/edit')
+  @Permissions(UserPermission.CreateProfession)
   async edit(
     @Res() res: Response,
     @Param('id') id: string,
@@ -53,6 +55,7 @@ export class RegulatoryBodyController {
   }
 
   @Post('/:id/regulatory-body')
+  @Permissions(UserPermission.CreateProfession)
   async update(
     @Res() res: Response,
     @Param('id') id: string,

--- a/src/professions/admin/add-profession/top-level-information.controller.ts
+++ b/src/professions/admin/add-profession/top-level-information.controller.ts
@@ -22,7 +22,8 @@ import { I18nService } from 'nestjs-i18n';
 import { Industry } from '../../../industries/industry.entity';
 import { TopLevelDetailsTemplate } from './interfaces/top-level-details.template';
 import { AuthenticationGuard } from '../../../common/authentication.guard';
-
+import { Permissions } from '../../../common/permissions.decorator';
+import { UserPermission } from '../../../users/user.entity';
 @UseGuards(AuthenticationGuard)
 @Controller('admin/professions')
 export class TopLevelInformationController {
@@ -33,6 +34,7 @@ export class TopLevelInformationController {
   ) {}
 
   @Get('/:id/top-level-information/edit')
+  @Permissions(UserPermission.CreateProfession)
   async edit(
     @Res() res: Response,
     @Param('id') id: string,
@@ -53,6 +55,7 @@ export class TopLevelInformationController {
   }
 
   @Post('/:id/top-level-information')
+  @Permissions(UserPermission.CreateProfession)
   async update(
     @Body() topLevelDetailsDto, // unfortunately we can't type this here without a validation error being thrown outside of this
     @Res() res: Response,

--- a/src/testutils/factories/user.ts
+++ b/src/testutils/factories/user.ts
@@ -1,11 +1,11 @@
 import { Factory } from 'fishery';
-import { User, UserRole } from '../../users/user.entity';
+import { User, UserPermission } from '../../users/user.entity';
 
 export default Factory.define<User>(({ sequence }) => ({
   id: sequence.toString(),
   email: 'user@example.com',
   name: 'Example User',
-  roles: [UserRole.Admin],
+  permissions: [UserPermission.CreateUser],
   externalIdentifier: 'extid|1234567',
   serviceOwner: false,
   confirmed: false,

--- a/src/users/interfaces/show-template.ts
+++ b/src/users/interfaces/show-template.ts
@@ -1,5 +1,5 @@
 import { User } from '../user.entity';
 
 export interface ShowTemplate extends User {
-  roleList: string;
+  permissionList: string;
 }

--- a/src/users/permissions/dto/permissions.dto.ts
+++ b/src/users/permissions/dto/permissions.dto.ts
@@ -1,12 +1,12 @@
 import { IsNotEmpty } from 'class-validator';
 import { Type } from 'class-transformer';
-import { UserRole } from '../../user.entity';
+import { UserPermission } from '../../user.entity';
 
-export class RolesDto {
+export class PermissionsDto {
   @IsNotEmpty({
     message: 'users.form.errors.roles.empty',
   })
-  roles: Array<UserRole>;
+  permissions: Array<UserPermission>;
 
   @Type(() => Boolean)
   @IsNotEmpty({

--- a/src/users/permissions/interfaces/edit-template.ts
+++ b/src/users/permissions/interfaces/edit-template.ts
@@ -1,0 +1,7 @@
+import { User, UserPermission } from '../../user.entity';
+
+export interface EditTemplate extends User {
+  backLink: string;
+  permissions: Array<UserPermission>;
+  change: boolean;
+}

--- a/src/users/permissions/permissions.controller.spec.ts
+++ b/src/users/permissions/permissions.controller.spec.ts
@@ -1,14 +1,14 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { UsersService } from '../users.service';
-import { User, UserRole } from '../user.entity';
-import { RolesController } from './roles.controller';
+import { User, UserPermission } from '../user.entity';
+import { PermissionsController } from './permissions.controller';
 import { createMock, DeepMocked } from '@golevelup/ts-jest';
 import { Request, Response } from 'express';
 import { createMockRequest } from '../../testutils/create-mock-request';
 import userFactory from '../../testutils/factories/user';
 
-describe('RolesController', () => {
-  let controller: RolesController;
+describe('PermissionsController', () => {
+  let controller: PermissionsController;
   let usersService: DeepMocked<UsersService>;
   let user: User;
 
@@ -27,7 +27,7 @@ describe('RolesController', () => {
     });
 
     const module: TestingModule = await Test.createTestingModule({
-      controllers: [RolesController],
+      controllers: [PermissionsController],
       providers: [
         {
           provide: UsersService,
@@ -36,7 +36,7 @@ describe('RolesController', () => {
       ],
     }).compile();
 
-    controller = module.get<RolesController>(RolesController);
+    controller = module.get<PermissionsController>(PermissionsController);
   });
 
   describe('edit', () => {
@@ -48,7 +48,18 @@ describe('RolesController', () => {
 
       expect(result).toEqual({
         ...user,
-        roles: ['admin', 'editor'],
+        permissions: [
+          'createUser',
+          'editUser',
+          'deleteUser',
+          'createOrganisation',
+          'deleteOrganisation',
+          'createProfession',
+          'deleteprofession',
+          'uploadDecisionData',
+          'downloadDecisionData',
+          'viewDecisionData',
+        ],
         backLink: referrer,
         change: false,
       });
@@ -59,7 +70,18 @@ describe('RolesController', () => {
 
       expect(result).toEqual({
         ...user,
-        roles: ['admin', 'editor'],
+        permissions: [
+          'createUser',
+          'editUser',
+          'deleteUser',
+          'createOrganisation',
+          'deleteOrganisation',
+          'createProfession',
+          'deleteprofession',
+          'uploadDecisionData',
+          'downloadDecisionData',
+          'viewDecisionData',
+        ],
         backLink: referrer,
         change: true,
       });
@@ -74,17 +96,17 @@ describe('RolesController', () => {
     });
 
     it('should redirect to confirm and update if the DTO is valid', async () => {
-      const rolesDto = {
-        roles: [UserRole.Admin],
+      const permissionsDto = {
+        permissions: [UserPermission.CreateUser],
         serviceOwner: true,
         change: true,
       };
-      await controller.create(rolesDto, 'user-uuid', res);
+      await controller.create(permissionsDto, 'user-uuid', res);
 
       expect(usersService.save).toHaveBeenCalledWith(
         expect.objectContaining({
           id: 'user-uuid',
-          ...rolesDto,
+          ...permissionsDto,
         }),
       );
       expect(res.redirect).toHaveBeenCalledWith(

--- a/src/users/permissions/permissions.controller.ts
+++ b/src/users/permissions/permissions.controller.ts
@@ -17,6 +17,7 @@ import { AuthenticationGuard } from '../../common/authentication.guard';
 import { UsersService } from '../users.service';
 import { UserPermission } from '../user.entity';
 import { PermissionsDto } from './dto/permissions.dto';
+import { Permissions } from '../../common/permissions.decorator';
 import { ValidationExceptionFilter } from '../../validation/validation-exception.filter';
 import { backLink } from '../../common/utils';
 import { EditTemplate } from './interfaces/edit-template';
@@ -26,7 +27,7 @@ export class PermissionsController {
   constructor(private readonly usersService: UsersService) {}
 
   @Get(':id/permissions/edit')
-  @UseGuards(AuthenticationGuard)
+  @Permissions(UserPermission.CreateUser, UserPermission.EditUser)
   @Render('users/permissions/edit')
   async edit(
     @Req() req: Request,
@@ -45,6 +46,7 @@ export class PermissionsController {
   }
 
   @Post(':id/permissions')
+  @Permissions(UserPermission.CreateUser, UserPermission.EditUser)
   @UseFilters(
     new ValidationExceptionFilter('users/permissions/edit', 'user', {
       permissions: Object.values(UserPermission),

--- a/src/users/permissions/permissions.controller.ts
+++ b/src/users/permissions/permissions.controller.ts
@@ -15,48 +15,48 @@ import { Request } from 'express';
 
 import { AuthenticationGuard } from '../../common/authentication.guard';
 import { UsersService } from '../users.service';
-import { UserRole } from '../user.entity';
-import { RolesDto } from './dto/roles.dto';
+import { UserPermission } from '../user.entity';
+import { PermissionsDto } from './dto/permissions.dto';
 import { ValidationExceptionFilter } from '../../validation/validation-exception.filter';
 import { backLink } from '../../common/utils';
 import { EditTemplate } from './interfaces/edit-template';
 @UseGuards(AuthenticationGuard)
 @Controller('/admin/users')
-export class RolesController {
+export class PermissionsController {
   constructor(private readonly usersService: UsersService) {}
 
-  @Get(':id/roles/edit')
+  @Get(':id/permissions/edit')
   @UseGuards(AuthenticationGuard)
-  @Render('users/roles/edit')
+  @Render('users/permissions/edit')
   async edit(
     @Req() req: Request,
     @Param('id') id,
     @Query('change') change: boolean,
   ): Promise<EditTemplate> {
     const user = await this.usersService.find(id);
-    const roles = Object.values(UserRole);
+    const permissions = Object.values(UserPermission);
 
     return {
       ...user,
-      roles,
+      permissions,
       backLink: backLink(req),
       change: change,
     };
   }
 
-  @Post(':id/roles')
+  @Post(':id/permissions')
   @UseFilters(
-    new ValidationExceptionFilter('users/roles/edit', 'blogPost', {
-      roles: Object.values(UserRole),
+    new ValidationExceptionFilter('users/permissions/edit', 'user', {
+      permissions: Object.values(UserPermission),
     }),
   )
   async create(
-    @Body() rolesDto: RolesDto,
+    @Body() permissionsDto: PermissionsDto,
     @Param('id') id,
     @Res() res,
   ): Promise<void> {
     const user = await this.usersService.find(id);
-    const updated = Object.assign(user, rolesDto);
+    const updated = Object.assign(user, permissionsDto);
 
     await this.usersService.save(updated);
 

--- a/src/users/personal-details/personal-details.controller.spec.ts
+++ b/src/users/personal-details/personal-details.controller.spec.ts
@@ -80,7 +80,7 @@ describe('PersonalDetailsController', () => {
       res = createMock<Response>();
     });
 
-    it('should redirect to roles and update the user the email address is not already in use and the body is populated', async () => {
+    it('should redirect to permissions and update the user the email address is not already in use and the body is populated', async () => {
       usersService.findByEmail.mockImplementationOnce(() => {
         return null;
       });
@@ -93,7 +93,7 @@ describe('PersonalDetailsController', () => {
         email: email,
       });
       expect(res.redirect).toHaveBeenCalledWith(
-        `/admin/users/user-uuid/roles/edit`,
+        `/admin/users/user-uuid/permissions/edit`,
       );
     });
 

--- a/src/users/personal-details/personal-details.controller.ts
+++ b/src/users/personal-details/personal-details.controller.ts
@@ -15,16 +15,19 @@ import { Request } from 'express';
 import { ValidationFailedError } from '../../validation/validation-failed.error';
 import { Validator } from '../../helpers/validator';
 import { UsersService } from '../users.service';
+import { UserPermission } from './../user.entity';
 import { PersonalDetailsDto } from './dto/personal-details.dto';
 import { AuthenticationGuard } from '../../common/authentication.guard';
+import { Permissions } from '../../common/permissions.decorator';
 import { backLink } from '../../common/utils';
 import { EditTemplate } from './interfaces/edit-template';
 @Controller('/admin/users')
+@UseGuards(AuthenticationGuard)
 export class PersonalDetailsController {
   constructor(private readonly usersService: UsersService) {}
 
   @Get(':id/personal-details/edit')
-  @UseGuards(AuthenticationGuard)
+  @Permissions(UserPermission.CreateUser, UserPermission.EditUser)
   @Render('users/personal-details/edit')
   async edit(
     @Req() req: Request,
@@ -41,7 +44,7 @@ export class PersonalDetailsController {
   }
 
   @Post(':id/personal-details')
-  @UseGuards(AuthenticationGuard)
+  @Permissions(UserPermission.CreateUser, UserPermission.EditUser)
   async create(
     @Body() personalDetailsDto,
     @Res() res,

--- a/src/users/personal-details/personal-details.controller.ts
+++ b/src/users/personal-details/personal-details.controller.ts
@@ -78,7 +78,7 @@ export class PersonalDetailsController {
     if (personalDetailsDto.change) {
       res.redirect(`/admin/users/${id}/confirm`);
     } else {
-      res.redirect(`/admin/users/${id}/roles/edit`);
+      res.redirect(`/admin/users/${id}/permissions/edit`);
     }
   }
 

--- a/src/users/roles/interfaces/edit-template.ts
+++ b/src/users/roles/interfaces/edit-template.ts
@@ -1,7 +1,0 @@
-import { User, UserRole } from '../../user.entity';
-
-export interface EditTemplate extends User {
-  backLink: string;
-  roles: Array<UserRole>;
-  change: boolean;
-}

--- a/src/users/user.entity.ts
+++ b/src/users/user.entity.ts
@@ -7,9 +7,17 @@ import {
   UpdateDateColumn,
 } from 'typeorm';
 
-export enum UserRole {
-  Admin = 'admin',
-  Editor = 'editor',
+export enum UserPermission {
+  CreateUser = 'createUser',
+  EditUser = 'editUser',
+  DeleteUser = 'deleteUser',
+  CreateOrganisation = 'createOrganisation',
+  DeleteOrganisation = 'deleteOrganisation',
+  CreateProfession = 'createProfession',
+  DeleteProfession = 'deleteprofession',
+  UploadDecisionData = 'uploadDecisionData',
+  DownloadDecisionData = 'downloadDecisionData',
+  ViewDecisionData = 'viewDecisionData',
 }
 
 @Entity({ name: 'users' })
@@ -29,11 +37,11 @@ export class User {
 
   @Column({
     type: 'enum',
-    enum: UserRole,
+    enum: UserPermission,
     array: true,
     default: [],
   })
-  roles: UserRole[];
+  permissions: UserPermission[];
 
   @CreateDateColumn({
     type: 'timestamp',
@@ -58,14 +66,14 @@ export class User {
     email?: string,
     name?: string,
     externalIdentifier?: string,
-    roles?: UserRole[],
+    permissions?: UserPermission[],
     serviceOwner?: boolean,
     confirmed?: boolean,
   ) {
     this.email = email || '';
     this.name = name || '';
     this.externalIdentifier = externalIdentifier || null;
-    this.roles = roles || [];
+    this.permissions = permissions || [];
     this.serviceOwner = serviceOwner || false;
     this.confirmed = confirmed || false;
   }

--- a/src/users/user.presenter.spec.ts
+++ b/src/users/user.presenter.spec.ts
@@ -2,17 +2,17 @@ import { createMock, DeepMocked } from '@golevelup/ts-jest';
 import { I18nService } from 'nestjs-i18n';
 import userFactory from '../testutils/factories/user';
 
-import { UserRole } from './user.entity';
+import { UserPermission } from './user.entity';
 import { UserPresenter } from './user.presenter';
 
 describe('UserPresenter', () => {
-  const roles: UserRole[] = [UserRole.Admin];
+  const permissions: UserPermission[] = [UserPermission.CreateUser];
   const user = userFactory.build({
     id: 'some-uuid-string',
     email: 'email@example.com',
     name: 'name',
     externalIdentifier: '212121',
-    roles: roles,
+    permissions: permissions,
   });
   const i18nService: DeepMocked<I18nService> = createMock<I18nService>();
   let presenter: UserPresenter;
@@ -51,41 +51,46 @@ describe('UserPresenter', () => {
     });
   });
 
-  describe('roleList', () => {
-    it('should return a single role', async () => {
-      i18nService.translate.mockResolvedValue('Administrator');
+  describe('permissionList', () => {
+    it('should return a single permission', async () => {
+      i18nService.translate.mockResolvedValue('Create User');
 
-      expect(await presenter.roleList()).toEqual('Administrator');
+      expect(await presenter.permissionList()).toEqual('Create User');
       expect(i18nService.translate).toHaveBeenCalledWith(
-        'users.form.label.admin',
+        'users.form.label.createUser',
       );
     });
 
-    describe('when there are multiple roles', () => {
-      const roles: UserRole[] = [UserRole.Admin, UserRole.Editor];
+    describe('when there are multiple permissions', () => {
+      const permissions: UserPermission[] = [
+        UserPermission.CreateUser,
+        UserPermission.DeleteUser,
+      ];
       const user = userFactory.build({
         id: 'some-uuid-string',
         name: 'name',
         email: 'email@example.com',
         externalIdentifier: '212121',
-        roles: roles,
+        permissions: permissions,
       });
 
       beforeEach(() => {
         presenter = new UserPresenter(user, i18nService);
       });
 
-      it('should return a list of roles', async () => {
+      it('should return a list of permissions', async () => {
         i18nService.translate
-          .mockResolvedValueOnce('Administrator')
-          .mockResolvedValueOnce('Editor');
+          .mockResolvedValueOnce('Create User')
+          .mockResolvedValueOnce('Delete User');
 
-        expect(await presenter.roleList()).toEqual('Administrator<br />Editor');
-        expect(i18nService.translate).toHaveBeenCalledWith(
-          'users.form.label.admin',
+        expect(await presenter.permissionList()).toEqual(
+          'Create User<br />Delete User',
         );
         expect(i18nService.translate).toHaveBeenCalledWith(
-          'users.form.label.editor',
+          'users.form.label.createUser',
+        );
+        expect(i18nService.translate).toHaveBeenCalledWith(
+          'users.form.label.deleteUser',
         );
       });
     });

--- a/src/users/user.presenter.ts
+++ b/src/users/user.presenter.ts
@@ -8,7 +8,7 @@ export class UserPresenter extends User {
       user.email,
       user.name,
       user.externalIdentifier,
-      user.roles,
+      user.permissions,
       user.confirmed,
     );
   }
@@ -38,13 +38,13 @@ export class UserPresenter extends User {
     `;
   }
 
-  public async roleList(): Promise<string> {
-    const roles = await Promise.all(
-      this.roles.map((role) => {
-        return this.i18n.translate(`users.form.label.${role}`);
+  public async permissionList(): Promise<string> {
+    const permissions = await Promise.all(
+      this.permissions.map((permission) => {
+        return this.i18n.translate(`users.form.label.${permission}`);
       }),
     );
 
-    return roles.join('<br />');
+    return permissions.join('<br />');
   }
 }

--- a/src/users/users.controller.spec.ts
+++ b/src/users/users.controller.spec.ts
@@ -6,7 +6,7 @@ import { I18nService } from 'nestjs-i18n';
 import { UsersService } from './users.service';
 import { Auth0Service } from './auth0.service';
 import { UsersController } from './users.controller';
-import { User, UserRole } from './user.entity';
+import { User, UserPermission } from './user.entity';
 import { UsersPresenter } from './users.presenter';
 import { UserPresenter } from './user.presenter';
 import { UserMailer } from './user.mailer';
@@ -17,7 +17,7 @@ import userFactory from '../testutils/factories/user';
 const name = 'Example Name';
 const email = 'name@example.com';
 const externalIdentifier = 'example-external-identifier';
-const roles = new Array<UserRole>();
+const permissions = new Array<UserPermission>();
 
 describe('UsersController', () => {
   let controller: UsersController;
@@ -35,7 +35,7 @@ describe('UsersController', () => {
       name: name,
       email: email,
       externalIdentifier: externalIdentifier,
-      roles: roles,
+      permissions: permissions,
     });
 
     request = createMock<Request>();
@@ -127,7 +127,7 @@ describe('UsersController', () => {
 
       expect(await controller.show('some-uuid')).toEqual({
         ...user,
-        roleList: await usersPresenter.roleList(),
+        permissionList: await usersPresenter.permissionList(),
       });
 
       expect(usersService.find).toHaveBeenCalledWith('some-uuid');
@@ -156,7 +156,7 @@ describe('UsersController', () => {
 
       expect(result).toEqual({
         ...user,
-        roleList: await usersPresenter.roleList(),
+        permissionList: await usersPresenter.permissionList(),
       });
     });
   });
@@ -177,7 +177,7 @@ describe('UsersController', () => {
           name,
           email,
           externalIdentifier,
-          roles,
+          permissions,
           confirmed: true,
         }),
       );
@@ -221,7 +221,7 @@ describe('UsersController', () => {
           name,
           email,
           externalIdentifier,
-          roles,
+          permissions,
           confirmed: true,
         }),
       );

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -61,7 +61,7 @@ export class UsersController {
 
     return {
       ...user,
-      roleList: await userPresenter.roleList(),
+      permissionList: await userPresenter.permissionList(),
     };
   }
 
@@ -82,7 +82,7 @@ export class UsersController {
 
     return {
       ...user,
-      roleList: await userPresenter.roleList(),
+      permissionList: await userPresenter.permissionList(),
     };
   }
 

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -14,15 +14,17 @@ import { I18nService } from 'nestjs-i18n';
 
 import { AuthenticationGuard } from '../common/authentication.guard';
 import { Auth0Service } from './auth0.service';
-import { User } from './user.entity';
+import { User, UserPermission } from './user.entity';
 import { UsersPresenter } from './users.presenter';
 import { UsersService } from './users.service';
 import { IndexTemplate } from './interfaces/index-template';
 import { ShowTemplate } from './interfaces/show-template';
+import { Permissions } from '../common/permissions.decorator';
 
 import { UserPresenter } from './user.presenter';
 import { UserMailer } from './user.mailer';
 @Controller()
+@UseGuards(AuthenticationGuard)
 export class UsersController {
   constructor(
     private readonly usersService: UsersService,
@@ -32,7 +34,7 @@ export class UsersController {
   ) {}
 
   @Get('/admin/users')
-  @UseGuards(AuthenticationGuard)
+  @Permissions(UserPermission.CreateUser, UserPermission.EditUser)
   @Render('users/index')
   async index(@Req() req): Promise<IndexTemplate> {
     const users = await this.usersService.where({ confirmed: true });
@@ -46,14 +48,14 @@ export class UsersController {
   }
 
   @Get('/admin/users/new')
-  @UseGuards(AuthenticationGuard)
+  @Permissions(UserPermission.CreateUser, UserPermission.EditUser)
   @Render('users/new')
   new(): object {
     return {};
   }
 
   @Get('/admin/users/:id')
-  @UseGuards(AuthenticationGuard)
+  @Permissions(UserPermission.CreateUser, UserPermission.EditUser)
   @Render('users/show')
   async show(@Param('id') id): Promise<ShowTemplate> {
     const user = await this.usersService.find(id);
@@ -66,7 +68,7 @@ export class UsersController {
   }
 
   @Post('/admin/users')
-  @UseGuards(AuthenticationGuard)
+  @Permissions(UserPermission.CreateUser, UserPermission.EditUser)
   async create(@Res() res) {
     const user = await this.usersService.save(new User());
 
@@ -74,7 +76,7 @@ export class UsersController {
   }
 
   @Get('/admin/users/:id/confirm')
-  @UseGuards(AuthenticationGuard)
+  @Permissions(UserPermission.CreateUser)
   @Render('users/confirm')
   async confirm(@Param('id') id): Promise<ShowTemplate> {
     const user = await this.usersService.find(id);
@@ -87,7 +89,7 @@ export class UsersController {
   }
 
   @Post('/admin/users/:id/confirm')
-  @UseGuards(AuthenticationGuard)
+  @Permissions(UserPermission.CreateUser)
   async complete(@Res() res, @Param('id') id): Promise<void> {
     const user = await this.usersService.find(id);
     const { email } = user;
@@ -123,7 +125,7 @@ export class UsersController {
   }
 
   @Get('/admin/users/:id/done')
-  @UseGuards(AuthenticationGuard)
+  @Permissions(UserPermission.CreateUser)
   @Render('users/done')
   async done(@Param('id') id): Promise<User> {
     const user = await this.usersService.find(id);
@@ -132,7 +134,7 @@ export class UsersController {
   }
 
   @Delete('/admin/users/:id')
-  @UseGuards(AuthenticationGuard)
+  @Permissions(UserPermission.DeleteUser)
   @Redirect('/admin/users')
   async delete(@Req() req, @Param('id') id): Promise<void> {
     req.flash(

--- a/src/users/users.module.ts
+++ b/src/users/users.module.ts
@@ -2,7 +2,7 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Auth0Service } from './auth0.service';
 import { PersonalDetailsController } from './personal-details/personal-details.controller';
-import { RolesController } from './roles/roles.controller';
+import { PermissionsController } from './permissions/permissions.controller';
 
 import { UsersController } from './users.controller';
 
@@ -23,7 +23,11 @@ import { Auth0Consumer } from './auth0.consumer';
     }),
   ],
   providers: [UsersService, UserMailer, Auth0Service, Auth0Consumer],
-  controllers: [UsersController, PersonalDetailsController, RolesController],
+  controllers: [
+    UsersController,
+    PersonalDetailsController,
+    PermissionsController,
+  ],
   exports: [UsersService],
 })
 export class UsersModule {}

--- a/src/users/users.seeder.ts
+++ b/src/users/users.seeder.ts
@@ -6,13 +6,13 @@ import { InjectRepository } from '@nestjs/typeorm';
 
 import { InjectData } from '../common/decorators/seeds.decorator';
 
-import { UserRole, User } from './user.entity';
+import { UserPermission, User } from './user.entity';
 
 type SeedUser = {
   email: string;
   name: string;
   externalIdentifier: string;
-  roles: string[];
+  permissions: string[];
   serviceOwner: boolean;
   confirmed: boolean;
 };
@@ -29,12 +29,12 @@ export class UsersSeeder implements Seeder {
 
   async seed(): Promise<any> {
     const users = this.data.map((user) => {
-      const roles = user.roles as UserRole[];
+      const permissions = user.permissions as UserPermission[];
       return new User(
         user.email,
         user.name,
         user.externalIdentifier,
-        roles,
+        permissions,
         user.serviceOwner,
         user.confirmed,
       );

--- a/views/admin/dashboard.njk
+++ b/views/admin/dashboard.njk
@@ -6,16 +6,18 @@
     <nav role="navigation" aria-labelledby="subsection-title">
       <ul class="govuk-list">
         <li>
-          <a class="govuk-link" href="/admin/professions">Regulated professions</a>
+          <a class="govuk-link" href="/admin/professions">{{ "professions.admin.heading" | t }}</a>
         </li>
         <li>
-          <a class="govuk-link" href="#">Regulatory authorities</a>
+          <a class="govuk-link" href="#">{{ "organisations.admin.heading" | t }}</a>
         </li>
+        {% if user.serviceOwner %}
+          <li>
+            <a class="govuk-link" href="/admin/users">{{ "users.headings.index" | t }}</a>
+          </li>
+        {% endif %}
         <li>
-          <a class="govuk-link" href="/admin/users">Manage users</a>
-        </li>
-        <li>
-          <a class="govuk-link" href="/logout">Logout</a>
+          <a class="govuk-link" href="/logout">{{ "app.logout" | t }}</a>
         </li>
       </ul>
     </nav>

--- a/views/admin/superadmin.njk
+++ b/views/admin/superadmin.njk
@@ -1,6 +1,0 @@
-{% extends "./base.njk" %}
-
-{% block content %}
-<h1 class="govuk-heading-l">{{ "app.welcome" | t({name: name}) }}</h1>
-<p class="govuk-body">{{ "app.superadmin" | t }}</p>
-{% endblock %}

--- a/views/professions/admin/index.njk
+++ b/views/professions/admin/index.njk
@@ -25,16 +25,18 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
 
-      <h2 class="govuk-heading-l">{{ "professions.admin.addHeading" | t }} </h2>
-      
-      <p class="govuk-body-m">{{ "professions.admin.addText" | t }}</p>
-      <form action="/admin/professions" method="post" class="form">
-        {{ govukButton({
-          text: "professions.admin.addButtonLabel" | t
-        }) }}
-      </form>
+      {% if 'createProfession' in user.permissions %}
+        <h2 class="govuk-heading-l">{{ "professions.admin.addHeading" | t }} </h2>
 
-      <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+        <p class="govuk-body-m">{{ "professions.admin.addText" | t }}</p>
+        <form action="/admin/professions" method="post" class="form">
+          {{ govukButton({
+            text: "professions.admin.addButtonLabel" | t
+          }) }}
+        </form>
+
+        <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+      {% endif %}
 
       <h2 class="govuk-heading-l">{{ "professions.admin.manageHeading" | t }} </h2>
 
@@ -65,7 +67,7 @@
                     },
                     classes: "{{ keywordsWidthClass }}",
                     hint: {
-                        text: "professions.admin.form.nameFilter.hint" | t 
+                        text: "professions.admin.form.nameFilter.hint" | t
                     },
                     name: "keywords",
                     value: filters.keywords
@@ -180,7 +182,7 @@
       {% endif %}
 
       {% if filters.nations | length %}
-        <p class="govuk-body-m rpr-listing__search-criteria-container"><span class="govuk-!-font-weight-bold">{{ "professions.admin.labels.nations" | t }}</span> 
+        <p class="govuk-body-m rpr-listing__search-criteria-container"><span class="govuk-!-font-weight-bold">{{ "professions.admin.labels.nations" | t }}</span>
         {% for nation in filters.nations %}
           <strong class="govuk-tag">{{ nation | t }}</strong>
         {% endfor %}
@@ -188,7 +190,7 @@
       {% endif %}
 
       {% if (filters.organisations | length) and (view === 'overview') %}
-        <p class="govuk-body-m rpr-listing__search-criteria-container"><span class="govuk-!-font-weight-bold">{{ "professions.admin.labels.organisations" | t }}</span> 
+        <p class="govuk-body-m rpr-listing__search-criteria-container"><span class="govuk-!-font-weight-bold">{{ "professions.admin.labels.organisations" | t }}</span>
         {% for organisation in filters.organisations %}
           <strong class="govuk-tag">{{ organisation }}</strong>
         {% endfor %}
@@ -196,7 +198,7 @@
       {% endif %}
 
       {% if filters.industries | length %}
-        <p class="govuk-body-m rpr-listing__search-criteria-container"><span class="govuk-!-font-weight-bold">{{ "professions.admin.labels.industries" | t }}</span> 
+        <p class="govuk-body-m rpr-listing__search-criteria-container"><span class="govuk-!-font-weight-bold">{{ "professions.admin.labels.industries" | t }}</span>
         {% for industry in filters.industries %}
           <strong class="govuk-tag">{{ industry | t }}</strong>
         {% endfor %}
@@ -204,7 +206,7 @@
       {% endif %}
 
       {% if filters.changedBy | length %}
-        <p class="govuk-body-m rpr-listing__search-criteria-container"><span class="govuk-!-font-weight-bold">{{ "professions.admin.labels.changedBy" | t }}</span> 
+        <p class="govuk-body-m rpr-listing__search-criteria-container"><span class="govuk-!-font-weight-bold">{{ "professions.admin.labels.changedBy" | t }}</span>
         {% for name in filters.changedBy %}
           <strong class="govuk-tag">{{ name | t }}</strong>
         {% endfor %}

--- a/views/users/_summary.njk
+++ b/views/users/_summary.njk
@@ -56,17 +56,17 @@
       },
       {
         key: {
-          text: ("users.form.label.roles" | t)
+          text: ("users.form.label.permissions" | t)
         },
         value: {
-          text: (roleList | safe)
+          text: (permissionList | safe)
         },
         actions: {
           items: [
             {
-              href: "/admin/users/" + id + "/roles/edit?change=true",
+              href: "/admin/users/" + id + "/permissions/edit?change=true",
               text: ("app.change" | t),
-              visuallyHiddenText: ("users.form.label.roles" | t)
+              visuallyHiddenText: ("users.form.label.permissions" | t)
             }
           ]
         }

--- a/views/users/confirm.njk
+++ b/views/users/confirm.njk
@@ -12,9 +12,9 @@
 
     {{ govukBackLink({
       text: ("app.back" | t),
-      href: "roles/edit"
+      href: "permissions/edit"
     }) }}
-    
+
     {% if userAlreadyExists %}
 
     {{ govukErrorSummary({

--- a/views/users/index.njk
+++ b/views/users/index.njk
@@ -11,21 +11,23 @@
 
       <h1 class="govuk-heading-xl">{{ "users.headings.index" | t }}</h1>
 
-      <h2 class="govuk-heading-l">{{ "users.headings.addNew" | t }}</h2>
-      <p class="govuk-body">{{ "users.body.intro" | t }}</p>
+      {% if 'createUser' in user.permissions %}
+        <h2 class="govuk-heading-l">{{ "users.headings.addNew" | t }}</h2>
+        <p class="govuk-body">{{ "users.body.intro" | t }}</p>
 
-      <form action="/admin/users/new/" method="get">
-        {{
-          govukButton({
-            id: "submit-button",
-            type: "Submit",
-            classes: "govuk-button",
-            text: ("users.form.button.add" | t)
-          })
-        }}
-      </form>
+        <form action="/admin/users/new/" method="get">
+          {{
+            govukButton({
+              id: "submit-button",
+              type: "Submit",
+              classes: "govuk-button",
+              text: ("users.form.button.add" | t)
+            })
+          }}
+        </form>
 
-      <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+        <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+      {% endif %}
 
       <h2 class="govuk-heading-l">{{ "users.headings.manageExisting" | t }}</h2>
 

--- a/views/users/permissions/edit.njk
+++ b/views/users/permissions/edit.njk
@@ -19,7 +19,7 @@
     {% include "../../shared/_errors.njk" %}
 
     <span class="govuk-caption-xl">{{ "users.form.headings.main" | t }}</span>
-    <h1 class="govuk-heading-xl">{{ "users.form.headings.roles" | t }}</h1>
+    <h1 class="govuk-heading-xl">{{ "users.form.headings.permissions" | t }}</h1>
 
     <form method="post" action="./">
 
@@ -51,17 +51,17 @@
       }) }}
 
       {% set roleItems = [] %}
-      {% for role in roles %}
+      {% for role in permissions %}
         {% set translation = "users.form.label." + role %}
         {% set roleItems = (roleItems.push({value: role, text: (translation | t)}), roleItems) %}
       {% endfor %}
 
       {{ govukCheckboxes({
-        id: "roles[]",
-        name: "roles[]",
+        id: "permissions[]",
+        name: "permissions[]",
         fieldset: {
           legend: {
-            text: ("users.form.label.roles" | t),
+            text: ("users.form.label.permissions" | t),
             isPageHeading: false,
             classes: "govuk-fieldset__legend--l"
           }

--- a/views/users/show.njk
+++ b/views/users/show.njk
@@ -12,30 +12,32 @@
       text: ("app.back" | t),
       href: "/admin/users"
     }) }}
-        
+
     <h1 class="govuk-heading-xl">{{ "users.headings.show" | t }}</h1>
     {% include "./_summary.njk" %}
 
   </div>
   <div class="govuk-grid-column-one-third">
     <aside class="rpr-sidebar rpr-internal__details-page-sidebar" role="complementary">
-      
+
       <nav role="navigation" aria-labelledby="subsection-title">
 
         <ul class="govuk-list">
-          <li>
-            <form action="{{ "/admin/users/" + id }}?_method=DELETE" method="post" data-confirm data-confirm-message="{{ ("users.form.delete.confirmMessage" | t) }}">
-              <input type="hidden" name="_method" value="DELETE" />
-              {{
-                govukButton({
-                  id: "submit-button",
-                  type: "Submit",
-                  classes: "govuk-button--warning",
-                  text: ("users.form.button.delete" | t)
-                })
-              }}
-            </form>
-          </li>
+          {% if 'deleteUser' in user.permissions %}
+            <li>
+              <form action="{{ "/admin/users/" + id }}?_method=DELETE" method="post" data-confirm data-confirm-message="{{ ("users.form.delete.confirmMessage" | t) }}">
+                <input type="hidden" name="_method" value="DELETE" />
+                {{
+                  govukButton({
+                    id: "submit-button",
+                    type: "Submit",
+                    classes: "govuk-button--warning",
+                    text: ("users.form.button.delete" | t)
+                  })
+                }}
+              </form>
+            </li>
+          {% endif %}
         </ul>
 
       </nav>


### PR DESCRIPTION
This updates the `roles` attribute on a user to `permissions`, and defines a whole bunch of new, more granular permissions
to allow us to specify exactly what a user can do. I've also applied these permissions in the controller using the `Permissions` controller decorator, and also added the ability to read data about a user and their permissions in the view, so we can conditionally show/hide buttons and navigation.