### PR TITLE
Allow organisations to be created

### DIFF
--- a/cypress/integration/admin/organisations/new.spec.ts
+++ b/cypress/integration/admin/organisations/new.spec.ts
@@ -1,0 +1,110 @@
+describe('Creating organisations', () => {
+  context('When I am logged in as admin', () => {
+    beforeEach(() => {
+      cy.loginAuth0('admin');
+      cy.visit('/admin');
+
+      cy.translate('organisations.admin.index.add.button').then(() => {
+        cy.get('a').contains('Regulatory authorities').click();
+      });
+
+      cy.translate('organisations.admin.index.add.button').then(
+        (buttonText) => {
+          cy.get('a').contains(buttonText).click();
+        },
+      );
+
+      cy.translate('app.start').then((startButton) => {
+        cy.get('button').contains(startButton).click();
+      });
+    });
+
+    it('Shows errors when I input data incorrectly', () => {
+      cy.get('input[name="name"]').invoke('val', '');
+
+      cy.get('input[name="contactUrl"]')
+        .invoke('val', '')
+        .type('this is not a url');
+
+      cy.get('input[name="email"]')
+        .invoke('val', '')
+        .type('this is not an email');
+
+      cy.translate('app.continue').then((buttonText) => {
+        cy.get('button').contains(buttonText).click();
+      });
+
+      cy.translate('organisations.admin.form.errors.name.empty').then(
+        (error) => {
+          cy.get('body').should('contain', error);
+        },
+      );
+
+      cy.translate('organisations.admin.form.errors.email.invalid').then(
+        (error) => {
+          cy.get('body').should('contain', error);
+        },
+      );
+
+      cy.translate('organisations.admin.form.errors.contactUrl.invalid').then(
+        (error) => {
+          cy.get('body').should('contain', error);
+        },
+      );
+    });
+
+    it('allows me to create an organisation', () => {
+      cy.get('input[name="name"]').invoke('val', 'New Organisation');
+
+      cy.get('input[name="alternateName"]').type('Alternate Name');
+
+      cy.get('input[name="url"]').type('http://example.com');
+      cy.get('input[name="contactUrl"]').type('http://example.com');
+
+      cy.get('textarea[name="address"]').type('123 Fake Street');
+
+      cy.get('input[name="email"]').type('foo@example.com');
+      cy.get('input[name="telephone"]').type('1234');
+
+      cy.translate('app.continue').then((buttonText) => {
+        cy.get('button').contains(buttonText).click();
+      });
+
+      cy.checkSummaryListRowValue(
+        'organisations.label.name',
+        'New Organisation',
+      );
+      cy.checkSummaryListRowValue(
+        'organisations.label.alternateName',
+        'Alternate Name',
+      );
+      cy.checkSummaryListRowValue(
+        'organisations.label.contactUrl',
+        'http://example.com',
+      );
+      cy.checkSummaryListRowValue(
+        'organisations.label.address',
+        '123 Fake Street',
+      );
+      cy.checkSummaryListRowValue(
+        'organisations.label.email',
+        'foo@example.com',
+      );
+      cy.checkSummaryListRowValue('organisations.label.telephone', '1234');
+
+      cy.translate('organisations.admin.button.amend').then((buttonText) => {
+        cy.get('button').contains(buttonText).click();
+      });
+
+      cy.translate('organisations.admin.form.headings.confirmation').then(
+        (confirmationText) => {
+          cy.get('html').should('contain', confirmationText);
+        },
+      );
+
+      cy.visit('/admin/organisations');
+
+      cy.get('body').should('contain', 'New Organisation');
+    });
+  });
+});

--- a/src/i18n/en/organisations.json
+++ b/src/i18n/en/organisations.json
@@ -38,6 +38,13 @@
     "new": {
       "heading": "Are you sure you want to create a new regulatory authority?"
     },
+    "index": {
+      "add": {
+        "heading": "Add a new regulatory authority",
+        "body": "You can add a new regulatory authority here.",
+        "button": "Add a new regulatory authority"
+      }
+    },
     "tableHeading": {
       "name": "Name",
       "alternateName": "Alternate name",

--- a/src/i18n/en/organisations.json
+++ b/src/i18n/en/organisations.json
@@ -35,6 +35,9 @@
     "edit": {
       "heading": "Amending a regulatory authority"
     },
+    "new": {
+      "heading": "Are you sure you want to create a new regulatory authority?"
+    },
     "tableHeading": {
       "name": "Name",
       "alternateName": "Alternate name",

--- a/src/main.ts
+++ b/src/main.ts
@@ -45,6 +45,7 @@ async function bootstrap() {
       exceptionFactory: (validationErrors: ValidationError[] = []) => {
         return new ValidationFailedError(validationErrors);
       },
+      skipUndefinedProperties: true,
     }),
   );
 

--- a/src/organisations/admin/dto/organisation.dto.ts
+++ b/src/organisations/admin/dto/organisation.dto.ts
@@ -37,4 +37,6 @@ export class OrganisationDto {
 
   telephone: string;
   fax: string;
+
+  confirm?: boolean;
 }

--- a/src/organisations/admin/interfaces/review-template.interface.ts
+++ b/src/organisations/admin/interfaces/review-template.interface.ts
@@ -1,6 +1,6 @@
 import { Organisation } from '../../organisation.entity';
 import { SummaryList } from '../../../common/interfaces/summary-list';
 
-export interface ConfirmTemplate extends Organisation {
+export interface ReviewTemplate extends Organisation {
   summaryList: SummaryList;
 }

--- a/src/organisations/admin/organisations.controller.spec.ts
+++ b/src/organisations/admin/organisations.controller.spec.ts
@@ -211,9 +211,11 @@ describe('OrganisationsController', () => {
   describe('edit', () => {
     it('should return the organisation', async () => {
       const organisation = createOrganisation();
-      organisationsService.findBySlug.mockResolvedValue(organisation);
 
-      expect(await controller.edit('slug')).toEqual(organisation);
+      organisationsService.find.mockResolvedValue(organisation);
+
+      expect(await controller.edit(organisation.id)).toEqual(organisation);
+      expect(organisationsService.find).toHaveBeenCalledWith(organisation.id);
     });
   });
 
@@ -228,7 +230,8 @@ describe('OrganisationsController', () => {
         OrganisationPresenter.prototype as DeepMocked<OrganisationPresenter>
       ).summaryList.mockResolvedValue(summaryList);
 
-      const slug = 'some-slug';
+      const id = 'some-uuid';
+
       const organisationDto: OrganisationDto = {
         name: 'Organisation',
         alternateName: '',
@@ -240,17 +243,17 @@ describe('OrganisationsController', () => {
         fax: '',
       };
 
-      const organisation = createOrganisation();
+      const organisation = organisationFactory.build();
 
       const newOrganisation = {
         ...organisation,
         ...organisationDto,
       };
 
-      organisationsService.findBySlug.mockResolvedValue(organisation);
+      organisationsService.find.mockResolvedValue(organisation);
       organisationsService.save.mockResolvedValue(newOrganisation);
 
-      const result = await controller.confirm(slug, organisationDto);
+      const result = await controller.confirm(id, organisationDto);
 
       expect(organisationsService.save).toHaveBeenCalledWith(
         expect.objectContaining(newOrganisation),
@@ -272,6 +275,18 @@ describe('OrganisationsController', () => {
         ...newOrganisation,
         summaryList: summaryList,
       });
+    });
+  });
+
+  describe('update', () => {
+    it('should update the organisation', async () => {
+      const organisation = createOrganisation();
+      organisationsService.find.mockResolvedValue(organisation);
+
+      expect(await controller.update('some-uuid')).toEqual(organisation);
+
+      expect(organisationsService.find).toHaveBeenCalledWith('some-uuid');
+      expect(organisationsService.save).toHaveBeenCalledWith(organisation);
     });
   });
 });

--- a/src/organisations/admin/organisations.controller.spec.ts
+++ b/src/organisations/admin/organisations.controller.spec.ts
@@ -176,6 +176,26 @@ describe('OrganisationsController', () => {
     });
   });
 
+  describe('create', () => {
+    it('should return the organisation', async () => {
+      const response = createMock<Response>();
+      const organisation = organisationFactory.build({
+        id: 'some-uuid',
+      });
+
+      organisationsService.save.mockResolvedValue(organisation);
+
+      await controller.create(response);
+
+      expect(organisationsService.save).toHaveBeenCalledWith(
+        expect.objectContaining(new Organisation()),
+      );
+      expect(response.redirect).toHaveBeenCalledWith(
+        `/admin/organisations/some-uuid/edit`,
+      );
+    });
+  });
+
   describe('show', () => {
     it('should return variables for the show template', async () => {
       const organisation = createOrganisation();
@@ -263,7 +283,7 @@ describe('OrganisationsController', () => {
         );
 
         expect(OrganisationPresenter).toHaveBeenCalledWith(
-          newOrganisation,
+          expect.objectContaining(newOrganisation),
           i18nService,
         );
 

--- a/src/organisations/admin/organisations.controller.ts
+++ b/src/organisations/admin/organisations.controller.ts
@@ -7,6 +7,7 @@ import {
   Body,
   UseFilters,
   Put,
+  Post,
   Query,
   Res,
 } from '@nestjs/common';
@@ -63,6 +64,23 @@ export class OrganisationsController {
     );
 
     return presenter.present();
+  }
+
+  @Get('/new')
+  @Render('admin/organisations/new')
+  @BackLink('/admin/organisations')
+  async new() {
+    // Do nothing
+  }
+
+  @Post('/')
+  async create(@Res() res: Response): Promise<void> {
+    const blankOrganisation = new Organisation();
+    const organisation = await this.organisationsService.save(
+      blankOrganisation,
+    );
+
+    return res.redirect(`/admin/organisations/${organisation.id}/edit`);
   }
 
   @Get('/:slug')

--- a/src/organisations/admin/organisations.controller.ts
+++ b/src/organisations/admin/organisations.controller.ts
@@ -79,24 +79,24 @@ export class OrganisationsController {
     return organisationSummaryPresenter.present();
   }
 
-  @Get('/:slug/edit')
+  @Get('/:id/edit')
   @Render('admin/organisations/edit')
-  @BackLink('/admin/organisations/:slug')
-  async edit(@Param('slug') slug: string): Promise<Organisation> {
-    const organisation = await this.organisationsService.findBySlug(slug);
+  @BackLink('/admin/organisations/:id')
+  async edit(@Param('id') id: string): Promise<Organisation> {
+    const organisation = await this.organisationsService.find(id);
 
     return organisation;
   }
 
-  @Post('/:slug/confirm')
+  @Post('/:id/confirm')
   @Render('admin/organisations/confirm')
-  @BackLink('/admin/organisations/:slug/edit')
+  @BackLink('/admin/organisations/:id/edit')
   @UseFilters(new ValidationExceptionFilter('admin/organisations/edit'))
   async confirm(
-    @Param('slug') slug: string,
+    @Param('id') id: string,
     @Body() organisationDto: OrganisationDto,
   ): Promise<ConfirmTemplate> {
-    const organisation = await this.organisationsService.findBySlug(slug);
+    const organisation = await this.organisationsService.find(id);
     const newOrganisation = {
       ...organisation,
       ...(organisationDto as Organisation),
@@ -122,10 +122,10 @@ export class OrganisationsController {
     };
   }
 
-  @Put('/:slug')
+  @Put('/:id')
   @Render('admin/organisations/complete')
-  async create(@Param('slug') slug: string): Promise<Organisation> {
-    const organisation = await this.organisationsService.findBySlug(slug);
+  async update(@Param('id') id: string): Promise<Organisation> {
+    const organisation = await this.organisationsService.find(id);
 
     // This should potentially add a confirmed flag to the object once
     // we have draft functionality in place

--- a/src/organisations/organisation.entity.ts
+++ b/src/organisations/organisation.entity.ts
@@ -81,7 +81,7 @@ export class Organisation {
   ) {
     this.name = name || '';
     this.alternateName = alternateName || '';
-    this.slug = slug || '';
+    this.slug = slug || null;
     this.address = address || '';
     this.url = url || '';
     this.email = email || '';

--- a/src/organisations/presenters/organisation.presenter.spec.ts
+++ b/src/organisations/presenters/organisation.presenter.spec.ts
@@ -262,7 +262,7 @@ describe('OrganisationPresenter', () => {
           expect(row.actions).toEqual({
             items: [
               {
-                href: `/admin/organisations/${organisation.slug}/edit`,
+                href: `/admin/organisations/${organisation.id}/edit`,
                 text: 'Translation of `app.change`',
                 visuallyHiddenText: visuallyHiddenText,
               },

--- a/src/organisations/presenters/organisation.presenter.ts
+++ b/src/organisations/presenters/organisation.presenter.ts
@@ -120,7 +120,7 @@ export class OrganisationPresenter {
             actions: {
               items: [
                 {
-                  href: `/admin/organisations/${this.organisation.slug}/edit`,
+                  href: `/admin/organisations/${this.organisation.id}/edit`,
                   text: await this.i18nService.translate('app.change'),
                   visuallyHiddenText: row.key.text,
                 },

--- a/views/admin/organisations/confirm.njk
+++ b/views/admin/organisations/confirm.njk
@@ -13,7 +13,7 @@
   <div class="govuk-grid-column-two-thirds">
       {{ govukSummaryList(summaryList) }}
 
-      <form action="/admin/organisations/{{ slug }}?_method=PUT" method="post">
+      <form action="/admin/organisations/{{ id }}?_method=PUT" method="post">
         <input type="hidden" name="_method" value="PUT" />
 
         {{

--- a/views/admin/organisations/edit.njk
+++ b/views/admin/organisations/edit.njk
@@ -15,7 +15,7 @@
     <div class="govuk-grid-column-two-thirds">
       {% include "../../shared/_errors.njk" %}
 
-      {% set targetUrl = ( currentUrl if '/confirm' in currentUrl else "/admin/organisations/"+ slug +"/confirm" ) %}
+      {% set targetUrl = ( currentUrl if '/confirm' in currentUrl else "/admin/organisations/"+ id +"/confirm" ) %}
 
       <form method="post" action="{{ targetUrl }}">
         {{

--- a/views/admin/organisations/edit.njk
+++ b/views/admin/organisations/edit.njk
@@ -15,7 +15,7 @@
     <div class="govuk-grid-column-two-thirds">
       {% include "../../shared/_errors.njk" %}
 
-      {% set targetUrl = ( currentUrl if '/confirm' in currentUrl else "/admin/organisations/"+ id +"/confirm" ) %}
+      {% set targetUrl = ( currentUrl if errors else "/admin/organisations/"+ id +"?_method=PUT" ) %}
 
       <form method="post" action="{{ targetUrl }}">
         {{

--- a/views/admin/organisations/index.njk
+++ b/views/admin/organisations/index.njk
@@ -1,5 +1,6 @@
 {% extends "base.njk" %}
 {% from "govuk/components/table/macro.njk" import govukTable %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
 
 {% set bodyClasses = "rpr-internal__listing rpr-internal__page" %}
 
@@ -7,6 +8,27 @@
   <h1 class="govuk-heading-xl">
     {{ "organisations.admin.heading" | t }}
   </h1>
+
+  {% if 'createOrganisation' in user.permissions %}
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-full">
+        <h2 class="govuk-heading-l">
+          {{ "organisations.admin.index.add.heading" | t }}
+        </h2>
+
+        <p class="govuk-body">{{ "organisations.admin.index.add.body" | t }}</p>
+
+        {{
+          govukButton({
+            text: ("organisations.admin.index.add.button" | t),
+            href: "/admin/organisations/new"
+          })
+        }}
+
+        <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+      </div>
+    </div>
+  {% endif %}
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">

--- a/views/admin/organisations/new.njk
+++ b/views/admin/organisations/new.njk
@@ -1,0 +1,25 @@
+{% extends "base.njk" %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% set bodyClasses = "rpr-internal__page" %}
+
+{% block content %}
+  <h1 class="govuk-heading-xl">
+    {{ "organisations.admin.new.heading" | t }}
+  </h1>
+
+  <div class="govuk-grid-row">
+
+    <div class="govuk-grid-column-full">
+      <form method="post" action="/admin/organisations">
+        {{ govukButton({
+          id: "submit-button",
+          type: "Submit",
+          text: ("app.start" | t)
+        }) }}
+      </form>
+    </div>
+
+  </div>
+
+{% endblock %}

--- a/views/admin/organisations/review.njk
+++ b/views/admin/organisations/review.njk
@@ -14,7 +14,7 @@
       {{ govukSummaryList(summaryList) }}
 
       <form action="/admin/organisations/{{ id }}?_method=PUT" method="post">
-        <input type="hidden" name="_method" value="PUT" />
+        <input type="hidden" name="confirm" value="true" />
 
         {{
           govukButton({

--- a/views/admin/organisations/show.njk
+++ b/views/admin/organisations/show.njk
@@ -23,7 +23,7 @@
               {{
                 govukButton({
                   text: ("organisations.admin.button.edit" | t),
-                  href: "/admin/organisations/" + organisation.slug + "/edit"
+                  href: "/admin/organisations/" + organisation.id + "/edit"
                 })
               }}
             </li>


### PR DESCRIPTION
This allows organisations to be created. The journey isn't 100% complete (for example, we don't create a slug), but there didn't seem much point in adding that given that we're going to make some quite significant changes to the model soon (given the changes in #151).

There are some copy changes that need making (for example, it still says "amending" rather than "creating" on the forms), but this can be tightened up once we start with the versioning.

![image](https://user-images.githubusercontent.com/109774/150972135-5bc1c476-f6d0-4ac9-98c0-c1c0c4378918.png)

![image](https://user-images.githubusercontent.com/109774/150972160-cdef3a45-50ef-40b8-9528-4b40a59073b2.png)

![image](https://user-images.githubusercontent.com/109774/150972189-5b1e8703-95de-4ea4-9751-a3f6d95479d4.png)

![image](https://user-images.githubusercontent.com/109774/150972254-26fd19d3-f315-42bc-8806-b6bc50be0d6f.png)
