### PR TITLE
Redirect user to `/admin` after login

### DIFF
--- a/src/middleware/authentication.middleware.ts
+++ b/src/middleware/authentication.middleware.ts
@@ -50,6 +50,11 @@ export class AuthenticationMidleware {
       afterCallback: async (_req, _res, session) => {
         return await this.afterCallback(session);
       },
+      getLoginState() {
+        return {
+          returnTo: '/admin',
+        };
+      },
     });
   }
 


### PR DESCRIPTION
Before, the user was getting redirected to the root url, which was annoying / unexpected. This redirects to the `/admin` route, which is more expected.