### PR TITLE
(2007) HTML escaping

### DIFF
--- a/src/helpers/escape.helper.spec.ts
+++ b/src/helpers/escape.helper.spec.ts
@@ -1,0 +1,13 @@
+import { escape } from './escape.helper';
+
+describe('escape', () => {
+  it('escapes HTML tags', () => {
+    expect(escape('<ul class="foo">')).toBe('&lt;ul class=&quot;foo&quot;&gt;');
+  });
+
+  it('escapes HTML reserved characters', () => {
+    expect(escape('It’s a great day for you & me')).toBe(
+      'It’s a great day for you &amp; me',
+    );
+  });
+});

--- a/src/helpers/escape.helper.ts
+++ b/src/helpers/escape.helper.ts
@@ -1,0 +1,6 @@
+import * as nunjucks from 'nunjucks';
+
+export function escape(text: string): string {
+  const escape = new nunjucks.Environment().getFilter('escape');
+  return escape(text).val;
+}

--- a/src/organisations/admin/organisations.controller.ts
+++ b/src/organisations/admin/organisations.controller.ts
@@ -145,7 +145,10 @@ export class OrganisationsController {
     }
   }
 
-  async confirm(res: Response, organisation: Organisation): Promise<void> {
+  private async confirm(
+    res: Response,
+    organisation: Organisation,
+  ): Promise<void> {
     // This should potentially add a confirmed flag to the object once
     // we have draft functionality in place
     await this.organisationsService.save(organisation);
@@ -153,7 +156,10 @@ export class OrganisationsController {
     res.render('admin/organisations/complete', organisation);
   }
 
-  async showReviewPage(res: Response, template: ReviewTemplate): Promise<void> {
+  private async showReviewPage(
+    res: Response,
+    template: ReviewTemplate,
+  ): Promise<void> {
     return res.render('admin/organisations/review', {
       ...template,
       backLink: `/admin/organisations/${template.id}/edit/`,

--- a/src/organisations/presenters/organisation.presenter.spec.ts
+++ b/src/organisations/presenters/organisation.presenter.spec.ts
@@ -10,6 +10,10 @@ import { createMockI18nService } from '../../testutils/create-mock-i18n-service'
 import organisationFactory from '../../testutils/factories/organisation';
 import professionFactory from '../../testutils/factories/profession';
 import industryFactory from '../../testutils/factories/industry';
+import { escape } from '../../helpers/escape.helper';
+import { escapeOf } from '../../testutils/escape-of';
+
+jest.mock('../../helpers/escape.helper');
 
 describe('OrganisationPresenter', () => {
   let organisation: Organisation;
@@ -34,6 +38,8 @@ describe('OrganisationPresenter', () => {
         });
 
         it('returns the table row data', async () => {
+          (escape as jest.Mock).mockImplementation(escapeOf);
+
           const presenter = new OrganisationPresenter(
             organisation,
             i18nService,
@@ -51,8 +57,12 @@ describe('OrganisationPresenter', () => {
             ),
           });
           expect(tableRow[3]).toEqual({
-            html: expect.stringContaining(`about ${organisation.name}`),
+            html: expect.stringContaining(
+              `about ${escapeOf(organisation.name)}`,
+            ),
           });
+
+          expect(escape).toBeCalledWith(organisation.name);
         });
       });
 
@@ -77,6 +87,8 @@ describe('OrganisationPresenter', () => {
         });
 
         it('returns the table row data', async () => {
+          (escape as jest.Mock).mockImplementation(escapeOf);
+
           const presenter = new OrganisationPresenter(
             organisation,
             i18nService,
@@ -136,6 +148,8 @@ describe('OrganisationPresenter', () => {
   describe('summaryList', () => {
     describe('when all fields are present', () => {
       it('should return all fields', async () => {
+        (escape as jest.Mock).mockImplementation(escapeOf);
+
         const presenter = new OrganisationPresenter(organisation, i18nService);
 
         expect(await presenter.summaryList()).toEqual({
@@ -189,6 +203,8 @@ describe('OrganisationPresenter', () => {
     describe('when a field is missing', () => {
       describe('when removeBlank is true', () => {
         it('should filter out empty fields', async () => {
+          (escape as jest.Mock).mockImplementation(escapeOf);
+
           organisation = organisationFactory.build({ alternateName: '' });
           const presenter = new OrganisationPresenter(
             organisation,
@@ -209,6 +225,8 @@ describe('OrganisationPresenter', () => {
 
       describe('when removeBlank is false', () => {
         it('keeps empty rows intact', async () => {
+          (escape as jest.Mock).mockImplementation(escapeOf);
+
           organisation = organisationFactory.build({ alternateName: '' });
           const presenter = new OrganisationPresenter(
             organisation,
@@ -232,6 +250,8 @@ describe('OrganisationPresenter', () => {
 
     describe('when includeName is true', () => {
       it('should include the name of the organisation', async () => {
+        (escape as jest.Mock).mockImplementation(escapeOf);
+
         organisation = organisationFactory.build({ name: 'My Organisation' });
         const presenter = new OrganisationPresenter(organisation, i18nService);
         const list = await presenter.summaryList({ includeName: true });
@@ -251,6 +271,8 @@ describe('OrganisationPresenter', () => {
 
     describe('when includeActions is true', () => {
       it('should include an actions column', async () => {
+        (escape as jest.Mock).mockImplementation(escapeOf);
+
         organisation = organisationFactory.build({ name: 'My Organisation' });
         const presenter = new OrganisationPresenter(organisation, i18nService);
         const list = await presenter.summaryList({ includeActions: true });
@@ -274,6 +296,8 @@ describe('OrganisationPresenter', () => {
 
     describe('when classes are specified', () => {
       it('should return the specified class', async () => {
+        (escape as jest.Mock).mockImplementation(escapeOf);
+
         const presenter = new OrganisationPresenter(organisation, i18nService);
         const list = await presenter.summaryList({ classes: 'foo' });
 
@@ -284,6 +308,8 @@ describe('OrganisationPresenter', () => {
 
   describe('address', () => {
     it('breaks the address into lines', () => {
+      (escape as jest.Mock).mockImplementation(escapeOf);
+
       organisation = organisationFactory.build({
         address: '123 Fake Street, London, SW1A 1AA',
       });
@@ -291,13 +317,17 @@ describe('OrganisationPresenter', () => {
       const presenter = new OrganisationPresenter(organisation, i18nService);
 
       expect(presenter.address()).toEqual(
-        '123 Fake Street<br /> London<br /> SW1A 1AA',
+        `${escapeOf('123 Fake Street<br /> London<br /> SW1A 1AA')}`,
       );
+
+      expect(escape).toBeCalledWith('123 Fake Street, London, SW1A 1AA');
     });
   });
 
   describe('email', () => {
     it('makes the email into a link', () => {
+      (escape as jest.Mock).mockImplementation(escapeOf);
+
       organisation = organisationFactory.build({
         email: 'foo@example.com',
       });
@@ -305,13 +335,19 @@ describe('OrganisationPresenter', () => {
       const presenter = new OrganisationPresenter(organisation, i18nService);
 
       expect(presenter.email()).toEqual(
-        '<a href="mailto:foo@example.com" class="govuk-link">foo@example.com</a>',
+        `<a href="mailto:${escapeOf(
+          'foo@example.com',
+        )}" class="govuk-link">${escapeOf('foo@example.com')}</a>`,
       );
+
+      expect(escape).toBeCalledWith('foo@example.com');
     });
   });
 
   describe('contactUrl', () => {
     it('makes the url into a link', () => {
+      (escape as jest.Mock).mockImplementation(escapeOf);
+
       organisation = organisationFactory.build({
         contactUrl: 'http://www.example.com',
       });
@@ -319,8 +355,12 @@ describe('OrganisationPresenter', () => {
       const presenter = new OrganisationPresenter(organisation, i18nService);
 
       expect(presenter.contactUrl()).toEqual(
-        '<a href="http://www.example.com" class="govuk-link">http://www.example.com</a>',
+        `<a href="${escapeOf(
+          'http://www.example.com',
+        )}" class="govuk-link">${escapeOf('http://www.example.com')}</a>`,
       );
+
+      expect(escape).toBeCalledWith('http://www.example.com');
     });
   });
 });

--- a/src/organisations/presenters/organisation.presenter.ts
+++ b/src/organisations/presenters/organisation.presenter.ts
@@ -2,6 +2,7 @@ import { I18nService } from 'nestjs-i18n';
 import { Organisation } from './../organisation.entity';
 import { TableRow } from '../../common/interfaces/table-row';
 import { SummaryList } from '../../common/interfaces/summary-list';
+import { escape } from '../../helpers/escape.helper';
 
 interface OrganisationSummaryListOptions {
   classes?: string;
@@ -28,10 +29,12 @@ export class OrganisationPresenter {
         html: await this.industries(),
       },
       {
-        html: `<a class="govuk-link" href="/admin/organisations/${this.organisation.slug}">
+        html: `<a class="govuk-link" href="/admin/organisations/${
+          this.organisation.slug
+        }">
           View details
           <span class="govuk-visually-hidden">
-            about ${this.organisation.name}
+            about ${escape(this.organisation.name)}
           </span>
         </a>`,
       },
@@ -138,15 +141,19 @@ export class OrganisationPresenter {
   }
 
   public address(): string {
-    return this.organisation.address.split(',').join('<br />');
+    return escape(this.organisation.address).split(',').join('<br />');
   }
 
   public email(): string {
-    return `<a href="mailto:${this.organisation.email}" class="govuk-link">${this.organisation.email}</a>`;
+    return `<a href="mailto:${escape(
+      this.organisation.email,
+    )}" class="govuk-link">${escape(this.organisation.email)}</a>`;
   }
 
   public contactUrl(): string {
-    return `<a href="${this.organisation.contactUrl}" class="govuk-link">${this.organisation.contactUrl}</a>`;
+    return `<a href="${escape(
+      this.organisation.contactUrl,
+    )}" class="govuk-link">${escape(this.organisation.contactUrl)}</a>`;
   }
 
   private async industries(): Promise<string> {

--- a/src/testutils/escape-of.ts
+++ b/src/testutils/escape-of.ts
@@ -1,0 +1,3 @@
+export function escapeOf(text: string): string {
+  return `Escape of '${text}'`;
+}

--- a/src/users/user.presenter.spec.ts
+++ b/src/users/user.presenter.spec.ts
@@ -1,9 +1,13 @@
+import { escape } from '../helpers/escape.helper';
 import { createMockI18nService } from '../testutils/create-mock-i18n-service';
+import { escapeOf } from '../testutils/escape-of';
 import userFactory from '../testutils/factories/user';
 import { translationOf } from '../testutils/translation-of';
 
 import { User, UserPermission } from './user.entity';
 import { UserPresenter } from './user.presenter';
+
+jest.mock('../helpers/escape.helper');
 
 describe('UserPresenter', () => {
   describe('tableRow', () => {
@@ -27,6 +31,8 @@ describe('UserPresenter', () => {
 
   describe('showLink', () => {
     it('should return a link to the user', () => {
+      (escape as jest.Mock).mockImplementation(escapeOf);
+
       const user = createSinglePermissionUser();
       const presenter = new UserPresenter(user, createMockI18nService());
 
@@ -34,11 +40,13 @@ describe('UserPresenter', () => {
       <a href="/admin/users/some-uuid-string" class="govuk-button" data-module="govuk-button">
         View
         <span class="govuk-visually-hidden">
-          name
+          ${escapeOf('name')}
         </span>
       </a>
     `.replace(/(\n)/gm, '');
       expect(presenter.showLink().replace(/(\n)/gm, '')).toEqual(expected);
+
+      expect(escape).toBeCalledWith('name');
     });
   });
 

--- a/src/users/user.presenter.ts
+++ b/src/users/user.presenter.ts
@@ -1,6 +1,7 @@
 import { User } from './user.entity';
 import { TableRow } from '../common/interfaces/table-row';
 import { I18nService } from 'nestjs-i18n';
+import { escape } from '../helpers/escape.helper';
 
 export class UserPresenter extends User {
   constructor(private user: User, private i18n: I18nService) {
@@ -29,10 +30,12 @@ export class UserPresenter extends User {
 
   public showLink(): string {
     return `
-      <a href="/admin/users/${this.user.id}" class="govuk-button" data-module="govuk-button">
+      <a href="/admin/users/${
+        this.user.id
+      }" class="govuk-button" data-module="govuk-button">
         View
         <span class="govuk-visually-hidden">
-          ${this.name}
+          ${escape(this.name)}
         </span>
       </a>
     `;

--- a/views/admin/organisations/complete.njk
+++ b/views/admin/organisations/complete.njk
@@ -10,7 +10,7 @@
       {{
         govukPanel({
           titleText: ("organisations.admin.form.headings.confirmation" | t),
-          html: ("organisations.admin.form.body.confirmation.panel" | t({name: name}) | safe)
+          html: "organisations.admin.form.body.confirmation.panel" | t({name: (name | escape)})
         })
       }}
 

--- a/views/admin/professions/check-your-answers.njk
+++ b/views/admin/professions/check-your-answers.njk
@@ -58,7 +58,7 @@
                   text: ("professions.form.label.topLevelInformation.nations" | t)
                 },
                 value: {
-                  html: selectedNationsSummaryListHtml | safe
+                  html: selectedNationsSummaryListHtml
                 },
                 actions: {
                   items: [
@@ -75,7 +75,7 @@
                   text: ("professions.form.label.topLevelInformation.industry" | t)
                 },
                 value: {
-                  html: selectedIndustriesSummaryListHtml | safe
+                  html: selectedIndustriesSummaryListHtml
                 },
                 actions: {
                   items: [

--- a/views/admin/professions/check-your-answers.njk
+++ b/views/admin/professions/check-your-answers.njk
@@ -46,7 +46,7 @@
                 actions: {
                   items: [
                     {
-                      href: "/admin/professions/" + professionId +"/top-level-information/edit?change=true",
+                      href: "/admin/professions/" + professionId + "/top-level-information/edit?change=true",
                       text: ("app.change" | t),
                       visuallyHiddenText: ("professions.form.label.topLevelInformation.name" | t)
                     }
@@ -106,7 +106,7 @@
                 actions: {
                   items: [
                     {
-                      href: "/admin/professions/" + professionId +"/regulatory-body/edit?change=true",
+                      href: "/admin/professions/" + professionId + "/regulatory-body/edit?change=true",
                       text: ("app.change" | t),
                       visuallyHiddenText: ("professions.form.label.regulatoryBody.regulatedAuthority" | t)
                     }
@@ -300,7 +300,7 @@
                   text: ("professions.form.label.legislation.link" | t)
                 },
                 value: {
-                  html: "<a class='govuk-link' href='" + legislation.url | escape + "'>" + legislation.url | escape + "</a>"
+                  html: "<a class='govuk-link' href='" + (legislation.url | escape) + "'>" + (legislation.url | escape) + "</a>"
                 },
                 actions: {
                   items: [

--- a/views/admin/professions/confirmation.njk
+++ b/views/admin/professions/confirmation.njk
@@ -11,14 +11,14 @@
         {{
           govukPanel({
             titleText: ("professions.form.headings.amended" | t),
-            html: ("professions.form.body.confirmation.panel" | t({name: name, action: "updated"}) | safe)
+            html: ("professions.form.body.confirmation.panel" | t({name: (name | escape), action: "updated"}))
           })
         }}
       {% else %}
         {{
           govukPanel({
             titleText: ("professions.form.headings.confirmation" | t),
-            html: ("professions.form.body.confirmation.panel" | t({name: name, action: "added"}) | safe)
+            html: ("professions.form.body.confirmation.panel" | t({name: (name | escape), action: "added"}))
           })
         }}
       {% endif %}

--- a/views/admin/users/_summary.njk
+++ b/views/admin/users/_summary.njk
@@ -59,7 +59,7 @@
           text: ("users.form.label.permissions" | t)
         },
         value: {
-          text: (permissionList | safe)
+          html: permissionList
         },
         actions: {
           items: [

--- a/views/admin/users/_summary.njk
+++ b/views/admin/users/_summary.njk
@@ -13,7 +13,7 @@
         actions: {
           items: [
             {
-              href: "/admin/users/" + id +"/personal-details/edit?change=true",
+              href: "/admin/users/" + id + "/personal-details/edit?change=true",
               text: ("app.change" | t),
               visuallyHiddenText: ("users.form.label.name" | t)
             }
@@ -30,7 +30,7 @@
         actions: {
           items: [
             {
-              href: "/admin/users/"+ id +"/personal-details/edit?change=true",
+              href: "/admin/users/"+ id + "/personal-details/edit?change=true",
               text: ("app.change" | t),
               visuallyHiddenText: ("users.form.label.email" | t)
             }

--- a/views/admin/users/done.njk
+++ b/views/admin/users/done.njk
@@ -7,7 +7,7 @@
   <div class="govuk-grid-column-two-thirds">
     {{ govukPanel({
       titleText: ("users.headings.done" | t),
-      html: ("users.body.panel" | t({email: email}) | safe)
+      html: "users.body.panel" | t({email: (email | escape)})
     }) }}
 
     <p class="govuk-body">{{ "users.body.confirmation" | t  }}</p>

--- a/views/admin/users/index.njk
+++ b/views/admin/users/index.njk
@@ -42,7 +42,7 @@
               text: "Email"
             },
             {
-              html: "Actions"
+              text: "Actions"
             }
 
           ],

--- a/views/admin/users/personal-details/edit.njk
+++ b/views/admin/users/personal-details/edit.njk
@@ -19,8 +19,7 @@
         {{ govukInput({
           label: {
             text: ('users.form.label.name' | t),
-            classes: "govuk-label--l",
-            isPageHeading: true
+            classes: "govuk-label--l"
           },
           hint: {
             text: ('users.form.hint.name' | t)
@@ -36,8 +35,7 @@
         {{ govukInput({
           label: {
             text: ('users.form.label.email' | t),
-            classes: "govuk-label--l",
-            isPageHeading: true
+            classes: "govuk-label--l"
           },
           hint: {
             text: ('users.form.hint.email' | t)

--- a/views/base.njk
+++ b/views/base.njk
@@ -22,7 +22,7 @@
 
     {% if backLink %}
       {{ govukBackLink({
-        text: ( "app.back" | t ),
+        text: ("app.back" | t),
         href: backLink
       }) }}
     {% endif %}

--- a/views/base.njk
+++ b/views/base.njk
@@ -16,7 +16,7 @@
         tag: {
           text: ("app.phase.beta.label" | t)
         },
-        html: ("app.phase.beta.html" | t | safe)
+        html: ("app.phase.beta.html" | t)
       })
     }}
 

--- a/views/professions/_profession-details.njk
+++ b/views/professions/_profession-details.njk
@@ -27,7 +27,7 @@
         text: ("professions.show.overview.nations" | t)
       },
       value: {
-        html: nationsHtml | safe
+        html: nationsHtml
       }
     },
     {
@@ -35,7 +35,7 @@
         text: ("professions.show.overview.industry" | t)
       },
       value: {
-        html: industriesHtml | safe
+        html: industriesHtml
       }
     }
   ]

--- a/views/professions/_profession-details.njk
+++ b/views/professions/_profession-details.njk
@@ -61,7 +61,7 @@
         text: ("professions.show.bodies.address" | t)
       },
       value: {
-        html: profession.organisation.address
+        text: profession.organisation.address
       }
     },
     {

--- a/views/professions/_profession-details.njk
+++ b/views/professions/_profession-details.njk
@@ -69,7 +69,7 @@
         text: ("professions.show.bodies.emailAddress" | t)
       },
       value: {
-        text: profession.organisation.email
+        html: ["<a class=\"govuk-link\" href=\"mailto:", (profession.organisation.email | escape), "\">", (profession.organisation.email | escape),  "</a>" ] | join
       }
     },
     {
@@ -77,7 +77,7 @@
         text: ("professions.show.bodies.url" | t)
       },
       value: {
-        text: profession.organisation.url
+        html: ["<a class=\"govuk-link\" href=\"", (profession.organisation.url | escape), "\">", (profession.organisation.url | escape),  "</a>" ] | join
       }
     },
     {

--- a/views/professions/search/index.njk
+++ b/views/professions/search/index.njk
@@ -54,7 +54,7 @@
                     text: ("professions.search.profession.industry" | t)
                   },
                   value: {
-                    html: industriesHtml | safe
+                    html: industriesHtml
                   }
                 }
               ]


### PR DESCRIPTION
# Changes in this PR

Fix instances where HTML entered by the user can be presented back unescaped

## Screenshots of UI changes

### Before
![localhost_3000_professions_registered-trademark-attorney](https://user-images.githubusercontent.com/94137563/151032961-fad6ccb7-6e8e-4b10-808c-3e89620cd54f.png)

### After
![localhost_3000_professions_registered-trademark-attorney (1)](https://user-images.githubusercontent.com/94137563/151033121-54dae7fc-983f-4c1b-ac13-84bd09eb512a.png)

