### PR TITLE
Remove invalid user seed

### DIFF
--- a/seeds/staging/users.json
+++ b/seeds/staging/users.json
@@ -22,7 +22,7 @@
     "email": "beis-rpr+editor@dxw.com",
     "name": "Editor",
     "externalIdentifier": "auth0|61d4220c20680d00696f50a1",
-    "permissions": ["editor"],
+    "permissions": [],
     "confirmed": true,
     "serviceOwner": false
   }


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR

Now that we have more granular permissions, `editor` isn't a
`permission`. This should be an empty user that we can give permissions
to on staging.
