### PR TITLE
Remove ID column from admin professions display

### DIFF
--- a/src/i18n/en/professions.json
+++ b/src/i18n/en/professions.json
@@ -228,7 +228,6 @@
     },
     "tableHeading": {
       "profession": "Profession",
-      "id": "ID",
       "nations": "Nations",
       "lastModified": "Last modified",
       "changedBy": "Changed by",

--- a/src/professions/admin/list-entry.presenter.spec.ts
+++ b/src/professions/admin/list-entry.presenter.spec.ts
@@ -30,7 +30,6 @@ describe('ListEntryPresenter', () => {
 
       const expected: TableRow = [
         { text: 'Example Profession' },
-        { text: 'PLCH0LD3R' },
         {
           text: `${translationOf('nations.scotland')}, ${translationOf(
             'nations.northernIreland',
@@ -76,7 +75,6 @@ describe('ListEntryPresenter', () => {
 
       const expected: TableRow = [
         { text: 'Example Profession' },
-        { text: 'PLCH0LD3R' },
         {
           text: `${translationOf('nations.scotland')}, ${translationOf(
             'nations.northernIreland',
@@ -102,7 +100,6 @@ describe('ListEntryPresenter', () => {
     it('returns a table row of headings when called with `overview`', () => {
       const expected = [
         { text: translationOf('professions.admin.tableHeading.profession') },
-        { text: translationOf('professions.admin.tableHeading.id') },
         { text: translationOf('professions.admin.tableHeading.nations') },
         { text: translationOf('professions.admin.tableHeading.lastModified') },
         { text: translationOf('professions.admin.tableHeading.organisation') },
@@ -119,7 +116,6 @@ describe('ListEntryPresenter', () => {
     it('returns a table row of headings when called with `single-organisation`', () => {
       const expected = [
         { text: translationOf('professions.admin.tableHeading.profession') },
-        { text: translationOf('professions.admin.tableHeading.id') },
         { text: translationOf('professions.admin.tableHeading.nations') },
         { text: translationOf('professions.admin.tableHeading.lastModified') },
         { text: translationOf('professions.admin.tableHeading.changedBy') },

--- a/src/professions/admin/list-entry.presenter.spec.ts
+++ b/src/professions/admin/list-entry.presenter.spec.ts
@@ -1,63 +1,53 @@
-import { DeepMocked } from '@golevelup/ts-jest';
-import { I18nService } from 'nestjs-i18n';
 import { createMockI18nService } from '../../testutils/create-mock-i18n-service';
 import { TableRow } from '../../common/interfaces/table-row';
 import { ListEntryPresenter } from './list-entry.presenter';
 import industryFactory from '../../testutils/factories/industry';
 import organisationFactory from '../../testutils/factories/organisation';
 import professionFactory from '../../testutils/factories/profession';
+import { translationOf } from '../../testutils/translation-of';
 
 describe('ListEntryPresenter', () => {
-  let i18nService: DeepMocked<I18nService>;
-
-  let presenter: ListEntryPresenter;
-
-  beforeEach(() => {
-    i18nService = createMockI18nService({
-      'nations.scotland': 'Scotland',
-      'nations.northernIreland': 'Northern Ireland',
-      'industries.law': 'Law',
-      'industries.finance': 'Finance',
-      'professions.admin.status.published': 'Published',
-      'professions.admin.viewDetails': 'View details',
-      'professions.admin.tableHeading.profession': 'Profession',
-      'professions.admin.tableHeading.id': 'ID',
-      'professions.admin.tableHeading.nations': 'Nations',
-      'professions.admin.tableHeading.lastModified': 'Last modified',
-      'professions.admin.tableHeading.changedBy': 'Changed by',
-      'professions.admin.tableHeading.organisation': 'Regulators',
-      'professions.admin.tableHeading.industry': 'Industry / sector',
-      'professions.admin.tableHeading.status': 'Status',
-      'professions.admin.tableHeading.actions': 'Actions',
-    });
-
-    const profession = professionFactory.build({
-      name: 'Example Profession',
-      slug: 'example-profession',
-      occupationLocations: ['GB-SCT', 'GB-NIR'],
-      organisation: organisationFactory.build({ name: 'Example Organisation' }),
-      industries: [
-        industryFactory.build({ name: 'industries.law' }),
-        industryFactory.build({ name: 'industries.finance' }),
-      ],
-      updated_at: new Date(2003, 7, 12),
-    });
-
-    presenter = new ListEntryPresenter(profession, i18nService);
-  });
-
   describe('tableRow', () => {
     it('returns a table row when called with `overview`', () => {
+      const profession = professionFactory.build({
+        name: 'Example Profession',
+        slug: 'example-profession',
+        occupationLocations: ['GB-SCT', 'GB-NIR'],
+        organisation: organisationFactory.build({
+          name: 'Example Organisation',
+        }),
+        industries: [
+          industryFactory.build({ name: 'industries.law' }),
+          industryFactory.build({ name: 'industries.finance' }),
+        ],
+        updated_at: new Date(2003, 7, 12),
+      });
+
+      const presenter = new ListEntryPresenter(
+        profession,
+        createMockI18nService(),
+      );
+
       const expected: TableRow = [
         { text: 'Example Profession' },
         { text: 'PLCH0LD3R' },
-        { text: 'Scotland, Northern Ireland' },
+        {
+          text: `${translationOf('nations.scotland')}, ${translationOf(
+            'nations.northernIreland',
+          )}`,
+        },
         { text: '12-08-2003' },
         { text: 'Example Organisation' },
-        { text: 'Law, Finance' },
-        { text: 'Published' },
         {
-          html: '<a href="/admin/professions/example-profession">View details</a>',
+          text: `${translationOf('industries.law')}, ${translationOf(
+            'industries.finance',
+          )}`,
+        },
+        { text: translationOf('professions.admin.status.published') },
+        {
+          html: `<a href="/admin/professions/example-profession">${translationOf(
+            'professions.admin.viewDetails',
+          )}</a>`,
         },
       ];
 
@@ -65,15 +55,40 @@ describe('ListEntryPresenter', () => {
     });
 
     it('returns a table row when called with `single-organisation`', () => {
+      const profession = professionFactory.build({
+        name: 'Example Profession',
+        slug: 'example-profession',
+        occupationLocations: ['GB-SCT', 'GB-NIR'],
+        organisation: organisationFactory.build({
+          name: 'Example Organisation',
+        }),
+        industries: [
+          industryFactory.build({ name: 'industries.law' }),
+          industryFactory.build({ name: 'industries.finance' }),
+        ],
+        updated_at: new Date(2003, 7, 12),
+      });
+
+      const presenter = new ListEntryPresenter(
+        profession,
+        createMockI18nService(),
+      );
+
       const expected: TableRow = [
         { text: 'Example Profession' },
         { text: 'PLCH0LD3R' },
-        { text: 'Scotland, Northern Ireland' },
+        {
+          text: `${translationOf('nations.scotland')}, ${translationOf(
+            'nations.northernIreland',
+          )}`,
+        },
         { text: '12-08-2003' },
         { text: 'Placeholder name' },
-        { text: 'Published' },
+        { text: translationOf('professions.admin.status.published') },
         {
-          html: '<a href="/admin/professions/example-profession">View details</a>',
+          html: `<a href="/admin/professions/example-profession">${translationOf(
+            'professions.admin.viewDetails',
+          )}</a>`,
         },
       ];
 
@@ -86,34 +101,37 @@ describe('ListEntryPresenter', () => {
   describe('headers', () => {
     it('returns a table row of headings when called with `overview`', () => {
       const expected = [
-        { text: 'Profession' },
-        { text: 'ID' },
-        { text: 'Nations' },
-        { text: 'Last modified' },
-        { text: 'Regulators' },
-        { text: 'Industry / sector' },
-        { text: 'Status' },
-        { text: 'Actions' },
+        { text: translationOf('professions.admin.tableHeading.profession') },
+        { text: translationOf('professions.admin.tableHeading.id') },
+        { text: translationOf('professions.admin.tableHeading.nations') },
+        { text: translationOf('professions.admin.tableHeading.lastModified') },
+        { text: translationOf('professions.admin.tableHeading.organisation') },
+        { text: translationOf('professions.admin.tableHeading.industry') },
+        { text: translationOf('professions.admin.tableHeading.status') },
+        { text: translationOf('professions.admin.tableHeading.actions') },
       ];
 
       expect(
-        ListEntryPresenter.headings(i18nService, 'overview'),
+        ListEntryPresenter.headings(createMockI18nService(), 'overview'),
       ).resolves.toEqual(expected);
     });
 
     it('returns a table row of headings when called with `single-organisation`', () => {
       const expected = [
-        { text: 'Profession' },
-        { text: 'ID' },
-        { text: 'Nations' },
-        { text: 'Last modified' },
-        { text: 'Changed by' },
-        { text: 'Status' },
-        { text: 'Actions' },
+        { text: translationOf('professions.admin.tableHeading.profession') },
+        { text: translationOf('professions.admin.tableHeading.id') },
+        { text: translationOf('professions.admin.tableHeading.nations') },
+        { text: translationOf('professions.admin.tableHeading.lastModified') },
+        { text: translationOf('professions.admin.tableHeading.changedBy') },
+        { text: translationOf('professions.admin.tableHeading.status') },
+        { text: translationOf('professions.admin.tableHeading.actions') },
       ];
 
       expect(
-        ListEntryPresenter.headings(i18nService, 'single-organisation'),
+        ListEntryPresenter.headings(
+          createMockI18nService(),
+          'single-organisation',
+        ),
       ).resolves.toEqual(expected);
     });
   });

--- a/src/professions/admin/list-entry.presenter.ts
+++ b/src/professions/admin/list-entry.presenter.ts
@@ -9,7 +9,6 @@ import { ProfessionsPresenterView } from './professions.presenter';
 
 type Field =
   | 'profession'
-  | 'id'
   | 'nations'
   | 'lastModified'
   | 'changedBy'
@@ -21,7 +20,6 @@ type Field =
 const fields = {
   overview: [
     'profession',
-    'id',
     'nations',
     'lastModified',
     'organisation',
@@ -31,7 +29,6 @@ const fields = {
   ],
   'single-organisation': [
     'profession',
-    'id',
     'nations',
     'lastModified',
     'changedBy',
@@ -85,7 +82,6 @@ export class ListEntryPresenter {
 
     const entries: { [K in Field]: TableCell } = {
       profession: { text: this.profession.name },
-      id: { text: 'PLCH0LD3R' },
       nations: { text: nations },
       lastModified: { text: formatDate(this.profession.updated_at) },
       changedBy: { text: 'Placeholder name' },

--- a/src/testutils/create-mock-i18n-service.ts
+++ b/src/testutils/create-mock-i18n-service.ts
@@ -1,5 +1,6 @@
 import { createMock, DeepMocked } from '@golevelup/ts-jest';
 import { I18nService } from 'nestjs-i18n';
+import { translationOf } from './translation-of';
 
 export function createMockI18nService(
   transations: {
@@ -9,7 +10,7 @@ export function createMockI18nService(
   const mock = createMock<I18nService>();
 
   mock.translate.mockImplementation(async (text: string) => {
-    return transations[text] || `Translation of \`${text}\``;
+    return transations[text] || translationOf(text);
   });
 
   return mock;

--- a/src/testutils/translation-of.ts
+++ b/src/testutils/translation-of.ts
@@ -1,0 +1,3 @@
+export function translationOf(text: string): string {
+  return `Translation of \`${text}\``;
+}


### PR DESCRIPTION
# Changes in this PR

Remove ID column from admin professions display

## Screenshots of UI changes

### Before

![localhost_3000_admin_professions](https://user-images.githubusercontent.com/94137563/150187101-ad8230d4-0138-4ddc-a755-ffb328493f01.png)

### After

![localhost_3000_admin_professions](https://user-images.githubusercontent.com/94137563/150187032-85965764-4697-4e1e-9f39-1a88fe55538d.png)

