### PR TITLE
(2035) Link to internal professions page from internal organisations page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Require users to be logged in to be able to add a profession
 - Change roles to permissions
 - Update entities on seed, rather than replacing them
+- Take users from internal organisations page to internal profession page via link, rather than to public-facing page
 
 ## [release-001] - 2022-01-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add public-facing Regulatory Authority pages
 - Allow Professions to be edited
 - Display real data on "view profession" pages
+- Add back link from internal professions page to index page
 
 ### Changed
 

--- a/cypress/integration/admin/organisations/show.spec.ts
+++ b/cypress/integration/admin/organisations/show.spec.ts
@@ -5,7 +5,7 @@ describe('Showing organisations', () => {
       cy.visit('/admin');
     });
 
-    it('Shows the detail of an organisation', () => {
+    it('Shows the detail of an organisation, with its professions and a link to the admin profession page', () => {
       cy.get('a').contains('Regulatory authorities').click();
 
       cy.readFile('./seeds/test/professions.json').then((professions) => {
@@ -31,6 +31,9 @@ describe('Showing organisations', () => {
               professionsForOrganisation.forEach((profession: any) => {
                 cy.should('contain', profession.name);
               });
+
+              cy.contains(professionsForOrganisation[0].name).click();
+              cy.get('body').should('contain', 'Edit this profession');
             });
         });
       });

--- a/cypress/integration/organisations/show.spec.ts
+++ b/cypress/integration/organisations/show.spec.ts
@@ -9,7 +9,7 @@ describe('Showing organisations', () => {
     );
   });
 
-  it('Shows the detail of an organisation', () => {
+  it('Shows the detail of an organisation, with its professions and a link to the public-facing profession page', () => {
     cy.readFile('./seeds/test/professions.json').then((professions) => {
       cy.readFile('./seeds/test/organisations.json').then((organisations) => {
         const organisation = organisations[0];
@@ -29,6 +29,9 @@ describe('Showing organisations', () => {
         professionsForOrganisation.forEach((profession: any) => {
           cy.should('contain', profession.name);
         });
+
+        cy.contains(professionsForOrganisation[0].name).click();
+        cy.get('body').should('not.contain', 'Edit this profession');
       });
     });
   });

--- a/src/professions/admin/professions.controller.spec.ts
+++ b/src/professions/admin/professions.controller.spec.ts
@@ -344,7 +344,7 @@ describe('ProfessionsController', () => {
         qualification: new QualificationPresenter(profession.qualification),
         nations: ['Translation of `nations.england`'],
         industries: ['Translation of `industries.example`'],
-        backLink: '',
+        backLink: '/admin/professions',
       });
 
       expect(professionsService.findBySlug).toHaveBeenCalledWith(

--- a/src/professions/admin/professions.controller.ts
+++ b/src/professions/admin/professions.controller.ts
@@ -90,7 +90,7 @@ export class ProfessionsController {
       qualification: new QualificationPresenter(profession.qualification),
       nations,
       industries,
-      backLink: '',
+      backLink: '/admin/professions',
     };
   }
 

--- a/views/admin/organisations/show.njk
+++ b/views/admin/organisations/show.njk
@@ -15,6 +15,7 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
+      {% set professionPagePrefix = "admin/professions"%}
       {% include "../../organisations/shared/_organisation.njk" %}
     </div>
     <div class="govuk-grid-column-one-third">

--- a/views/admin/professions/show.njk
+++ b/views/admin/professions/show.njk
@@ -9,7 +9,7 @@
 <div class="govuk-width-container">
   {{ govukBackLink({
     text: ("app.back" | t),
-    href: backUrl
+    href: backLink
   }) }}
 
   <main class="govuk-main-wrapper">

--- a/views/organisations/shared/_organisation.njk
+++ b/views/organisations/shared/_organisation.njk
@@ -11,7 +11,7 @@
 {% for profession in professions %}
   <div class="rpr-listing__ra-container">
     <h3>
-      <a class="govuk-link govuk-heading-m rpr-listing__profession-title" class="govuk-link" href="/professions/{{ profession.slug }}">
+      <a class="govuk-link govuk-heading-m rpr-listing__profession-title" class="govuk-link" href="/{{professionPagePrefix}}/{{ profession.slug }}">
         {{ profession.name }}
       </a>
     </h3>

--- a/views/organisations/show.njk
+++ b/views/organisations/show.njk
@@ -13,6 +13,7 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
+    {% set professionPagePrefix = "professions"%}
       {% include "./shared/_organisation.njk" %}
     </div>
     <div class="govuk-grid-column-one-third">


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR

- Make Profession link from `admin/organisation/:slug` take users to `admin/profession/:slug` rather than public-facing profession page.
- Add back link to internal `admin/profession/:slug` page to take users to index page
