### PR TITLE
Disable Cypress video recording

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -1,4 +1,5 @@
 {
   "baseUrl": "http://localhost:3000",
-  "experimentalSessionSupport": true
+  "experimentalSessionSupport": true,
+  "video": false
 }


### PR DESCRIPTION
It slows down the test runs. We can turn it on manually if we need to do any debugging