### PR TITLE
(1977) Move back button to under phase banner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Change roles to permissions
 - Update entities on seed, rather than replacing them
 - Take users from internal organisations page to internal profession page via link, rather than to public-facing page
+- Move back link to under phase banner
 
 ## [release-001] - 2022-01-10
 

--- a/src/common/back-link.interceptor.spec.ts
+++ b/src/common/back-link.interceptor.spec.ts
@@ -1,0 +1,88 @@
+import { ExecutionContext, CallHandler } from '@nestjs/common';
+import { BackLinkInterceptor } from './back-link.interceptor';
+import { createMock, DeepMocked } from '@golevelup/ts-jest';
+import { of } from 'rxjs';
+
+describe('BackLinkInterceptor', () => {
+  let context: DeepMocked<ExecutionContext>;
+  let next: DeepMocked<CallHandler>;
+
+  beforeEach(() => {
+    data = { foo: 'bar' };
+    context = createMock<ExecutionContext>();
+    next = createMock<CallHandler>({
+      handle: jest.fn(() => of(data)),
+    });
+  });
+
+  it('should add the backLink to the call handler', () => {
+    const backLink = '/foo/bar';
+    const interceptor = new BackLinkInterceptor(backLink);
+
+    const response = interceptor.intercept(context, next);
+
+    response.subscribe({
+      next: (value) => {
+        expect(value).toEqual({ ...data, backLink: backLink });
+      },
+    });
+  });
+
+  describe('when there are params specified', () => {
+    beforeEach(() => {
+      context = createMock<ExecutionContext>({
+        switchToHttp: () => ({
+          getRequest: () => {
+            return {
+              params: {
+                baz: 'boo',
+                id: 123,
+              },
+            };
+          },
+        }),
+      });
+    });
+
+    it('replace placeholders with params', () => {
+      const backLink = '/foo/bar/:baz';
+      const interceptor = new BackLinkInterceptor(backLink);
+
+      const response = interceptor.intercept(context, next);
+
+      response.subscribe({
+        next: (value) => {
+          expect(value).toEqual({ ...data, backLink: '/foo/bar/boo' });
+        },
+      });
+    });
+
+    it('should ignore non-existent params', () => {
+      const backLink = '/foo/bar/:biff';
+
+      const interceptor = new BackLinkInterceptor(backLink);
+
+      const response = interceptor.intercept(context, next);
+
+      response.subscribe({
+        next: (value) => {
+          expect(value).toEqual({ ...data, backLink: backLink });
+        },
+      });
+    });
+
+    it('should use multiple params', () => {
+      const backLink = '/foo/:id/:baz';
+
+      const interceptor = new BackLinkInterceptor(backLink);
+
+      const response = interceptor.intercept(context, next);
+
+      response.subscribe({
+        next: (value) => {
+          expect(value).toEqual({ ...data, backLink: '/foo/123/boo' });
+        },
+      });
+    });
+  });
+});

--- a/src/common/back-link.interceptor.spec.ts
+++ b/src/common/back-link.interceptor.spec.ts
@@ -1,87 +1,114 @@
 import { ExecutionContext, CallHandler } from '@nestjs/common';
 import { BackLinkInterceptor } from './back-link.interceptor';
 import { createMock, DeepMocked } from '@golevelup/ts-jest';
-import { of } from 'rxjs';
+import { Request, Response } from 'express';
 
 describe('BackLinkInterceptor', () => {
   let context: DeepMocked<ExecutionContext>;
   let next: DeepMocked<CallHandler>;
+  let request: DeepMocked<Request>;
+  let response: DeepMocked<Response>;
 
   beforeEach(() => {
-    data = { foo: 'bar' };
-    context = createMock<ExecutionContext>();
-    next = createMock<CallHandler>({
-      handle: jest.fn(() => of(data)),
+    next = createMock<CallHandler>();
+    request = createMock<Request>();
+    response = createMock<Response>();
+
+    context = createMock<ExecutionContext>({
+      switchToHttp: () => ({
+        getRequest: () => request,
+        getResponse: () => response,
+      }),
     });
   });
 
-  it('should add the backLink to the call handler', () => {
-    const backLink = '/foo/bar';
-    const interceptor = new BackLinkInterceptor(backLink);
+  describe('when the argument is a string', () => {
+    it('should add the backLink to the call handler', () => {
+      const backLink = '/foo/bar';
+      const interceptor = new BackLinkInterceptor(backLink);
 
-    const response = interceptor.intercept(context, next);
+      interceptor.intercept(context, next);
 
-    response.subscribe({
-      next: (value) => {
-        expect(value).toEqual({ ...data, backLink: backLink });
-      },
+      expect(response.locals.backLink).toEqual(backLink);
     });
-  });
 
-  describe('when there are params specified', () => {
-    beforeEach(() => {
-      context = createMock<ExecutionContext>({
-        switchToHttp: () => ({
-          getRequest: () => {
-            return {
-              params: {
-                baz: 'boo',
-                id: 123,
-              },
-            };
+    describe('when there are params specified', () => {
+      beforeEach(() => {
+        request = createMock<Request>({
+          params: {
+            baz: 'boo',
+            id: '123',
           },
-        }),
+        });
+      });
+
+      it('should replace placeholders with params', () => {
+        const backLink = '/foo/bar/:baz';
+        const interceptor = new BackLinkInterceptor(backLink);
+
+        interceptor.intercept(context, next);
+
+        expect(response.locals.backLink).toEqual('/foo/bar/boo');
+      });
+
+      it('should ignore non-existent params', () => {
+        const backLink = '/foo/bar/:biff';
+
+        const interceptor = new BackLinkInterceptor(backLink);
+
+        interceptor.intercept(context, next);
+
+        expect(response.locals.backLink).toEqual(backLink);
+      });
+
+      it('should use multiple params', () => {
+        const backLink = '/foo/:id/:baz';
+
+        const interceptor = new BackLinkInterceptor(backLink);
+
+        interceptor.intercept(context, next);
+
+        expect(response.locals.backLink).toEqual('/foo/123/boo');
+      });
+    });
+  });
+
+  describe('when the argument is a function', () => {
+    const generator = (request: Request) =>
+      request.params.foo === 'bar' ? '/foo' : '/foo/:id';
+    const interceptor = new BackLinkInterceptor(generator);
+
+    describe('when the generator conditional is true', () => {
+      beforeEach(() => {
+        request = createMock<Request>({
+          params: {
+            foo: 'bar',
+            id: '123',
+          },
+        });
+      });
+
+      it('should generate a backlink depending on the params', () => {
+        interceptor.intercept(context, next);
+
+        expect(response.locals.backLink).toEqual('/foo');
       });
     });
 
-    it('replace placeholders with params', () => {
-      const backLink = '/foo/bar/:baz';
-      const interceptor = new BackLinkInterceptor(backLink);
-
-      const response = interceptor.intercept(context, next);
-
-      response.subscribe({
-        next: (value) => {
-          expect(value).toEqual({ ...data, backLink: '/foo/bar/boo' });
-        },
+    describe('when the generator conditional is false', () => {
+      beforeEach(() => {
+        request = createMock<Request>({
+          params: {
+            foo: 'baz',
+            id: '123',
+          },
+        });
       });
-    });
 
-    it('should ignore non-existent params', () => {
-      const backLink = '/foo/bar/:biff';
+      it('should generate a backlink depending on the params', () => {
+        interceptor.intercept(context, next);
 
-      const interceptor = new BackLinkInterceptor(backLink);
-
-      const response = interceptor.intercept(context, next);
-
-      response.subscribe({
-        next: (value) => {
-          expect(value).toEqual({ ...data, backLink: backLink });
-        },
-      });
-    });
-
-    it('should use multiple params', () => {
-      const backLink = '/foo/:id/:baz';
-
-      const interceptor = new BackLinkInterceptor(backLink);
-
-      const response = interceptor.intercept(context, next);
-
-      response.subscribe({
-        next: (value) => {
-          expect(value).toEqual({ ...data, backLink: '/foo/123/boo' });
-        },
+        expect(response.locals.backLink).toEqual('/foo/123');
       });
     });
   });

--- a/src/common/back-link.interceptor.ts
+++ b/src/common/back-link.interceptor.ts
@@ -1,0 +1,47 @@
+import {
+  Injectable,
+  NestInterceptor,
+  ExecutionContext,
+  CallHandler,
+} from '@nestjs/common';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+import { Request } from 'express';
+
+export interface Response<T> {
+  data: T;
+}
+
+@Injectable()
+export class BackLinkInterceptor<T> implements NestInterceptor<T, Response<T>> {
+  constructor(private readonly backLink: string) {}
+
+  intercept(
+    context: ExecutionContext,
+    next: CallHandler,
+  ): Observable<Response<T>> {
+    const request = context.switchToHttp().getRequest();
+
+    return next
+      .handle()
+      .pipe(
+        map((data) => ({ ...data, backLink: this.generateBackLink(request) })),
+      );
+  }
+
+  private generateBackLink(request: Request) {
+    const regexp = new RegExp(':([a-z]+)', 'g');
+    const matches = [...this.backLink.matchAll(regexp)];
+
+    let backLink = this.backLink;
+
+    matches.forEach((match) => {
+      const key = match[1];
+      if (request.params[key]) {
+        backLink = backLink.replace(`:${key}`, request.params[key]);
+      }
+    });
+
+    return backLink;
+  }
+}

--- a/src/common/decorators/back-link.decorator.ts
+++ b/src/common/decorators/back-link.decorator.ts
@@ -1,5 +1,5 @@
 import { UseInterceptors } from '@nestjs/common';
-import { BackLinkInterceptor } from '../back-link.interceptor';
+import { BackLinkInterceptor, Generator } from '../back-link.interceptor';
 
-export const BackLink = (backLink: string) =>
-  UseInterceptors(new BackLinkInterceptor(backLink));
+export const BackLink = (arg: string | Generator) =>
+  UseInterceptors(new BackLinkInterceptor(arg));

--- a/src/common/decorators/back-link.decorator.ts
+++ b/src/common/decorators/back-link.decorator.ts
@@ -1,0 +1,5 @@
+import { UseInterceptors } from '@nestjs/common';
+import { BackLinkInterceptor } from '../back-link.interceptor';
+
+export const BackLink = (backLink: string) =>
+  UseInterceptors(new BackLinkInterceptor(backLink));

--- a/src/common/utils.spec.ts
+++ b/src/common/utils.spec.ts
@@ -1,10 +1,10 @@
 import { DeepMocked } from '@golevelup/ts-jest';
 import { Request } from 'express';
-import { backLink, formatDate } from './utils';
+import { getReferrer, formatDate } from './utils';
 import { createMockRequest } from '../testutils/create-mock-request';
 
 describe('utils', () => {
-  describe('backLink', () => {
+  describe('getReferrer', () => {
     let req: DeepMocked<Request>;
     let referrer: string;
     let host: string;
@@ -21,7 +21,7 @@ describe('utils', () => {
         });
 
         it('returns the referrer', () => {
-          expect(backLink(req)).toEqual(referrer);
+          expect(getReferrer(req)).toEqual(referrer);
         });
       });
 
@@ -32,7 +32,7 @@ describe('utils', () => {
         });
 
         it('returns undefined', () => {
-          expect(backLink(req)).toBeUndefined();
+          expect(getReferrer(req)).toBeUndefined();
         });
       });
     });
@@ -44,7 +44,7 @@ describe('utils', () => {
       });
 
       it('returns undefined', () => {
-        expect(backLink(req)).toBeUndefined();
+        expect(getReferrer(req)).toBeUndefined();
       });
     });
   });

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -1,7 +1,7 @@
 import { format } from 'date-fns';
 import { Request } from 'express';
 
-export function backLink(req: Request): string {
+export function getReferrer(req: Request): string {
   const referrer = req.get('Referrer') || '';
   const host = req.get('host');
 

--- a/src/organisations/admin/organisations.controller.spec.ts
+++ b/src/organisations/admin/organisations.controller.spec.ts
@@ -129,7 +129,6 @@ describe('OrganisationsController', () => {
     it('should return variables for the show template', async () => {
       const expected = await new OrganisationSummaryPresenter(
         organisation,
-        '/admin/organisations',
         i18nService,
       ).present();
 
@@ -142,7 +141,6 @@ describe('OrganisationsController', () => {
       expect(OrganisationSummaryPresenter).toHaveBeenNthCalledWith(
         2,
         organisation,
-        '/admin/organisations',
         i18nService,
       );
     });

--- a/src/organisations/admin/organisations.controller.ts
+++ b/src/organisations/admin/organisations.controller.ts
@@ -22,6 +22,7 @@ import { ConfirmTemplate } from './interfaces/confirm-template.interface';
 import { ShowTemplate } from '../interfaces/show-template.interface';
 import { OrganisationDto } from './dto/organisation.dto';
 import { OrganisationSummaryPresenter } from '../presenters/organisation-summary.presenter';
+import { BackLink } from '../../common/decorators/back-link.decorator';
 
 @UseGuards(AuthenticationGuard)
 @Controller('/admin/organisations')
@@ -33,6 +34,7 @@ export class OrganisationsController {
 
   @Get()
   @Render('admin/organisations/index')
+  @BackLink('/admin')
   async index() {
     const organisations = await this.organisationsService.allWithProfessions();
     const presenter = new OrganisationsPresenter(
@@ -47,6 +49,7 @@ export class OrganisationsController {
 
   @Get('/:slug')
   @Render('admin/organisations/show')
+  @BackLink('/admin/organisations')
   async show(@Param('slug') slug: string): Promise<ShowTemplate> {
     const organisation =
       await this.organisationsService.findBySlugWithProfessions(slug);
@@ -62,6 +65,7 @@ export class OrganisationsController {
 
   @Get('/:slug/edit')
   @Render('admin/organisations/edit')
+  @BackLink('/admin/organisations/:slug')
   async edit(@Param('slug') slug: string): Promise<Organisation> {
     const organisation = await this.organisationsService.findBySlug(slug);
 
@@ -70,6 +74,7 @@ export class OrganisationsController {
 
   @Post('/:slug/confirm')
   @Render('admin/organisations/confirm')
+  @BackLink('/admin/organisations/:slug/edit')
   @UseFilters(new ValidationExceptionFilter('admin/organisations/edit'))
   async confirm(
     @Param('slug') slug: string,

--- a/src/organisations/admin/organisations.controller.ts
+++ b/src/organisations/admin/organisations.controller.ts
@@ -56,7 +56,6 @@ export class OrganisationsController {
 
     const organisationSummaryPresenter = new OrganisationSummaryPresenter(
       organisation,
-      '/admin/organisations',
       this.i18nService,
     );
 

--- a/src/organisations/interfaces/show-template.interface.ts
+++ b/src/organisations/interfaces/show-template.interface.ts
@@ -9,5 +9,4 @@ export interface ShowTemplate {
     slug: string;
     summaryList: SummaryList;
   }[];
-  backLink: string;
 }

--- a/src/organisations/organisations.controller.spec.ts
+++ b/src/organisations/organisations.controller.spec.ts
@@ -53,7 +53,6 @@ describe('OrganisationsController', () => {
     it('should return variables for the show template', async () => {
       const expected = await new OrganisationSummaryPresenter(
         organisation,
-        '/regulatory-authorities/search',
         i18nService,
       ).present();
 
@@ -66,7 +65,6 @@ describe('OrganisationsController', () => {
       expect(OrganisationSummaryPresenter).toHaveBeenNthCalledWith(
         2,
         organisation,
-        '/regulatory-authorities/search',
         i18nService,
       );
     });

--- a/src/organisations/organisations.controller.ts
+++ b/src/organisations/organisations.controller.ts
@@ -4,7 +4,7 @@ import { I18nService } from 'nestjs-i18n';
 import { OrganisationsService } from './organisations.service';
 import { ShowTemplate } from './interfaces/show-template.interface';
 import { OrganisationSummaryPresenter } from './presenters/organisation-summary.presenter';
-
+import { BackLink } from '../common/decorators/back-link.decorator';
 @Controller()
 export class OrganisationsController {
   constructor(
@@ -14,6 +14,7 @@ export class OrganisationsController {
 
   @Get('/regulatory-authorities/:slug')
   @Render('organisations/show')
+  @BackLink('/regulatory-authorities/search')
   async show(@Param('slug') slug: string): Promise<ShowTemplate> {
     const organisation =
       await this.organisationsService.findBySlugWithProfessions(slug);

--- a/src/organisations/organisations.controller.ts
+++ b/src/organisations/organisations.controller.ts
@@ -21,7 +21,6 @@ export class OrganisationsController {
 
     const organisationSummaryPresenter = new OrganisationSummaryPresenter(
       organisation,
-      '/regulatory-authorities/search',
       this.i18nService,
     );
 

--- a/src/organisations/presenters/organisation-summary.presenter.spec.ts
+++ b/src/organisations/presenters/organisation-summary.presenter.spec.ts
@@ -56,12 +56,10 @@ describe('OrganisationSummaryPresenter', () => {
       it("should return tempalate variables contraining an organisation's summary", async () => {
         const presenter = new OrganisationSummaryPresenter(
           organisation,
-          'back-link',
           i18nService,
         );
 
         expect(await presenter.present()).toEqual({
-          backLink: 'back-link',
           organisation: organisation,
           summaryList: mockSummaryList(),
           professions: [
@@ -107,7 +105,6 @@ describe('OrganisationSummaryPresenter', () => {
       it('should raise an error', async () => {
         const presenter = new OrganisationSummaryPresenter(
           organisation,
-          'back-link',
           i18nService,
         );
         expect(async () => {

--- a/src/organisations/presenters/organisation-summary.presenter.ts
+++ b/src/organisations/presenters/organisation-summary.presenter.ts
@@ -7,7 +7,6 @@ import { OrganisationPresenter } from './organisation.presenter';
 export class OrganisationSummaryPresenter {
   constructor(
     private readonly organisation: Organisation,
-    private readonly backLink: string,
     private readonly i18nService: I18nService,
   ) {}
 
@@ -41,7 +40,6 @@ export class OrganisationSummaryPresenter {
           };
         }),
       ),
-      backLink: this.backLink,
     };
   }
 }

--- a/src/organisations/search/interfaces/index-template.interface.ts
+++ b/src/organisations/search/interfaces/index-template.interface.ts
@@ -13,6 +13,4 @@ export interface IndexTemplate {
   nationsCheckboxArgs: CheckboxArgs[];
 
   industriesCheckboxArgs: CheckboxArgs[];
-
-  backLink: string;
 }

--- a/src/organisations/search/search.controller.spec.ts
+++ b/src/organisations/search/search.controller.spec.ts
@@ -100,7 +100,6 @@ describe('SearchController', () => {
         industries,
         [organisation1, organisation2],
         i18nService,
-        '/',
       ).present();
 
       expect(result).toEqual(expected);
@@ -136,7 +135,6 @@ describe('SearchController', () => {
         industries,
         [],
         i18nService,
-        '/',
       ).present();
 
       expect(result).toEqual(expected);
@@ -159,7 +157,6 @@ describe('SearchController', () => {
         industries,
         [organisation1],
         i18nService,
-        '/',
       ).present();
 
       expect(result).toEqual(expected);
@@ -182,7 +179,6 @@ describe('SearchController', () => {
         industries,
         [organisation2],
         i18nService,
-        '/',
       ).present();
 
       expect(result).toEqual(expected);
@@ -205,7 +201,6 @@ describe('SearchController', () => {
         industries,
         [organisation1],
         i18nService,
-        '/',
       ).present();
 
       expect(result).toEqual(expected);
@@ -228,7 +223,6 @@ describe('SearchController', () => {
         industries,
         [organisation1, organisation2],
         i18nService,
-        '/',
       ).present();
 
       expect(result).toEqual(expected);

--- a/src/organisations/search/search.controller.ts
+++ b/src/organisations/search/search.controller.ts
@@ -10,6 +10,7 @@ import { FilterDto } from './dto/filter.dto';
 
 import { IndexTemplate } from './interfaces/index-template.interface';
 import { SearchPresenter } from './search.presenter';
+import { BackLink } from '../../common/decorators/back-link.decorator';
 
 @Controller('regulatory-authorities/search')
 export class SearchController {
@@ -21,12 +22,14 @@ export class SearchController {
 
   @Get()
   @Render('organisations/search/index')
+  @BackLink('/')
   async index(): Promise<IndexTemplate> {
     return this.createSearchResults(new FilterDto());
   }
 
   @Post()
   @Render('organisations/search/index')
+  @BackLink('/')
   async create(@Body() filter: FilterDto): Promise<IndexTemplate> {
     return this.createSearchResults(filter);
   }
@@ -50,7 +53,6 @@ export class SearchController {
       allIndustries,
       filteredOrganisations,
       this.i18nService,
-      '/',
     ).present();
   }
 

--- a/src/organisations/search/search.presenter.spec.ts
+++ b/src/organisations/search/search.presenter.spec.ts
@@ -60,7 +60,6 @@ describe('SearchPresenter', () => {
         industries,
         [organisation1, organisation2, organisation3],
         i18nService,
-        'back-link',
       );
 
       const result = await presenter.present();
@@ -90,7 +89,6 @@ describe('SearchPresenter', () => {
           await new OrganisationSearchResultPresenter(organisation2).present(),
           await new OrganisationSearchResultPresenter(organisation3).present(),
         ],
-        backLink: 'back-link',
       };
 
       expect(result).toEqual(expected);

--- a/src/organisations/search/search.presenter.ts
+++ b/src/organisations/search/search.presenter.ts
@@ -15,7 +15,6 @@ export class SearchPresenter {
     private readonly allIndustries: Industry[],
     private readonly filteredOrganisations: Organisation[],
     private readonly i18nService: I18nService,
-    private readonly backLink: string,
   ) {}
 
   async present(): Promise<IndexTemplate> {
@@ -48,7 +47,6 @@ export class SearchPresenter {
           (industry) => industry.name,
         ),
       },
-      backLink: this.backLink,
     };
   }
 }

--- a/src/professions/admin/check-your-answers.controller.ts
+++ b/src/professions/admin/check-your-answers.controller.ts
@@ -10,7 +10,7 @@ import {
 import { Request } from 'express';
 import { I18nService } from 'nestjs-i18n';
 import { AuthenticationGuard } from '../../common/authentication.guard';
-import { backLink } from '../../common/utils';
+import { getReferrer } from '../../common/utils';
 
 import { Nation } from '../../nations/nation';
 import { ProfessionsService } from '../professions.service';
@@ -19,6 +19,7 @@ import { CheckYourAnswersTemplate } from './interfaces/check-your-answers.templa
 import { Permissions } from '../../common/permissions.decorator';
 import { UserPermission } from '../../users/user.entity';
 import ViewUtils from './viewUtils';
+import { BackLink } from '../../common/decorators/back-link.decorator';
 @UseGuards(AuthenticationGuard)
 @Controller('admin/professions')
 export class CheckYourAnswersController {
@@ -30,6 +31,7 @@ export class CheckYourAnswersController {
   @Get(':id/check-your-answers')
   @Permissions(UserPermission.CreateProfession)
   @Render('admin/professions/check-your-answers')
+  @BackLink((request: Request) => getReferrer(request))
   async show(
     @Req() req: Request,
     @Param('id') id: string,
@@ -67,7 +69,6 @@ export class CheckYourAnswersController {
       confirmed: Boolean(draftProfession.confirmed),
       captionText: ViewUtils.captionText(draftProfession.confirmed),
       edit: Boolean(edit),
-      backLink: backLink(req),
     };
   }
 }

--- a/src/professions/admin/interfaces/check-your-answers.template.ts
+++ b/src/professions/admin/interfaces/check-your-answers.template.ts
@@ -15,5 +15,4 @@ export interface CheckYourAnswersTemplate {
   captionText: string;
   confirmed: boolean;
   edit: boolean;
-  backLink: string;
 }

--- a/src/professions/admin/interfaces/index-template.interface.ts
+++ b/src/professions/admin/interfaces/index-template.interface.ts
@@ -22,6 +22,4 @@ export interface IndexTemplate {
   organisationsCheckboxArgs: CheckboxArgs[];
   industriesCheckboxArgs: CheckboxArgs[];
   changedByCheckboxArgs: CheckboxArgs[];
-
-  backLink: string;
 }

--- a/src/professions/admin/interfaces/legislation.template.ts
+++ b/src/professions/admin/interfaces/legislation.template.ts
@@ -3,6 +3,5 @@ import { Legislation } from '../../../legislations/legislation.entity';
 export interface LegislationTemplate {
   legislation: Legislation | null;
   captionText: string;
-  backLink: string;
-  errors: object | undefined;
+  errors?: object;
 }

--- a/src/professions/admin/interfaces/qualification-information.template.ts
+++ b/src/professions/admin/interfaces/qualification-information.template.ts
@@ -8,6 +8,5 @@ export interface QualificationInformationTemplate {
   mandatoryProfessionalExperienceRadioButtonArgs: RadioButtonArgs[];
   captionText: string;
   change: boolean;
-  backLink: string;
   errors: object | undefined;
 }

--- a/src/professions/admin/interfaces/regulated-activities.template.ts
+++ b/src/professions/admin/interfaces/regulated-activities.template.ts
@@ -3,6 +3,5 @@ export interface RegulatedActivitiesTemplate {
   regulationDescription: string;
   captionText: string;
   change: boolean;
-  backLink: string;
   errors: object | undefined;
 }

--- a/src/professions/admin/interfaces/regulatory-body.template.ts
+++ b/src/professions/admin/interfaces/regulatory-body.template.ts
@@ -6,6 +6,5 @@ export interface RegulatoryBodyTemplate {
   mandatoryRegistrationRadioButtonArgs: RadioButtonArgs[];
   change: boolean;
   captionText: string;
-  backLink: string;
   errors: object | undefined;
 }

--- a/src/professions/admin/interfaces/top-level-details.template.ts
+++ b/src/professions/admin/interfaces/top-level-details.template.ts
@@ -6,6 +6,5 @@ export interface TopLevelDetailsTemplate {
   nationsCheckboxArgs: CheckboxArgs[];
   captionText: string;
   change: boolean;
-  backLink: string;
   errors: object | undefined;
 }

--- a/src/professions/admin/legislation.controller.spec.ts
+++ b/src/professions/admin/legislation.controller.spec.ts
@@ -40,7 +40,7 @@ describe(LegislationController, () => {
 
       professionsService.find.mockResolvedValue(profession);
 
-      await controller.edit(response, 'profession-id', true);
+      await controller.edit(response, 'profession-id');
 
       expect(response.render).toHaveBeenCalledWith(
         'admin/professions/legislation',
@@ -63,7 +63,7 @@ describe(LegislationController, () => {
 
         professionsService.find.mockResolvedValue(profession);
 
-        await controller.update(response, 'profession-id', dto, false);
+        await controller.update(response, 'profession-id', dto);
 
         expect(professionsService.save).toHaveBeenCalledWith(
           expect.objectContaining({
@@ -91,7 +91,7 @@ describe(LegislationController, () => {
 
         professionsService.find.mockResolvedValue(profession);
 
-        await controller.update(response, 'profession-id', dto, false);
+        await controller.update(response, 'profession-id', dto);
 
         expect(professionsService.save).not.toHaveBeenCalled();
 
@@ -106,47 +106,6 @@ describe(LegislationController, () => {
                 text: 'professions.form.errors.legislation.nationalLegislation.empty',
               },
             },
-          }),
-        );
-      });
-    });
-  });
-
-  describe('back links', () => {
-    describe('when the "Change" query param is false', () => {
-      it('links back to the previous page in the journey', async () => {
-        const profession = professionFactory.build({
-          id: 'profession-id',
-        });
-
-        professionsService.find.mockImplementation(async () => profession);
-
-        await controller.edit(response, 'profession-id', false);
-
-        expect(response.render).toHaveBeenCalledWith(
-          'admin/professions/legislation',
-          expect.objectContaining({
-            backLink:
-              '/admin/professions/profession-id/qualification-information/edit',
-          }),
-        );
-      });
-    });
-
-    describe('when the "Change" query param is true', () => {
-      it('links back to the Check your Answers page', async () => {
-        const profession = professionFactory.build({
-          id: 'profession-id',
-        });
-
-        professionsService.find.mockImplementation(async () => profession);
-
-        await controller.edit(response, 'profession-id', true);
-
-        expect(response.render).toHaveBeenCalledWith(
-          'admin/professions/legislation',
-          expect.objectContaining({
-            backLink: '/admin/professions/profession-id/check-your-answers',
           }),
         );
       });

--- a/src/professions/admin/professions.controller.spec.ts
+++ b/src/professions/admin/professions.controller.spec.ts
@@ -416,7 +416,6 @@ function createPresenter(
     organisations,
     industries,
     professions,
-    request,
     i18nService,
   );
 }

--- a/src/professions/admin/professions.controller.spec.ts
+++ b/src/professions/admin/professions.controller.spec.ts
@@ -344,7 +344,6 @@ describe('ProfessionsController', () => {
         qualification: new QualificationPresenter(profession.qualification),
         nations: ['Translation of `nations.england`'],
         industries: ['Translation of `industries.example`'],
-        backLink: '/admin/professions',
       });
 
       expect(professionsService.findBySlug).toHaveBeenCalledWith(

--- a/src/professions/admin/professions.controller.ts
+++ b/src/professions/admin/professions.controller.ts
@@ -169,7 +169,6 @@ export class ProfessionsController {
       allOrganisations,
       allIndustries,
       filteredProfessions,
-      request,
       this.i18Service,
     ).present(view);
   }

--- a/src/professions/admin/professions.controller.ts
+++ b/src/professions/admin/professions.controller.ts
@@ -32,6 +32,7 @@ import { Profession } from '../profession.entity';
 import { ShowTemplate } from '../interfaces/show-template.interface';
 import { EditTemplate } from './interfaces/edit-template.interface';
 import { Permissions } from '../../common/permissions.decorator';
+import { BackLink } from '../../common/decorators/back-link.decorator';
 import QualificationPresenter from '../../qualifications/presenters/qualification.presenter';
 
 @UseGuards(AuthenticationGuard)
@@ -55,6 +56,7 @@ export class ProfessionsController {
 
   @Get()
   @Render('admin/professions/index')
+  @BackLink('/admin')
   async index(
     @Req() request: Request,
     @Query() query: FilterDto = null,
@@ -64,6 +66,7 @@ export class ProfessionsController {
 
   @Get('/:slug')
   @Render('admin/professions/show')
+  @BackLink('/admin/professions')
   async show(@Param('slug') slug: string): Promise<ShowTemplate> {
     const profession = await this.professionsService.findBySlug(slug);
 
@@ -90,13 +93,13 @@ export class ProfessionsController {
       qualification: new QualificationPresenter(profession.qualification),
       nations,
       industries,
-      backLink: '/admin/professions',
     };
   }
 
   @Get('/:slug/edit')
   @Permissions(UserPermission.CreateProfession)
   @Render('admin/professions/edit')
+  @BackLink('/admin/professions/:slug')
   async edit(@Param('slug') slug: string): Promise<EditTemplate> {
     const profession = await this.professionsService.findBySlug(slug);
 

--- a/src/professions/admin/professions.presenter.spec.ts
+++ b/src/professions/admin/professions.presenter.spec.ts
@@ -1,7 +1,6 @@
 import { DeepMocked } from '@golevelup/ts-jest';
 import { I18nService } from 'nestjs-i18n';
 import { createMockI18nService } from '../../testutils/create-mock-i18n-service';
-import { createMockRequest } from '../../testutils/create-mock-request';
 import { IndustriesCheckboxPresenter } from '../../industries/industries-checkbox.presenter';
 import { Nation } from '../../nations/nation';
 import { NationsCheckboxPresenter } from '../../nations/nations-checkbox.presenter';
@@ -74,11 +73,6 @@ describe('ProfessionsPresenter', () => {
       industries: [transportIndustry],
     };
 
-    const request = createMockRequest(
-      'http://example.com/some/path',
-      'example.com',
-    );
-
     professionsPresenter = new ProfessionsPresenter(
       filterInput,
       organisation1,
@@ -86,7 +80,6 @@ describe('ProfessionsPresenter', () => {
       organisations,
       industries,
       [profession1, profession2, profession3],
-      request,
       i18nService,
     );
   });
@@ -133,8 +126,6 @@ describe('ProfessionsPresenter', () => {
           i18nService,
         ).checkboxArgs(),
         changedByCheckboxArgs: [],
-
-        backLink: 'http://example.com/some/path',
       };
 
       expect(result).toEqual(expected);
@@ -184,8 +175,6 @@ describe('ProfessionsPresenter', () => {
           i18nService,
         ).checkboxArgs(),
         changedByCheckboxArgs: [],
-
-        backLink: 'http://example.com/some/path',
       };
 
       expect(result).toEqual(expected);

--- a/src/professions/admin/professions.presenter.ts
+++ b/src/professions/admin/professions.presenter.ts
@@ -1,6 +1,4 @@
-import { Request } from 'express';
 import { I18nService } from 'nestjs-i18n';
-import { backLink } from '../../common/utils';
 import { IndustriesCheckboxPresenter } from '../../industries/industries-checkbox.presenter';
 import { Industry } from '../../industries/industry.entity';
 import { Nation } from '../../nations/nation';
@@ -22,7 +20,6 @@ export class ProfessionsPresenter {
     private readonly allOrganisations: Organisation[],
     private readonly allIndustries: Industry[],
     private readonly filteredProfessions: Profession[],
-    private readonly request: Request,
     private readonly i18nService: I18nService,
   ) {}
 
@@ -77,7 +74,6 @@ export class ProfessionsPresenter {
         ),
         changedBy: [],
       },
-      backLink: backLink(this.request),
     };
   }
 }

--- a/src/professions/admin/qualification-information.controller.spec.ts
+++ b/src/professions/admin/qualification-information.controller.spec.ts
@@ -206,47 +206,6 @@ describe(QualificationInformationController, () => {
         );
       });
     });
-
-    describe('back links', () => {
-      describe('when the "Change" query param is false', () => {
-        it('links back to the previous page in the journey', async () => {
-          const profession = professionFactory.build({
-            id: 'profession-id',
-          });
-
-          professionsService.find.mockImplementation(async () => profession);
-
-          await controller.edit(response, 'profession-id', false);
-
-          expect(response.render).toHaveBeenCalledWith(
-            'admin/professions/qualification-information',
-            expect.objectContaining({
-              backLink:
-                '/admin/professions/profession-id/regulated-activities/edit',
-            }),
-          );
-        });
-      });
-
-      describe('when the "Change" query param is true', () => {
-        it('links back to the Check your Answers page', async () => {
-          const profession = professionFactory.build({
-            id: 'profession-id',
-          });
-
-          professionsService.find.mockImplementation(async () => profession);
-
-          await controller.edit(response, 'profession-id', true);
-
-          expect(response.render).toHaveBeenCalledWith(
-            'admin/professions/qualification-information',
-            expect.objectContaining({
-              backLink: '/admin/professions/profession-id/check-your-answers',
-            }),
-          );
-        });
-      });
-    });
   });
 
   afterEach(() => {

--- a/src/professions/admin/qualification-information.controller.ts
+++ b/src/professions/admin/qualification-information.controller.ts
@@ -8,7 +8,7 @@ import {
   Res,
   UseGuards,
 } from '@nestjs/common';
-import { Response } from 'express';
+import { Response, Request } from 'express';
 import { I18nService } from 'nestjs-i18n';
 import { AuthenticationGuard } from '../../common/authentication.guard';
 import { Permissions } from '../../common/permissions.decorator';
@@ -21,6 +21,7 @@ import { MethodToObtainQualificationRadioButtonsPresenter } from './method-to-ob
 import { YesNoRadioButtonArgsPresenter } from './yes-no-radio-buttons-presenter';
 import { QualificationInformationDto } from './dto/qualification-information.dto';
 import { QualificationInformationTemplate } from './interfaces/qualification-information.template';
+import { BackLink } from '../../common/decorators/back-link.decorator';
 import ViewUtils from './viewUtils';
 
 @UseGuards(AuthenticationGuard)
@@ -33,6 +34,11 @@ export class QualificationInformationController {
 
   @Get('/:id/qualification-information/edit')
   @Permissions(UserPermission.CreateProfession)
+  @BackLink((request: Request) =>
+    request.query.change === 'true'
+      ? '/admin/professions/:id/check-your-answers'
+      : '/admin/professions/:id/regulated-activities/edit',
+  )
   async edit(
     @Res() res: Response,
     @Param('id') id: string,
@@ -45,12 +51,16 @@ export class QualificationInformationController {
       profession.qualification,
       profession.confirmed,
       change,
-      this.backLink(change, profession.id),
     );
   }
 
   @Post('/:id/qualification-information')
   @Permissions(UserPermission.CreateProfession)
+  @BackLink((request: Request) =>
+    request.query.change === 'true'
+      ? '/admin/professions/:id/check-your-answers'
+      : '/admin/professions/:id/regulated-activities/edit',
+  )
   async update(
     @Res() res: Response,
     @Param('id') id: string,
@@ -93,7 +103,6 @@ export class QualificationInformationController {
         updatedQualification,
         profession.confirmed,
         submittedValues.change,
-        this.backLink(submittedValues.change, profession.id),
         errors,
       );
     }
@@ -114,7 +123,6 @@ export class QualificationInformationController {
     qualification: Qualification | null,
     isEditing: boolean,
     change: boolean,
-    backLink: string,
     errors: object | undefined = undefined,
   ) {
     const mostCommonPathToObtainQualificationRadioButtonArgs =
@@ -147,7 +155,6 @@ export class QualificationInformationController {
       duration: qualification?.educationDuration,
       captionText: ViewUtils.captionText(isEditing),
       change,
-      backLink,
       errors,
     };
 
@@ -155,11 +162,5 @@ export class QualificationInformationController {
       'admin/professions/qualification-information',
       templateArgs,
     );
-  }
-
-  private backLink(change: boolean, id: string) {
-    return change
-      ? `/admin/professions/${id}/check-your-answers`
-      : `/admin/professions/${id}/regulated-activities/edit`;
   }
 }

--- a/src/professions/admin/regulated-activities.controller.spec.ts
+++ b/src/professions/admin/regulated-activities.controller.spec.ts
@@ -52,46 +52,6 @@ describe(RegulatedActivitiesController, () => {
         }),
       );
     });
-
-    describe('back links', () => {
-      describe('when the "Change" query param is false', () => {
-        it('links back to the previous page in the journey', async () => {
-          const profession = professionFactory.build({
-            id: 'profession-id',
-          });
-
-          professionsService.find.mockImplementation(async () => profession);
-
-          await controller.edit(response, 'profession-id', false);
-
-          expect(response.render).toHaveBeenCalledWith(
-            'admin/professions/regulated-activities',
-            expect.objectContaining({
-              backLink: '/admin/professions/profession-id/regulatory-body/edit',
-            }),
-          );
-        });
-      });
-
-      describe('when the "Change" query param is true', () => {
-        it('links back to the Check your Answers page', async () => {
-          const profession = professionFactory.build({
-            id: 'profession-id',
-          });
-
-          professionsService.find.mockImplementation(async () => profession);
-
-          await controller.edit(response, 'profession-id', true);
-
-          expect(response.render).toHaveBeenCalledWith(
-            'admin/professions/regulated-activities',
-            expect.objectContaining({
-              backLink: '/admin/professions/profession-id/check-your-answers',
-            }),
-          );
-        });
-      });
-    });
   });
 
   describe('update', () => {

--- a/src/professions/admin/regulatory-body.controller.spec.ts
+++ b/src/professions/admin/regulatory-body.controller.spec.ts
@@ -256,23 +256,6 @@ describe(RegulatoryBodyController, () => {
             '/admin/professions/profession-id/check-your-answers',
           );
         });
-
-        it('sets the back link to point to check your answers', async () => {
-          const profession = professionFactory.build({
-            id: 'profession-id',
-          });
-
-          professionsService.find.mockImplementation(async () => profession);
-
-          await controller.edit(response, 'profession-id', true);
-
-          expect(response.render).toHaveBeenCalledWith(
-            'admin/professions/regulatory-body',
-            expect.objectContaining({
-              backLink: '/admin/professions/profession-id/check-your-answers',
-            }),
-          );
-        });
       });
 
       describe('when false or missing', () => {
@@ -311,24 +294,6 @@ describe(RegulatoryBodyController, () => {
 
           expect(response.redirect).toHaveBeenCalledWith(
             '/admin/professions/profession-id/regulated-activities/edit',
-          );
-        });
-
-        it('sets the back link to point to the previous step in the journey', async () => {
-          const profession = professionFactory.build({
-            id: 'profession-id',
-          });
-
-          professionsService.find.mockImplementation(async () => profession);
-
-          await controller.edit(response, 'profession-id', false);
-
-          expect(response.render).toHaveBeenCalledWith(
-            'admin/professions/regulatory-body',
-            expect.objectContaining({
-              backLink:
-                '/admin/professions/profession-id/top-level-information/edit',
-            }),
           );
         });
       });

--- a/src/professions/admin/top-level-information.controller.spec.ts
+++ b/src/professions/admin/top-level-information.controller.spec.ts
@@ -288,23 +288,6 @@ describe('TopLevelInformationController', () => {
             '/admin/professions/profession-id/check-your-answers',
           );
         });
-
-        it('sets the back link to point to check your answers', async () => {
-          const profession = professionFactory.build({
-            id: 'profession-id',
-          });
-
-          professionsService.find.mockImplementation(async () => profession);
-
-          await controller.edit(response, 'profession-id', true);
-
-          expect(response.render).toHaveBeenCalledWith(
-            'admin/professions/top-level-information',
-            expect.objectContaining({
-              backLink: '/admin/professions/profession-id/check-your-answers',
-            }),
-          );
-        });
       });
 
       describe('when set to false', () => {
@@ -333,23 +316,6 @@ describe('TopLevelInformationController', () => {
             '/admin/professions/profession-id/regulatory-body/edit',
           );
         });
-      });
-
-      it('sets the back link to point to the previous page in the journey', async () => {
-        const profession = professionFactory.build({
-          id: 'profession-id',
-        });
-
-        professionsService.find.mockImplementation(async () => profession);
-
-        await controller.edit(response, 'profession-id', false);
-
-        expect(response.render).toHaveBeenCalledWith(
-          'admin/professions/top-level-information',
-          expect.objectContaining({
-            backLink: '/admin/professions',
-          }),
-        );
       });
     });
   });

--- a/src/professions/interfaces/show-template.interface.ts
+++ b/src/professions/interfaces/show-template.interface.ts
@@ -6,5 +6,4 @@ export interface ShowTemplate {
   qualification: QualificationPresenter;
   nations: string[];
   industries: string[];
-  backLink: string;
 }

--- a/src/professions/professions.controller.spec.ts
+++ b/src/professions/professions.controller.spec.ts
@@ -74,7 +74,6 @@ describe('ProfessionsController', () => {
         ),
         nations: ['England'],
         industries: ['Example industry'],
-        backLink: '/professions/search',
       });
 
       expect(professionsService.findBySlug).toBeCalledWith('example-slug');

--- a/src/professions/professions.controller.ts
+++ b/src/professions/professions.controller.ts
@@ -10,6 +10,7 @@ import { Nation } from '../nations/nation';
 import QualificationPresenter from '../qualifications/presenters/qualification.presenter';
 import { ShowTemplate } from './interfaces/show-template.interface';
 import { ProfessionsService } from './professions.service';
+import { BackLink } from '../common/decorators/back-link.decorator';
 
 @Controller()
 export class ProfessionsController {
@@ -20,6 +21,7 @@ export class ProfessionsController {
 
   @Get('/professions/:slug')
   @Render('professions/show')
+  @BackLink('/professions/search')
   async show(@Param('slug') slug: string): Promise<ShowTemplate> {
     const profession = await this.professionsService.findBySlug(slug);
 
@@ -50,7 +52,6 @@ export class ProfessionsController {
       qualification: qualification,
       nations,
       industries,
-      backLink: '/professions/search',
     };
   }
 }

--- a/src/professions/search/interfaces/index-template.interface.ts
+++ b/src/professions/search/interfaces/index-template.interface.ts
@@ -13,6 +13,4 @@ export interface IndexTemplate {
   nationsCheckboxArgs: CheckboxArgs[];
 
   industriesCheckboxArgs: CheckboxArgs[];
-
-  backLink: string;
 }

--- a/src/professions/search/search.controller.spec.ts
+++ b/src/professions/search/search.controller.spec.ts
@@ -90,7 +90,6 @@ describe('SearchController', () => {
         industries,
         [profession1, profession2],
         i18nService,
-        '/',
       ).present();
 
       expect(result).toEqual(expected);
@@ -126,7 +125,6 @@ describe('SearchController', () => {
         industries,
         [],
         i18nService,
-        '/',
       ).present();
 
       expect(result).toEqual(expected);
@@ -149,7 +147,6 @@ describe('SearchController', () => {
         industries,
         [profession2],
         i18nService,
-        '/',
       ).present();
 
       expect(result).toEqual(expected);
@@ -172,7 +169,6 @@ describe('SearchController', () => {
         industries,
         [profession1],
         i18nService,
-        '/',
       ).present();
 
       expect(result).toEqual(expected);
@@ -195,7 +191,6 @@ describe('SearchController', () => {
         industries,
         [profession2],
         i18nService,
-        '/',
       ).present();
 
       expect(result).toEqual(expected);
@@ -218,7 +213,6 @@ describe('SearchController', () => {
         industries,
         [profession1, profession2],
         i18nService,
-        '/',
       ).present();
 
       expect(result).toEqual(expected);

--- a/src/professions/search/search.controller.ts
+++ b/src/professions/search/search.controller.ts
@@ -9,6 +9,7 @@ import { ProfessionsFilterHelper } from '../helpers/professions-filter.helper';
 import { FilterInput } from '../../common/interfaces/filter-input.interface';
 import { IndexTemplate } from './interfaces/index-template.interface';
 import { SearchPresenter } from './search.presenter';
+import { BackLink } from '../../common/decorators/back-link.decorator';
 
 @Controller('professions/search')
 export class SearchController {
@@ -20,12 +21,14 @@ export class SearchController {
 
   @Get()
   @Render('professions/search/index')
+  @BackLink('/')
   async index(): Promise<IndexTemplate> {
     return this.createSearchResults(new FilterDto());
   }
 
   @Post()
   @Render('professions/search/index')
+  @BackLink('/')
   async create(@Body() filter: FilterDto): Promise<IndexTemplate> {
     return this.createSearchResults(filter);
   }
@@ -48,7 +51,6 @@ export class SearchController {
       allIndustries,
       filteredProfessions,
       this.i18nService,
-      '/',
     ).present();
   }
 

--- a/src/professions/search/search.presenter.spec.ts
+++ b/src/professions/search/search.presenter.spec.ts
@@ -66,7 +66,6 @@ describe('SearchPresenter', () => {
         industries,
         [profession1, profession2, profession3],
         i18nService,
-        'back-link',
       );
 
       const result = await presenter.present();
@@ -105,7 +104,6 @@ describe('SearchPresenter', () => {
             i18nService,
           ).present(),
         ],
-        backLink: 'back-link',
       };
 
       expect(result).toEqual(expected);

--- a/src/professions/search/search.presenter.ts
+++ b/src/professions/search/search.presenter.ts
@@ -15,7 +15,6 @@ export class SearchPresenter {
     private readonly allIndustries: Industry[],
     private readonly filteredProfessions: Profession[],
     private readonly i18nService: I18nService,
-    private readonly backLink: string,
   ) {}
 
   async present(): Promise<IndexTemplate> {
@@ -51,7 +50,6 @@ export class SearchPresenter {
           (industry) => industry.name,
         ),
       },
-      backLink: this.backLink,
     };
   }
 }

--- a/src/users/permissions/interfaces/edit-template.ts
+++ b/src/users/permissions/interfaces/edit-template.ts
@@ -1,7 +1,6 @@
 import { User, UserPermission } from '../../user.entity';
 
 export interface EditTemplate extends User {
-  backLink: string;
   permissions: Array<UserPermission>;
   change: boolean;
 }

--- a/src/users/permissions/permissions.controller.spec.ts
+++ b/src/users/permissions/permissions.controller.spec.ts
@@ -60,7 +60,6 @@ describe('PermissionsController', () => {
           'downloadDecisionData',
           'viewDecisionData',
         ],
-        backLink: referrer,
         change: false,
       });
     });
@@ -82,7 +81,6 @@ describe('PermissionsController', () => {
           'downloadDecisionData',
           'viewDecisionData',
         ],
-        backLink: referrer,
         change: true,
       });
     });

--- a/src/users/permissions/permissions.controller.ts
+++ b/src/users/permissions/permissions.controller.ts
@@ -19,8 +19,8 @@ import { UserPermission } from '../user.entity';
 import { PermissionsDto } from './dto/permissions.dto';
 import { Permissions } from '../../common/permissions.decorator';
 import { ValidationExceptionFilter } from '../../common/validation/validation-exception.filter';
-import { backLink } from '../../common/utils';
 import { EditTemplate } from './interfaces/edit-template';
+import { BackLink } from '../../common/decorators/back-link.decorator';
 @UseGuards(AuthenticationGuard)
 @Controller('/admin/users')
 export class PermissionsController {
@@ -29,6 +29,11 @@ export class PermissionsController {
   @Get(':id/permissions/edit')
   @Permissions(UserPermission.CreateUser, UserPermission.EditUser)
   @Render('admin/users/permissions/edit')
+  @BackLink((request: Request) =>
+    request.query.change === 'true'
+      ? '/admin/users/:id/check-your-answers'
+      : '/admin/users/:id/personal-details/edit',
+  )
   async edit(
     @Req() req: Request,
     @Param('id') id,
@@ -40,7 +45,6 @@ export class PermissionsController {
     return {
       ...user,
       permissions,
-      backLink: backLink(req),
       change: change,
     };
   }

--- a/src/users/personal-details/interfaces/edit-template.ts
+++ b/src/users/personal-details/interfaces/edit-template.ts
@@ -1,6 +1,5 @@
 import { User } from '../../user.entity';
 
 export interface EditTemplate extends User {
-  backLink: string;
   change: boolean;
 }

--- a/src/users/personal-details/personal-details.controller.spec.ts
+++ b/src/users/personal-details/personal-details.controller.spec.ts
@@ -5,7 +5,6 @@ import { UsersService } from '../users.service';
 import { User } from '../user.entity';
 import { PersonalDetailsController } from './personal-details.controller';
 import { createMock, DeepMocked } from '@golevelup/ts-jest';
-import { createMockRequest } from '../../testutils/create-mock-request';
 
 const name = 'Example Name';
 const email = 'name@example.com';
@@ -49,15 +48,13 @@ describe('PersonalDetailsController', () => {
   });
 
   describe('edit', () => {
-    const referrer = 'http://example.com/some/path';
-    const request: Request = createMockRequest(referrer, 'example.com');
+    const request: Request = createMock<Request>();
 
     it('should get and return the user from an id', async () => {
       const result = await controller.edit(request, 'user-uuid', false);
 
       expect(result).toEqual({
         ...user,
-        backLink: referrer,
         change: false,
       });
     });
@@ -67,7 +64,6 @@ describe('PersonalDetailsController', () => {
 
       expect(result).toEqual({
         ...user,
-        backLink: referrer,
         change: true,
       });
     });

--- a/src/users/personal-details/personal-details.controller.ts
+++ b/src/users/personal-details/personal-details.controller.ts
@@ -19,8 +19,8 @@ import { UserPermission } from './../user.entity';
 import { PersonalDetailsDto } from './dto/personal-details.dto';
 import { AuthenticationGuard } from '../../common/authentication.guard';
 import { Permissions } from '../../common/permissions.decorator';
-import { backLink } from '../../common/utils';
 import { EditTemplate } from './interfaces/edit-template';
+import { BackLink } from '../../common/decorators/back-link.decorator';
 @Controller('/admin/users')
 @UseGuards(AuthenticationGuard)
 export class PersonalDetailsController {
@@ -29,6 +29,7 @@ export class PersonalDetailsController {
   @Get(':id/personal-details/edit')
   @Permissions(UserPermission.CreateUser, UserPermission.EditUser)
   @Render('admin/users/personal-details/edit')
+  @BackLink('/admin/users')
   async edit(
     @Req() req: Request,
     @Param('id') id,
@@ -38,7 +39,6 @@ export class PersonalDetailsController {
 
     return {
       ...user,
-      backLink: backLink(req),
       change: change,
     };
   }

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -23,6 +23,7 @@ import { Permissions } from '../common/permissions.decorator';
 
 import { UserPresenter } from './user.presenter';
 import { UserMailer } from './user.mailer';
+import { BackLink } from '../common/decorators/back-link.decorator';
 @Controller()
 @UseGuards(AuthenticationGuard)
 export class UsersController {
@@ -36,6 +37,7 @@ export class UsersController {
   @Get('/admin/users')
   @Permissions(UserPermission.CreateUser, UserPermission.EditUser)
   @Render('admin/users/index')
+  @BackLink('/admin')
   async index(@Req() req): Promise<IndexTemplate> {
     const users = await this.usersService.where({ confirmed: true });
     const usersPresenter = new UsersPresenter(users, this.i18nService);
@@ -50,6 +52,7 @@ export class UsersController {
   @Get('/admin/users/new')
   @Permissions(UserPermission.CreateUser, UserPermission.EditUser)
   @Render('admin/users/new')
+  @BackLink('/admin/users')
   new(): object {
     return {};
   }

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -11,6 +11,7 @@ import {
   Redirect,
 } from '@nestjs/common';
 import { I18nService } from 'nestjs-i18n';
+import { Request } from 'express';
 
 import { AuthenticationGuard } from '../common/authentication.guard';
 import { Auth0Service } from './auth0.service';
@@ -20,6 +21,7 @@ import { UsersService } from './users.service';
 import { IndexTemplate } from './interfaces/index-template';
 import { ShowTemplate } from './interfaces/show-template';
 import { Permissions } from '../common/permissions.decorator';
+import { getReferrer } from '../common/utils';
 
 import { UserPresenter } from './user.presenter';
 import { UserMailer } from './user.mailer';
@@ -81,6 +83,7 @@ export class UsersController {
   @Get('/admin/users/:id/confirm')
   @Permissions(UserPermission.CreateUser)
   @Render('admin/users/confirm')
+  @BackLink((request: Request) => getReferrer(request))
   async confirm(@Param('id') id): Promise<ShowTemplate> {
     const user = await this.usersService.find(id);
     const userPresenter = new UserPresenter(user, this.i18nService);

--- a/views/admin/organisations/edit.njk
+++ b/views/admin/organisations/edit.njk
@@ -6,14 +6,6 @@
 {% set bodyClasses = "rpr-internal__page" %}
 
 {% block content %}
-
-  {% if backLink %}
-    {{ govukBackLink({
-      text: ( "app.back" | t ),
-      href: backLink
-    }) }}
-  {% endif %}
-
   <h1 class="govuk-heading-xl">
     {{ "organisations.admin.edit.heading" | t }}
   </h1>

--- a/views/admin/organisations/index.njk
+++ b/views/admin/organisations/index.njk
@@ -4,14 +4,6 @@
 {% set bodyClasses = "rpr-internal__listing rpr-internal__page" %}
 
 {% block content %}
-
-  {% if backLink %}
-    {{ govukBackLink({
-      text: ( "app.back" | t ),
-      href: backLink
-    }) }}
-  {% endif %}
-
   <h1 class="govuk-heading-xl">
     {{ "organisations.admin.heading" | t }}
   </h1>

--- a/views/admin/organisations/show.njk
+++ b/views/admin/organisations/show.njk
@@ -1,18 +1,9 @@
 {% extends "base.njk" %}
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
 {% set bodyClasses = "rpr-internal__page rpr-details__page" %}
 
 {% block content %}
-
-  {% if backLink %}
-    {{ govukBackLink({
-      text: ( "app.back" | t ),
-      href: backLink
-    }) }}
-  {% endif %}
-
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       {% set professionPagePrefix = "admin/professions"%}

--- a/views/admin/professions/check-your-answers.njk
+++ b/views/admin/professions/check-your-answers.njk
@@ -7,8 +7,6 @@
 {% block content %}
 
   <div class="govuk-width-container">
-    <a href="{{backLink}}" class="govuk-back-link">{{ ("app.back" | t) }}</a>
-
     <main class="govuk-main-wrapper">
 
       <div class="govuk-grid-row">

--- a/views/admin/professions/edit.njk
+++ b/views/admin/professions/edit.njk
@@ -7,8 +7,6 @@
 {% block content %}
 
   <div class="govuk-width-container">
-    <a href="/admin/professions/{{ profession.slug }}" class="govuk-back-link">{{ ('app.back' | t) }}</a>
-
     <main class="govuk-main-wrapper">
 
       <div class="govuk-grid-row">

--- a/views/admin/professions/index.njk
+++ b/views/admin/professions/index.njk
@@ -4,19 +4,10 @@
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
 {% from "govuk/components/table/macro.njk" import govukTable %}
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 
 {% set bodyClasses = "rpr-internal__listing rpr-internal__page" %}
 
 {% block content %}
-
-{% if backLink %}
-{{ govukBackLink({
-  text: ( "app.back" | t ),
-  href: backLink
-}) }}
-{% endif %}
-
   <h1 class="govuk-heading-xl">
     <span class="govuk-caption-l">{{ organisation }}</span>
     {{ "professions.admin.heading" | t }}

--- a/views/admin/professions/legislation.njk
+++ b/views/admin/professions/legislation.njk
@@ -6,9 +6,6 @@
 {% set bodyClasses = "rpr-internal__page" %}
 
 {% block content %}
-
-  <a href="{{backLink}}" class="govuk-back-link">{{ ('app.back' | t) }}</a>
-
   {% include "../../shared/_errors.njk" %}
 
   <div class="govuk-grid-row">

--- a/views/admin/professions/qualification-information.njk
+++ b/views/admin/professions/qualification-information.njk
@@ -7,9 +7,6 @@
 {% set bodyClasses = "rpr-internal__page" %}
 
 {% block content %}
-
-  <a href="{{backLink}}" class="govuk-back-link">{{ ('app.back' | t) }}</a>
-
   {% include "../../shared/_errors.njk" %}
 
   <div class="govuk-grid-row">

--- a/views/admin/professions/regulated-activities.njk
+++ b/views/admin/professions/regulated-activities.njk
@@ -6,9 +6,6 @@
 {% set bodyClasses = "rpr-internal__page" %}
 
 {% block content %}
-
-  <a href="{{backLink}}" class="govuk-back-link">{{ ('app.back' | t) }}</a>
-
   {% include "../../shared/_errors.njk" %}
 
   <div class="govuk-grid-row">

--- a/views/admin/professions/regulatory-body.njk
+++ b/views/admin/professions/regulatory-body.njk
@@ -7,9 +7,6 @@
 {% set bodyClasses = "rpr-internal__page" %}
 
 {% block content %}
-
-  <a href="{{backLink}}" class="govuk-back-link">{{ ('app.back' | t) }}</a>
-
   {% include "../../shared/_errors.njk" %}
 
   <div class="govuk-grid-row">

--- a/views/admin/professions/show.njk
+++ b/views/admin/professions/show.njk
@@ -1,5 +1,4 @@
 {% extends "base.njk" %}
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
 {% set bodyClasses = "rpr-internal__page rpr-details__page" %}
@@ -7,11 +6,6 @@
 {% block content %}
 
 <div class="govuk-width-container">
-  {{ govukBackLink({
-    text: ("app.back" | t),
-    href: backLink
-  }) }}
-
   <main class="govuk-main-wrapper">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">

--- a/views/admin/professions/top-level-information.njk
+++ b/views/admin/professions/top-level-information.njk
@@ -9,8 +9,6 @@
 {% block content %}
 
   <div class="govuk-width-container">
-    <a href="{{backLink}}" class="govuk-back-link">{{ ('app.back' | t) }}</a>
-
     {% include "../../shared/_errors.njk" %}
 
     <main class="govuk-main-wrapper">

--- a/views/admin/users/confirm.njk
+++ b/views/admin/users/confirm.njk
@@ -2,19 +2,12 @@
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 
 {% block content %}
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-
-    {{ govukBackLink({
-      text: ("app.back" | t),
-      href: "permissions/edit"
-    }) }}
-
     {% if userAlreadyExists %}
 
     {{ govukErrorSummary({

--- a/views/admin/users/new.njk
+++ b/views/admin/users/new.njk
@@ -3,9 +3,6 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
 {% block content %}
-
-  <a href="#" class="govuk-back-link">{{ "app.back" | t }}</a>
-  
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
@@ -25,6 +22,4 @@
     <div class="govuk-grid-column-one-third">
     </div>
   </div>
-
-
 {% endblock %}

--- a/views/admin/users/permissions/edit.njk
+++ b/views/admin/users/permissions/edit.njk
@@ -1,6 +1,5 @@
 {% extends "base.njk" %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 
@@ -8,14 +7,6 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-
-    {% if backLink %}
-      {{ govukBackLink({
-        text: ( "app.back" | t ),
-        href: backLink
-      }) }}
-    {% endif %}
-
     {% include "../../../shared/_errors.njk" %}
 
     <span class="govuk-caption-xl">{{ "users.form.headings.main" | t }}</span>

--- a/views/admin/users/personal-details/edit.njk
+++ b/views/admin/users/personal-details/edit.njk
@@ -1,20 +1,11 @@
 {% extends "base.njk" %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 
 {% block content %}
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-
-    {% if backLink %}
-      {{ govukBackLink({
-        text: ( "app.back" | t ),
-        href: backLink
-      }) }}
-    {% endif %}
-
     {% include "../../../shared/_errors.njk" %}
 
     <span class="govuk-caption-xl">{{ "users.form.headings.main" | t }}</span>

--- a/views/admin/users/show.njk
+++ b/views/admin/users/show.njk
@@ -1,21 +1,13 @@
 {% extends "base.njk" %}
 {% from "govuk/components/table/macro.njk" import govukTable %}
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
 {% block content %}
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-
-    {{ govukBackLink({
-      text: ("app.back" | t),
-      href: "/admin/users"
-    }) }}
-
     <h1 class="govuk-heading-xl">{{ "users.headings.show" | t }}</h1>
     {% include "./_summary.njk" %}
-
   </div>
   <div class="govuk-grid-column-one-third">
     <aside class="rpr-sidebar rpr-internal__details-page-sidebar" role="complementary">

--- a/views/base.njk
+++ b/views/base.njk
@@ -1,5 +1,6 @@
 {% extends "govuk/template.njk" %}
 {% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 
 {% block header %}
   {{
@@ -18,6 +19,13 @@
         html: ("app.phase.beta.html" | t | safe)
       })
     }}
+
+    {% if backLink %}
+      {{ govukBackLink({
+        text: ( "app.back" | t ),
+        href: backLink
+      }) }}
+    {% endif %}
   </div>
 {% endblock %}
 

--- a/views/organisations/search/index.njk
+++ b/views/organisations/search/index.njk
@@ -1,15 +1,6 @@
 {% extends "base.njk" %}
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 
 {% block content %}
-
-  {% if backLink %}
-    {{ govukBackLink({
-      text: ( "app.back" | t ),
-      href: backLink
-    }) }}
-  {% endif %}
-
   <h1 class="govuk-heading-xl">{{ "organisations.search.heading" | t }}</h1>
 
   <div class="govuk-grid-row">
@@ -25,7 +16,7 @@
 
       {% set filterCriteriaTextPrefix = "organisations.search" %}
       {% include "../../shared/_filter-criteria.njk" %}
-      
+
       <p class="govuk-body-m">
         <span class="govuk-!-font-size-36 govuk-!-font-weight-bold">{{ organisations.length }}</span> {{ ("organisations.search.foundSingular" | t) if (organisations.length === 1) else ("organisations.search.foundPlural" | t) }}
       </p>
@@ -37,7 +28,7 @@
           <h2>
             <a class="govuk-link govuk-heading-m rpr-listing__ra-title" href="/regulatory-authorities/{{ organisation.slug }}">{{ organisation.name }}<br>
           </h2>
-      
+
           {% if not loop.last %}
             <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
           {% endif %}

--- a/views/organisations/show.njk
+++ b/views/organisations/show.njk
@@ -1,18 +1,9 @@
 {% extends "base.njk" %}
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
 {% set bodyClasses = "rpr-details__page" %}
 
 {% block content %}
-
-  {% if backLink %}
-    {{ govukBackLink({
-      text: ( "app.back" | t ),
-      href: backLink
-    }) }}
-  {% endif %}
-
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
     {% set professionPagePrefix = "professions"%}
@@ -21,5 +12,4 @@
     <div class="govuk-grid-column-one-third">
     </div>
   </div>
-
 {% endblock %}

--- a/views/professions/search/index.njk
+++ b/views/professions/search/index.njk
@@ -1,16 +1,7 @@
 {% extends "base.njk" %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 
 {% block content %}
-
-{% if backLink %}
-  {{ govukBackLink({
-    text: ( "app.back" | t ),
-    href: backLink
-  }) }}
-{% endif %}
-
 <h1 class="govuk-heading-xl">{{ "professions.search.heading" | t }}</h1>
 
   <div class="govuk-grid-row">
@@ -26,7 +17,7 @@
 
       {% set filterCriteriaTextPrefix = "professions.search" %}
       {% include "../../shared/_filter-criteria.njk" %}
-      
+
       <p class="govuk-body-m">
         <span class="govuk-!-font-size-36 govuk-!-font-weight-bold">{{ professions.length }}</span> {{ ("professions.search.foundSingular" | t) if (professions.length === 1) else ("professions.search.foundPlural" | t) }}
       </p>
@@ -46,7 +37,7 @@
             <a class="govuk-link govuk-heading-l rpr-listing__profession-title" href="/professions/{{ profession.slug }}">{{ profession.name }}<br>
               <span class="govuk-caption-l">{{ profession.nations }}</span></a>
           </h2>
-      
+
             {{ govukSummaryList({
               classes: 'govuk-summary-list--no-border rpr-listing__profession-summary-list',
               rows: [

--- a/views/professions/show.njk
+++ b/views/professions/show.njk
@@ -1,18 +1,10 @@
 {% extends "base.njk" %}
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 
 {% set bodyClasses = "rpr-details__page" %}
 
 {% block content %}
 
 <div class="govuk-width-container">
-  {% if backLink %}
-    {{ govukBackLink({
-      text: ( "app.back" | t ),
-      href: backLink
-    }) }}
-  {% endif %}
-
   <main class="govuk-main-wrapper">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">


### PR DESCRIPTION
This moves the back button to under the phase banner to avoid the awkward spacing issues we have had and also DRY up the templates. I've also added a `BackLink` decorator, which sets the `backLink` without it having to be present in templates. 

## Screenshots of UI changes

### Before

![image](https://user-images.githubusercontent.com/109774/150387461-476ff580-f944-4e96-adaa-b4f17d042b2d.png)

### After

![image](https://user-images.githubusercontent.com/109774/150387522-63901640-b3b9-4212-aaf3-cc4d5355be5b.png)

