### PR TITLE
1942 Show Regulatory Authorities to an admin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Define new user permissions
 - List Regulatory Authorities
 - Add page for adding a new qualification to a profession
+- Show Regulatory Authorities to an admin
 
 ### Changed
 

--- a/assets/stylesheets/application.scss
+++ b/assets/stylesheets/application.scss
@@ -3,95 +3,92 @@ $govuk-assets-path: '~govuk-frontend/govuk/assets/';
 @import 'govuk/all';
 @import './admin.scss';
 
-.rpr-details__section-title {
-  text-transform: uppercase;
-}
-
-.rpr-listing__filters-container {
-  background-color: govuk-colour('light-grey');
-  padding: 1rem;
-}
-
-.rpr-listing__filter {
-  background-color: govuk-colour('white');
-  height: 180px;
-  overflow-y: auto;
-}
-
-.rpr-listing__search-criteria-container {
-  margin-bottom: 5px;
-}
-
-.rpr-listing__profession-title:link,
-.rpr-listing__ra-title:link {
-  text-decoration: none;
-}
-
-.rpr-listing__profession-title:hover,
-.rpr-listing__ra-title:hover {
-  text-decoration: underline;
-}
-
-.rpr-listing__profession-summary-list dt,
-.rpr-listing__profession-summary-list dd,
-.rpr-listing__ra-summary-list dt,
-.rpr-listing__ra-summary-list dd {
-  padding: 2px 0;
-}
-
-.rpr-internal__page {
-  .govuk-header__container {
-    border-bottom: 10px solid govuk-colour('yellow');
-  }
-}
-
-.rpr-listing__filters-container {
-  background-color: govuk-colour('light-grey');
-  padding: 1rem;
-}
-
-.rpr-listing__filter {
-  background-color: govuk-colour('white');
-  height: 180px;
-  overflow-y: auto;
-}
-
-.rpr-internal__listing {
-  .govuk-width-container {
-    max-width: 1200px;
-  }
-}
-
-.rpr-internal-listing__filters-container {
-  background-color: govuk-colour('light-grey');
-  padding: 1rem;
-
-  .govuk-details__text {
-    border: 0;
-  }
-
-  .govuk-details {
-    margin-bottom: 0;
-  }
-}
-
-.rpr-internal-listing__filter {
-  background-color: govuk-colour('white');
-  height: 180px;
-  overflow-y: auto;
-}
-
-.rpr-internal-listing__filter-button {
-  margin-bottom: 10px;
-  background-color: govuk-colour('black');
-  color: govuk-colour('white');
-}
-
-.rpr-details__section-title {
-  text-transform: uppercase;
-}
-
 .rpr-sidebar {
   border-top: 2px solid #1d70b8;
   padding-top: 10px;
+}
+
+.rpr-details {
+  &__section-title {
+    text-transform: uppercase;
+  }
+
+  &__section-title {
+    text-transform: uppercase;
+  }
+}
+
+.rpr-listing {
+  &__filters-container {
+    background-color: govuk-colour('light-grey');
+    padding: 1rem;
+  }
+
+  &__filter {
+    background-color: govuk-colour('white');
+    height: 180px;
+    overflow-y: auto;
+  }
+
+  &__search-criteria-container {
+    margin-bottom: 5px;
+  }
+
+  &__profession-title:link,
+  &__ra-title:link {
+    text-decoration: none;
+  }
+
+  &__profession-title:hover,
+  &__ra-title:hover {
+    text-decoration: underline;
+  }
+
+  &__profession-summary-list dt,
+  &__profession-summary-list dd,
+  &__ra-summary-list dt,
+  &__ra-summary-list dd {
+    padding: 2px 0;
+  }
+}
+
+.rpr-internal {
+  &__page {
+    .govuk-header__container {
+      border-bottom: 10px solid govuk-colour('yellow');
+    }
+  }
+
+  &__listing {
+    .govuk-width-container {
+      max-width: 1200px;
+    }
+  }
+
+  &__filters-container {
+    background-color: govuk-colour('light-grey');
+    padding: 1rem;
+
+    .govuk-details__text {
+      border: 0;
+    }
+
+    .govuk-details {
+      margin-bottom: 0;
+    }
+  }
+
+  &-listing {
+    &__filter {
+      background-color: govuk-colour('white');
+      height: 180px;
+      overflow-y: auto;
+    }
+
+    &__filter-button {
+      margin-bottom: 10px;
+      background-color: govuk-colour('black');
+      color: govuk-colour('white');
+    }
+  }
 }

--- a/assets/stylesheets/application.scss
+++ b/assets/stylesheets/application.scss
@@ -91,4 +91,19 @@ $govuk-assets-path: '~govuk-frontend/govuk/assets/';
       color: govuk-colour('white');
     }
   }
+
+  &__details-page {
+    &-sidebar {
+      border-top: 2px solid govuk-colour('blue');
+      padding-top: govuk-spacing(2);
+
+      .govuk-list > li {
+        margin-bottom: govuk-spacing(2);
+      }
+
+      .govuk-button {
+        margin-bottom: 0;
+      }
+    }
+  }
 }

--- a/cypress/integration/admin/organisations/show.spec.ts
+++ b/cypress/integration/admin/organisations/show.spec.ts
@@ -1,0 +1,38 @@
+describe('Showing organisations', () => {
+  context('When I am logged in as admin', () => {
+    beforeEach(() => {
+      cy.loginAuth0('admin');
+      cy.visit('/admin');
+    });
+
+    it('Shows the detail of an organisation', () => {
+      cy.get('a').contains('Regulatory authorities').click();
+
+      cy.readFile('./seeds/test/professions.json').then((professions) => {
+        cy.readFile('./seeds/test/organisations.json').then((organisations) => {
+          const organisation = organisations[0];
+
+          cy.contains(organisation.name)
+            .parent('tr')
+            .within(() => {
+              cy.get('a').contains('View details').click();
+            })
+            .then(() => {
+              cy.get('body').should('contain', organisation.name);
+              cy.get('body').should('contain', organisation.email);
+              cy.get('body').should('contain', organisation.contactUrl);
+
+              const professionsForOrganisation = professions.filter(
+                (profession: any) =>
+                  profession.organisation == organisation.name,
+              );
+
+              professionsForOrganisation.forEach((profession: any) => {
+                cy.should('contain', profession.name);
+              });
+            });
+        });
+      });
+    });
+  });
+});

--- a/src/common/interfaces/summary-list.ts
+++ b/src/common/interfaces/summary-list.ts
@@ -1,0 +1,9 @@
+type SummaryListItem = {
+  key: { text: string } | { html: string };
+  value: { text: string } | { html: string };
+};
+
+export type SummaryList = {
+  classes: string;
+  rows: SummaryListItem[];
+};

--- a/src/i18n/en/organisations.json
+++ b/src/i18n/en/organisations.json
@@ -6,6 +6,16 @@
       "alternateName": "Alternate name",
       "industries": "Industry/Sector(s)",
       "actions": "Actions"
+    },
+    "form": {
+      "label": {
+        "name": "Name",
+        "alternateName": "Alternate name",
+        "contactUrl": "Website",
+        "address": "Address",
+        "email": "Email",
+        "telephone": "Phone number"
+      }
     }
   }
 }

--- a/src/i18n/en/organisations.json
+++ b/src/i18n/en/organisations.json
@@ -17,5 +17,8 @@
         "telephone": "Phone number"
       }
     }
+  },
+  "headings": {
+    "professions": "Regulated professions"
   }
 }

--- a/src/organisations/admin/interfaces/edit-template.interface.ts
+++ b/src/organisations/admin/interfaces/edit-template.interface.ts
@@ -1,0 +1,13 @@
+import { Organisation } from '../../organisation.entity';
+import { SummaryList } from '../../../common/interfaces/summary-list';
+
+export interface EditTemplate {
+  organisation: Organisation;
+  summaryList: SummaryList;
+  professions: {
+    name: string;
+    slug: string;
+    summaryList: SummaryList;
+  }[];
+  backLink: string;
+}

--- a/src/organisations/admin/organisations.controller.spec.ts
+++ b/src/organisations/admin/organisations.controller.spec.ts
@@ -6,7 +6,11 @@ import { OrganisationsController } from './organisations.controller';
 import { OrganisationsService } from '../organisations.service';
 import { Organisation } from '../organisation.entity';
 import { Table } from '../../common/interfaces/table';
+import { SummaryList } from '../../common/interfaces/summary-list';
+
 import { OrganisationsPresenter } from '../presenters/organisations.presenter';
+import { OrganisationPresenter } from '../presenters/organisation.presenter';
+import { ProfessionPresenter } from '../../professions/presenters/profession.presenter';
 
 import organisationFactory from '../../testutils/factories/organisation';
 import professionFactory from '../../testutils/factories/profession';
@@ -16,6 +20,13 @@ const mockTable = (): Table => {
     firstCellIsHeader: true,
     head: [{ text: 'Headers' }],
     rows: [[{ text: 'Row 1' }], [{ text: 'Row 2' }], [{ text: 'Row 3' }]],
+  };
+};
+
+const mockSummaryList = (): SummaryList => {
+  return {
+    classes: 'govuk-summary-list--no-border',
+    rows: [],
   };
 };
 
@@ -31,20 +42,54 @@ jest.mock('../presenters/organisations.presenter', () => {
   };
 });
 
+jest.mock('../presenters/organisation.presenter', () => {
+  return {
+    OrganisationPresenter: jest.fn().mockImplementation(() => {
+      return {
+        summaryList: mockSummaryList,
+      };
+    }),
+  };
+});
+
+jest.mock('../../professions/presenters/profession.presenter', () => {
+  return {
+    ProfessionPresenter: jest.fn().mockImplementation((profession) => {
+      return {
+        profession: profession,
+        summaryList: mockSummaryList,
+      };
+    }),
+  };
+});
+
 describe('OrganisationsController', () => {
   let controller: OrganisationsController;
   let organisationsService: DeepMocked<OrganisationsService>;
   let organisations: Organisation[];
-  const i18nService = createMock<I18nService>();
+  let organisation: Organisation;
+
+  const i18nService: DeepMocked<I18nService> = createMock<I18nService>({
+    translate: async (key: string) => {
+      return key;
+    },
+  });
 
   beforeEach(async () => {
     organisations = organisationFactory.buildList(5, {
       professions: professionFactory.buildList(2),
     });
 
+    organisation = organisationFactory.build({
+      professions: professionFactory.buildList(2),
+    });
+
     organisationsService = createMock<OrganisationsService>({
       all: async () => {
         return organisations;
+      },
+      findBySlug: async () => {
+        return organisation;
       },
     });
 
@@ -78,6 +123,47 @@ describe('OrganisationsController', () => {
 
       expect(OrganisationsPresenter).toHaveBeenCalledWith(
         organisations,
+        i18nService,
+      );
+    });
+  });
+
+  describe('show', () => {
+    it('should return variables for the show template', async () => {
+      expect(await controller.show('slug')).toEqual({
+        backLink: '/admin/organisations',
+        organisation: organisation,
+        summaryList: mockSummaryList(),
+        professions: [
+          {
+            name: organisation.professions[0].name,
+            slug: organisation.professions[0].slug,
+            summaryList: mockSummaryList(),
+          },
+          {
+            name: organisation.professions[1].name,
+            slug: organisation.professions[1].slug,
+            summaryList: mockSummaryList(),
+          },
+        ],
+      });
+
+      expect(organisationsService.findBySlug).toHaveBeenCalledWith('slug', {
+        relations: ['professions'],
+      });
+
+      expect(OrganisationPresenter).toHaveBeenCalledWith(
+        organisation,
+        i18nService,
+      );
+
+      expect(ProfessionPresenter).toHaveBeenCalledWith(
+        organisation.professions[0],
+        i18nService,
+      );
+
+      expect(ProfessionPresenter).toHaveBeenCalledWith(
+        organisation.professions[1],
         i18nService,
       );
     });

--- a/src/organisations/organisation.presenter.spec.ts
+++ b/src/organisations/organisation.presenter.spec.ts
@@ -1,0 +1,130 @@
+import { createMock, DeepMocked } from '@golevelup/ts-jest';
+
+import { I18nService } from 'nestjs-i18n';
+import { OrganisationPresenter } from './organisation.presenter';
+import { Organisation } from './organisation.entity';
+import { Industry } from '../industries/industry.entity';
+import { Profession } from '../professions/profession.entity';
+
+import organisationFactory from '../testutils/factories/organisation';
+import professionFactory from '../testutils/factories/profession';
+import industryFactory from '../testutils/factories/industry';
+
+describe('OrganisationPresenter', () => {
+  let organisation: Organisation;
+  let industries: Industry[];
+  let professions: Profession[];
+
+  const i18nService: DeepMocked<I18nService> = createMock<I18nService>({
+    translate: async (key: string) => {
+      return key;
+    },
+  });
+
+  describe('tableRow', () => {
+    describe('when all relations are present', () => {
+      describe('when the professions share one industry', () => {
+        beforeEach(() => {
+          industries = [industryFactory.build({ name: 'Industry 1' })];
+
+          professions = [
+            professionFactory.buildList(4, { industries: [industries[0]] }),
+          ].flat();
+
+          organisation = organisationFactory.build({
+            professions: professions,
+          });
+        });
+
+        it('returns the table row data', async () => {
+          const presenter = new OrganisationPresenter(
+            organisation,
+            i18nService,
+          );
+          const tableRow = await presenter.tableRow();
+
+          expect(tableRow[0]).toEqual({ text: organisation.name });
+          expect(tableRow[1]).toEqual({ text: organisation.alternateName });
+          expect(tableRow[2]).toEqual({
+            html: industries[0].name,
+          });
+        });
+      });
+
+      describe('when the professions share multiple industries', () => {
+        beforeEach(() => {
+          industries = [
+            industryFactory.build({ name: 'Industry 1' }),
+            industryFactory.build({ name: 'Industry 2' }),
+            industryFactory.build({ name: 'Industry 3' }),
+          ];
+
+          professions = [
+            professionFactory.buildList(4, { industries: [industries[0]] }),
+            professionFactory.buildList(2, {
+              industries: [industries[1], industries[2]],
+            }),
+          ].flat();
+
+          organisation = organisationFactory.build({
+            professions: professions,
+          });
+        });
+
+        it('returns the table row data', async () => {
+          const presenter = new OrganisationPresenter(
+            organisation,
+            i18nService,
+          );
+          const tableRow = await presenter.tableRow();
+
+          expect(tableRow[0]).toEqual({ text: organisation.name });
+          expect(tableRow[1]).toEqual({ text: organisation.alternateName });
+          expect(tableRow[2]).toEqual({
+            html: [
+              industries[0].name,
+              industries[1].name,
+              industries[2].name,
+            ].join('<br />'),
+          });
+        });
+      });
+    });
+
+    describe('when the profession relation is not loaded', () => {
+      beforeEach(() => {
+        organisation = organisationFactory.build({
+          professions: undefined,
+        });
+      });
+
+      it('should raise an error', async () => {
+        const presenter = new OrganisationPresenter(organisation, i18nService);
+
+        expect(async () => {
+          await presenter.tableRow();
+        }).rejects.toThrowError(
+          "You must eagerly load professions to show industries. Try adding `{ relations: ['professions'] }` to your finder in the `OrganisationsService` class",
+        );
+      });
+    });
+
+    describe('when the industries relation is not loaded', () => {
+      beforeEach(() => {
+        organisation = organisationFactory.build({
+          professions: [professionFactory.build({ industries: undefined })],
+        });
+      });
+
+      it('should raise an error', async () => {
+        const presenter = new OrganisationPresenter(organisation, i18nService);
+
+        expect(async () => {
+          await presenter.tableRow();
+        }).rejects.toThrowError(
+          "You must eagerly load industries to show industries. Try adding `{ relations: ['professions.industries'] }` to your finder in the `OrganisationsService` class",
+        );
+      });
+    });
+  });
+});

--- a/src/organisations/organisation.presenter.ts
+++ b/src/organisations/organisation.presenter.ts
@@ -1,0 +1,58 @@
+import { I18nService } from 'nestjs-i18n';
+import { Organisation } from './organisation.entity';
+import { TableRow } from '../common/interfaces/table-row';
+
+export class OrganisationPresenter {
+  constructor(
+    private readonly organisation: Organisation,
+    private readonly i18nService: I18nService,
+  ) {}
+
+  public async tableRow(): Promise<TableRow> {
+    return [
+      {
+        text: this.organisation.name,
+      },
+      {
+        text: this.organisation.alternateName,
+      },
+      {
+        html: await this.industries(),
+      },
+      {
+        text: '',
+      },
+    ];
+  }
+
+  private async industries(): Promise<string> {
+    const professions = this.organisation.professions;
+
+    if (professions === undefined) {
+      throw new Error(
+        "You must eagerly load professions to show industries. Try adding `{ relations: ['professions'] }` to your finder in the `OrganisationsService` class",
+      );
+    }
+
+    const industries = professions
+      .map((profession) => {
+        if (profession.industries === undefined) {
+          throw new Error(
+            "You must eagerly load industries to show industries. Try adding `{ relations: ['professions.industries'] }` to your finder in the `OrganisationsService` class",
+          );
+        }
+
+        return profession.industries;
+      })
+      .flat();
+
+    const industryNames = await Promise.all(
+      industries.map(
+        (industry) =>
+          this.i18nService.translate(industry.name) as Promise<string>,
+      ),
+    );
+
+    return [...new Set(industryNames)].join('<br />');
+  }
+}

--- a/src/organisations/organisations.presenter.spec.ts
+++ b/src/organisations/organisations.presenter.spec.ts
@@ -1,0 +1,54 @@
+import { createMock, DeepMocked } from '@golevelup/ts-jest';
+import { I18nService } from 'nestjs-i18n';
+
+import organisationFactory from '../testutils/factories/organisation';
+import { OrganisationsPresenter } from './organisations.presenter';
+
+const mockTableRow = () => {
+  return [
+    {
+      text: 'Some text',
+    },
+  ];
+};
+
+jest.mock('./organisation.presenter', () => {
+  return {
+    OrganisationPresenter: jest.fn().mockImplementation(() => {
+      return {
+        tableRow: mockTableRow,
+      };
+    }),
+  };
+});
+
+describe('OrganisationsPresenter', () => {
+  const i18nService: DeepMocked<I18nService> = createMock<I18nService>({
+    translate: async (key: string) => {
+      return key;
+    },
+  });
+
+  describe('table', () => {
+    it('returns data for a table', async () => {
+      const organisations = organisationFactory.buildList(5);
+      const presenter = new OrganisationsPresenter(organisations, i18nService);
+      const table = await presenter.table();
+
+      expect(table.firstCellIsHeader).toEqual(true);
+      expect(table.head).toEqual([
+        { text: 'organisations.admin.tableHeading.name' },
+        { text: 'organisations.admin.tableHeading.alternateName' },
+        { text: 'organisations.admin.tableHeading.industries' },
+        { text: 'organisations.admin.tableHeading.actions' },
+      ]);
+      expect(table.rows).toEqual([
+        mockTableRow(),
+        mockTableRow(),
+        mockTableRow(),
+        mockTableRow(),
+        mockTableRow(),
+      ]);
+    });
+  });
+});

--- a/src/organisations/organisations.presenter.ts
+++ b/src/organisations/organisations.presenter.ts
@@ -1,0 +1,44 @@
+import { I18nService } from 'nestjs-i18n';
+import { Organisation } from './organisation.entity';
+import { OrganisationPresenter } from './organisation.presenter';
+import { TableRow } from '../common/interfaces/table-row';
+import { Table } from '../common/interfaces/table';
+
+type Field = 'name' | 'alternateName' | 'industries' | 'actions';
+const fields = ['name', 'alternateName', 'industries', 'actions'] as Field[];
+
+export class OrganisationsPresenter {
+  constructor(
+    private readonly organisations: Organisation[],
+    private readonly i18nService: I18nService,
+  ) {}
+
+  async table(firstCellIsHeader = true): Promise<Table> {
+    return {
+      firstCellIsHeader: firstCellIsHeader,
+      head: await this.headers(),
+      rows: await Promise.all(
+        this.organisations.map(
+          async (organisation) =>
+            await new OrganisationPresenter(
+              organisation,
+              this.i18nService,
+            ).tableRow(),
+        ),
+      ),
+    };
+  }
+
+  private async headers(): Promise<TableRow> {
+    return (
+      await Promise.all(
+        fields.map(
+          (field) =>
+            this.i18nService.translate(
+              `organisations.admin.tableHeading.${field}`,
+            ) as Promise<string>,
+        ),
+      )
+    ).map((text) => ({ text }));
+  }
+}

--- a/src/organisations/organisations.service.spec.ts
+++ b/src/organisations/organisations.service.spec.ts
@@ -71,5 +71,18 @@ describe('OrganisationsService', () => {
       expect(organisation).toEqual(organisation);
       expect(repoSpy).toHaveBeenCalledWith({ where: { slug: 'some-slug' } });
     });
+
+    it('should allow options to be passed', async () => {
+      const repoSpy = jest.spyOn(repo, 'findOne');
+      const organisation = await service.findBySlug('some-slug', {
+        order: { id: 'DESC' },
+      });
+
+      expect(organisation).toEqual(organisation);
+      expect(repoSpy).toHaveBeenCalledWith({
+        where: { slug: 'some-slug' },
+        order: { id: 'DESC' },
+      });
+    });
   });
 });

--- a/src/organisations/organisations.service.spec.ts
+++ b/src/organisations/organisations.service.spec.ts
@@ -62,4 +62,14 @@ describe('OrganisationsService', () => {
       expect(repoSpy).toHaveBeenCalled();
     });
   });
+
+  describe('findBySlug', () => {
+    it('should return a organisation', async () => {
+      const repoSpy = jest.spyOn(repo, 'findOne');
+      const organisation = await service.findBySlug('some-slug');
+
+      expect(organisation).toEqual(organisation);
+      expect(repoSpy).toHaveBeenCalledWith({ where: { slug: 'some-slug' } });
+    });
+  });
 });

--- a/src/organisations/organisations.service.ts
+++ b/src/organisations/organisations.service.ts
@@ -1,4 +1,4 @@
-import { FindManyOptions, Repository } from 'typeorm';
+import { FindManyOptions, FindOneOptions, Repository } from 'typeorm';
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Organisation } from './organisation.entity';
@@ -18,7 +18,11 @@ export class OrganisationsService {
     return this.repository.findOne(id);
   }
 
-  findBySlug(slug: string): Promise<Organisation> {
-    return this.repository.findOne({ where: { slug } });
+  findBySlug(
+    slug: string,
+    options: FindOneOptions = {},
+  ): Promise<Organisation> {
+    options = Object.assign({ where: { slug } }, options);
+    return this.repository.findOne(options);
   }
 }

--- a/src/organisations/organisations.service.ts
+++ b/src/organisations/organisations.service.ts
@@ -17,4 +17,8 @@ export class OrganisationsService {
   find(id: string): Promise<Organisation> {
     return this.repository.findOne(id);
   }
+
+  findBySlug(slug: string): Promise<Organisation> {
+    return this.repository.findOne({ where: { slug } });
+  }
 }

--- a/src/organisations/presenters/organisation.presenter.spec.ts
+++ b/src/organisations/presenters/organisation.presenter.spec.ts
@@ -124,4 +124,117 @@ describe('OrganisationPresenter', () => {
       });
     });
   });
+
+  describe('summaryList', () => {
+    describe('when all fields are present', () => {
+      it('should return all fields', async () => {
+        const presenter = new OrganisationPresenter(organisation, i18nService);
+
+        expect(await presenter.summaryList()).toEqual({
+          classes: 'govuk-summary-list--no-border',
+          rows: [
+            {
+              key: {
+                text: 'Translation of `organisations.admin.form.label.alternateName`',
+              },
+              value: {
+                text: organisation.alternateName,
+              },
+            },
+            {
+              key: {
+                text: 'Translation of `organisations.admin.form.label.contactUrl`',
+              },
+              value: {
+                html: presenter.contactUrl(),
+              },
+            },
+            {
+              key: {
+                text: 'Translation of `organisations.admin.form.label.address`',
+              },
+              value: {
+                html: presenter.address(),
+              },
+            },
+            {
+              key: {
+                text: 'Translation of `organisations.admin.form.label.email`',
+              },
+              value: {
+                html: presenter.email(),
+              },
+            },
+            {
+              key: {
+                text: 'Translation of `organisations.admin.form.label.telephone`',
+              },
+              value: {
+                text: organisation.telephone,
+              },
+            },
+          ],
+        });
+      });
+    });
+
+    describe('when a field is missing', () => {
+      it('should filter out empty fields', async () => {
+        organisation = organisationFactory.build({ alternateName: '' });
+        const presenter = new OrganisationPresenter(organisation, i18nService);
+        const list = await presenter.summaryList();
+
+        expect(list.rows.length).toEqual(4);
+        expect(
+          list.rows.filter(
+            (item) =>
+              item.key ===
+              { text: 'organisations.admin.form.label.alternateName' },
+          ).length,
+        ).toEqual(0);
+      });
+    });
+  });
+
+  describe('address', () => {
+    it('breaks the address into lines', () => {
+      organisation = organisationFactory.build({
+        address: '123 Fake Street, London, SW1A 1AA',
+      });
+
+      const presenter = new OrganisationPresenter(organisation, i18nService);
+
+      expect(presenter.address()).toEqual(
+        '123 Fake Street<br /> London<br /> SW1A 1AA',
+      );
+    });
+  });
+
+  describe('email', () => {
+    it('makes the email into a link', () => {
+      organisation = organisationFactory.build({
+        email: 'foo@example.com',
+      });
+
+      const presenter = new OrganisationPresenter(organisation, i18nService);
+
+      expect(presenter.email()).toEqual(
+        '<a href="mailto:foo@example.com" class="govuk-link">foo@example.com</a>',
+      );
+    });
+  });
+
+  describe('contactUrl', () => {
+    it('makes the url into a link', () => {
+      organisation = organisationFactory.build({
+        contactUrl: 'http://www.example.com',
+      });
+
+      const presenter = new OrganisationPresenter(organisation, i18nService);
+
+      expect(presenter.contactUrl()).toEqual(
+        '<a href="http://www.example.com" class="govuk-link">http://www.example.com</a>',
+      );
+    });
+  });
 });

--- a/src/organisations/presenters/organisation.presenter.spec.ts
+++ b/src/organisations/presenters/organisation.presenter.spec.ts
@@ -45,6 +45,14 @@ describe('OrganisationPresenter', () => {
           expect(tableRow[2]).toEqual({
             html: `Translation of \`${industries[0].name}\``,
           });
+          expect(tableRow[3]).toEqual({
+            html: expect.stringContaining(
+              `<a class="govuk-link" href="/admin/organisations/${organisation.slug}">`,
+            ),
+          });
+          expect(tableRow[3]).toEqual({
+            html: expect.stringContaining(`about ${organisation.name}`),
+          });
         });
       });
 

--- a/src/organisations/presenters/organisation.presenter.ts
+++ b/src/organisations/presenters/organisation.presenter.ts
@@ -20,7 +20,12 @@ export class OrganisationPresenter {
         html: await this.industries(),
       },
       {
-        text: '',
+        html: `<a class="govuk-link" href="/admin/organisations/${this.organisation.slug}">
+          View details
+          <span class="govuk-visually-hidden">
+            about ${this.organisation.name}
+          </span>
+        </a>`,
       },
     ];
   }

--- a/src/organisations/presenters/organisation.presenter.ts
+++ b/src/organisations/presenters/organisation.presenter.ts
@@ -1,7 +1,7 @@
 import { I18nService } from 'nestjs-i18n';
 import { Organisation } from './../organisation.entity';
 import { TableRow } from '../../common/interfaces/table-row';
-
+import { SummaryList } from '../../common/interfaces/summary-list';
 export class OrganisationPresenter {
   constructor(
     private readonly organisation: Organisation,
@@ -23,6 +23,78 @@ export class OrganisationPresenter {
         text: '',
       },
     ];
+  }
+
+  public async summaryList(): Promise<SummaryList> {
+    return {
+      classes: 'govuk-summary-list--no-border',
+      rows: [
+        {
+          key: {
+            text: await this.i18nService.translate(
+              'organisations.admin.form.label.alternateName',
+            ),
+          },
+          value: {
+            text: this.organisation.alternateName,
+          },
+        },
+        {
+          key: {
+            text: await this.i18nService.translate(
+              'organisations.admin.form.label.contactUrl',
+            ),
+          },
+          value: {
+            html: this.contactUrl(),
+          },
+        },
+        {
+          key: {
+            text: await this.i18nService.translate(
+              'organisations.admin.form.label.address',
+            ),
+          },
+          value: {
+            html: this.address(),
+          },
+        },
+        {
+          key: {
+            text: await this.i18nService.translate(
+              'organisations.admin.form.label.email',
+            ),
+          },
+          value: {
+            html: this.email(),
+          },
+        },
+        {
+          key: {
+            text: await this.i18nService.translate(
+              'organisations.admin.form.label.telephone',
+            ),
+          },
+          value: {
+            text: this.organisation.telephone,
+          },
+        },
+      ].filter((item) => {
+        return item.value.text !== '' && item.value.html !== '';
+      }),
+    };
+  }
+
+  public address(): string {
+    return this.organisation.address.split(',').join('<br />');
+  }
+
+  public email(): string {
+    return `<a href="mailto:${this.organisation.email}" class="govuk-link">${this.organisation.email}</a>`;
+  }
+
+  public contactUrl(): string {
+    return `<a href="${this.organisation.contactUrl}" class="govuk-link">${this.organisation.contactUrl}</a>`;
   }
 
   private async industries(): Promise<string> {

--- a/src/professions/presenters/profession.presenter.spec.ts
+++ b/src/professions/presenters/profession.presenter.spec.ts
@@ -1,0 +1,92 @@
+import { createMock, DeepMocked } from '@golevelup/ts-jest';
+import { I18nService } from 'nestjs-i18n';
+
+import { Profession } from './../profession.entity';
+import { ProfessionPresenter } from './profession.presenter';
+import { Nation } from '../../nations/nation';
+
+import { stringifyNations } from '../../nations/helpers/stringifyNations';
+
+import professionFactory from '../../testutils/factories/profession';
+import industryFactory from '../../testutils/factories/industry';
+
+jest.mock('../../nations/helpers/stringifyNations');
+
+describe('ProfessionPresenter', () => {
+  let profession: Profession;
+  const i18nService: DeepMocked<I18nService> = createMock<I18nService>({
+    translate: async (key: string) => {
+      return key;
+    },
+  });
+
+  describe('summaryList', () => {
+    it('should return a summary list', async () => {
+      profession = professionFactory.build();
+
+      const presenter = new ProfessionPresenter(profession, i18nService);
+
+      expect(await presenter.summaryList()).toEqual({
+        classes: 'govuk-summary-list--no-border',
+        rows: [
+          {
+            key: {
+              text: 'professions.show.overview.nations',
+            },
+            value: {
+              text: await presenter.occupationLocations(),
+            },
+          },
+          {
+            key: {
+              text: 'professions.show.overview.industry',
+            },
+            value: {
+              text: await presenter.industries(),
+            },
+          },
+          {
+            key: {
+              text: 'professions.show.qualification.level',
+            },
+            value: {
+              text: profession.qualification.level,
+            },
+          },
+        ],
+      });
+    });
+  });
+
+  describe('occupationLocations', () => {
+    it('should pass the locations to stringifyNations', async () => {
+      profession = professionFactory.build({
+        occupationLocations: ['GB-ENG', 'GB-SCT', 'GB-WLS', 'GB-NIR'],
+      });
+
+      const presenter = new ProfessionPresenter(profession, i18nService);
+      const nations = profession.occupationLocations.map((code) =>
+        Nation.find(code),
+      );
+
+      await presenter.occupationLocations();
+
+      expect(stringifyNations).toHaveBeenCalledWith(nations, i18nService);
+    });
+  });
+
+  describe('industries', () => {
+    it('should return a comma-separated list of industry names', async () => {
+      profession = professionFactory.build({
+        industries: [
+          industryFactory.build({ name: 'foo' }),
+          industryFactory.build({ name: 'bar' }),
+        ],
+      });
+
+      const presenter = new ProfessionPresenter(profession, i18nService);
+
+      expect(await presenter.industries()).toEqual('foo, bar');
+    });
+  });
+});

--- a/src/professions/presenters/profession.presenter.ts
+++ b/src/professions/presenters/profession.presenter.ts
@@ -1,0 +1,67 @@
+import { I18nService } from 'nestjs-i18n';
+import { Profession } from '../profession.entity';
+import { SummaryList } from '../../common/interfaces/summary-list';
+import { stringifyNations } from '../../nations/helpers/stringifyNations';
+import { Nation } from '../../nations/nation';
+
+export class ProfessionPresenter {
+  constructor(
+    readonly profession: Profession,
+    private readonly i18nService: I18nService,
+  ) {}
+
+  public async summaryList(): Promise<SummaryList> {
+    return {
+      classes: 'govuk-summary-list--no-border',
+      rows: [
+        {
+          key: {
+            text: await this.i18nService.translate(
+              'professions.show.overview.nations',
+            ),
+          },
+          value: {
+            text: await this.occupationLocations(),
+          },
+        },
+        {
+          key: {
+            text: await this.i18nService.translate(
+              'professions.show.overview.industry',
+            ),
+          },
+          value: {
+            text: await this.industries(),
+          },
+        },
+        {
+          key: {
+            text: await this.i18nService.translate(
+              'professions.show.qualification.level',
+            ),
+          },
+          value: {
+            text: this.profession.qualification.level,
+          },
+        },
+      ],
+    };
+  }
+
+  public async occupationLocations(): Promise<string> {
+    return await stringifyNations(
+      this.profession.occupationLocations.map((code) => Nation.find(code)),
+      this.i18nService,
+    );
+  }
+
+  public async industries(): Promise<string> {
+    const industries = await Promise.all(
+      this.profession.industries.map(
+        async (industry) => await this.i18nService.translate(industry.name),
+      ),
+    );
+
+    return industries.join(', ');
+  }
+}

--- a/views/admin/organisations/show.njk
+++ b/views/admin/organisations/show.njk
@@ -1,0 +1,73 @@
+{% extends "base.njk" %}
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% set bodyClasses = "rpr-internal__page" %}
+
+{% block content %}
+
+  {% if backLink %}
+    {{ govukBackLink({
+      text: ( "app.back" | t ),
+      href: backLink
+    }) }}
+  {% endif %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-xl">{{ organisation.name }}</h1>
+
+      {{ govukSummaryList(summaryList) }}
+
+      <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible"/>
+
+      <h2 class="govuk-heading-l">{{ "organisations.headings.professions" | t }}</h2>
+
+      {% for profession in professions %}
+        <div class="rpr-listing__ra-container">
+          <h3>
+            <a class="govuk-link govuk-heading-m rpr-listing__profession-title" class="govuk-link" href="/professions/{{ profession.slug }}">
+              {{ profession.name }}
+            </a>
+          </h3>
+
+          {{ govukSummaryList(profession.summaryList) }}
+        </div>
+      {% endfor %}
+
+    </div>
+    <div class="govuk-grid-column-one-third">
+      <aside class="app-related-items rpr-internal__details-page-sidebar" role="complementary">
+
+        <h2 class="govuk-heading-s">
+          Status<br>
+          <span class="govuk-body">Published</span>
+        </h2>
+
+        <nav role="navigation" aria-labelledby="subsection-title">
+          <ul class="govuk-list">
+            <li>
+              {{
+                govukButton({
+                  text: "Edit this regulatory authority",
+                  href: "#"
+                })
+              }}
+            </li>
+            <li>
+              {{
+                govukButton({
+                  text: "Delete this regulatory authority",
+                  href: "#",
+                  classes: "govuk-button--warning"
+                })
+              }}
+            </li>
+          </ul>
+        </nav>
+      </aside>
+    </div>
+  </div>
+
+{% endblock %}


### PR DESCRIPTION
This builds on #111 to add a view of a regulatory authority on the admin side. The buttons to edit and delete are currently not functional, but will be sorted in th next bit of work. 

# Screenshots 

![image](https://user-images.githubusercontent.com/109774/149376821-7fe614f6-4255-48e7-83e4-bc76c74c7481.png)
