### PR TITLE
(1985) Add page for setting Legislation information on a Profession

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - List Regulatory Authorities
 - Add page for adding a new qualification to a profession
 - Show Regulatory Authorities to an admin
+- Add page for setting legislation information on a profession
 
 ### Changed
 

--- a/cypress/integration/admin/professions/add-a-profession.spec.ts
+++ b/cypress/integration/admin/professions/add-a-profession.spec.ts
@@ -103,6 +103,14 @@ describe('Adding a new profession', () => {
         cy.get('button').contains(buttonText).click();
       });
 
+      cy.translate('professions.form.headings.legislation').then((heading) => {
+        cy.get('body').should('contain', heading);
+      });
+
+      cy.translate('app.continue').then((buttonText) => {
+        cy.get('button').contains(buttonText).click();
+      });
+
       cy.translate('professions.form.headings.checkAnswers').then((heading) => {
         cy.get('body').should('contain', heading);
       });

--- a/cypress/integration/admin/professions/add-a-profession.spec.ts
+++ b/cypress/integration/admin/professions/add-a-profession.spec.ts
@@ -146,6 +146,9 @@ describe('Adding a new profession', () => {
         cy.get('body').should('contain', yes);
       });
 
+      cy.get('body').should('contain', 'National legislation description');
+      cy.get('body').should('contain', 'www.example-legislation.com');
+
       cy.translate('professions.form.button.create').then((buttonText) => {
         cy.get('button').contains(buttonText).click();
       });

--- a/cypress/integration/admin/professions/add-a-profession.spec.ts
+++ b/cypress/integration/admin/professions/add-a-profession.spec.ts
@@ -107,6 +107,11 @@ describe('Adding a new profession', () => {
         cy.get('body').should('contain', heading);
       });
 
+      cy.get('textarea[name="nationalLegislation"]').type(
+        'National legislation description',
+      );
+      cy.get('input[name="link"]').type('www.example-legislation.com');
+
       cy.translate('app.continue').then((buttonText) => {
         cy.get('button').contains(buttonText).click();
       });

--- a/seeds/development/professions.json
+++ b/seeds/development/professions.json
@@ -9,7 +9,7 @@
     "industries": ["industries.law"],
     "qualification": "DSE - Diploma (post-secondary education), including Annex II (ex 92/51, Annex C,D) , Art. 11 c",
     "reservedActivities": "England and Wales: the exercise of a right of audience; the conduct of litigation; reserved instrument activities; probate activities; the administration of oaths (see section 12 Legal Services Act 2007).",
-    "legislations": ["The Trade Marks Act 1994", "Legal Services Act 2007"],
+    "legislation": "The Trade Marks Act 1994",
     "organisation": "Law Society of England and Wales",
     "mandatoryRegistration": "voluntary",
     "confirmed": true
@@ -24,10 +24,7 @@
     "industries": ["industries.education"],
     "qualification": "PS3 - Diploma of post-secondary level (3-4 years) , Art. 11 d",
     "reservedActivities": "No information submitted",
-    "legislations": [
-      "The Education (School Teachers' Qualifications) (England) Regulations 2003/1662 (as amended)",
-      "The Education (Induction Arrangements for School Teachers) (England) Regulations 2012/1115 (as amended)"
-    ],
+    "legislation": "The Education (School Teachers' Qualifications) (England) Regulations 2003/1662 (as amended)",
     "organisation": "Department for Education",
     "mandatoryRegistration": "mandatory",
     "confirmed": true

--- a/seeds/staging/professions.json
+++ b/seeds/staging/professions.json
@@ -9,7 +9,7 @@
     "industries": ["industries.law"],
     "qualification": "DSE - Diploma (post-secondary education), including Annex II (ex 92/51, Annex C,D) , Art. 11 c",
     "reservedActivities": "England and Wales: the exercise of a right of audience; the conduct of litigation; reserved instrument activities; probate activities; the administration of oaths (see section 12 Legal Services Act 2007).",
-    "legislations": ["The Trade Marks Act 1994", "Legal Services Act 2007"],
+    "legislation": "The Trade Marks Act 1994",
     "mandatoryRegistration": "voluntary",
     "confirmed": true
   },
@@ -23,10 +23,7 @@
     "industries": ["industries.education"],
     "qualification": "PS3 - Diploma of post-secondary level (3-4 years) , Art. 11 d",
     "reservedActivities": "No information submitted",
-    "legislations": [
-      "The Education (School Teachers' Qualifications) (England) Regulations 2003/1662 (as amended)",
-      "The Education (Induction Arrangements for School Teachers) (England) Regulations 2012/1115 (as amended)"
-    ],
+    "legislation": "The Education (School Teachers' Qualifications) (England) Regulations 2003/1662 (as amended)",
     "mandatoryRegistration": "mandatory",
     "confirmed": true
   },

--- a/seeds/test/professions.json
+++ b/seeds/test/professions.json
@@ -9,7 +9,7 @@
     "industries": ["industries.law"],
     "qualification": "DSE - Diploma (post-secondary education), including Annex II (ex 92/51, Annex C,D) , Art. 11 c",
     "reservedActivities": "England and Wales: the exercise of a right of audience; the conduct of litigation; reserved instrument activities; probate activities; the administration of oaths (see section 12 Legal Services Act 2007).",
-    "legislations": ["The Trade Marks Act 1994", "Legal Services Act 2007"],
+    "legislation": "The Trade Marks Act 1994",
     "organisation": "Law Society of England and Wales",
     "mandatoryRegistration": "voluntary",
     "confirmed": true
@@ -24,10 +24,7 @@
     "industries": ["industries.education"],
     "qualification": "PS3 - Diploma of post-secondary level (3-4 years) , Art. 11 d",
     "reservedActivities": "No information submitted",
-    "legislations": [
-      "The Education (School Teachers' Qualifications) (England) Regulations 2003/1662 (as amended)",
-      "The Education (Induction Arrangements for School Teachers) (England) Regulations 2012/1115 (as amended)"
-    ],
+    "legislation": "The Education (School Teachers' Qualifications) (England) Regulations 2003/1662 (as amended)",
     "organisation": "Department for Education",
     "mandatoryRegistration": "mandatory",
     "confirmed": true

--- a/src/db/migrate/1642179131892-AddSingleLegislationToProfession.ts
+++ b/src/db/migrate/1642179131892-AddSingleLegislationToProfession.ts
@@ -1,0 +1,31 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddSingleLegislationToProfession1642179131892
+  implements MigrationInterface
+{
+  name = 'AddSingleLegislationToProfession1642179131892';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "professions" ADD "legislationId" uuid`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "professions" ADD CONSTRAINT "UQ_ad9cd8ba819522509b3cc2363a4" UNIQUE ("legislationId")`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "professions" ADD CONSTRAINT "FK_ad9cd8ba819522509b3cc2363a4" FOREIGN KEY ("legislationId") REFERENCES "legislations"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "professions" DROP CONSTRAINT "FK_ad9cd8ba819522509b3cc2363a4"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "professions" DROP CONSTRAINT "UQ_ad9cd8ba819522509b3cc2363a4"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "professions" DROP COLUMN "legislationId"`,
+    );
+  }
+}

--- a/src/i18n/en/professions.json
+++ b/src/i18n/en/professions.json
@@ -7,7 +7,8 @@
       "checkAnswers": "Check your answers",
       "confirmation": "New profession created",
       "regulatedActivities": "Regulated activities",
-      "qualificationInformation": "Qualification information"
+      "qualificationInformation": "Qualification information",
+      "legislation": "Legislation"
     },
     "description": "Use this section of the site to add a new profession",
     "label": {
@@ -30,6 +31,10 @@
         "mostCommonPathToObtainQualification": "Most common path to obtain qualification",
         "duration": "Duration of qualification",
         "mandatoryProfessionalExperience": "Existence of mandatory professional experience"
+      },
+      "legislation": {
+        "nationalLegislation": "National legislation",
+        "link": "Legislation link"
       }
     },
     "details": {

--- a/src/i18n/en/professions.json
+++ b/src/i18n/en/professions.json
@@ -125,6 +125,14 @@
         "mandatoryProfessionalExperience": {
           "empty": "Select whether existence of professional experience is mandatory"
         }
+      },
+      "legislation": {
+        "nationalLegislation": {
+          "empty": "Enter the national legislation"
+        },
+        "link": {
+          "empty": "Enter a link to the registration"
+        }
       }
     }
   },

--- a/src/professions/admin/add-profession/check-your-answers.controller.spec.ts
+++ b/src/professions/admin/add-profession/check-your-answers.controller.spec.ts
@@ -5,6 +5,7 @@ import { I18nService } from 'nestjs-i18n';
 import QualificationPresenter from '../../../qualifications/presenters/qualification.presenter';
 import { createMockRequest } from '../../../testutils/create-mock-request';
 import industryFactory from '../../../testutils/factories/industry';
+import legislationFactory from '../../../testutils/factories/legislation';
 import organisationFactory from '../../../testutils/factories/organisation';
 import professionFactory from '../../../testutils/factories/profession';
 import qualificationFactory from '../../../testutils/factories/qualification';
@@ -18,6 +19,10 @@ describe('CheckYourAnswersController', () => {
   let i18nService: DeepMocked<I18nService>;
 
   const qualification = qualificationFactory.build();
+  const legislation = legislationFactory.build({
+    url: 'www.gas-legislation.com',
+    name: 'Gas Safety Legislation',
+  });
 
   beforeEach(async () => {
     const profession = professionFactory.build({
@@ -32,6 +37,7 @@ describe('CheckYourAnswersController', () => {
       description: 'A description of the regulation',
       reservedActivities: 'Some reserved activities',
       qualification,
+      legislation,
     });
 
     professionsService = createMock<ProfessionsService>({
@@ -91,6 +97,12 @@ describe('CheckYourAnswersController', () => {
         );
         expect(templateParams.qualification).toEqual(
           new QualificationPresenter(qualification),
+        );
+        expect(templateParams.legislation.url).toEqual(
+          'www.gas-legislation.com',
+        );
+        expect(templateParams.legislation.name).toEqual(
+          'Gas Safety Legislation',
         );
 
         expect(professionsService.find).toHaveBeenCalledWith('profession-id');

--- a/src/professions/admin/add-profession/check-your-answers.controller.ts
+++ b/src/professions/admin/add-profession/check-your-answers.controller.ts
@@ -53,6 +53,7 @@ export class CheckYourAnswersController {
       description: draftProfession.description,
       reservedActivities: draftProfession.reservedActivities,
       qualification: new QualificationPresenter(draftProfession.qualification),
+      legislation: draftProfession.legislation,
       backLink: backLink(req),
     };
   }

--- a/src/professions/admin/add-profession/dto/legislation.dto.ts
+++ b/src/professions/admin/add-profession/dto/legislation.dto.ts
@@ -1,0 +1,13 @@
+import { IsNotEmpty } from 'class-validator';
+
+export default class LegislationDto {
+  @IsNotEmpty({
+    message: 'professions.form.errors.legislation.nationalLegislation.empty',
+  })
+  nationalLegislation: string;
+
+  @IsNotEmpty({
+    message: 'professions.form.errors.legislation.link.empty',
+  })
+  link: string;
+}

--- a/src/professions/admin/add-profession/interfaces/check-your-answers.template.ts
+++ b/src/professions/admin/add-profession/interfaces/check-your-answers.template.ts
@@ -1,3 +1,4 @@
+import { Legislation } from '../../../../legislations/legislation.entity';
 import QualificationPresenter from '../../../../qualifications/presenters/qualification.presenter';
 
 export interface CheckYourAnswersTemplate {
@@ -10,5 +11,6 @@ export interface CheckYourAnswersTemplate {
   reservedActivities: string;
   description: string;
   qualification: QualificationPresenter;
+  legislation: Legislation;
   backLink: string;
 }

--- a/src/professions/admin/add-profession/interfaces/legislation.template.ts
+++ b/src/professions/admin/add-profession/interfaces/legislation.template.ts
@@ -1,3 +1,7 @@
+import { Legislation } from '../../../../legislations/legislation.entity';
+
 export interface LegislationTemplate {
+  legislation: Legislation | null;
   backLink: string;
+  errors: object | undefined;
 }

--- a/src/professions/admin/add-profession/interfaces/legislation.template.ts
+++ b/src/professions/admin/add-profession/interfaces/legislation.template.ts
@@ -1,0 +1,3 @@
+export interface LegislationTemplate {
+  backLink: string;
+}

--- a/src/professions/admin/add-profession/legislation.controller.spec.ts
+++ b/src/professions/admin/add-profession/legislation.controller.spec.ts
@@ -1,38 +1,114 @@
-import { createMock } from '@golevelup/ts-jest';
+import { createMock, DeepMocked } from '@golevelup/ts-jest';
 import { Test, TestingModule } from '@nestjs/testing';
 import { Response } from 'express';
+import legislationFactory from '../../../testutils/factories/legislation';
+import professionFactory from '../../../testutils/factories/profession';
+import { ProfessionsService } from '../../professions.service';
+import LegislationDto from './dto/legislation.dto';
 import { LegislationController } from './legislation.controller';
 
 describe(LegislationController, () => {
   let controller: LegislationController;
+  let professionsService: DeepMocked<ProfessionsService>;
+  let response: DeepMocked<Response>;
 
   beforeEach(async () => {
+    professionsService = createMock<ProfessionsService>();
+
     const module: TestingModule = await Test.createTestingModule({
       controllers: [LegislationController],
-      providers: [],
+      providers: [
+        { provide: ProfessionsService, useValue: professionsService },
+      ],
     }).compile();
+
+    response = createMock<Response>();
 
     controller = module.get<LegislationController>(LegislationController);
   });
 
   describe('edit', () => {
-    it('renders a page with a back link', async () => {
-      expect(await controller.edit('profession-id')).toEqual({
-        backLink:
-          '/admin/professions/profession-id/qualification-information/edit',
+    it('renders the Legislation page, passing in any values on the Profession that have already been set', async () => {
+      const legislation = legislationFactory.build({
+        name: 'Legal Services Act 2007',
+        url: 'www.example.com',
       });
+      const profession = professionFactory.build({
+        id: 'profession-id',
+        legislation,
+      });
+
+      professionsService.find.mockResolvedValue(profession);
+
+      await controller.edit(response, 'profession-id');
+
+      expect(response.render).toHaveBeenCalledWith(
+        'admin/professions/add-profession/legislation',
+        expect.objectContaining({
+          legislation: legislation,
+        }),
+      );
     });
   });
 
   describe('update', () => {
-    it('redirects to Check your answers', async () => {
-      const response = createMock<Response>();
+    describe('when all required parameters are entered', () => {
+      it('creates a new Legislation on the Profession and redirects to Check your answers', async () => {
+        const profession = professionFactory.build({ id: 'profession-id' });
 
-      await controller.update(response, 'profession-id');
+        const dto: LegislationDto = {
+          link: 'www.legal-legislation.com',
+          nationalLegislation: 'Legal Services Act 2008',
+        };
 
-      expect(response.redirect).toHaveBeenCalledWith(
-        '/admin/professions/profession-id/check-your-answers',
-      );
+        professionsService.find.mockResolvedValue(profession);
+
+        await controller.update(response, 'profession-id', dto);
+
+        expect(professionsService.save).toHaveBeenCalledWith(
+          expect.objectContaining({
+            legislation: expect.objectContaining({
+              url: 'www.legal-legislation.com',
+              name: 'Legal Services Act 2008',
+            }),
+          }),
+        );
+
+        expect(response.redirect).toHaveBeenCalledWith(
+          '/admin/professions/profession-id/check-your-answers',
+        );
+      });
+    });
+
+    describe('when required parameters are not entered', () => {
+      it('renders the edit page with errors and does not update the Profession', async () => {
+        const profession = professionFactory.build({ id: 'profession-id' });
+
+        const dto: LegislationDto = {
+          link: undefined,
+          nationalLegislation: undefined,
+        };
+
+        professionsService.find.mockResolvedValue(profession);
+
+        await controller.update(response, 'profession-id', dto);
+
+        expect(professionsService.save).not.toHaveBeenCalled();
+
+        expect(response.render).toHaveBeenCalledWith(
+          'admin/professions/add-profession/legislation',
+          expect.objectContaining({
+            errors: {
+              link: {
+                text: 'professions.form.errors.legislation.link.empty',
+              },
+              nationalLegislation: {
+                text: 'professions.form.errors.legislation.nationalLegislation.empty',
+              },
+            },
+          }),
+        );
+      });
     });
   });
 

--- a/src/professions/admin/add-profession/legislation.controller.spec.ts
+++ b/src/professions/admin/add-profession/legislation.controller.spec.ts
@@ -40,7 +40,7 @@ describe(LegislationController, () => {
 
       professionsService.find.mockResolvedValue(profession);
 
-      await controller.edit(response, 'profession-id');
+      await controller.edit(response, 'profession-id', true);
 
       expect(response.render).toHaveBeenCalledWith(
         'admin/professions/add-profession/legislation',
@@ -63,7 +63,7 @@ describe(LegislationController, () => {
 
         professionsService.find.mockResolvedValue(profession);
 
-        await controller.update(response, 'profession-id', dto);
+        await controller.update(response, 'profession-id', dto, false);
 
         expect(professionsService.save).toHaveBeenCalledWith(
           expect.objectContaining({
@@ -91,7 +91,7 @@ describe(LegislationController, () => {
 
         professionsService.find.mockResolvedValue(profession);
 
-        await controller.update(response, 'profession-id', dto);
+        await controller.update(response, 'profession-id', dto, false);
 
         expect(professionsService.save).not.toHaveBeenCalled();
 
@@ -106,6 +106,47 @@ describe(LegislationController, () => {
                 text: 'professions.form.errors.legislation.nationalLegislation.empty',
               },
             },
+          }),
+        );
+      });
+    });
+  });
+
+  describe('back links', () => {
+    describe('when the "Change" query param is false', () => {
+      it('links back to the previous page in the journey', async () => {
+        const profession = professionFactory.build({
+          id: 'profession-id',
+        });
+
+        professionsService.find.mockImplementation(async () => profession);
+
+        await controller.edit(response, 'profession-id', false);
+
+        expect(response.render).toHaveBeenCalledWith(
+          'admin/professions/add-profession/legislation',
+          expect.objectContaining({
+            backLink:
+              '/admin/professions/profession-id/qualification-information/edit',
+          }),
+        );
+      });
+    });
+
+    describe('when the "Change" query param is true', () => {
+      it('links back to the Check your Answers page', async () => {
+        const profession = professionFactory.build({
+          id: 'profession-id',
+        });
+
+        professionsService.find.mockImplementation(async () => profession);
+
+        await controller.edit(response, 'profession-id', true);
+
+        expect(response.render).toHaveBeenCalledWith(
+          'admin/professions/add-profession/legislation',
+          expect.objectContaining({
+            backLink: '/admin/professions/profession-id/check-your-answers',
           }),
         );
       });

--- a/src/professions/admin/add-profession/legislation.controller.spec.ts
+++ b/src/professions/admin/add-profession/legislation.controller.spec.ts
@@ -1,0 +1,42 @@
+import { createMock } from '@golevelup/ts-jest';
+import { Test, TestingModule } from '@nestjs/testing';
+import { Response } from 'express';
+import { LegislationController } from './legislation.controller';
+
+describe(LegislationController, () => {
+  let controller: LegislationController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [LegislationController],
+      providers: [],
+    }).compile();
+
+    controller = module.get<LegislationController>(LegislationController);
+  });
+
+  describe('edit', () => {
+    it('renders a page with a back link', async () => {
+      expect(await controller.edit('profession-id')).toEqual({
+        backLink:
+          '/admin/professions/profession-id/qualification-information/edit',
+      });
+    });
+  });
+
+  describe('update', () => {
+    it('redirects to Check your answers', async () => {
+      const response = createMock<Response>();
+
+      await controller.update(response, 'profession-id');
+
+      expect(response.redirect).toHaveBeenCalledWith(
+        '/admin/professions/profession-id/check-your-answers',
+      );
+    });
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+});

--- a/src/professions/admin/add-profession/legislation.controller.ts
+++ b/src/professions/admin/add-profession/legislation.controller.ts
@@ -1,0 +1,33 @@
+import {
+  Controller,
+  Get,
+  Param,
+  Post,
+  Render,
+  Res,
+  UseGuards,
+} from '@nestjs/common';
+import { Response } from 'express';
+import { AuthenticationGuard } from '../../../common/authentication.guard';
+import { Permissions } from '../../../common/permissions.decorator';
+import { UserPermission } from '../../../users/user.entity';
+import { LegislationTemplate } from './interfaces/legislation.template';
+
+@UseGuards(AuthenticationGuard)
+@Controller('admin/professions')
+export class LegislationController {
+  @Get('/:id/legislation/edit')
+  @Render('admin/professions/add-profession/legislation')
+  @Permissions(UserPermission.CreateProfession)
+  async edit(@Param('id') id: string): Promise<LegislationTemplate> {
+    return {
+      backLink: `/admin/professions/${id}/qualification-information/edit`,
+    };
+  }
+
+  @Post('/:id/legislation')
+  @Permissions(UserPermission.CreateProfession)
+  async update(@Res() res: Response, @Param('id') id: string): Promise<void> {
+    res.redirect(`/admin/professions/${id}/check-your-answers`);
+  }
+}

--- a/src/professions/admin/add-profession/legislation.controller.ts
+++ b/src/professions/admin/add-profession/legislation.controller.ts
@@ -28,10 +28,14 @@ export class LegislationController {
 
   @Get('/:id/legislation/edit')
   @Permissions(UserPermission.CreateProfession)
-  async edit(@Res() res: Response, @Param('id') id: string): Promise<void> {
+  async edit(
+    @Res() res: Response,
+    @Param('id') id: string,
+    @Query('change') change: boolean,
+  ): Promise<void> {
     const profession = await this.professionsService.find(id);
 
-    this.renderForm(res, profession.legislation, this.backLink(id));
+    this.renderForm(res, profession.legislation, this.backLink(change, id));
   }
 
   @Post('/:id/legislation')
@@ -46,6 +50,7 @@ export class LegislationController {
     @Res() res: Response,
     @Param('id') id: string,
     @Body() legislationDto,
+    @Query() change: boolean,
   ): Promise<void> {
     const validator = await Validator.validate(LegislationDto, legislationDto);
 
@@ -67,7 +72,7 @@ export class LegislationController {
       return this.renderForm(
         res,
         updatedLegislation,
-        this.backLink(id),
+        this.backLink(change, id),
         errors,
       );
     }
@@ -97,7 +102,9 @@ export class LegislationController {
     );
   }
 
-  private backLink(id: string) {
-    return `/admin/professions/${id}/qualification-information/edit`;
+  private backLink(change: boolean, id: string) {
+    return change
+      ? `/admin/professions/${id}/check-your-answers`
+      : `/admin/professions/${id}/qualification-information/edit`;
   }
 }

--- a/src/professions/admin/add-profession/qualification-information.controller.spec.ts
+++ b/src/professions/admin/add-profession/qualification-information.controller.spec.ts
@@ -113,8 +113,7 @@ describe(QualificationInformationController, () => {
           );
 
           expect(response.redirect).toHaveBeenCalledWith(
-            // This will be the Legislation page in future
-            '/admin/professions/profession-id/check-your-answers',
+            '/admin/professions/profession-id/legislation/edit',
           );
         });
       });

--- a/src/professions/admin/add-profession/qualification-information.controller.ts
+++ b/src/professions/admin/add-profession/qualification-information.controller.ts
@@ -103,8 +103,7 @@ export class QualificationInformationController {
       return res.redirect(`/admin/professions/${id}/check-your-answers`);
     }
 
-    // This will go to the Legislation information page in future
-    return res.redirect(`/admin/professions/${id}/check-your-answers`);
+    return res.redirect(`/admin/professions/${id}/legislation/edit`);
   }
 
   private async renderForm(

--- a/src/professions/profession.entity.ts
+++ b/src/professions/profession.entity.ts
@@ -63,6 +63,13 @@ export class Profession {
   @Column({ nullable: true })
   reservedActivities: string;
 
+  @OneToOne(() => Legislation, {
+    eager: true,
+    cascade: true,
+  })
+  @JoinColumn()
+  legislation: Legislation;
+
   @ManyToMany(() => Legislation, {
     eager: true,
   })
@@ -102,6 +109,7 @@ export class Profession {
     qualification?: Qualification,
     reservedActivities?: string,
     legislations?: Legislation[],
+    legislation?: Legislation,
     organisation?: Organisation,
     confirmed?: boolean,
   ) {
@@ -116,6 +124,7 @@ export class Profession {
     this.qualification = qualification || null;
     this.reservedActivities = reservedActivities || null;
     this.legislations = legislations || null;
+    this.legislation = legislation || null;
     this.organisation = organisation || null;
     this.confirmed = confirmed || false;
   }

--- a/src/professions/professions.module.ts
+++ b/src/professions/professions.module.ts
@@ -15,6 +15,7 @@ import { OrganisationsService } from '../organisations/organisations.service';
 import { RegulatedActivitiesController } from './admin/add-profession/regulated-activities.controller';
 import { ProfessionsController as AdminProfessionsController } from './admin/professions.controller';
 import { QualificationInformationController } from './admin/add-profession/qualification-information.controller';
+import { LegislationController } from './admin/add-profession/legislation.controller';
 
 @Module({
   imports: [
@@ -30,6 +31,7 @@ import { QualificationInformationController } from './admin/add-profession/quali
     RegulatoryBodyController,
     RegulatedActivitiesController,
     QualificationInformationController,
+    LegislationController,
     CheckYourAnswersController,
     ConfirmationController,
     AdminProfessionsController,

--- a/src/professions/professions.seeder.ts
+++ b/src/professions/professions.seeder.ts
@@ -21,7 +21,7 @@ type SeedProfession = {
   industries: string[];
   qualification: string;
   reservedActivities: string;
-  legislations: string[];
+  legislation: string;
   organisation: string;
   mandatoryRegistration: MandatoryRegistration;
   confirmed: boolean;
@@ -56,13 +56,10 @@ export class ProfessionsSeeder implements Seeder {
           where: { level: profession.qualification },
         });
 
-        const legislations: Array<Legislation> = await Promise.all(
-          (profession.legislations || []).map(async (legislation) => {
-            return this.legislationsRepository.findOne({
-              where: { name: legislation },
-            });
-          }),
-        );
+        const legislation: Legislation =
+          await this.legislationsRepository.findOne({
+            where: { name: profession.legislation },
+          });
 
         const organisation = await this.organisationRepository.findOne({
           where: { name: profession.organisation },
@@ -83,7 +80,8 @@ export class ProfessionsSeeder implements Seeder {
           industries,
           qualification,
           profession.reservedActivities,
-          legislations,
+          [],
+          legislation,
           organisation,
           profession.confirmed,
         );

--- a/src/professions/professions.service.spec.ts
+++ b/src/professions/professions.service.spec.ts
@@ -124,22 +124,6 @@ describe('Profession', () => {
             where: { slug: 'example-profession' },
           });
 
-          new Profession(
-            'Example Profession',
-            '',
-            'example-profession',
-            '',
-            null,
-            '',
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            true,
-          );
-
           expect(result.slug).toEqual('example-profession');
         });
       });

--- a/src/testutils/factories/profession.ts
+++ b/src/testutils/factories/profession.ts
@@ -4,7 +4,7 @@ import {
   Profession,
 } from '../../professions/profession.entity';
 import industryFactory from './industry';
-import legislation from './legislation';
+import legislationFactory from './legislation';
 import qualificationFactory from './qualification';
 
 class ProfessionFactory extends Factory<Profession> {
@@ -22,6 +22,7 @@ class ProfessionFactory extends Factory<Profession> {
       qualification: undefined,
       confirmed: undefined,
       legislations: undefined,
+      legislation: undefined,
       organisation: undefined,
       reservedActivities: undefined,
     });
@@ -44,7 +45,8 @@ export default ProfessionFactory.define(({ sequence }) => ({
   qualification: qualificationFactory.build(),
   confirmed: false,
   created_at: new Date(),
-  legislations: [legislation.build()],
+  legislations: [],
+  legislation: legislationFactory.build(),
   organisation: undefined,
   reservedActivities: 'Stuff',
   updated_at: new Date(),

--- a/views/admin/professions/add-profession/check-your-answers.njk
+++ b/views/admin/professions/add-profession/check-your-answers.njk
@@ -270,6 +270,49 @@
               })
             }}
 
+            <h2 class="govuk-heading-m">{{ ("professions.form.headings.legislation" | t) }}</h2>
+
+            {{
+              govukSummaryList({
+                rows: [
+                  {
+                    key: {
+                      text: ("professions.form.label.legislation.nationalLegislation" | t)
+                    },
+                    value: {
+                      text: legislation.name
+                    },
+                    actions: {
+                      items: [
+                        {
+                          href: "/admin/professions/" + professionId + "/legislation/edit",
+                          text: ("app.change" | t),
+                          visuallyHiddenText: ("professions.form.label.legislation.nationalLegislation" | t)
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    key: {
+                      text: ("professions.form.label.legislation.link" | t)
+                    },
+                    value: {
+                      html: "<a class='govuk-link' href='" + legislation.url | escape + "'>" + legislation.url | escape + "</a>"
+                    },
+                    actions: {
+                      items: [
+                        {
+                          href: "/admin/professions/" + professionId + "/legislation/edit",
+                          text: ("app.change" | t),
+                          visuallyHiddenText: ("professions.form.label.legislation.nationalLegislation" | t)
+                        }
+                      ]
+                    }
+                  }
+                ]
+              })
+            }}
+
             {{
               govukButton({
                 id: "submit-button",

--- a/views/admin/professions/add-profession/check-your-answers.njk
+++ b/views/admin/professions/add-profession/check-your-answers.njk
@@ -285,7 +285,7 @@
                     actions: {
                       items: [
                         {
-                          href: "/admin/professions/" + professionId + "/legislation/edit",
+                          href: "/admin/professions/" + professionId + "/legislation/edit?change=true",
                           text: ("app.change" | t),
                           visuallyHiddenText: ("professions.form.label.legislation.nationalLegislation" | t)
                         }
@@ -302,7 +302,7 @@
                     actions: {
                       items: [
                         {
-                          href: "/admin/professions/" + professionId + "/legislation/edit",
+                          href: "/admin/professions/" + professionId + "/legislation/edit?change=true",
                           text: ("app.change" | t),
                           visuallyHiddenText: ("professions.form.label.legislation.nationalLegislation" | t)
                         }

--- a/views/admin/professions/add-profession/legislation.njk
+++ b/views/admin/professions/add-profession/legislation.njk
@@ -24,7 +24,9 @@
               isPageHeading: false
             },
             id: "nationalLegislation",
-            name: "nationalLegislation"
+            name: "nationalLegislation",
+            value: legislation.name,
+            errorMessage: errors.nationalLegislation | tError
           })
         }}
 
@@ -36,7 +38,9 @@
               isPageHeading: false
             },
             id: "link",
-            name: "link"
+            name: "link",
+            value: legislation.url,
+            errorMessage: errors.link | tError
           })
         }}
 

--- a/views/admin/professions/add-profession/legislation.njk
+++ b/views/admin/professions/add-profession/legislation.njk
@@ -1,0 +1,55 @@
+{% extends "base.njk" %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/textarea/macro.njk" import govukTextarea %}
+{% from "govuk/components/input/macro.njk" import govukInput %}
+
+{% block content %}
+
+  <a href="{{backLink}}" class="govuk-back-link">{{ ('app.back' | t) }}</a>
+
+  {% include "../../../shared/_errors.njk" %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-l">{{ ("professions.form.headings.legislation" | t) }}</h1>
+
+      <form method="post" action="./">
+
+        {{
+          govukTextarea({
+            label: {
+              text: ("professions.form.label.legislation.nationalLegislation" | t),
+              classes: "govuk-label--m",
+              isPageHeading: false
+            },
+            id: "nationalLegislation",
+            name: "nationalLegislation"
+          })
+        }}
+
+        {{
+          govukInput({
+            label: {
+              text: ("professions.form.label.legislation.link" | t),
+              classes: "govuk-label--m",
+              isPageHeading: false
+            },
+            id: "link",
+            name: "link"
+          })
+        }}
+
+        {{
+          govukButton({
+            id: "submit-button",
+            type: "Submit",
+            text: ("app.continue" | t)
+          })
+        }}
+      </form>
+
+    </div>
+  </div>
+
+{% endblock %}

--- a/views/professions/show.njk
+++ b/views/professions/show.njk
@@ -196,30 +196,27 @@
 
         <h2 class="govuk-heading-m rpr-details__section-title">{{ "professions.show.legislation.heading" | t}}</h2>
 
-        {% for legislation in profession.legislations %}
-
-          {{ govukSummaryList({
-          classes: 'govuk-summary-list--no-border',
-          rows: [
-            {
-              key: {
-                text: ( "professions.show.legislation.nationalLegislation" | t)
-              },
-              value: {
-                text: legislation.name
-              }
+        {{ govukSummaryList({
+        classes: 'govuk-summary-list--no-border',
+        rows: [
+          {
+            key: {
+              text: ( "professions.show.legislation.nationalLegislation" | t)
             },
-            {
-              key: {
-                text: ( "professions.show.legislation.legislationLink" | t)
-              },
-              value: {
-                html: ["<a class=\"govuk-link\" href=\"", (legislation.url | escape), "\">", (legislation.url | escape),  "</a>" ] | join
-              }
+            value: {
+              text: profession.legislation.name
             }
-          ]
-          }) }}
-        {% endfor %}
+          },
+          {
+            key: {
+              text: ( "professions.show.legislation.legislationLink" | t)
+            },
+            value: {
+              html: ["<a class=\"govuk-link\" href=\"", (profession.legislation.url | escape), "\">", (profession.legislation.url | escape),  "</a>" ] | join
+            }
+          }
+        ]
+        }) }}
       </div>
 
       <div class="govuk-grid-column-one-third">


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR

Adds final page to "Add a profession" journey for adding Legislation information. This creates a new Legislation on the Profession.

We initially planned to store multiple Legislations on the Profession, but it looks like this was in error, so we've added a single "one-to-one" field here. We'll remove the additional field once this is merged in.

## Screenshots of UI changes

### Legislation page

![image](https://user-images.githubusercontent.com/19826940/149563292-15b02214-28d6-42d3-a69f-7e603dfc7bd3.png)

#### Legislation page with errors

![image](https://user-images.githubusercontent.com/19826940/149563386-332485a5-5a97-4cb3-8230-52dc19b8804c.png)

### Check your answers

![image](https://user-images.githubusercontent.com/19826940/149564286-4853192e-24ae-46f8-9d0f-a019a177efe4.png)


