### PR TITLE
(2057) Fix admin view where no qualifications are found for a profession

### DIFF
--- a/src/professions/admin/professions.controller.spec.ts
+++ b/src/professions/admin/professions.controller.spec.ts
@@ -19,6 +19,7 @@ import organisationFactory from '../../testutils/factories/organisation';
 import professionFactory from '../../testutils/factories/profession';
 import { NotFoundException } from '@nestjs/common';
 import QualificationPresenter from '../../qualifications/presenters/qualification.presenter';
+import { translationOf } from '../../testutils/translation-of';
 
 const referrer = 'http://example.com/some/path';
 const host = 'example.com';
@@ -357,6 +358,27 @@ describe('ProfessionsController', () => {
       expect(async () => {
         await controller.show('example-invalid-slug');
       }).rejects.toThrowError(NotFoundException);
+    });
+
+    describe('when the Profession has no qualification set', () => {
+      it('passes a null value for the qualification', async () => {
+        const profession = professionFactory.build({
+          qualification: null,
+          occupationLocations: ['GB-ENG'],
+          industries: [industryFactory.build({ name: 'industries.example' })],
+        });
+
+        professionsService.findBySlug.mockResolvedValue(profession);
+
+        const result = await controller.show('example-slug');
+
+        expect(result).toEqual({
+          profession: profession,
+          qualification: null,
+          nations: [translationOf('nations.england')],
+          industries: [translationOf('industries.example')],
+        });
+      });
     });
   });
 

--- a/src/professions/admin/professions.controller.ts
+++ b/src/professions/admin/professions.controller.ts
@@ -86,9 +86,13 @@ export class ProfessionsController {
       ),
     );
 
+    const qualification = profession.qualification
+      ? new QualificationPresenter(profession.qualification)
+      : null;
+
     return {
       profession,
-      qualification: new QualificationPresenter(profession.qualification),
+      qualification: qualification,
       nations,
       industries,
     };

--- a/src/professions/professions.controller.spec.ts
+++ b/src/professions/professions.controller.spec.ts
@@ -5,6 +5,7 @@ import { I18nService } from 'nestjs-i18n';
 import QualificationPresenter from '../qualifications/presenters/qualification.presenter';
 import industryFactory from '../testutils/factories/industry';
 import professionFactory from '../testutils/factories/profession';
+import { translationOf } from '../testutils/translation-of';
 
 import { ProfessionsController } from './professions.controller';
 import { ProfessionsService } from './professions.service';
@@ -87,6 +88,27 @@ describe('ProfessionsController', () => {
       expect(async () => {
         await controller.show('example-invalid-slug');
       }).rejects.toThrowError(NotFoundException);
+    });
+
+    describe('when the Profession has no qualification set', () => {
+      it('passes a null value for the qualification', async () => {
+        const profession = professionFactory.build({
+          qualification: null,
+          occupationLocations: ['GB-ENG'],
+          industries: [industryFactory.build({ name: 'industries.example' })],
+        });
+
+        professionsService.findBySlug.mockResolvedValue(profession);
+
+        const result = await controller.show('example-slug');
+
+        expect(result).toEqual({
+          profession: profession,
+          qualification: null,
+          nations: [translationOf('nations.england')],
+          industries: [translationOf('industries.example')],
+        });
+      });
     });
   });
 });

--- a/src/professions/professions.controller.spec.ts
+++ b/src/professions/professions.controller.spec.ts
@@ -3,6 +3,7 @@ import { NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { I18nService } from 'nestjs-i18n';
 import QualificationPresenter from '../qualifications/presenters/qualification.presenter';
+import { createMockI18nService } from '../testutils/create-mock-i18n-service';
 import industryFactory from '../testutils/factories/industry';
 import professionFactory from '../testutils/factories/profession';
 import { translationOf } from '../testutils/translation-of';
@@ -10,26 +11,14 @@ import { translationOf } from '../testutils/translation-of';
 import { ProfessionsController } from './professions.controller';
 import { ProfessionsService } from './professions.service';
 
-const industry = industryFactory.build({ name: 'industries.example' });
-const exampleProfession = professionFactory.build({
-  id: 'profession-id',
-  name: 'Example Profession',
-  occupationLocations: ['GB-ENG'],
-  industries: [industry],
-});
-
 describe('ProfessionsController', () => {
   let controller: ProfessionsController;
   let professionsService: DeepMocked<ProfessionsService>;
   let i18nService: DeepMocked<I18nService>;
 
   beforeEach(async () => {
-    professionsService = createMock<ProfessionsService>({
-      save: async () => {
-        return exampleProfession;
-      },
-    });
-    i18nService = createMock<I18nService>();
+    professionsService = createMock<ProfessionsService>();
+    i18nService = createMockI18nService();
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -45,45 +34,32 @@ describe('ProfessionsController', () => {
     controller = module.get<ProfessionsController>(ProfessionsController);
   });
 
-  it('should be defined', () => {
-    expect(controller).toBeDefined();
-  });
-
   describe('show', () => {
     it('should return populated template params', async () => {
-      professionsService.findBySlug.mockImplementationOnce(
-        async () => exampleProfession,
-      );
-
-      i18nService.translate.mockImplementation(async (text) => {
-        switch (text) {
-          case 'industries.example':
-            return 'Example industry';
-          case 'nations.england':
-            return 'England';
-          default:
-            return '';
-        }
+      const industry = industryFactory.build({ name: 'industries.example' });
+      const profession = professionFactory.build({
+        id: 'profession-id',
+        name: 'Example Profession',
+        occupationLocations: ['GB-ENG'],
+        industries: [industry],
       });
+
+      professionsService.findBySlug.mockResolvedValue(profession);
 
       const result = await controller.show('example-slug');
 
       expect(result).toEqual({
-        profession: exampleProfession,
-        qualification: new QualificationPresenter(
-          exampleProfession.qualification,
-        ),
-        nations: ['England'],
-        industries: ['Example industry'],
+        profession: profession,
+        qualification: new QualificationPresenter(profession.qualification),
+        nations: [translationOf('nations.england')],
+        industries: [translationOf('industries.example')],
       });
 
       expect(professionsService.findBySlug).toBeCalledWith('example-slug');
     });
 
     it('should throw an error when the slug does not match a profession', () => {
-      professionsService.findBySlug.mockImplementationOnce(async () => {
-        return null;
-      });
+      professionsService.findBySlug.mockResolvedValue(null);
 
       expect(async () => {
         await controller.show('example-invalid-slug');


### PR DESCRIPTION
# Changes in this PR

- Ensures we don't create a `QualificationPresenter` with `null` when the Profession has no Qualification. This was causing the 'view details' link to break on staging.
- Tidies up tests a bit
