### PR TITLE
(2023) Remove placeholder text on Professions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Update start page
 - Add public-facing Regulatory Authority pages
 - Allow Professions to be edited
+- Display real data on "view profession" pages
 
 ### Changed
 

--- a/cypress/integration/professions/show.spec.ts
+++ b/cypress/integration/professions/show.spec.ts
@@ -49,6 +49,35 @@ describe('Showing a profession', () => {
       'professions.show.qualification.level',
       'DSE - Diploma (post-secondary education), including Annex II (ex 92/51, Annex C,D) , Art. 11 c',
     );
+    cy.translate(
+      'professions.form.radioButtons.methodsToObtainQualification.generalSecondaryEducation',
+    ).then((method) => {
+      cy.checkSummaryListRowValue(
+        'professions.show.qualification.methods',
+        method,
+      );
+    });
+
+    cy.translate(
+      'professions.form.radioButtons.methodsToObtainQualification.generalSecondaryEducation',
+    ).then((method) => {
+      cy.checkSummaryListRowValue(
+        'professions.show.qualification.commonPath',
+        method,
+      );
+    });
+
+    cy.checkSummaryListRowValue(
+      'professions.show.qualification.duration',
+      '5.0 Year',
+    );
+
+    cy.translate('app.yes').then((value) => {
+      cy.checkSummaryListRowValue(
+        'professions.show.qualification.mandatoryExperience',
+        value,
+      );
+    });
 
     cy.translate('professions.show.legislation.heading').then((heading) => {
       cy.get('body').should('contain', heading);

--- a/cypress/integration/professions/show.spec.ts
+++ b/cypress/integration/professions/show.spec.ts
@@ -3,8 +3,6 @@ describe('Showing a profession', () => {
     cy.visit('/professions/registered-trademark-attorney');
 
     cy.get('body').should('contain', 'Registered Trademark Attorney');
-    cy.get('body').should('contain', 'Law');
-    cy.get('body').should('contain', 'The Trade Marks Act 1994');
 
     cy.translate('professions.show.overview.heading').then((heading) => {
       cy.get('body').should('contain', heading);
@@ -13,18 +11,54 @@ describe('Showing a profession', () => {
     cy.translate('professions.show.bodies.heading').then((heading) => {
       cy.get('body').should('contain', heading);
     });
+    cy.checkSummaryListRowValue(
+      'professions.show.bodies.regulatedAuthority',
+      'Law Society of England and Wales',
+    );
+    cy.checkSummaryListRowValue(
+      'professions.show.bodies.address',
+      '456 Example Street, London, EC1 1AB',
+    );
+    cy.checkSummaryListRowValue(
+      'professions.show.bodies.emailAddress',
+      'law@example.com',
+    );
+    cy.checkSummaryListRowValue(
+      'professions.show.bodies.url',
+      'www.lawsociety.org.uk',
+    );
+    cy.checkSummaryListRowValue(
+      'professions.show.bodies.phoneNumber',
+      '+44 0123 456789',
+    );
 
     cy.translate('professions.show.regulatedActivities.heading').then(
       (heading) => {
         cy.get('body').should('contain', heading);
       },
     );
+    cy.checkSummaryListRowValue(
+      'professions.show.regulatedActivities.description',
+      'Registration protection and exploitation of trade marks',
+    );
 
     cy.translate('professions.show.qualification.heading').then((heading) => {
       cy.get('body').should('contain', heading);
     });
+    cy.checkSummaryListRowValue(
+      'professions.show.qualification.level',
+      'DSE - Diploma (post-secondary education), including Annex II (ex 92/51, Annex C,D) , Art. 11 c',
+    );
 
     cy.translate('professions.show.legislation.heading').then((heading) => {
+      cy.get('body').should('contain', heading);
+    });
+    cy.checkSummaryListRowValue(
+      'professions.show.legislation.nationalLegislation',
+      'The Trade Marks Act 1994',
+    );
+
+    cy.translate('professions.show.overview.heading').then((heading) => {
       cy.get('body').should('contain', heading);
     });
   });

--- a/src/i18n/en/professions.json
+++ b/src/i18n/en/professions.json
@@ -158,8 +158,7 @@
       "address": "Address",
       "emailAddress": "Email address",
       "url": "URL",
-      "phoneNumber": "Phone number",
-      "mandatoryRegistration": "Mandatory registration with professional bodies"
+      "phoneNumber": "Phone number"
     },
     "regulatedActivities": {
       "heading": "Regulated activities",

--- a/src/i18n/en/professions.json
+++ b/src/i18n/en/professions.json
@@ -167,7 +167,7 @@
     },
     "qualification": {
       "heading": "Qualification information",
-      "level": "Qualificiation level",
+      "level": "Qualification level",
       "methods": "Method to obtain qualification",
       "commonPath": "Most common path to obtain qualification",
       "duration": "Duration of qualification",

--- a/src/professions/admin/professions.controller.spec.ts
+++ b/src/professions/admin/professions.controller.spec.ts
@@ -18,6 +18,7 @@ import industryFactory from '../../testutils/factories/industry';
 import organisationFactory from '../../testutils/factories/organisation';
 import professionFactory from '../../testutils/factories/profession';
 import { NotFoundException } from '@nestjs/common';
+import QualificationPresenter from '../../qualifications/presenters/qualification.presenter';
 
 const referrer = 'http://example.com/some/path';
 const host = 'example.com';
@@ -340,6 +341,7 @@ describe('ProfessionsController', () => {
 
       expect(result).toEqual({
         profession: profession,
+        qualification: new QualificationPresenter(profession.qualification),
         nations: ['Translation of `nations.england`'],
         industries: ['Translation of `industries.example`'],
         backLink: '',

--- a/src/professions/admin/professions.controller.ts
+++ b/src/professions/admin/professions.controller.ts
@@ -32,6 +32,7 @@ import { Profession } from '../profession.entity';
 import { ShowTemplate } from '../interfaces/show-template.interface';
 import { EditTemplate } from './interfaces/edit-template.interface';
 import { Permissions } from '../../common/permissions.decorator';
+import QualificationPresenter from '../../qualifications/presenters/qualification.presenter';
 
 @UseGuards(AuthenticationGuard)
 @Controller('admin/professions')
@@ -84,7 +85,13 @@ export class ProfessionsController {
       ),
     );
 
-    return { profession, nations, industries, backLink: '' };
+    return {
+      profession,
+      qualification: new QualificationPresenter(profession.qualification),
+      nations,
+      industries,
+      backLink: '',
+    };
   }
 
   @Get('/:slug/edit')

--- a/src/professions/interfaces/show-template.interface.ts
+++ b/src/professions/interfaces/show-template.interface.ts
@@ -1,7 +1,9 @@
+import QualificationPresenter from '../../qualifications/presenters/qualification.presenter';
 import { Profession } from '../profession.entity';
 
 export interface ShowTemplate {
   profession: Profession;
+  qualification: QualificationPresenter;
   nations: string[];
   industries: string[];
   backLink: string;

--- a/src/professions/professions.controller.spec.ts
+++ b/src/professions/professions.controller.spec.ts
@@ -2,6 +2,7 @@ import { createMock, DeepMocked } from '@golevelup/ts-jest';
 import { NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { I18nService } from 'nestjs-i18n';
+import QualificationPresenter from '../qualifications/presenters/qualification.presenter';
 import industryFactory from '../testutils/factories/industry';
 import professionFactory from '../testutils/factories/profession';
 
@@ -68,6 +69,9 @@ describe('ProfessionsController', () => {
 
       expect(result).toEqual({
         profession: exampleProfession,
+        qualification: new QualificationPresenter(
+          exampleProfession.qualification,
+        ),
         nations: ['England'],
         industries: ['Example industry'],
         backLink: '/professions/search',

--- a/src/professions/professions.controller.ts
+++ b/src/professions/professions.controller.ts
@@ -7,6 +7,7 @@ import {
 } from '@nestjs/common';
 import { I18nService } from 'nestjs-i18n';
 import { Nation } from '../nations/nation';
+import QualificationPresenter from '../qualifications/presenters/qualification.presenter';
 import { ShowTemplate } from './interfaces/show-template.interface';
 import { ProfessionsService } from './professions.service';
 
@@ -40,6 +41,12 @@ export class ProfessionsController {
       ),
     );
 
-    return { profession, nations, industries, backLink: '/professions/search' };
+    return {
+      profession,
+      qualification: new QualificationPresenter(profession.qualification),
+      nations,
+      industries,
+      backLink: '/professions/search',
+    };
   }
 }

--- a/views/professions/_profession-details.njk
+++ b/views/professions/_profession-details.njk
@@ -1,6 +1,6 @@
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 
-<span class="govuk-caption-l">Placeholder Authority</span>
+<span class="govuk-caption-l">{{ profession.organisation.name }}</span>
 
 <h1 class="govuk-heading-xl">{{ profession.name }}</h1>
 
@@ -53,7 +53,7 @@
         text: ("professions.show.bodies.regulatedAuthority" | t)
       },
       value: {
-        text: "Placeholder authority"
+        text: profession.organisation.name
       }
     },
     {
@@ -61,7 +61,7 @@
         text: ("professions.show.bodies.address" | t)
       },
       value: {
-        html: 'Placeholder address'
+        html: profession.organisation.address
       }
     },
     {
@@ -69,7 +69,7 @@
         text: ("professions.show.bodies.emailAddress" | t)
       },
       value: {
-        text: "Placeholder email"
+        text: profession.organisation.email
       }
     },
     {
@@ -77,7 +77,7 @@
         text: ("professions.show.bodies.url" | t)
       },
       value: {
-        text: "Placeholder url"
+        text: profession.organisation.url
       }
     },
     {
@@ -85,15 +85,7 @@
         text: ("professions.show.bodies.phoneNumber" | t)
       },
       value: {
-        text: "Placeholder phone numer"
-      }
-    },
-    {
-      key: {
-        text: ("professions.show.bodies.mandatoryRegistration" | t)
-      },
-      value: {
-        text: "Placeholder response"
+        text: profession.organisation.telephone
       }
     }
   ]

--- a/views/professions/_profession-details.njk
+++ b/views/professions/_profession-details.njk
@@ -129,7 +129,7 @@
         text: ("professions.show.qualification.level" | t)
       },
       value: {
-        text: profession.qualification.level
+        text: qualification.level
       }
     },
     {
@@ -137,7 +137,7 @@
         text: ("professions.show.qualification.methods" | t)
       },
       value: {
-        text: profession.qualification.methodToObtain
+        text: qualification.methodToObtainQualification | t
       }
     },
     {
@@ -145,7 +145,7 @@
         text: ("professions.show.qualification.commonPath" | t)
       },
       value: {
-        text: profession.qualification.commonPathToObtain
+        text: qualification.mostCommonPathToObtainQualification | t
       }
     },
     {
@@ -153,7 +153,7 @@
         text: ("professions.show.qualification.duration" | t)
       },
       value: {
-        text: profession.qualification.educationDuration
+        text: qualification.duration
       }
     },
     {
@@ -161,7 +161,7 @@
         text: ("professions.show.qualification.mandatoryExperience" | t)
       },
       value: {
-        text: ("app.yes" | t) if profession.qualification.mandatoryProfessionalExperience else ("app.no" | t)
+        text: qualification.mandatoryProfessionalExperience | t
       }
     }
   ]


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR

- Displays real Organisation on a Profession page, rather than placeholder text
- Fixes typo
- Removes duplicate "mandatory professional experience" answer
- Displays human-readable qualification answers, rather than ugly raw data values

## Screenshots of UI changes

### Before

![image](https://user-images.githubusercontent.com/19826940/150169754-fbcb9215-2420-4e9b-9611-1675258899c3.png)

### After

![image](https://user-images.githubusercontent.com/19826940/150169674-90ab582b-e9e4-4d2c-add9-b837ac0d775f.png)

