### PR TITLE
Move methods to obtain qualification translations

### DIFF
--- a/cypress/integration/admin/professions/add-a-profession.spec.ts
+++ b/cypress/integration/admin/professions/add-a-profession.spec.ts
@@ -148,7 +148,7 @@ describe('Adding a new profession', () => {
       cy.get('body').should('contain', 'An example Qualification level');
       cy.get('body').should('contain', 'Another method');
       cy.translate(
-        'professions.form.radioButtons.methodsToObtainQualification.generalSecondaryEducation',
+        'professions.methodsToObtainQualification.generalSecondaryEducation',
       ).then((method) => {
         cy.get('body').should('contain', method);
       });

--- a/cypress/integration/professions/show.spec.ts
+++ b/cypress/integration/professions/show.spec.ts
@@ -50,7 +50,7 @@ describe('Showing a profession', () => {
       'DSE - Diploma (post-secondary education), including Annex II (ex 92/51, Annex C,D) , Art. 11 c',
     );
     cy.translate(
-      'professions.form.radioButtons.methodsToObtainQualification.generalSecondaryEducation',
+      'professions.methodsToObtainQualification.generalSecondaryEducation',
     ).then((method) => {
       cy.checkSummaryListRowValue(
         'professions.show.qualification.methods',
@@ -59,7 +59,7 @@ describe('Showing a profession', () => {
     });
 
     cy.translate(
-      'professions.form.radioButtons.methodsToObtainQualification.generalSecondaryEducation',
+      'professions.methodsToObtainQualification.generalSecondaryEducation',
     ).then((method) => {
       cy.checkSummaryListRowValue(
         'professions.show.qualification.commonPath',

--- a/src/i18n/en/professions.json
+++ b/src/i18n/en/professions.json
@@ -56,15 +56,6 @@
         "mandatory": "Mandatory",
         "voluntary": "Voluntary",
         "unknown": "Unknown"
-      },
-      "methodsToObtainQualification": {
-        "generalSecondaryEducation": "General secondary education",
-        "generalOrVocationalPostSecondaryEducation": "General or vocational post-secondary education",
-        "generalPostSecondaryEducationMandatoryVocational": "General post-secondary education incorporating mandatory vocational content",
-        "vocationalPostSecondaryEducation": "Vocational post-secondary education level",
-        "degreeLevel": "Degree level education in an approved education institution",
-        "others": "Others",
-        "otherHint": "Please provide the methods to obtain the qualification"
       }
     },
     "checkboxes": {
@@ -178,6 +169,15 @@
       "nationalLegislation": "National legislation",
       "legislationLink": "Legislation link"
     }
+  },
+  "methodsToObtainQualification": {
+    "generalSecondaryEducation": "General secondary education",
+    "generalOrVocationalPostSecondaryEducation": "General or vocational post-secondary education",
+    "generalPostSecondaryEducationMandatoryVocational": "General post-secondary education incorporating mandatory vocational content",
+    "vocationalPostSecondaryEducation": "Vocational post-secondary education level",
+    "degreeLevel": "Degree level education in an approved education institution",
+    "others": "Others",
+    "otherHint": "Please provide the methods to obtain the qualification"
   },
   "mandatoryRegistration": {
     "mandatory": "Mandatory",

--- a/src/professions/admin/method-to-obtain-qualification-radio-buttons.presenter.spec.ts
+++ b/src/professions/admin/method-to-obtain-qualification-radio-buttons.presenter.spec.ts
@@ -24,42 +24,42 @@ describe(MethodToObtainQualificationRadioButtonsPresenter, () => {
         presenter.radioButtonArgs('methodToObtainQualification'),
       ).resolves.toEqual([
         {
-          text: 'Translation of `professions.form.radioButtons.methodsToObtainQualification.generalSecondaryEducation`',
+          text: 'Translation of `professions.methodsToObtainQualification.generalSecondaryEducation`',
           value: MethodToObtain.GeneralSecondaryEducation,
           checked: false,
           conditional: null,
         },
         {
-          text: 'Translation of `professions.form.radioButtons.methodsToObtainQualification.generalOrVocationalPostSecondaryEducation`',
+          text: 'Translation of `professions.methodsToObtainQualification.generalOrVocationalPostSecondaryEducation`',
           value: MethodToObtain.GeneralOrVocationalPostSecondaryEducation,
           checked: false,
           conditional: null,
         },
         {
-          text: 'Translation of `professions.form.radioButtons.methodsToObtainQualification.generalPostSecondaryEducationMandatoryVocational`',
+          text: 'Translation of `professions.methodsToObtainQualification.generalPostSecondaryEducationMandatoryVocational`',
           value:
             MethodToObtain.GeneralPostSecondaryEducationMandatoryVocational,
           checked: false,
           conditional: null,
         },
         {
-          text: 'Translation of `professions.form.radioButtons.methodsToObtainQualification.vocationalPostSecondaryEducation`',
+          text: 'Translation of `professions.methodsToObtainQualification.vocationalPostSecondaryEducation`',
           value: MethodToObtain.VocationalPostSecondaryEducation,
           checked: false,
           conditional: null,
         },
         {
-          text: 'Translation of `professions.form.radioButtons.methodsToObtainQualification.degreeLevel`',
+          text: 'Translation of `professions.methodsToObtainQualification.degreeLevel`',
           value: MethodToObtain.DegreeLevel,
           checked: false,
           conditional: null,
         },
         {
-          text: 'Translation of `professions.form.radioButtons.methodsToObtainQualification.others`',
+          text: 'Translation of `professions.methodsToObtainQualification.others`',
           value: MethodToObtain.Others,
           checked: false,
           conditional: {
-            html: `<div class="govuk-form-group"><div id="methodToObtainQualification-hint" class="govuk-hint">Translation of \`professions.form.radioButtons.methodsToObtainQualification.otherHint\`</div><textarea class="govuk-textarea" id="otherMethodToObtainQualification" rows="5" name="otherMethodToObtainQualification"></textarea></div>`,
+            html: `<div class="govuk-form-group"><div id="methodToObtainQualification-hint" class="govuk-hint">Translation of \`professions.methodsToObtainQualification.otherHint\`</div><textarea class="govuk-textarea" id="otherMethodToObtainQualification" rows="5" name="otherMethodToObtainQualification"></textarea></div>`,
           },
         },
       ]);
@@ -77,42 +77,42 @@ describe(MethodToObtainQualificationRadioButtonsPresenter, () => {
         presenter.radioButtonArgs('methodToObtainQualification'),
       ).resolves.toEqual([
         {
-          text: 'Translation of `professions.form.radioButtons.methodsToObtainQualification.generalSecondaryEducation`',
+          text: 'Translation of `professions.methodsToObtainQualification.generalSecondaryEducation`',
           value: MethodToObtain.GeneralSecondaryEducation,
           checked: false,
           conditional: null,
         },
         {
-          text: 'Translation of `professions.form.radioButtons.methodsToObtainQualification.generalOrVocationalPostSecondaryEducation`',
+          text: 'Translation of `professions.methodsToObtainQualification.generalOrVocationalPostSecondaryEducation`',
           value: MethodToObtain.GeneralOrVocationalPostSecondaryEducation,
           checked: false,
           conditional: null,
         },
         {
-          text: 'Translation of `professions.form.radioButtons.methodsToObtainQualification.generalPostSecondaryEducationMandatoryVocational`',
+          text: 'Translation of `professions.methodsToObtainQualification.generalPostSecondaryEducationMandatoryVocational`',
           value:
             MethodToObtain.GeneralPostSecondaryEducationMandatoryVocational,
           checked: false,
           conditional: null,
         },
         {
-          text: 'Translation of `professions.form.radioButtons.methodsToObtainQualification.vocationalPostSecondaryEducation`',
+          text: 'Translation of `professions.methodsToObtainQualification.vocationalPostSecondaryEducation`',
           value: MethodToObtain.VocationalPostSecondaryEducation,
           checked: false,
           conditional: null,
         },
         {
-          text: 'Translation of `professions.form.radioButtons.methodsToObtainQualification.degreeLevel`',
+          text: 'Translation of `professions.methodsToObtainQualification.degreeLevel`',
           value: MethodToObtain.DegreeLevel,
           checked: true,
           conditional: null,
         },
         {
-          text: 'Translation of `professions.form.radioButtons.methodsToObtainQualification.others`',
+          text: 'Translation of `professions.methodsToObtainQualification.others`',
           value: MethodToObtain.Others,
           checked: false,
           conditional: {
-            html: `<div class="govuk-form-group"><div id="methodToObtainQualification-hint" class="govuk-hint">Translation of \`professions.form.radioButtons.methodsToObtainQualification.otherHint\`</div><textarea class="govuk-textarea" id="otherMethodToObtainQualification" rows="5" name="otherMethodToObtainQualification"></textarea></div>`,
+            html: `<div class="govuk-form-group"><div id="methodToObtainQualification-hint" class="govuk-hint">Translation of \`professions.methodsToObtainQualification.otherHint\`</div><textarea class="govuk-textarea" id="otherMethodToObtainQualification" rows="5" name="otherMethodToObtainQualification"></textarea></div>`,
           },
         },
       ]);
@@ -133,10 +133,10 @@ describe(MethodToObtainQualificationRadioButtonsPresenter, () => {
             presenter.radioButtonArgs('methodToObtainQualification'),
           ).resolves.toContainEqual({
             value: MethodToObtain.Others,
-            text: 'Translation of `professions.form.radioButtons.methodsToObtainQualification.others`',
+            text: 'Translation of `professions.methodsToObtainQualification.others`',
             checked: true,
             conditional: {
-              html: `<div class="govuk-form-group"><div id="methodToObtainQualification-hint" class="govuk-hint">Translation of \`professions.form.radioButtons.methodsToObtainQualification.otherHint\`</div><textarea class="govuk-textarea" id="otherMethodToObtainQualification" rows="5" name="otherMethodToObtainQualification">Another method for obtaining the qualification</textarea></div>`,
+              html: `<div class="govuk-form-group"><div id="methodToObtainQualification-hint" class="govuk-hint">Translation of \`professions.methodsToObtainQualification.otherHint\`</div><textarea class="govuk-textarea" id="otherMethodToObtainQualification" rows="5" name="otherMethodToObtainQualification">Another method for obtaining the qualification</textarea></div>`,
             },
           });
         });
@@ -167,10 +167,10 @@ describe(MethodToObtainQualificationRadioButtonsPresenter, () => {
             presenter.radioButtonArgs('methodToObtainQualification'),
           ).resolves.toContainEqual({
             value: MethodToObtain.Others,
-            text: 'Translation of `professions.form.radioButtons.methodsToObtainQualification.others`',
+            text: 'Translation of `professions.methodsToObtainQualification.others`',
             checked: true,
             conditional: {
-              html: `<div class="govuk-form-group ${expectedErrorFormClass}"><div id="methodToObtainQualification-hint" class="govuk-hint">Translation of \`professions.form.radioButtons.methodsToObtainQualification.otherHint\`</div>${expectedErrorParagraph}<textarea class="govuk-textarea" id="otherMethodToObtainQualification" rows="5" name="otherMethodToObtainQualification"></textarea></div>`,
+              html: `<div class="govuk-form-group ${expectedErrorFormClass}"><div id="methodToObtainQualification-hint" class="govuk-hint">Translation of \`professions.methodsToObtainQualification.otherHint\`</div>${expectedErrorParagraph}<textarea class="govuk-textarea" id="otherMethodToObtainQualification" rows="5" name="otherMethodToObtainQualification"></textarea></div>`,
             },
           });
         });

--- a/src/professions/admin/method-to-obtain-qualification-radio-buttons.presenter.ts
+++ b/src/professions/admin/method-to-obtain-qualification-radio-buttons.presenter.ts
@@ -15,7 +15,7 @@ export class MethodToObtainQualificationRadioButtonsPresenter {
       Object.values(MethodToObtain).map(async (method) => ({
         value: method,
         text: await this.i18nService.translate(
-          `professions.form.radioButtons.methodsToObtainQualification.${method}`,
+          `professions.methodsToObtainQualification.${method}`,
         ),
         checked: this.methodToObtain === method,
         conditional: await this.otherMethodTextAreaHTML(
@@ -43,7 +43,7 @@ export class MethodToObtainQualificationRadioButtonsPresenter {
     }`;
 
     const hintHTML = `<div id="${name}-hint" class="govuk-hint">${await this.i18nService.translate(
-      'professions.form.radioButtons.methodsToObtainQualification.otherHint',
+      'professions.methodsToObtainQualification.otherHint',
     )}</div>`;
 
     const errorMessageHTML = await this.errorMessageHTML(

--- a/src/qualifications/presenters/qualification.presenter.spec.ts
+++ b/src/qualifications/presenters/qualification.presenter.spec.ts
@@ -27,7 +27,7 @@ describe(QualificationPresenter, () => {
         const presenter = new QualificationPresenter(qualification);
 
         expect(presenter.methodToObtainQualification).toEqual(
-          'professions.form.radioButtons.methodsToObtainQualification.degreeLevel',
+          'professions.methodsToObtainQualification.degreeLevel',
         );
       });
     });
@@ -59,7 +59,7 @@ describe(QualificationPresenter, () => {
         const presenter = new QualificationPresenter(qualification);
 
         expect(presenter.mostCommonPathToObtainQualification).toEqual(
-          'professions.form.radioButtons.methodsToObtainQualification.degreeLevel',
+          'professions.methodsToObtainQualification.degreeLevel',
         );
       });
     });

--- a/src/qualifications/presenters/qualification.presenter.ts
+++ b/src/qualifications/presenters/qualification.presenter.ts
@@ -8,12 +8,12 @@ export default class QualificationPresenter {
   readonly methodToObtainQualification: string =
     this.qualification.methodToObtain === MethodToObtain.Others
       ? this.qualification.otherMethodToObtain
-      : `professions.form.radioButtons.methodsToObtainQualification.${this.qualification.methodToObtain}`;
+      : `professions.methodsToObtainQualification.${this.qualification.methodToObtain}`;
 
   readonly mostCommonPathToObtainQualification: string =
     this.qualification.commonPathToObtain === MethodToObtain.Others
       ? this.qualification.otherCommonPathToObtain
-      : `professions.form.radioButtons.methodsToObtainQualification.${this.qualification.commonPathToObtain}`;
+      : `professions.methodsToObtainQualification.${this.qualification.commonPathToObtain}`;
 
   readonly duration = this.qualification.educationDuration;
 


### PR DESCRIPTION
A small tweak, cleanup of #128. Methods to obtain qualifications don't need to be nested under `radioButtons` as they're used outside of the radio buttons e.g. on the show Profession page.

