### PR TITLE
(1984) Add Qualification information screen to "Add a profession"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add a service owner boolean to a user
 - Define new user permissions
 - List Regulatory Authorities
+- Add page for adding a new qualification to a profession
 
 ### Changed
 

--- a/cypress/integration/admin/professions/add-a-profession.spec.ts
+++ b/cypress/integration/admin/professions/add-a-profession.spec.ts
@@ -78,6 +78,16 @@ describe('Adding a new profession', () => {
         cy.get('button').contains(buttonText).click();
       });
 
+      cy.translate('professions.form.headings.qualificationInformation').then(
+        (heading) => {
+          cy.get('body').should('contain', heading);
+        },
+      );
+
+      cy.translate('app.continue').then((buttonText) => {
+        cy.get('button').contains(buttonText).click();
+      });
+
       cy.translate('professions.form.headings.checkAnswers').then((heading) => {
         cy.get('body').should('contain', heading);
       });

--- a/cypress/integration/admin/professions/add-a-profession.spec.ts
+++ b/cypress/integration/admin/professions/add-a-profession.spec.ts
@@ -121,6 +121,18 @@ describe('Adding a new profession', () => {
       cy.get('body').should('contain', 'An example activity');
       cy.get('body').should('contain', 'A description of the regulation');
 
+      cy.get('body').should('contain', 'An example Qualification level');
+      cy.get('body').should('contain', 'Another method');
+      cy.translate(
+        'professions.form.radioButtons.methodsToObtainQualification.generalSecondaryEducation',
+      ).then((method) => {
+        cy.get('body').should('contain', method);
+      });
+      cy.get('body').should('contain', '4.0 Years');
+      cy.translate('app.yes').then((yes) => {
+        cy.get('body').should('contain', yes);
+      });
+
       cy.translate('professions.form.button.create').then((buttonText) => {
         cy.get('button').contains(buttonText).click();
       });

--- a/cypress/integration/admin/professions/add-a-profession.spec.ts
+++ b/cypress/integration/admin/professions/add-a-profession.spec.ts
@@ -84,6 +84,21 @@ describe('Adding a new profession', () => {
         },
       );
 
+      cy.get('textarea[name="level"]').type('An example Qualification level');
+      cy.get(
+        'input[name="methodToObtainQualification"][value="others"]',
+      ).check();
+      cy.get('textarea[name="otherMethodToObtainQualification"]').type(
+        'Another method',
+      );
+      cy.get(
+        'input[name="mostCommonPathToObtainQualification"][value="generalSecondaryEducation"]',
+      ).check();
+      cy.get('input[name="duration"]').type('4.0 Years');
+      cy.get(
+        'input[name="mandatoryProfessionalExperience"][value="1"]',
+      ).check();
+
       cy.translate('app.continue').then((buttonText) => {
         cy.get('button').contains(buttonText).click();
       });

--- a/src/common/interfaces/radio-button-args.interface.ts
+++ b/src/common/interfaces/radio-button-args.interface.ts
@@ -2,4 +2,5 @@ export interface RadioButtonArgs {
   text: string;
   value: string;
   checked: boolean;
+  conditional?: { html: string };
 }

--- a/src/db/migrate/1641927337680-MakeQualificationAndProfessionRelationshipOneToOne.ts
+++ b/src/db/migrate/1641927337680-MakeQualificationAndProfessionRelationshipOneToOne.ts
@@ -1,0 +1,31 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class MakeQualificationAndProfessionRelationshipOneToOne1641927337680
+  implements MigrationInterface
+{
+  name = 'MakeQualificationAndProfessionRelationshipOneToOne1641927337680';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "professions" DROP CONSTRAINT "FK_e2c4688b8f8b296d88e0945f796"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "professions" ADD CONSTRAINT "UQ_e2c4688b8f8b296d88e0945f796" UNIQUE ("qualificationId")`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "professions" ADD CONSTRAINT "FK_e2c4688b8f8b296d88e0945f796" FOREIGN KEY ("qualificationId") REFERENCES "qualifications"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "professions" DROP CONSTRAINT "FK_e2c4688b8f8b296d88e0945f796"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "professions" DROP CONSTRAINT "UQ_e2c4688b8f8b296d88e0945f796"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "professions" ADD CONSTRAINT "FK_e2c4688b8f8b296d88e0945f796" FOREIGN KEY ("qualificationId") REFERENCES "qualifications"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    );
+  }
+}

--- a/src/i18n/en/professions.json
+++ b/src/i18n/en/professions.json
@@ -6,7 +6,8 @@
       "regulatoryBody": "Regulatory / professional bodies",
       "checkAnswers": "Check your answers",
       "confirmation": "New profession created",
-      "regulatedActivities": "Regulated activities"
+      "regulatedActivities": "Regulated activities",
+      "qualificationInformation": "Qualification information"
     },
     "description": "Use this section of the site to add a new profession",
     "label": {
@@ -22,6 +23,13 @@
       "regulatedActivities": {
         "activities": "Reserved activities",
         "description": "Description of activities / regulation description"
+      },
+      "qualificationInformation": {
+        "qualificationLevel": "Qualification level",
+        "methodsToObtainQualification": "Method to obtain qualification",
+        "mostCommonPathToObtainQualification": "Most common path to obtain qualification",
+        "duration": "Duration of qualification",
+        "mandatoryProfessionalExperience": "Existence of mandatory professional experience"
       }
     },
     "details": {
@@ -36,6 +44,15 @@
         "mandatory": "Mandatory",
         "voluntary": "Voluntary",
         "unknown": "Unknown"
+      },
+      "methodsToObtainQualification": {
+        "generalSecondaryEducation": "General secondary education",
+        "generalOrVocationalPostSecondaryEducation": "General or vocational post-secondary education",
+        "generalPostSecondaryEducationMandatoryVocational": "General post-secondary education incorporating mandatory vocational content",
+        "vocationalPostSecondaryEducation": "Vocational post-secondary education level",
+        "degreeLevel": "Degree level education in an approved education institution",
+        "others": "Others",
+        "otherHint": "Please provide the methods to obtain the qualification"
       }
     },
     "checkboxes": {
@@ -80,6 +97,29 @@
       },
       "description": {
         "empty": "Enter a description of the regulation / reserved activities"
+      },
+      "qualification": {
+        "level": {
+          "empty": "Enter the qualification level"
+        },
+        "methodToObtain": {
+          "empty": "Select the method to obtain the qualification"
+        },
+        "otherMethodToObtain": {
+          "empty": "Enter the other method to obtain the qualification"
+        },
+        "mostCommonPathToObtain": {
+          "empty": "Select the most common path to obtain the qualification"
+        },
+        "otherMostCommonPathToObtain": {
+          "empty": "Enter the other most common path to obtain the qualification"
+        },
+        "duration": {
+          "empty": "Enter the duration of the qualification"
+        },
+        "mandatoryProfessionalExperience": {
+          "empty": "Select whether existence of professional experience is mandatory"
+        }
       }
     }
   },
@@ -107,7 +147,7 @@
     "qualification": {
       "heading": "Qualification information",
       "level": "Qualificiation level",
-      "methods": "Methods to obtain qualification",
+      "methods": "Method to obtain qualification",
       "commonPath": "Most common path to obtain qualification",
       "duration": "Duration of qualification",
       "mandatoryExperience": "Existence of mandatory professional experience"

--- a/src/professions/admin/add-profession/check-your-answers.controller.spec.ts
+++ b/src/professions/admin/add-profession/check-your-answers.controller.spec.ts
@@ -2,10 +2,12 @@ import { DeepMocked, createMock } from '@golevelup/ts-jest';
 import { TestingModule, Test } from '@nestjs/testing';
 import { Request } from 'express';
 import { I18nService } from 'nestjs-i18n';
+import QualificationPresenter from '../../../qualifications/presenters/qualification.presenter';
 import { createMockRequest } from '../../../testutils/create-mock-request';
 import industryFactory from '../../../testutils/factories/industry';
 import organisationFactory from '../../../testutils/factories/organisation';
 import professionFactory from '../../../testutils/factories/profession';
+import qualificationFactory from '../../../testutils/factories/qualification';
 import { MandatoryRegistration } from '../../profession.entity';
 import { ProfessionsService } from '../../professions.service';
 import { CheckYourAnswersController } from './check-your-answers.controller';
@@ -14,6 +16,8 @@ describe('CheckYourAnswersController', () => {
   let controller: CheckYourAnswersController;
   let professionsService: DeepMocked<ProfessionsService>;
   let i18nService: DeepMocked<I18nService>;
+
+  const qualification = qualificationFactory.build();
 
   beforeEach(async () => {
     const profession = professionFactory.build({
@@ -27,6 +31,7 @@ describe('CheckYourAnswersController', () => {
       mandatoryRegistration: MandatoryRegistration.Voluntary,
       description: 'A description of the regulation',
       reservedActivities: 'Some reserved activities',
+      qualification,
     });
 
     professionsService = createMock<ProfessionsService>({
@@ -84,6 +89,10 @@ describe('CheckYourAnswersController', () => {
         expect(templateParams.description).toEqual(
           'A description of the regulation',
         );
+        expect(templateParams.qualification).toEqual(
+          new QualificationPresenter(qualification),
+        );
+
         expect(professionsService.find).toHaveBeenCalledWith('profession-id');
       });
     });

--- a/src/professions/admin/add-profession/check-your-answers.controller.ts
+++ b/src/professions/admin/add-profession/check-your-answers.controller.ts
@@ -6,6 +6,7 @@ import { backLink } from '../../../common/utils';
 
 import { Nation } from '../../../nations/nation';
 import { ProfessionsService } from '../../professions.service';
+import QualificationPresenter from '../../../qualifications/presenters/qualification.presenter';
 import { CheckYourAnswersTemplate } from './interfaces/check-your-answers.template';
 import { Permissions } from '../../../common/permissions.decorator';
 import { UserPermission } from '../../../users/user.entity';
@@ -51,6 +52,7 @@ export class CheckYourAnswersController {
       mandatoryRegistration: draftProfession.mandatoryRegistration,
       description: draftProfession.description,
       reservedActivities: draftProfession.reservedActivities,
+      qualification: new QualificationPresenter(draftProfession.qualification),
       backLink: backLink(req),
     };
   }

--- a/src/professions/admin/add-profession/dto/qualification-information.dto.ts
+++ b/src/professions/admin/add-profession/dto/qualification-information.dto.ts
@@ -45,4 +45,6 @@ export class QualificationInformationDto {
       'professions.form.errors.qualification.mandatoryProfessionalExperience.empty',
   })
   mandatoryProfessionalExperience: string;
+
+  change: boolean;
 }

--- a/src/professions/admin/add-profession/dto/qualification-information.dto.ts
+++ b/src/professions/admin/add-profession/dto/qualification-information.dto.ts
@@ -1,0 +1,48 @@
+import { IsNotEmpty, ValidateIf } from 'class-validator';
+import { MethodToObtain } from '../../../../qualifications/qualification.entity';
+
+export class QualificationInformationDto {
+  @IsNotEmpty({ message: 'professions.form.errors.qualification.level.empty' })
+  level: string;
+
+  @IsNotEmpty({
+    message: 'professions.form.errors.qualification.methodToObtain.empty',
+  })
+  methodToObtainQualification: MethodToObtain;
+
+  @ValidateIf(
+    (dto: QualificationInformationDto) =>
+      dto.methodToObtainQualification === MethodToObtain.Others,
+  )
+  @IsNotEmpty({
+    message: 'professions.form.errors.qualification.otherMethodToObtain.empty',
+  })
+  otherMethodToObtainQualification: string;
+
+  @IsNotEmpty({
+    message:
+      'professions.form.errors.qualification.mostCommonPathToObtain.empty',
+  })
+  mostCommonPathToObtainQualification: MethodToObtain;
+
+  @ValidateIf(
+    (dto: QualificationInformationDto) =>
+      dto.mostCommonPathToObtainQualification === MethodToObtain.Others,
+  )
+  @IsNotEmpty({
+    message:
+      'professions.form.errors.qualification.otherMostCommonPathToObtain.empty',
+  })
+  otherMostCommonPathToObtainQualification: string;
+
+  @IsNotEmpty({
+    message: 'professions.form.errors.qualification.duration.empty',
+  })
+  duration: string;
+
+  @IsNotEmpty({
+    message:
+      'professions.form.errors.qualification.mandatoryProfessionalExperience.empty',
+  })
+  mandatoryProfessionalExperience: string;
+}

--- a/src/professions/admin/add-profession/interfaces/check-your-answers.template.ts
+++ b/src/professions/admin/add-profession/interfaces/check-your-answers.template.ts
@@ -1,3 +1,5 @@
+import QualificationPresenter from '../../../../qualifications/presenters/qualification.presenter';
+
 export interface CheckYourAnswersTemplate {
   name: string;
   nations: string[];
@@ -7,5 +9,6 @@ export interface CheckYourAnswersTemplate {
   mandatoryRegistration: string;
   reservedActivities: string;
   description: string;
+  qualification: QualificationPresenter;
   backLink: string;
 }

--- a/src/professions/admin/add-profession/interfaces/qualification-information.template.ts
+++ b/src/professions/admin/add-profession/interfaces/qualification-information.template.ts
@@ -6,5 +6,6 @@ export interface QualificationInformationTemplate {
   mostCommonPathToObtainQualificationRadioButtonArgs: RadioButtonArgs[];
   duration: string;
   mandatoryProfessionalExperienceRadioButtonArgs: RadioButtonArgs[];
+  change: boolean;
   errors: object | undefined;
 }

--- a/src/professions/admin/add-profession/interfaces/qualification-information.template.ts
+++ b/src/professions/admin/add-profession/interfaces/qualification-information.template.ts
@@ -7,5 +7,6 @@ export interface QualificationInformationTemplate {
   duration: string;
   mandatoryProfessionalExperienceRadioButtonArgs: RadioButtonArgs[];
   change: boolean;
+  backLink: string;
   errors: object | undefined;
 }

--- a/src/professions/admin/add-profession/interfaces/qualification-information.template.ts
+++ b/src/professions/admin/add-profession/interfaces/qualification-information.template.ts
@@ -1,0 +1,10 @@
+import { RadioButtonArgs } from '../../../../common/interfaces/radio-button-args.interface';
+
+export interface QualificationInformationTemplate {
+  level: string;
+  methodToObtainQualificationRadioButtonArgs: RadioButtonArgs[];
+  mostCommonPathToObtainQualificationRadioButtonArgs: RadioButtonArgs[];
+  duration: string;
+  mandatoryProfessionalExperienceRadioButtonArgs: RadioButtonArgs[];
+  errors: object | undefined;
+}

--- a/src/professions/admin/add-profession/qualification-information.controller.spec.ts
+++ b/src/professions/admin/add-profession/qualification-information.controller.spec.ts
@@ -207,6 +207,47 @@ describe(QualificationInformationController, () => {
         );
       });
     });
+
+    describe('back links', () => {
+      describe('when the "Change" query param is false', () => {
+        it('links back to the previous page in the journey', async () => {
+          const profession = professionFactory.build({
+            id: 'profession-id',
+          });
+
+          professionsService.find.mockImplementation(async () => profession);
+
+          await controller.edit(response, 'profession-id', false);
+
+          expect(response.render).toHaveBeenCalledWith(
+            'admin/professions/add-profession/qualification-information',
+            expect.objectContaining({
+              backLink:
+                '/admin/professions/profession-id/regulated-activities/edit',
+            }),
+          );
+        });
+      });
+
+      describe('when the "Change" query param is true', () => {
+        it('links back to the Check your Answers page', async () => {
+          const profession = professionFactory.build({
+            id: 'profession-id',
+          });
+
+          professionsService.find.mockImplementation(async () => profession);
+
+          await controller.edit(response, 'profession-id', true);
+
+          expect(response.render).toHaveBeenCalledWith(
+            'admin/professions/add-profession/qualification-information',
+            expect.objectContaining({
+              backLink: '/admin/professions/profession-id/check-your-answers',
+            }),
+          );
+        });
+      });
+    });
   });
 
   afterEach(() => {

--- a/src/professions/admin/add-profession/qualification-information.controller.spec.ts
+++ b/src/professions/admin/add-profession/qualification-information.controller.spec.ts
@@ -2,22 +2,31 @@ import { createMock, DeepMocked } from '@golevelup/ts-jest';
 import { Test, TestingModule } from '@nestjs/testing';
 import { Response } from 'express';
 import { I18nService } from 'nestjs-i18n';
+import { MethodToObtain } from '../../../qualifications/qualification.entity';
 import { createMockI18nService } from '../../../testutils/create-mock-i18n-service';
+import professionFactory from '../../../testutils/factories/profession';
+import { ProfessionsService } from '../../professions.service';
 import { MethodToObtainQualificationRadioButtonsPresenter } from '../method-to-obtain-qualification-radio-buttons.presenter';
 import { YesNoRadioButtonArgsPresenter } from '../yes-no-radio-buttons-presenter';
+import { QualificationInformationDto } from './dto/qualification-information.dto';
 import { QualificationInformationController } from './qualification-information.controller';
 
 describe(QualificationInformationController, () => {
   let controller: QualificationInformationController;
   let response: DeepMocked<Response>;
+  let professionsService: DeepMocked<ProfessionsService>;
   let i18nService: I18nService;
 
   beforeEach(async () => {
     i18nService = createMockI18nService();
+    professionsService = createMock<ProfessionsService>();
 
     const module: TestingModule = await Test.createTestingModule({
       controllers: [QualificationInformationController],
-      providers: [{ provide: I18nService, useValue: i18nService }],
+      providers: [
+        { provide: ProfessionsService, useValue: professionsService },
+        { provide: I18nService, useValue: i18nService },
+      ],
     }).compile();
 
     response = createMock<Response>();
@@ -29,9 +38,13 @@ describe(QualificationInformationController, () => {
 
   describe('edit', () => {
     it('should render form page', async () => {
+      const profession = professionFactory.build({
+        id: 'profession-id',
+      });
+
       const methodToObtainQualificationRadioButtonArgs =
         await new MethodToObtainQualificationRadioButtonsPresenter(
-          null,
+          profession.qualification.methodToObtain,
           undefined,
           undefined,
           i18nService,
@@ -39,13 +52,15 @@ describe(QualificationInformationController, () => {
 
       const mostCommonPathToObtainQualificationRadioButtonArgs =
         await new MethodToObtainQualificationRadioButtonsPresenter(
-          null,
+          profession.qualification.commonPathToObtain,
           undefined,
           undefined,
           i18nService,
         ).radioButtonArgs('mostCommonPathToObtainQualification');
 
-      await controller.edit(response);
+      professionsService.find.mockResolvedValue(profession);
+
+      await controller.edit(response, 'profession-id');
 
       expect(response.render).toHaveBeenCalledWith(
         'admin/professions/add-profession/qualification-information',
@@ -54,7 +69,7 @@ describe(QualificationInformationController, () => {
           mostCommonPathToObtainQualificationRadioButtonArgs,
           mandatoryProfessionalExperienceRadioButtonArgs:
             await new YesNoRadioButtonArgsPresenter(
-              null,
+              profession.qualification.mandatoryProfessionalExperience,
               i18nService,
             ).radioButtonArgs(),
         }),
@@ -63,12 +78,90 @@ describe(QualificationInformationController, () => {
   });
 
   describe('update', () => {
-    it('redirects to "Check your answers"', async () => {
-      await controller.update(response, 'profession-id');
+    describe('when all required parameters are entered', () => {
+      it('creates a new Qualification on the Profession and redirects to "Check your answers"', async () => {
+        const profession = professionFactory.build({ id: 'profession-id' });
 
-      expect(response.redirect).toHaveBeenCalledWith(
-        '/admin/professions/profession-id/check-your-answers',
-      );
+        const dto: QualificationInformationDto = {
+          level: 'Qualification level',
+          methodToObtainQualification: MethodToObtain.DegreeLevel,
+          otherMethodToObtainQualification: '',
+          mostCommonPathToObtainQualification: MethodToObtain.DegreeLevel,
+          otherMostCommonPathToObtainQualification: '',
+          duration: '3.0 Years',
+          mandatoryProfessionalExperience: '1',
+        };
+
+        professionsService.find.mockResolvedValue(profession);
+
+        await controller.update(response, 'profession-id', dto);
+
+        expect(professionsService.save).toHaveBeenCalledWith(
+          expect.objectContaining({
+            qualification: expect.objectContaining({
+              commonPathToObtain: 'degreeLevel',
+              otherMethodToObtain: '',
+              otherCommonPathToObtain: '',
+              educationDuration: '3.0 Years',
+              level: 'Qualification level',
+              mandatoryProfessionalExperience: true,
+              methodToObtain: 'degreeLevel',
+            }),
+          }),
+        );
+
+        expect(response.redirect).toHaveBeenCalledWith(
+          '/admin/professions/profession-id/check-your-answers',
+        );
+      });
+    });
+
+    describe('when required parameters are not entered', () => {
+      it('does not update the Profession and reloads the form with errors and successfully submitted values', async () => {
+        const profession = professionFactory.build({ id: 'profession-id' });
+
+        const dto: QualificationInformationDto = {
+          level: undefined,
+          methodToObtainQualification: undefined,
+          otherMethodToObtainQualification: '',
+          mostCommonPathToObtainQualification: undefined,
+          otherMostCommonPathToObtainQualification: '',
+          duration: '',
+          mandatoryProfessionalExperience: undefined,
+        };
+
+        professionsService.find.mockResolvedValue(profession);
+
+        await controller.update(response, 'profession-id', dto);
+
+        expect(response.render).toHaveBeenCalledWith(
+          'admin/professions/add-profession/qualification-information',
+          expect.objectContaining({
+            mandatoryProfessionalExperienceRadioButtonArgs:
+              await new YesNoRadioButtonArgsPresenter(
+                undefined,
+                i18nService,
+              ).radioButtonArgs(),
+            errors: {
+              level: {
+                text: 'professions.form.errors.qualification.level.empty',
+              },
+              mandatoryProfessionalExperience: {
+                text: 'professions.form.errors.qualification.mandatoryProfessionalExperience.empty',
+              },
+              methodToObtainQualification: {
+                text: 'professions.form.errors.qualification.methodToObtain.empty',
+              },
+              duration: {
+                text: 'professions.form.errors.qualification.duration.empty',
+              },
+              mostCommonPathToObtainQualification: {
+                text: 'professions.form.errors.qualification.mostCommonPathToObtain.empty',
+              },
+            },
+          }),
+        );
+      });
     });
   });
 

--- a/src/professions/admin/add-profession/qualification-information.controller.spec.ts
+++ b/src/professions/admin/add-profession/qualification-information.controller.spec.ts
@@ -1,0 +1,78 @@
+import { createMock, DeepMocked } from '@golevelup/ts-jest';
+import { Test, TestingModule } from '@nestjs/testing';
+import { Response } from 'express';
+import { I18nService } from 'nestjs-i18n';
+import { createMockI18nService } from '../../../testutils/create-mock-i18n-service';
+import { MethodToObtainQualificationRadioButtonsPresenter } from '../method-to-obtain-qualification-radio-buttons.presenter';
+import { YesNoRadioButtonArgsPresenter } from '../yes-no-radio-buttons-presenter';
+import { QualificationInformationController } from './qualification-information.controller';
+
+describe(QualificationInformationController, () => {
+  let controller: QualificationInformationController;
+  let response: DeepMocked<Response>;
+  let i18nService: I18nService;
+
+  beforeEach(async () => {
+    i18nService = createMockI18nService();
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [QualificationInformationController],
+      providers: [{ provide: I18nService, useValue: i18nService }],
+    }).compile();
+
+    response = createMock<Response>();
+
+    controller = module.get<QualificationInformationController>(
+      QualificationInformationController,
+    );
+  });
+
+  describe('edit', () => {
+    it('should render form page', async () => {
+      const methodToObtainQualificationRadioButtonArgs =
+        await new MethodToObtainQualificationRadioButtonsPresenter(
+          null,
+          undefined,
+          undefined,
+          i18nService,
+        ).radioButtonArgs('methodToObtainQualification');
+
+      const mostCommonPathToObtainQualificationRadioButtonArgs =
+        await new MethodToObtainQualificationRadioButtonsPresenter(
+          null,
+          undefined,
+          undefined,
+          i18nService,
+        ).radioButtonArgs('mostCommonPathToObtainQualification');
+
+      await controller.edit(response);
+
+      expect(response.render).toHaveBeenCalledWith(
+        'admin/professions/add-profession/qualification-information',
+        expect.objectContaining({
+          methodToObtainQualificationRadioButtonArgs,
+          mostCommonPathToObtainQualificationRadioButtonArgs,
+          mandatoryProfessionalExperienceRadioButtonArgs:
+            await new YesNoRadioButtonArgsPresenter(
+              null,
+              i18nService,
+            ).radioButtonArgs(),
+        }),
+      );
+    });
+  });
+
+  describe('update', () => {
+    it('redirects to "Check your answers"', async () => {
+      await controller.update(response, 'profession-id');
+
+      expect(response.redirect).toHaveBeenCalledWith(
+        '/admin/professions/profession-id/check-your-answers',
+      );
+    });
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+});

--- a/src/professions/admin/add-profession/qualification-information.controller.spec.ts
+++ b/src/professions/admin/add-profession/qualification-information.controller.spec.ts
@@ -60,7 +60,7 @@ describe(QualificationInformationController, () => {
 
       professionsService.find.mockResolvedValue(profession);
 
-      await controller.edit(response, 'profession-id');
+      await controller.edit(response, 'profession-id', false);
 
       expect(response.render).toHaveBeenCalledWith(
         'admin/professions/add-profession/qualification-information',
@@ -79,40 +79,83 @@ describe(QualificationInformationController, () => {
 
   describe('update', () => {
     describe('when all required parameters are entered', () => {
-      it('creates a new Qualification on the Profession and redirects to "Check your answers"', async () => {
-        const profession = professionFactory.build({ id: 'profession-id' });
+      describe('when the "Change" query param is false', () => {
+        it('creates a new Qualification on the Profession and redirects to the next page in the journey', async () => {
+          const profession = professionFactory.build({ id: 'profession-id' });
 
-        const dto: QualificationInformationDto = {
-          level: 'Qualification level',
-          methodToObtainQualification: MethodToObtain.DegreeLevel,
-          otherMethodToObtainQualification: '',
-          mostCommonPathToObtainQualification: MethodToObtain.DegreeLevel,
-          otherMostCommonPathToObtainQualification: '',
-          duration: '3.0 Years',
-          mandatoryProfessionalExperience: '1',
-        };
+          const dto: QualificationInformationDto = {
+            level: 'Qualification level',
+            methodToObtainQualification: MethodToObtain.DegreeLevel,
+            otherMethodToObtainQualification: '',
+            mostCommonPathToObtainQualification: MethodToObtain.DegreeLevel,
+            otherMostCommonPathToObtainQualification: '',
+            duration: '3.0 Years',
+            mandatoryProfessionalExperience: '1',
+            change: false,
+          };
 
-        professionsService.find.mockResolvedValue(profession);
+          professionsService.find.mockResolvedValue(profession);
 
-        await controller.update(response, 'profession-id', dto);
+          await controller.update(response, 'profession-id', dto);
 
-        expect(professionsService.save).toHaveBeenCalledWith(
-          expect.objectContaining({
-            qualification: expect.objectContaining({
-              commonPathToObtain: 'degreeLevel',
-              otherMethodToObtain: '',
-              otherCommonPathToObtain: '',
-              educationDuration: '3.0 Years',
-              level: 'Qualification level',
-              mandatoryProfessionalExperience: true,
-              methodToObtain: 'degreeLevel',
+          expect(professionsService.save).toHaveBeenCalledWith(
+            expect.objectContaining({
+              qualification: expect.objectContaining({
+                commonPathToObtain: 'degreeLevel',
+                otherMethodToObtain: '',
+                otherCommonPathToObtain: '',
+                educationDuration: '3.0 Years',
+                level: 'Qualification level',
+                mandatoryProfessionalExperience: true,
+                methodToObtain: 'degreeLevel',
+              }),
             }),
-          }),
-        );
+          );
 
-        expect(response.redirect).toHaveBeenCalledWith(
-          '/admin/professions/profession-id/check-your-answers',
-        );
+          expect(response.redirect).toHaveBeenCalledWith(
+            // This will be the Legislation page in future
+            '/admin/professions/profession-id/check-your-answers',
+          );
+        });
+      });
+
+      describe('when the "Change" query param is true', () => {
+        it('creates a new Qualification on the Profession and redirects to "Check your answers"', async () => {
+          const profession = professionFactory.build({ id: 'profession-id' });
+
+          const dto: QualificationInformationDto = {
+            level: 'Qualification level',
+            methodToObtainQualification: MethodToObtain.DegreeLevel,
+            otherMethodToObtainQualification: '',
+            mostCommonPathToObtainQualification: MethodToObtain.DegreeLevel,
+            otherMostCommonPathToObtainQualification: '',
+            duration: '3.0 Years',
+            mandatoryProfessionalExperience: '1',
+            change: true,
+          };
+
+          professionsService.find.mockResolvedValue(profession);
+
+          await controller.update(response, 'profession-id', dto);
+
+          expect(professionsService.save).toHaveBeenCalledWith(
+            expect.objectContaining({
+              qualification: expect.objectContaining({
+                commonPathToObtain: 'degreeLevel',
+                otherMethodToObtain: '',
+                otherCommonPathToObtain: '',
+                educationDuration: '3.0 Years',
+                level: 'Qualification level',
+                mandatoryProfessionalExperience: true,
+                methodToObtain: 'degreeLevel',
+              }),
+            }),
+          );
+
+          expect(response.redirect).toHaveBeenCalledWith(
+            '/admin/professions/profession-id/check-your-answers',
+          );
+        });
       });
     });
 
@@ -128,6 +171,7 @@ describe(QualificationInformationController, () => {
           otherMostCommonPathToObtainQualification: '',
           duration: '',
           mandatoryProfessionalExperience: undefined,
+          change: false,
         };
 
         professionsService.find.mockResolvedValue(profession);

--- a/src/professions/admin/add-profession/qualification-information.controller.ts
+++ b/src/professions/admin/add-profession/qualification-information.controller.ts
@@ -1,0 +1,43 @@
+import { Controller, Get, Param, Post, Res } from '@nestjs/common';
+import { Response } from 'express';
+import { I18nService } from 'nestjs-i18n';
+import { MethodToObtainQualificationRadioButtonsPresenter } from '../method-to-obtain-qualification-radio-buttons.presenter';
+import { YesNoRadioButtonArgsPresenter } from '../yes-no-radio-buttons-presenter';
+
+@Controller('admin/professions')
+export class QualificationInformationController {
+  constructor(private readonly i18nService: I18nService) {}
+
+  @Get('/:id/qualification-information/edit')
+  async edit(@Res() res: Response): Promise<void> {
+    return res.render(
+      'admin/professions/add-profession/qualification-information',
+      {
+        methodToObtainQualificationRadioButtonArgs:
+          await new MethodToObtainQualificationRadioButtonsPresenter(
+            null,
+            undefined,
+            undefined,
+            this.i18nService,
+          ).radioButtonArgs('methodToObtainQualification'),
+        mostCommonPathToObtainQualificationRadioButtonArgs:
+          await new MethodToObtainQualificationRadioButtonsPresenter(
+            null,
+            undefined,
+            undefined,
+            this.i18nService,
+          ).radioButtonArgs('mostCommonPathToObtainQualification'),
+        mandatoryProfessionalExperienceRadioButtonArgs:
+          await new YesNoRadioButtonArgsPresenter(
+            null,
+            this.i18nService,
+          ).radioButtonArgs(),
+      },
+    );
+  }
+
+  @Post('/:id/qualification-information')
+  async update(@Res() res: Response, @Param('id') id: string): Promise<void> {
+    return res.redirect(`/admin/professions/${id}/check-your-answers`);
+  }
+}

--- a/src/professions/admin/add-profession/qualification-information.controller.ts
+++ b/src/professions/admin/add-profession/qualification-information.controller.ts
@@ -1,43 +1,116 @@
-import { Controller, Get, Param, Post, Res } from '@nestjs/common';
+import { Body, Controller, Get, Param, Post, Res } from '@nestjs/common';
 import { Response } from 'express';
 import { I18nService } from 'nestjs-i18n';
+import { Validator } from '../../../helpers/validator';
+import { Qualification } from '../../../qualifications/qualification.entity';
+import { ValidationFailedError } from '../../../validation/validation-failed.error';
+import { ProfessionsService } from '../../professions.service';
 import { MethodToObtainQualificationRadioButtonsPresenter } from '../method-to-obtain-qualification-radio-buttons.presenter';
 import { YesNoRadioButtonArgsPresenter } from '../yes-no-radio-buttons-presenter';
+import { QualificationInformationDto } from './dto/qualification-information.dto';
+import { QualificationInformationTemplate } from './interfaces/qualification-information.template';
 
 @Controller('admin/professions')
 export class QualificationInformationController {
-  constructor(private readonly i18nService: I18nService) {}
+  constructor(
+    private readonly professionsService: ProfessionsService,
+    private readonly i18nService: I18nService,
+  ) {}
 
   @Get('/:id/qualification-information/edit')
-  async edit(@Res() res: Response): Promise<void> {
-    return res.render(
-      'admin/professions/add-profession/qualification-information',
-      {
-        methodToObtainQualificationRadioButtonArgs:
-          await new MethodToObtainQualificationRadioButtonsPresenter(
-            null,
-            undefined,
-            undefined,
-            this.i18nService,
-          ).radioButtonArgs('methodToObtainQualification'),
-        mostCommonPathToObtainQualificationRadioButtonArgs:
-          await new MethodToObtainQualificationRadioButtonsPresenter(
-            null,
-            undefined,
-            undefined,
-            this.i18nService,
-          ).radioButtonArgs('mostCommonPathToObtainQualification'),
-        mandatoryProfessionalExperienceRadioButtonArgs:
-          await new YesNoRadioButtonArgsPresenter(
-            null,
-            this.i18nService,
-          ).radioButtonArgs(),
-      },
-    );
+  async edit(@Res() res: Response, @Param('id') id: string): Promise<void> {
+    const profession = await this.professionsService.find(id);
+
+    return this.renderForm(res, profession.qualification);
   }
 
   @Post('/:id/qualification-information')
-  async update(@Res() res: Response, @Param('id') id: string): Promise<void> {
+  async update(
+    @Res() res: Response,
+    @Param('id') id: string,
+    @Body() qualificationInformationDto,
+  ): Promise<void> {
+    const validator = await Validator.validate(
+      QualificationInformationDto,
+      qualificationInformationDto,
+    );
+
+    const profession = await this.professionsService.find(id);
+
+    const submittedValues: QualificationInformationDto =
+      qualificationInformationDto;
+
+    const mandatoryProfessionalExperience =
+      submittedValues.mandatoryProfessionalExperience === undefined
+        ? undefined
+        : Boolean(Number(submittedValues.mandatoryProfessionalExperience));
+
+    const updatedQualification: Qualification = {
+      ...profession.qualification,
+      ...{
+        level: submittedValues.level,
+        methodToObtain: submittedValues.methodToObtainQualification,
+        otherMethodToObtain: submittedValues.otherMethodToObtainQualification,
+        commonPathToObtain: submittedValues.mostCommonPathToObtainQualification,
+        otherCommonPathToObtain:
+          submittedValues.otherMostCommonPathToObtainQualification,
+        educationDuration: submittedValues.duration,
+        mandatoryProfessionalExperience,
+      },
+    };
+
+    if (!validator.valid()) {
+      const errors = new ValidationFailedError(validator.errors).fullMessages();
+
+      return this.renderForm(res, updatedQualification, errors);
+    }
+
+    profession.qualification = updatedQualification;
+
+    await this.professionsService.save(profession);
+
     return res.redirect(`/admin/professions/${id}/check-your-answers`);
+  }
+
+  private async renderForm(
+    res: Response,
+    qualification: Qualification | null,
+    errors: object | undefined = undefined,
+  ) {
+    const mostCommonPathToObtainQualificationRadioButtonArgs =
+      await new MethodToObtainQualificationRadioButtonsPresenter(
+        qualification?.commonPathToObtain,
+        qualification?.otherCommonPathToObtain,
+        errors,
+        this.i18nService,
+      ).radioButtonArgs('mostCommonPathToObtainQualification');
+
+    const methodToObtainQualificationRadioButtonArgs =
+      await new MethodToObtainQualificationRadioButtonsPresenter(
+        qualification?.methodToObtain,
+        qualification?.otherMethodToObtain,
+        errors,
+        this.i18nService,
+      ).radioButtonArgs('methodToObtainQualification');
+
+    const mandatoryProfessionalExperienceRadioButtonArgs =
+      await new YesNoRadioButtonArgsPresenter(
+        qualification?.mandatoryProfessionalExperience,
+        this.i18nService,
+      ).radioButtonArgs();
+
+    const templateArgs: QualificationInformationTemplate = {
+      level: qualification?.level,
+      methodToObtainQualificationRadioButtonArgs,
+      mostCommonPathToObtainQualificationRadioButtonArgs,
+      mandatoryProfessionalExperienceRadioButtonArgs,
+      duration: qualification?.educationDuration,
+      errors,
+    };
+
+    return res.render(
+      'admin/professions/add-profession/qualification-information',
+      templateArgs,
+    );
   }
 }

--- a/src/professions/admin/add-profession/qualification-information.controller.ts
+++ b/src/professions/admin/add-profession/qualification-information.controller.ts
@@ -1,8 +1,20 @@
-import { Body, Controller, Get, Param, Post, Query, Res } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  Post,
+  Query,
+  Res,
+  UseGuards,
+} from '@nestjs/common';
 import { Response } from 'express';
 import { I18nService } from 'nestjs-i18n';
+import { AuthenticationGuard } from '../../../common/authentication.guard';
+import { Permissions } from '../../../common/permissions.decorator';
 import { Validator } from '../../../helpers/validator';
 import { Qualification } from '../../../qualifications/qualification.entity';
+import { UserPermission } from '../../../users/user.entity';
 import { ValidationFailedError } from '../../../validation/validation-failed.error';
 import { ProfessionsService } from '../../professions.service';
 import { MethodToObtainQualificationRadioButtonsPresenter } from '../method-to-obtain-qualification-radio-buttons.presenter';
@@ -10,6 +22,7 @@ import { YesNoRadioButtonArgsPresenter } from '../yes-no-radio-buttons-presenter
 import { QualificationInformationDto } from './dto/qualification-information.dto';
 import { QualificationInformationTemplate } from './interfaces/qualification-information.template';
 
+@UseGuards(AuthenticationGuard)
 @Controller('admin/professions')
 export class QualificationInformationController {
   constructor(
@@ -18,6 +31,7 @@ export class QualificationInformationController {
   ) {}
 
   @Get('/:id/qualification-information/edit')
+  @Permissions(UserPermission.CreateProfession)
   async edit(
     @Res() res: Response,
     @Param('id') id: string,
@@ -34,6 +48,7 @@ export class QualificationInformationController {
   }
 
   @Post('/:id/qualification-information')
+  @Permissions(UserPermission.CreateProfession)
   async update(
     @Res() res: Response,
     @Param('id') id: string,

--- a/src/professions/admin/add-profession/qualification-information.controller.ts
+++ b/src/professions/admin/add-profession/qualification-information.controller.ts
@@ -25,7 +25,12 @@ export class QualificationInformationController {
   ): Promise<void> {
     const profession = await this.professionsService.find(id);
 
-    return this.renderForm(res, profession.qualification, change);
+    return this.renderForm(
+      res,
+      profession.qualification,
+      change,
+      this.backLink(change, profession.id),
+    );
   }
 
   @Post('/:id/qualification-information')
@@ -70,6 +75,7 @@ export class QualificationInformationController {
         res,
         updatedQualification,
         submittedValues.change,
+        this.backLink(submittedValues.change, profession.id),
         errors,
       );
     }
@@ -90,6 +96,7 @@ export class QualificationInformationController {
     res: Response,
     qualification: Qualification | null,
     change: boolean,
+    backLink: string,
     errors: object | undefined = undefined,
   ) {
     const mostCommonPathToObtainQualificationRadioButtonArgs =
@@ -121,6 +128,7 @@ export class QualificationInformationController {
       mandatoryProfessionalExperienceRadioButtonArgs,
       duration: qualification?.educationDuration,
       change,
+      backLink,
       errors,
     };
 
@@ -128,5 +136,11 @@ export class QualificationInformationController {
       'admin/professions/add-profession/qualification-information',
       templateArgs,
     );
+  }
+
+  private backLink(change: boolean, id: string) {
+    return change
+      ? `/admin/professions/${id}/check-your-answers`
+      : `/admin/professions/${id}/regulated-activities/edit`;
   }
 }

--- a/src/professions/admin/add-profession/regulated-activities.controller.spec.ts
+++ b/src/professions/admin/add-profession/regulated-activities.controller.spec.ts
@@ -122,9 +122,8 @@ describe(RegulatedActivitiesController, () => {
             }),
           );
 
-          // This will be the Qualification information page in future
           expect(response.redirect).toHaveBeenCalledWith(
-            '/admin/professions/profession-id/check-your-answers',
+            '/admin/professions/profession-id/qualification-information/edit',
           );
         });
       });

--- a/src/professions/admin/add-profession/regulated-activities.controller.ts
+++ b/src/professions/admin/add-profession/regulated-activities.controller.ts
@@ -84,8 +84,9 @@ export class RegulatedActivitiesController {
       return res.redirect(`/admin/professions/${id}/check-your-answers`);
     }
 
-    // This will go to the Qualification information in future
-    return res.redirect(`/admin/professions/${id}/check-your-answers`);
+    return res.redirect(
+      `/admin/professions/${id}/qualification-information/edit`,
+    );
   }
 
   private async renderForm(

--- a/src/professions/admin/method-to-obtain-qualification-radio-buttons.presenter.spec.ts
+++ b/src/professions/admin/method-to-obtain-qualification-radio-buttons.presenter.spec.ts
@@ -1,0 +1,180 @@
+import { DeepMocked } from '@golevelup/ts-jest';
+import { I18nService } from 'nestjs-i18n';
+import { MethodToObtain } from '../../qualifications/qualification.entity';
+import { createMockI18nService } from '../../testutils/create-mock-i18n-service';
+import { MethodToObtainQualificationRadioButtonsPresenter } from './method-to-obtain-qualification-radio-buttons.presenter';
+
+describe(MethodToObtainQualificationRadioButtonsPresenter, () => {
+  let i18nService: DeepMocked<I18nService>;
+
+  beforeEach(async () => {
+    i18nService = createMockI18nService();
+  });
+
+  describe('radioButtonArgs', () => {
+    it('should return translated values with unchecked radio buttons when called with a null Method to Obtain value', async () => {
+      const presenter = new MethodToObtainQualificationRadioButtonsPresenter(
+        null,
+        undefined,
+        undefined,
+        i18nService,
+      );
+
+      await expect(
+        presenter.radioButtonArgs('methodToObtainQualification'),
+      ).resolves.toEqual([
+        {
+          text: 'Translation of `professions.form.radioButtons.methodsToObtainQualification.generalSecondaryEducation`',
+          value: MethodToObtain.GeneralSecondaryEducation,
+          checked: false,
+          conditional: null,
+        },
+        {
+          text: 'Translation of `professions.form.radioButtons.methodsToObtainQualification.generalOrVocationalPostSecondaryEducation`',
+          value: MethodToObtain.GeneralOrVocationalPostSecondaryEducation,
+          checked: false,
+          conditional: null,
+        },
+        {
+          text: 'Translation of `professions.form.radioButtons.methodsToObtainQualification.generalPostSecondaryEducationMandatoryVocational`',
+          value:
+            MethodToObtain.GeneralPostSecondaryEducationMandatoryVocational,
+          checked: false,
+          conditional: null,
+        },
+        {
+          text: 'Translation of `professions.form.radioButtons.methodsToObtainQualification.vocationalPostSecondaryEducation`',
+          value: MethodToObtain.VocationalPostSecondaryEducation,
+          checked: false,
+          conditional: null,
+        },
+        {
+          text: 'Translation of `professions.form.radioButtons.methodsToObtainQualification.degreeLevel`',
+          value: MethodToObtain.DegreeLevel,
+          checked: false,
+          conditional: null,
+        },
+        {
+          text: 'Translation of `professions.form.radioButtons.methodsToObtainQualification.others`',
+          value: MethodToObtain.Others,
+          checked: false,
+          conditional: {
+            html: `<div class="govuk-form-group"><div id="methodToObtainQualification-hint" class="govuk-hint">Translation of \`professions.form.radioButtons.methodsToObtainQualification.otherHint\`</div><textarea class="govuk-textarea" id="otherMethodToObtainQualification" rows="5" name="otherMethodToObtainQualification"></textarea></div>`,
+          },
+        },
+      ]);
+    });
+
+    it('should pre-check the relevant radio button for a matching Method to Obtain value', async () => {
+      const presenter = new MethodToObtainQualificationRadioButtonsPresenter(
+        MethodToObtain.DegreeLevel,
+        undefined,
+        undefined,
+        i18nService,
+      );
+
+      await expect(
+        presenter.radioButtonArgs('methodToObtainQualification'),
+      ).resolves.toEqual([
+        {
+          text: 'Translation of `professions.form.radioButtons.methodsToObtainQualification.generalSecondaryEducation`',
+          value: MethodToObtain.GeneralSecondaryEducation,
+          checked: false,
+          conditional: null,
+        },
+        {
+          text: 'Translation of `professions.form.radioButtons.methodsToObtainQualification.generalOrVocationalPostSecondaryEducation`',
+          value: MethodToObtain.GeneralOrVocationalPostSecondaryEducation,
+          checked: false,
+          conditional: null,
+        },
+        {
+          text: 'Translation of `professions.form.radioButtons.methodsToObtainQualification.generalPostSecondaryEducationMandatoryVocational`',
+          value:
+            MethodToObtain.GeneralPostSecondaryEducationMandatoryVocational,
+          checked: false,
+          conditional: null,
+        },
+        {
+          text: 'Translation of `professions.form.radioButtons.methodsToObtainQualification.vocationalPostSecondaryEducation`',
+          value: MethodToObtain.VocationalPostSecondaryEducation,
+          checked: false,
+          conditional: null,
+        },
+        {
+          text: 'Translation of `professions.form.radioButtons.methodsToObtainQualification.degreeLevel`',
+          value: MethodToObtain.DegreeLevel,
+          checked: true,
+          conditional: null,
+        },
+        {
+          text: 'Translation of `professions.form.radioButtons.methodsToObtainQualification.others`',
+          value: MethodToObtain.Others,
+          checked: false,
+          conditional: {
+            html: `<div class="govuk-form-group"><div id="methodToObtainQualification-hint" class="govuk-hint">Translation of \`professions.form.radioButtons.methodsToObtainQualification.otherHint\`</div><textarea class="govuk-textarea" id="otherMethodToObtainQualification" rows="5" name="otherMethodToObtainQualification"></textarea></div>`,
+          },
+        },
+      ]);
+    });
+
+    describe('"Other" values', () => {
+      describe('for a previously-entered "other" value', () => {
+        it('should pre-check that checkbox and pre-fill the user-entered text in the textarea', async () => {
+          const presenter =
+            new MethodToObtainQualificationRadioButtonsPresenter(
+              MethodToObtain.Others,
+              'Another method for obtaining the qualification',
+              undefined,
+              i18nService,
+            );
+
+          await expect(
+            presenter.radioButtonArgs('methodToObtainQualification'),
+          ).resolves.toContainEqual({
+            value: MethodToObtain.Others,
+            text: 'Translation of `professions.form.radioButtons.methodsToObtainQualification.others`',
+            checked: true,
+            conditional: {
+              html: `<div class="govuk-form-group"><div id="methodToObtainQualification-hint" class="govuk-hint">Translation of \`professions.form.radioButtons.methodsToObtainQualification.otherHint\`</div><textarea class="govuk-textarea" id="otherMethodToObtainQualification" rows="5" name="otherMethodToObtainQualification">Another method for obtaining the qualification</textarea></div>`,
+            },
+          });
+        });
+      });
+
+      describe('validation errors', () => {
+        it('should display an error on the text field', async () => {
+          const expectedErrorParagraph =
+            '<p id="otherMethodToObtainQualification-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Translation of `professions.form.errors.qualification.otherMostCommonPathToObtain.empty`</p>';
+
+          const expectedErrorFormClass = 'govuk-form-group--error';
+
+          const errors = {
+            otherMethodToObtainQualification: {
+              text: 'professions.form.errors.qualification.otherMostCommonPathToObtain.empty',
+            },
+          };
+
+          const presenter =
+            new MethodToObtainQualificationRadioButtonsPresenter(
+              MethodToObtain.Others,
+              undefined,
+              errors,
+              i18nService,
+            );
+
+          await expect(
+            presenter.radioButtonArgs('methodToObtainQualification'),
+          ).resolves.toContainEqual({
+            value: MethodToObtain.Others,
+            text: 'Translation of `professions.form.radioButtons.methodsToObtainQualification.others`',
+            checked: true,
+            conditional: {
+              html: `<div class="govuk-form-group ${expectedErrorFormClass}"><div id="methodToObtainQualification-hint" class="govuk-hint">Translation of \`professions.form.radioButtons.methodsToObtainQualification.otherHint\`</div>${expectedErrorParagraph}<textarea class="govuk-textarea" id="otherMethodToObtainQualification" rows="5" name="otherMethodToObtainQualification"></textarea></div>`,
+            },
+          });
+        });
+      });
+    });
+  });
+});

--- a/src/professions/admin/method-to-obtain-qualification-radio-buttons.presenter.ts
+++ b/src/professions/admin/method-to-obtain-qualification-radio-buttons.presenter.ts
@@ -1,0 +1,84 @@
+import { I18nService } from 'nestjs-i18n';
+import { RadioButtonArgs } from '../../common/interfaces/radio-button-args.interface';
+import { MethodToObtain } from '../../qualifications/qualification.entity';
+
+export class MethodToObtainQualificationRadioButtonsPresenter {
+  constructor(
+    private readonly methodToObtain: MethodToObtain | null,
+    private readonly otherMethodToObtainText: string | undefined,
+    private readonly errors: object | undefined,
+    private readonly i18nService: I18nService,
+  ) {}
+
+  async radioButtonArgs(name: string): Promise<RadioButtonArgs[]> {
+    return Promise.all(
+      Object.values(MethodToObtain).map(async (method) => ({
+        value: method,
+        text: await this.i18nService.translate(
+          `professions.form.radioButtons.methodsToObtainQualification.${method}`,
+        ),
+        checked: this.methodToObtain === method,
+        conditional: await this.otherMethodTextAreaHTML(
+          method,
+          name,
+          this.otherMethodToObtainText,
+          this.errors,
+        ),
+      })),
+    );
+  }
+
+  private async otherMethodTextAreaHTML(
+    methodToObtain: MethodToObtain,
+    name: string,
+    otherMethodToObtainText: string | undefined,
+    errors: object | undefined = undefined,
+  ): Promise<{ html: string } | null> {
+    if (methodToObtain !== MethodToObtain.Others) {
+      return null;
+    }
+
+    const otherFieldName = `other${
+      name.charAt(0).toUpperCase() + name.slice(1)
+    }`;
+
+    const hintHTML = `<div id="${name}-hint" class="govuk-hint">${await this.i18nService.translate(
+      'professions.form.radioButtons.methodsToObtainQualification.otherHint',
+    )}</div>`;
+
+    const errorMessageHTML = await this.errorMessageHTML(
+      errors,
+      otherFieldName,
+    );
+
+    const textareaHTML = this.textareaHTML(
+      otherFieldName,
+      otherMethodToObtainText,
+    );
+
+    return {
+      html: errorMessageHTML
+        ? `<div class="govuk-form-group govuk-form-group--error">${hintHTML}${errorMessageHTML}${textareaHTML}</div>`
+        : `<div class="govuk-form-group">${hintHTML}${textareaHTML}</div>`,
+    };
+  }
+
+  private async errorMessageHTML(
+    errors: object | undefined,
+    name: string,
+  ): Promise<string> {
+    if (errors && errors[name] !== undefined) {
+      return `<p id="${name}-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> ${await this.i18nService.translate(
+        errors[name].text,
+      )}</p>`;
+    }
+
+    return '';
+  }
+
+  private textareaHTML(name: string, value: string | undefined): string {
+    return value
+      ? `<textarea class="govuk-textarea" id="${name}" rows="5" name="${name}">${value}</textarea>`
+      : `<textarea class="govuk-textarea" id="${name}" rows="5" name="${name}"></textarea>`;
+  }
+}

--- a/src/professions/admin/yes-no-radio-buttons-presenter.spec.ts
+++ b/src/professions/admin/yes-no-radio-buttons-presenter.spec.ts
@@ -1,0 +1,72 @@
+import { DeepMocked } from '@golevelup/ts-jest';
+import { I18nService } from 'nestjs-i18n';
+import { createMockI18nService } from '../../testutils/create-mock-i18n-service';
+import { YesNoRadioButtonArgsPresenter } from './yes-no-radio-buttons-presenter';
+
+describe(YesNoRadioButtonArgsPresenter, () => {
+  let i18nService: DeepMocked<I18nService>;
+
+  beforeEach(async () => {
+    i18nService = createMockI18nService({
+      'app.yes': 'Yes',
+      'app.no': 'No',
+    });
+  });
+
+  describe('radioButtonArgs', () => {
+    it('should return translated values with unchecked radio buttons when called with a null Yes or No value', async () => {
+      const presenter = new YesNoRadioButtonArgsPresenter(null, i18nService);
+
+      await expect(presenter.radioButtonArgs()).resolves.toEqual([
+        {
+          text: 'Yes',
+          value: '1',
+          checked: false,
+        },
+        {
+          text: 'No',
+          value: '0',
+          checked: false,
+        },
+      ]);
+    });
+
+    it('should pre-check the relevant radio button for the relevant boolean value', async () => {
+      const truePresenter = new YesNoRadioButtonArgsPresenter(
+        true,
+        i18nService,
+      );
+
+      const falsePresenter = new YesNoRadioButtonArgsPresenter(
+        false,
+        i18nService,
+      );
+
+      await expect(truePresenter.radioButtonArgs()).resolves.toEqual([
+        {
+          text: 'Yes',
+          value: '1',
+          checked: true,
+        },
+        {
+          text: 'No',
+          value: '0',
+          checked: false,
+        },
+      ]);
+
+      await expect(falsePresenter.radioButtonArgs()).resolves.toEqual([
+        {
+          text: 'Yes',
+          value: '1',
+          checked: false,
+        },
+        {
+          text: 'No',
+          value: '0',
+          checked: true,
+        },
+      ]);
+    });
+  });
+});

--- a/src/professions/admin/yes-no-radio-buttons-presenter.ts
+++ b/src/professions/admin/yes-no-radio-buttons-presenter.ts
@@ -1,0 +1,24 @@
+import { I18nService } from 'nestjs-i18n';
+import { RadioButtonArgs } from '../../common/interfaces/radio-button-args.interface';
+
+export class YesNoRadioButtonArgsPresenter {
+  constructor(
+    private readonly yesOrNoValue: boolean | null,
+    private readonly i18nService: I18nService,
+  ) {}
+
+  async radioButtonArgs(): Promise<RadioButtonArgs[]> {
+    return [
+      {
+        value: '1',
+        text: await this.i18nService.translate('app.yes'),
+        checked: this.yesOrNoValue === true,
+      },
+      {
+        value: '0',
+        text: await this.i18nService.translate('app.no'),
+        checked: this.yesOrNoValue === false,
+      },
+    ];
+  }
+}

--- a/src/professions/profession.entity.ts
+++ b/src/professions/profession.entity.ts
@@ -10,6 +10,8 @@ import {
   Index,
   CreateDateColumn,
   UpdateDateColumn,
+  OneToOne,
+  JoinColumn,
 } from 'typeorm';
 import { Industry } from '../industries/industry.entity';
 import { Organisation } from '../organisations/organisation.entity';
@@ -51,9 +53,10 @@ export class Profession {
   @JoinTable()
   industries: Industry[];
 
-  @ManyToOne(() => Qualification, {
+  @OneToOne(() => Qualification, {
     eager: true,
   })
+  @JoinColumn()
   qualification: Qualification;
 
   @Column({ nullable: true })

--- a/src/professions/profession.entity.ts
+++ b/src/professions/profession.entity.ts
@@ -55,6 +55,7 @@ export class Profession {
 
   @OneToOne(() => Qualification, {
     eager: true,
+    cascade: true,
   })
   @JoinColumn()
   qualification: Qualification;

--- a/src/professions/professions.module.ts
+++ b/src/professions/professions.module.ts
@@ -14,6 +14,7 @@ import { Organisation } from '../organisations/organisation.entity';
 import { OrganisationsService } from '../organisations/organisations.service';
 import { RegulatedActivitiesController } from './admin/add-profession/regulated-activities.controller';
 import { ProfessionsController as AdminProfessionsController } from './admin/professions.controller';
+import { QualificationInformationController } from './admin/add-profession/qualification-information.controller';
 
 @Module({
   imports: [
@@ -28,6 +29,7 @@ import { ProfessionsController as AdminProfessionsController } from './admin/pro
     TopLevelInformationController,
     RegulatoryBodyController,
     RegulatedActivitiesController,
+    QualificationInformationController,
     CheckYourAnswersController,
     ConfirmationController,
     AdminProfessionsController,

--- a/src/qualifications/presenters/qualification.presenter.spec.ts
+++ b/src/qualifications/presenters/qualification.presenter.spec.ts
@@ -1,0 +1,93 @@
+import { MethodToObtain } from '../qualification.entity';
+import qualificationFactory from '../../testutils/factories/qualification';
+import QualificationPresenter from './qualification.presenter';
+
+describe(QualificationPresenter, () => {
+  describe('methodToObtainQualification', () => {
+    describe('when the method to ObtainQualification is "others"', () => {
+      it('returns the other text value', () => {
+        const qualification = qualificationFactory.build({
+          methodToObtain: MethodToObtain.Others,
+          otherMethodToObtain: 'other value',
+        });
+
+        const presenter = new QualificationPresenter(qualification);
+
+        expect(presenter.methodToObtainQualification).toEqual('other value');
+      });
+    });
+
+    describe('when the method to ObtainQualification is not "others"', () => {
+      it('returns the localisation id for the selected method', () => {
+        const qualification = qualificationFactory.build({
+          methodToObtain: MethodToObtain.DegreeLevel,
+          otherMethodToObtain: 'other value',
+        });
+
+        const presenter = new QualificationPresenter(qualification);
+
+        expect(presenter.methodToObtainQualification).toEqual(
+          'professions.form.radioButtons.methodsToObtainQualification.degreeLevel',
+        );
+      });
+    });
+  });
+
+  describe('mostCommonPathToObtainQualification', () => {
+    describe('when the method to ObtainQualification is "others"', () => {
+      it('returns the other text value', () => {
+        const qualification = qualificationFactory.build({
+          commonPathToObtain: MethodToObtain.Others,
+          otherCommonPathToObtain: 'other value',
+        });
+
+        const presenter = new QualificationPresenter(qualification);
+
+        expect(presenter.mostCommonPathToObtainQualification).toEqual(
+          'other value',
+        );
+      });
+    });
+
+    describe('when the method to ObtainQualification is not "others"', () => {
+      it('returns the localisation id for the selected method', () => {
+        const qualification = qualificationFactory.build({
+          commonPathToObtain: MethodToObtain.DegreeLevel,
+          otherCommonPathToObtain: 'other value',
+        });
+
+        const presenter = new QualificationPresenter(qualification);
+
+        expect(presenter.mostCommonPathToObtainQualification).toEqual(
+          'professions.form.radioButtons.methodsToObtainQualification.degreeLevel',
+        );
+      });
+    });
+  });
+
+  describe('mandatoryProfessionalExperience', () => {
+    describe('when true', () => {
+      it('returns the localisation id for "Yes"', () => {
+        const qualification = qualificationFactory.build({
+          mandatoryProfessionalExperience: true,
+        });
+
+        const presenter = new QualificationPresenter(qualification);
+
+        expect(presenter.mandatoryProfessionalExperience).toEqual('app.yes');
+      });
+    });
+
+    describe('when false', () => {
+      it('returns the localisation id for "No"', () => {
+        const qualification = qualificationFactory.build({
+          mandatoryProfessionalExperience: false,
+        });
+
+        const presenter = new QualificationPresenter(qualification);
+
+        expect(presenter.mandatoryProfessionalExperience).toEqual('app.no');
+      });
+    });
+  });
+});

--- a/src/qualifications/presenters/qualification.presenter.ts
+++ b/src/qualifications/presenters/qualification.presenter.ts
@@ -1,0 +1,24 @@
+import { MethodToObtain, Qualification } from '../qualification.entity';
+
+export default class QualificationPresenter {
+  constructor(private readonly qualification: Qualification) {}
+
+  readonly level = this.qualification.level;
+
+  readonly methodToObtainQualification: string =
+    this.qualification.methodToObtain === MethodToObtain.Others
+      ? this.qualification.otherMethodToObtain
+      : `professions.form.radioButtons.methodsToObtainQualification.${this.qualification.methodToObtain}`;
+
+  readonly mostCommonPathToObtainQualification: string =
+    this.qualification.commonPathToObtain === MethodToObtain.Others
+      ? this.qualification.otherCommonPathToObtain
+      : `professions.form.radioButtons.methodsToObtainQualification.${this.qualification.commonPathToObtain}`;
+
+  readonly duration = this.qualification.educationDuration;
+
+  readonly mandatoryProfessionalExperience = this.qualification
+    .mandatoryProfessionalExperience
+    ? 'app.yes'
+    : 'app.no';
+}

--- a/views/admin/professions/add-profession/check-your-answers.njk
+++ b/views/admin/professions/add-profession/check-your-answers.njk
@@ -191,7 +191,7 @@
                     actions: {
                       items: [
                         {
-                          href: "/admin/professions/" + professionId + "/qualification-information/edit",
+                          href: "/admin/professions/" + professionId + "/qualification-information/edit?change=true",
                           text: ("app.change" | t),
                           visuallyHiddenText: ("professions.form.label.qualificationInformation.qualificationLevel" | t)
                         }
@@ -208,7 +208,7 @@
                     actions: {
                       items: [
                         {
-                          href: "/admin/professions/" + professionId + "/qualification-information/edit",
+                          href: "/admin/professions/" + professionId + "/qualification-information/edit?change=true",
                           text: ("app.change" | t),
                           visuallyHiddenText: ("professions.form.label.qualificationInformation.methodsToObtainQualification" | t)
                         }
@@ -225,7 +225,7 @@
                     actions: {
                       items: [
                         {
-                          href: "/admin/professions/" + professionId + "/qualification-information/edit",
+                          href: "/admin/professions/" + professionId + "/qualification-information/edit?change=true",
                           text: ("app.change" | t),
                           visuallyHiddenText: ("professions.form.label.qualificationInformation.mostCommonPathToObtainQualification" | t)
                         }
@@ -242,7 +242,7 @@
                     actions: {
                       items: [
                         {
-                          href: "/admin/professions/" + professionId + "/qualification-information/edit",
+                          href: "/admin/professions/" + professionId + "/qualification-information/edit?change=true",
                           text: ("app.change" | t),
                           visuallyHiddenText: ("professions.form.label.qualificationInformation.mostCommonPathToObtainQualification" | t)
                         }
@@ -259,7 +259,7 @@
                     actions: {
                       items: [
                         {
-                          href: "/admin/professions/" + professionId + "/qualification-information/edit",
+                          href: "/admin/professions/" + professionId + "/qualification-information/edit?change=true",
                           text: ("app.change" | t),
                           visuallyHiddenText: ("professions.form.label.qualificationInformation.mandatoryProfessionalExperience" | t)
                         }

--- a/views/admin/professions/add-profession/check-your-answers.njk
+++ b/views/admin/professions/add-profession/check-your-answers.njk
@@ -176,6 +176,100 @@
               })
             }}
 
+            <h2 class="govuk-heading-m">{{ ("professions.form.headings.qualificationInformation" | t) }}</h2>
+
+            {{
+              govukSummaryList({
+                rows: [
+                  {
+                    key: {
+                      text: ("professions.form.label.qualificationInformation.qualificationLevel" | t)
+                    },
+                    value: {
+                      text: qualification.level
+                    },
+                    actions: {
+                      items: [
+                        {
+                          href: "/admin/professions/" + professionId + "/qualification-information/edit",
+                          text: ("app.change" | t),
+                          visuallyHiddenText: ("professions.form.label.qualificationInformation.qualificationLevel" | t)
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    key: {
+                      text: ("professions.form.label.qualificationInformation.methodsToObtainQualification" | t)
+                    },
+                    value: {
+                      text: (qualification.methodToObtainQualification | t)
+                    },
+                    actions: {
+                      items: [
+                        {
+                          href: "/admin/professions/" + professionId + "/qualification-information/edit",
+                          text: ("app.change" | t),
+                          visuallyHiddenText: ("professions.form.label.qualificationInformation.methodsToObtainQualification" | t)
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    key: {
+                      text: ("professions.form.label.qualificationInformation.mostCommonPathToObtainQualification" | t)
+                    },
+                    value: {
+                      text: (qualification.mostCommonPathToObtainQualification | t)
+                    },
+                    actions: {
+                      items: [
+                        {
+                          href: "/admin/professions/" + professionId + "/qualification-information/edit",
+                          text: ("app.change" | t),
+                          visuallyHiddenText: ("professions.form.label.qualificationInformation.mostCommonPathToObtainQualification" | t)
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    key: {
+                      text: ("professions.form.label.qualificationInformation.duration" | t)
+                    },
+                    value: {
+                      text: qualification.duration
+                    },
+                    actions: {
+                      items: [
+                        {
+                          href: "/admin/professions/" + professionId + "/qualification-information/edit",
+                          text: ("app.change" | t),
+                          visuallyHiddenText: ("professions.form.label.qualificationInformation.mostCommonPathToObtainQualification" | t)
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    key: {
+                      text: ("professions.form.label.qualificationInformation.mandatoryProfessionalExperience" | t)
+                    },
+                    value: {
+                      text: qualification.mandatoryProfessionalExperience | t
+                    },
+                    actions: {
+                      items: [
+                        {
+                          href: "/admin/professions/" + professionId + "/qualification-information/edit",
+                          text: ("app.change" | t),
+                          visuallyHiddenText: ("professions.form.label.qualificationInformation.mandatoryProfessionalExperience" | t)
+                        }
+                      ]
+                    }
+                  }
+                ]
+              })
+            }}
+
             {{
               govukButton({
                 id: "submit-button",

--- a/views/admin/professions/add-profession/qualification-information.njk
+++ b/views/admin/professions/add-profession/qualification-information.njk
@@ -6,7 +6,7 @@
 
 {% block content %}
 
-  <a href="#" class="govuk-back-link">{{ ('app.back' | t) }}</a>
+  <a href="{{backLink}}" class="govuk-back-link">{{ ('app.back' | t) }}</a>
 
   {% include "../../../shared/_errors.njk" %}
 

--- a/views/admin/professions/add-profession/qualification-information.njk
+++ b/views/admin/professions/add-profession/qualification-information.njk
@@ -16,6 +16,7 @@
       <h1 class="govuk-heading-l">{{ ("professions.form.headings.qualificationInformation" | t) }}</h1>
 
       <form method="post" action="./">
+        <input type="hidden" name="change" value="{{ change }}" />
         {{
           govukTextarea({
             label: {

--- a/views/admin/professions/add-profession/qualification-information.njk
+++ b/views/admin/professions/add-profession/qualification-information.njk
@@ -25,7 +25,9 @@
             },
             id: "level",
             name: "level",
-            rows: "7"
+            rows: "7",
+            value: level,
+            errorMessage: errors.level | tError
           })
         }}
 
@@ -43,7 +45,8 @@
             hint: {
               text: ("professions.form.radioButtons.hint" | t)
             },
-            items: methodToObtainQualificationRadioButtonArgs
+            items: methodToObtainQualificationRadioButtonArgs,
+            errorMessage: errors.methodToObtainQualification | tError
           })
         }}
 
@@ -61,7 +64,8 @@
             hint: {
               text: ("professions.form.radioButtons.hint" | t)
             },
-            items: mostCommonPathToObtainQualificationRadioButtonArgs
+            items: mostCommonPathToObtainQualificationRadioButtonArgs,
+            errorMessage: errors.mostCommonPathToObtainQualification | tError
           })
         }}
 
@@ -72,9 +76,12 @@
               classes: "govuk-label--m"
             },
             id: "duration",
-            name: "duration"
+            name: "duration",
+            value: duration,
+            errorMessage: errors.duration | tError
           })
         }}
+
         {{
           govukRadios({
             id: "mandatoryProfessionalExperience",
@@ -89,7 +96,8 @@
             hint: {
               text: ("professions.form.radioButtons.hint" | t)
             },
-            items: mandatoryProfessionalExperienceRadioButtonArgs
+            items: mandatoryProfessionalExperienceRadioButtonArgs,
+            errorMessage: errors.mandatoryProfessionalExperience | tError
           })
         }}
 

--- a/views/admin/professions/add-profession/qualification-information.njk
+++ b/views/admin/professions/add-profession/qualification-information.njk
@@ -1,0 +1,108 @@
+{% extends "base.njk" %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/textarea/macro.njk" import govukTextarea %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "govuk/components/input/macro.njk" import govukInput %}
+
+{% block content %}
+
+  <a href="#" class="govuk-back-link">{{ ('app.back' | t) }}</a>
+
+  {% include "../../../shared/_errors.njk" %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-l">{{ ("professions.form.headings.qualificationInformation" | t) }}</h1>
+
+      <form method="post" action="./">
+        {{
+          govukTextarea({
+            label: {
+              text: ("professions.form.label.qualificationInformation.qualificationLevel" | t),
+              classes: "govuk-label--m",
+              isPageHeading: false
+            },
+            id: "level",
+            name: "level",
+            rows: "7"
+          })
+        }}
+
+        {{
+          govukRadios({
+            idPrefix: "methodToObtainQualification",
+            name: "methodToObtainQualification",
+            fieldset: {
+              legend: {
+                text: ("professions.form.label.qualificationInformation.methodsToObtainQualification" | t),
+                isPageHeading: false,
+                classes: "govuk-fieldset__legend--m"
+              }
+            },
+            hint: {
+              text: ("professions.form.radioButtons.hint" | t)
+            },
+            items: methodToObtainQualificationRadioButtonArgs
+          })
+        }}
+
+        {{
+          govukRadios({
+            idPrefix: "mostCommonPathToObtainQualification",
+            name: "mostCommonPathToObtainQualification",
+            fieldset: {
+              legend: {
+                text: ("professions.form.label.qualificationInformation.mostCommonPathToObtainQualification" | t),
+                isPageHeading: false,
+                classes: "govuk-fieldset__legend--m"
+              }
+            },
+            hint: {
+              text: ("professions.form.radioButtons.hint" | t)
+            },
+            items: mostCommonPathToObtainQualificationRadioButtonArgs
+          })
+        }}
+
+        {{
+          govukInput({
+            label: {
+              text: ("professions.form.label.qualificationInformation.duration" | t),
+              classes: "govuk-label--m"
+            },
+            id: "duration",
+            name: "duration"
+          })
+        }}
+        {{
+          govukRadios({
+            id: "mandatoryProfessionalExperience",
+            name: "mandatoryProfessionalExperience",
+            fieldset: {
+              legend: {
+                text: ("professions.form.label.qualificationInformation.mandatoryProfessionalExperience" | t),
+                isPageHeading: false,
+                classes: "govuk-fieldset__legend--m"
+              }
+            },
+            hint: {
+              text: ("professions.form.radioButtons.hint" | t)
+            },
+            items: mandatoryProfessionalExperienceRadioButtonArgs
+          })
+        }}
+
+        {{
+          govukButton({
+            id: "submit-button",
+            type: "Submit",
+            text: ("app.continue" | t)
+          })
+        }}
+      </form>
+
+    </div>
+  </div>
+
+{% endblock %}


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR

Adds Qualification Information page to the "Add a profession" journey. This creates a new Qualification on the profession.

Although we recently added the granular "education duration" years/months/days/hours fields in a previous piece of work, we've decided to go back to the single field text input here until we know a bit more about how users might enter these values.

## Screenshots of UI changes

#### Qualification information

![image](https://user-images.githubusercontent.com/19826940/149376397-96aa9b02-d0a4-4bd8-ac51-2b9e2a460a4e.png)

#### Check your answers

![image](https://user-images.githubusercontent.com/19826940/149376287-bcae6c1d-7c85-45d6-84f2-632152ea92a7.png)

