### PR TITLE
Update internal `OrganisationsController` tests

### DIFF
--- a/src/organisations/admin/organisations.controller.spec.ts
+++ b/src/organisations/admin/organisations.controller.spec.ts
@@ -16,6 +16,7 @@ import professionFactory from '../../testutils/factories/profession';
 import { OrganisationSummaryPresenter } from '../presenters/organisation-summary.presenter';
 import { createMockI18nService } from '../../testutils/create-mock-i18n-service';
 import { SummaryList } from '../../common/interfaces/summary-list';
+import { ShowTemplate } from '../interfaces/show-template.interface';
 
 jest.mock('../presenters/organisations.presenter');
 jest.mock('../presenters/organisation.presenter');
@@ -85,19 +86,26 @@ describe('OrganisationsController', () => {
         organisation,
       );
 
-      const expected = await new OrganisationSummaryPresenter(
+      const showTemplate: ShowTemplate = {
         organisation,
-        i18nService,
-      ).present();
+        summaryList: {
+          classes: 'govuk-summary-list--no-border',
+          rows: [],
+        },
+        professions: [],
+      };
 
-      expect(await controller.show('slug')).toEqual(expected);
+      (
+        OrganisationSummaryPresenter.prototype as DeepMocked<OrganisationSummaryPresenter>
+      ).present.mockResolvedValue(showTemplate);
+
+      expect(await controller.show('slug')).toEqual(showTemplate);
 
       expect(
         organisationsService.findBySlugWithProfessions,
       ).toHaveBeenCalledWith('slug');
 
-      expect(OrganisationSummaryPresenter).toHaveBeenNthCalledWith(
-        2,
+      expect(OrganisationSummaryPresenter).toHaveBeenCalledWith(
         organisation,
         i18nService,
       );


### PR DESCRIPTION
This reduces the reliance on `beforeEach`, and makes more explicit what test depend on which `OrganisationsService` methods.

I've kept the creation of the controller itself inside the `beforeEach`, which seems reasonable for controller tests, and I think it makes sense to keep `i18nService` and `organisationsService` as variables in the top level `describe`, rather than each `it` to avoid a lot of repetition.

I'd maybe want to move the `jest.mock()` module mocking calls into the `it` blocks, but this doesn't seem possible without everything breaking, and it makes some sense to have these just after the imports