### PR TITLE
Filter unconfirmed professions in `OrganisationService`

### DIFF
--- a/cypress/integration/admin/organisations/index.spec.ts
+++ b/cypress/integration/admin/organisations/index.spec.ts
@@ -19,7 +19,8 @@ describe('Listing organisations', () => {
 
                 const professionsForOrganisation = professions.filter(
                   (profession: any) =>
-                    profession.organisation == organisation.name,
+                    profession.organisation == organisation.name &&
+                    profession.confirmed,
                 );
 
                 professionsForOrganisation.forEach((profession: any) => {

--- a/cypress/integration/admin/organisations/show.spec.ts
+++ b/cypress/integration/admin/organisations/show.spec.ts
@@ -24,7 +24,8 @@ describe('Showing organisations', () => {
 
               const professionsForOrganisation = professions.filter(
                 (profession: any) =>
-                  profession.organisation == organisation.name,
+                  profession.organisation == organisation.name &&
+                  profession.confirmed,
               );
 
               professionsForOrganisation.forEach((profession: any) => {

--- a/cypress/integration/organisations/show.spec.ts
+++ b/cypress/integration/organisations/show.spec.ts
@@ -21,7 +21,9 @@ describe('Showing organisations', () => {
         cy.get('body').should('contain', organisation.contactUrl);
 
         const professionsForOrganisation = professions.filter(
-          (profession: any) => profession.organisation == organisation.name,
+          (profession: any) =>
+            profession.organisation == organisation.name &&
+            profession.confirmed,
         );
 
         professionsForOrganisation.forEach((profession: any) => {

--- a/seeds/development/professions.json
+++ b/seeds/development/professions.json
@@ -31,6 +31,7 @@
   },
   {
     "name": "Draft Profession",
+    "organisation": "Department for Education",
     "confirmed": false
   }
 ]

--- a/seeds/staging/professions.json
+++ b/seeds/staging/professions.json
@@ -31,6 +31,7 @@
   },
   {
     "name": "Draft Profession",
+    "organisation": "Department for Education",
     "confirmed": false
   }
 ]

--- a/seeds/test/professions.json
+++ b/seeds/test/professions.json
@@ -31,6 +31,7 @@
   },
   {
     "name": "Draft Profession",
+    "organisation": "Department for Education",
     "confirmed": false
   }
 ]

--- a/src/organisations/organisations.service.spec.ts
+++ b/src/organisations/organisations.service.spec.ts
@@ -91,9 +91,9 @@ describe('OrganisationsService', () => {
   describe('find', () => {
     it('returns an Organisation', async () => {
       const repoSpy = jest.spyOn(repo, 'findOne');
-      const organisations = await service.find('some-uuid');
+      const foundOrganisation = await service.find('some-uuid');
 
-      expect(organisations).toEqual(organisation);
+      expect(foundOrganisation).toEqual(organisation);
       expect(repoSpy).toHaveBeenCalled();
     });
   });
@@ -101,9 +101,9 @@ describe('OrganisationsService', () => {
   describe('findBySlug', () => {
     it('should return an Organisation', async () => {
       const repoSpy = jest.spyOn(repo, 'findOne');
-      const organisation = await service.findBySlug('some-slug');
+      const foundOrganisation = await service.findBySlug('some-slug');
 
-      expect(organisation).toEqual(organisation);
+      expect(foundOrganisation).toEqual(organisation);
       expect(repoSpy).toHaveBeenCalledWith({
         where: { slug: 'some-slug' },
       });
@@ -113,9 +113,9 @@ describe('OrganisationsService', () => {
   describe('findBySlugWithProfessions', () => {
     it('should return an Organisation, populated with Professions', async () => {
       const repoSpy = jest.spyOn(repo, 'findOne');
-      const organisation = await service.findBySlugWithProfessions('some-slug');
+      const foundOrganisation = await service.findBySlugWithProfessions('some-slug');
 
-      expect(organisation).toEqual(organisation);
+      expect(foundOrganisation).toEqual(organisation);
       expect(repoSpy).toHaveBeenCalledWith({
         where: { slug: 'some-slug' },
         relations: ['professions'],

--- a/src/organisations/organisations.service.ts
+++ b/src/organisations/organisations.service.ts
@@ -14,11 +14,15 @@ export class OrganisationsService {
     return this.repository.find({ order: { name: 'ASC' } });
   }
 
-  allWithProfessions(): Promise<Organisation[]> {
-    return this.repository.find({
+  async allWithProfessions(): Promise<Organisation[]> {
+    const organisations = await this.repository.find({
       order: { name: 'ASC' },
       relations: ['professions'],
     });
+
+    return organisations.map((organisation) =>
+      this.filterConfirmedProfessions(organisation),
+    );
   }
 
   find(id: string): Promise<Organisation> {
@@ -31,14 +35,24 @@ export class OrganisationsService {
     });
   }
 
-  findBySlugWithProfessions(slug: string): Promise<Organisation> {
-    return this.repository.findOne({
+  async findBySlugWithProfessions(slug: string): Promise<Organisation> {
+    const organisation = await this.repository.findOne({
       where: { slug },
       relations: ['professions'],
     });
+
+    return this.filterConfirmedProfessions(organisation);
   }
 
   async save(organisation: Organisation): Promise<Organisation> {
     return this.repository.save(organisation);
+  }
+
+  private filterConfirmedProfessions(organisation: Organisation): Organisation {
+    organisation.professions = organisation.professions.filter(
+      (profession) => profession.confirmed,
+    );
+
+    return organisation;
   }
 }


### PR DESCRIPTION
# Changes in this PR

When requesting Organisations with the professions relation from `OrganisationService`, remove unconfirmed Professions. This fixes the issue currently visible on staging, where trying to view a profession with an unconfirmed Profession gives an error