### PR TITLE
(2036) Add an OrganisationsVersions table

### DIFF
--- a/src/db/migrate/1642781768700-AddOrganisationVersion.ts
+++ b/src/db/migrate/1642781768700-AddOrganisationVersion.ts
@@ -1,0 +1,39 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddOrganisationVersion1642781768700 implements MigrationInterface {
+  name = 'AddOrganisationVersion1642781768700';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TYPE "public"."organisationVersions_status_enum" AS ENUM('live', 'draft', 'archived')`,
+    );
+    await queryRunner.query(
+      `CREATE TABLE "organisationVersions" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "slug" character varying, "status" "public"."organisationVersions_status_enum" NOT NULL DEFAULT 'draft', "created_at" TIMESTAMP NOT NULL DEFAULT ('now'::text)::timestamp(6) with time zone, "updated_at" TIMESTAMP NOT NULL DEFAULT ('now'::text)::timestamp(6) with time zone, "organisationId" uuid, "userId" uuid, CONSTRAINT "REL_81a209c70f4c7e5a9743e6cb07" UNIQUE ("organisationId"), CONSTRAINT "PK_2f5f9d21aa796fc308e09489350" PRIMARY KEY ("id"))`,
+    );
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX "IDX_e349c236153a972d31b5f72e67" ON "organisationVersions" ("slug") WHERE "slug" IS NOT NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "organisationVersions" ADD CONSTRAINT "FK_81a209c70f4c7e5a9743e6cb077" FOREIGN KEY ("organisationId") REFERENCES "organisations"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "organisationVersions" ADD CONSTRAINT "FK_37c90fe3da5c8598ac272ef1a87" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "organisationVersions" DROP CONSTRAINT "FK_37c90fe3da5c8598ac272ef1a87"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "organisationVersions" DROP CONSTRAINT "FK_81a209c70f4c7e5a9743e6cb077"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_e349c236153a972d31b5f72e67"`,
+    );
+    await queryRunner.query(`DROP TABLE "organisationVersions"`);
+    await queryRunner.query(
+      `DROP TYPE "public"."organisationVersions_status_enum"`,
+    );
+  }
+}

--- a/src/organisations/organisation-version.entity.ts
+++ b/src/organisations/organisation-version.entity.ts
@@ -1,0 +1,56 @@
+import { Organisation } from './organisation.entity';
+import { User } from '../users/user.entity';
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  Index,
+  OneToOne,
+  JoinColumn,
+  ManyToOne,
+} from 'typeorm';
+
+export enum OrganisationVersionStatus {
+  Live = 'live',
+  Draft = 'draft',
+  Archived = 'archived',
+}
+
+@Entity({ name: 'organisationVersions' })
+export class OrganisationVersion {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Index({ unique: true, where: '"slug" IS NOT NULL' })
+  @Column({ nullable: true })
+  slug: string;
+
+  @OneToOne(() => Organisation, (organisation) => organisation.version)
+  @JoinColumn()
+  organisation: Organisation;
+
+  @ManyToOne(() => User, (user) => user.organisationVersions)
+  user: User;
+
+  @Column({
+    type: 'enum',
+    enum: OrganisationVersionStatus,
+    default: OrganisationVersionStatus.Draft,
+  })
+  status: OrganisationVersionStatus;
+
+  @CreateDateColumn({
+    type: 'timestamp',
+    default: () => 'CURRENT_TIMESTAMP(6)',
+  })
+  created_at: Date;
+
+  @UpdateDateColumn({
+    type: 'timestamp',
+    default: () => 'CURRENT_TIMESTAMP(6)',
+    onUpdate: 'CURRENT_TIMESTAMP(6)',
+  })
+  updated_at: Date;
+}

--- a/src/organisations/organisation-versions.service.spec.ts
+++ b/src/organisations/organisation-versions.service.spec.ts
@@ -1,0 +1,46 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import organisationVersionFactory from '../testutils/factories/organisation-version';
+import { OrganisationVersion } from './organisation-version.entity';
+import { OrganisationVersionsService } from './organisation-versions.service';
+
+describe('OrganisationVersionsService', () => {
+  let service: OrganisationVersionsService;
+  let repo: Repository<OrganisationVersion>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        OrganisationVersionsService,
+        {
+          provide: getRepositoryToken(OrganisationVersion),
+          useValue: {
+            save: () => {
+              return null;
+            },
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<OrganisationVersionsService>(
+      OrganisationVersionsService,
+    );
+    repo = module.get<Repository<OrganisationVersion>>(
+      getRepositoryToken(OrganisationVersion),
+    );
+  });
+
+  describe('save', () => {
+    it('saves the entity', async () => {
+      const organisationVersion = organisationVersionFactory.build();
+
+      const repoSpy = jest.spyOn(repo, 'save');
+
+      await service.save(organisationVersion);
+
+      expect(repoSpy).toHaveBeenCalledWith(organisationVersion);
+    });
+  });
+});

--- a/src/organisations/organisation-versions.service.ts
+++ b/src/organisations/organisation-versions.service.ts
@@ -1,0 +1,16 @@
+import { Repository } from 'typeorm';
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { OrganisationVersion } from './organisation-version.entity';
+
+@Injectable()
+export class OrganisationVersionsService {
+  constructor(
+    @InjectRepository(OrganisationVersion)
+    private repository: Repository<OrganisationVersion>,
+  ) {}
+
+  async save(organisation: OrganisationVersion): Promise<OrganisationVersion> {
+    return this.repository.save(organisation);
+  }
+}

--- a/src/organisations/organisation.entity.ts
+++ b/src/organisations/organisation.entity.ts
@@ -1,4 +1,6 @@
 import { Profession } from '../professions/profession.entity';
+import { OrganisationVersion } from './organisation-version.entity';
+
 import {
   Entity,
   PrimaryGeneratedColumn,
@@ -7,6 +9,7 @@ import {
   UpdateDateColumn,
   OneToMany,
   Index,
+  OneToOne,
 } from 'typeorm';
 
 @Entity({ name: 'organisations' })
@@ -44,6 +47,12 @@ export class Organisation {
 
   @OneToMany(() => Profession, (profession) => profession.organisation)
   professions: Profession[];
+
+  @OneToOne(
+    () => OrganisationVersion,
+    (organisationVersion) => organisationVersion.organisation,
+  )
+  version: OrganisationVersion;
 
   @CreateDateColumn({
     type: 'timestamp',

--- a/src/organisations/organisations.module.ts
+++ b/src/organisations/organisations.module.ts
@@ -3,13 +3,19 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { IndustriesService } from '../industries/industries.service';
 import { Industry } from '../industries/industry.entity';
 import { Organisation } from './organisation.entity';
+import { OrganisationVersion } from './organisation-version.entity';
 import { OrganisationsService } from './organisations.service';
+import { OrganisationVersionsService } from './organisation-versions.service';
 import { OrganisationsController as AdminOrganisationsController } from './admin/organisations.controller';
 import { SearchController } from './search/search.controller';
 import { OrganisationsController } from './organisations.controller';
 
 @Module({
-  providers: [OrganisationsService, IndustriesService],
+  providers: [
+    OrganisationsService,
+    IndustriesService,
+    OrganisationVersionsService,
+  ],
   controllers: [
     AdminOrganisationsController,
     SearchController,
@@ -17,6 +23,7 @@ import { OrganisationsController } from './organisations.controller';
   ],
   imports: [
     TypeOrmModule.forFeature([Organisation]),
+    TypeOrmModule.forFeature([OrganisationVersion]),
     TypeOrmModule.forFeature([Industry]),
   ],
 })

--- a/src/testutils/factories/organisation-version.ts
+++ b/src/testutils/factories/organisation-version.ts
@@ -1,0 +1,17 @@
+import { Factory } from 'fishery';
+import {
+  OrganisationVersion,
+  OrganisationVersionStatus,
+} from '../../organisations/organisation-version.entity';
+import organisationFactory from './organisation';
+import userFactory from './user';
+
+export default Factory.define<OrganisationVersion>(({ sequence }) => ({
+  id: sequence.toString(),
+  slug: 'example-slug',
+  organisation: organisationFactory.build(),
+  user: userFactory.build(),
+  status: OrganisationVersionStatus.Draft,
+  created_at: new Date(),
+  updated_at: new Date(),
+}));

--- a/src/testutils/factories/organisation.ts
+++ b/src/testutils/factories/organisation.ts
@@ -13,6 +13,7 @@ export default Factory.define<Organisation>(({ sequence }) => ({
   telephone: '+441234567890',
   fax: '+441234567891',
   professions: undefined,
+  version: undefined,
   created_at: new Date(),
   updated_at: new Date(),
 }));

--- a/src/testutils/factories/user.ts
+++ b/src/testutils/factories/user.ts
@@ -7,6 +7,7 @@ export default Factory.define<User>(({ sequence }) => ({
   name: 'Example User',
   permissions: [UserPermission.CreateUser],
   externalIdentifier: 'extid|1234567',
+  organisationVersions: [],
   serviceOwner: false,
   confirmed: false,
   created_at: new Date(),

--- a/src/users/user.entity.ts
+++ b/src/users/user.entity.ts
@@ -5,7 +5,9 @@ import {
   Index,
   CreateDateColumn,
   UpdateDateColumn,
+  OneToMany,
 } from 'typeorm';
+import { OrganisationVersion } from '../organisations/organisation-version.entity';
 
 export enum UserPermission {
   CreateUser = 'createUser',
@@ -61,6 +63,12 @@ export class User {
 
   @Column({ default: false })
   confirmed: boolean;
+
+  @OneToMany(
+    () => OrganisationVersion,
+    (organisationVersion) => organisationVersion.user,
+  )
+  organisationVersions: OrganisationVersion[];
 
   constructor(
     email?: string,


### PR DESCRIPTION
This adds an `OrganisationVersions` entity and service, which is the first part of the puzzle for versioning and making draft versions of our Organisations.