### PR TITLE
Miscellaneous Profession refactoring

### DIFF
--- a/src/common/back-link.interceptor.spec.ts
+++ b/src/common/back-link.interceptor.spec.ts
@@ -36,14 +36,14 @@ describe('BackLinkInterceptor', () => {
       beforeEach(() => {
         request = createMock<Request>({
           params: {
-            baz: 'boo',
+            bazName: 'boo',
             id: '123',
           },
         });
       });
 
       it('should replace placeholders with params', () => {
-        const backLink = '/foo/bar/:baz';
+        const backLink = '/foo/bar/:bazName';
         const interceptor = new BackLinkInterceptor(backLink);
 
         interceptor.intercept(context, next);
@@ -62,7 +62,7 @@ describe('BackLinkInterceptor', () => {
       });
 
       it('should use multiple params', () => {
-        const backLink = '/foo/:id/:baz';
+        const backLink = '/foo/:id/:bazName';
 
         const interceptor = new BackLinkInterceptor(backLink);
 

--- a/src/common/back-link.interceptor.ts
+++ b/src/common/back-link.interceptor.ts
@@ -38,7 +38,7 @@ export class BackLinkInterceptor<T> implements NestInterceptor<T, Response<T>> {
   }
 
   private generateBackLink(request: Request) {
-    const regexp = new RegExp(':([a-z]+)', 'g');
+    const regexp = new RegExp(':([a-zA-Z]+)', 'g');
 
     let backLink = this.backLink ? this.backLink : this.generator(request);
 

--- a/src/professions/admin/professions.controller.spec.ts
+++ b/src/professions/admin/professions.controller.spec.ts
@@ -385,39 +385,34 @@ describe('ProfessionsController', () => {
   describe('edit', () => {
     it('should render the name of the profession passed in', async () => {
       const profession = professionFactory.build({
-        slug: 'example-slug',
+        id: 'profession-id',
       });
 
-      professionsService.findBySlug.mockResolvedValue(profession);
+      professionsService.find.mockResolvedValue(profession);
 
-      const result = await controller.edit('example-slug');
+      const result = await controller.edit('profession-id');
 
       expect(result).toEqual({
         profession: profession,
       });
 
-      expect(professionsService.findBySlug).toHaveBeenCalledWith(
-        'example-slug',
-      );
+      expect(professionsService.find).toHaveBeenCalledWith('profession-id');
     });
   });
 
   describe('update', () => {
-    it('should look up the profession via its slug and redirect to the "Check your answers" page', async () => {
+    it('should look up the profession and redirect to the "Check your answers" page', async () => {
       const profession = professionFactory.build({
         id: 'profession-id',
-        slug: 'example-slug',
       });
 
       const res = createMock<Response>();
 
-      professionsService.findBySlug.mockResolvedValue(profession);
+      professionsService.find.mockResolvedValue(profession);
 
-      await controller.update(res, 'example-slug');
+      await controller.update(res, 'profession-id');
 
-      expect(professionsService.findBySlug).toHaveBeenCalledWith(
-        'example-slug',
-      );
+      expect(professionsService.find).toHaveBeenCalledWith('profession-id');
 
       expect(res.redirect).toHaveBeenCalledWith(
         `/admin/professions/profession-id/check-your-answers?edit=true`,

--- a/src/professions/admin/professions.controller.ts
+++ b/src/professions/admin/professions.controller.ts
@@ -98,25 +98,27 @@ export class ProfessionsController {
     };
   }
 
-  @Get('/:slug/edit')
+  @Get('/:professionId/edit')
   @Permissions(UserPermission.CreateProfession)
   @Render('admin/professions/edit')
-  @BackLink('/admin/professions/:slug')
-  async edit(@Param('slug') slug: string): Promise<EditTemplate> {
-    const profession = await this.professionsService.findBySlug(slug);
+  @BackLink('/admin/professions/:professionId')
+  async edit(
+    @Param('professionId') professionId: string,
+  ): Promise<EditTemplate> {
+    const profession = await this.professionsService.find(professionId);
 
     return {
       profession,
     };
   }
 
-  @Post(':slug/edit')
+  @Post('/:professionId/edit')
   @Permissions(UserPermission.CreateProfession)
   async update(
     @Res() res: Response,
-    @Param('slug') slug: string,
+    @Param('professionId') professionId: string,
   ): Promise<void> {
-    const profession = await this.professionsService.findBySlug(slug);
+    const profession = await this.professionsService.find(professionId);
 
     return res.redirect(
       `/admin/professions/${profession.id}/check-your-answers?edit=true`,

--- a/src/professions/admin/regulated-activities.controller.spec.ts
+++ b/src/professions/admin/regulated-activities.controller.spec.ts
@@ -12,11 +12,7 @@ describe(RegulatedActivitiesController, () => {
   let response: DeepMocked<Response>;
 
   beforeEach(async () => {
-    const profession = professionFactory.build();
-
-    professionsService = createMock<ProfessionsService>({
-      find: async () => profession,
-    });
+    professionsService = createMock<ProfessionsService>();
 
     const module: TestingModule = await Test.createTestingModule({
       controllers: [RegulatedActivitiesController],
@@ -40,7 +36,7 @@ describe(RegulatedActivitiesController, () => {
         description: 'A description of the profession',
       });
 
-      professionsService.find.mockImplementation(async () => profession);
+      professionsService.find.mockResolvedValue(profession);
 
       await controller.edit(response, 'profession-id', false);
 
@@ -60,7 +56,7 @@ describe(RegulatedActivitiesController, () => {
         it('updates the Profession and redirects to the next page in the journey', async () => {
           const profession = professionFactory.build({ id: 'profession-id' });
 
-          professionsService.find.mockImplementation(async () => profession);
+          professionsService.find.mockResolvedValue(profession);
 
           const regulatedActivitiesDto: RegulatedActivitiesDto = {
             activities: 'Example reserved activities',
@@ -92,7 +88,7 @@ describe(RegulatedActivitiesController, () => {
         it('updates the Profession and redirects to the Check your answers page', async () => {
           const profession = professionFactory.build({ id: 'profession-id' });
 
-          professionsService.find.mockImplementation(async () => profession);
+          professionsService.find.mockResolvedValue(profession);
 
           const regulatedActivitiesDto: RegulatedActivitiesDto = {
             activities: 'Example reserved activities',
@@ -125,7 +121,7 @@ describe(RegulatedActivitiesController, () => {
       it('does not update the profession, and re-renders the regulated activities form page with errors', async () => {
         const profession = professionFactory.build();
 
-        professionsService.find.mockImplementation(async () => profession);
+        professionsService.find.mockResolvedValue(profession);
 
         const regulatedActivitiesDto: RegulatedActivitiesDto = {
           activities: undefined,

--- a/src/professions/professions.service.spec.ts
+++ b/src/professions/professions.service.spec.ts
@@ -7,15 +7,6 @@ import professionFactory from '../testutils/factories/profession';
 import { Profession } from './profession.entity';
 import { ProfessionsService } from './professions.service';
 
-const gasSafeEngineer = professionFactory.build({
-  name: 'Registered Gas Engineer',
-});
-
-const professionArray = [
-  gasSafeEngineer,
-  professionFactory.build({ name: 'Social worker' }),
-];
-
 describe('Profession', () => {
   let service: ProfessionsService;
   let repo: Repository<Profession>;
@@ -34,17 +25,7 @@ describe('Profession', () => {
         ProfessionsService,
         {
           provide: getRepositoryToken(Profession),
-          useValue: {
-            find: () => {
-              return professionArray;
-            },
-            findOne: () => {
-              return gasSafeEngineer;
-            },
-            save: () => {
-              return gasSafeEngineer;
-            },
-          },
+          useValue: createMock<Repository<Profession>>(),
         },
         {
           provide: Connection,
@@ -58,20 +39,11 @@ describe('Profession', () => {
   });
 
   describe('all', () => {
-    let repoSpy: jest.SpyInstance<Promise<Profession[]>>;
-    let professions: Profession[];
+    it('should return all Professions, sorted by name', async () => {
+      const professions = professionFactory.buildList(2);
+      const repoSpy = jest.spyOn(repo, 'find').mockResolvedValue(professions);
 
-    beforeEach(async () => {
-      repoSpy = jest.spyOn(repo, 'find');
-      professions = await service.all();
-    });
-
-    it('should return all Professions', async () => {
-      expect(professions).toEqual(professionArray);
-      expect(repoSpy).toHaveBeenCalled();
-    });
-
-    it('Professions should be sorted', () => {
+      expect(service.all()).resolves.toEqual(professions);
       expect(repoSpy).toHaveBeenCalledWith(
         expect.objectContaining({
           order: { name: 'ASC' },
@@ -81,26 +53,14 @@ describe('Profession', () => {
   });
 
   describe('allConfirmed', () => {
-    let repoSpy: jest.SpyInstance<Promise<Profession[]>>;
-    let professions: Profession[];
+    it('should return all confirmed Professions, sorted by name', async () => {
+      const professions = professionFactory.buildList(2);
+      const repoSpy = jest.spyOn(repo, 'find').mockResolvedValue(professions);
 
-    beforeEach(async () => {
-      repoSpy = jest.spyOn(repo, 'find');
-      professions = await service.allConfirmed();
-    });
-
-    it('should return all confirmed Professions', async () => {
-      expect(professions).toEqual(professionArray);
+      expect(service.allConfirmed()).resolves.toEqual(professions);
       expect(repoSpy).toHaveBeenCalledWith(
         expect.objectContaining({
           where: { confirmed: true },
-        }),
-      );
-    });
-
-    it('Professions should be sorted', () => {
-      expect(repoSpy).toHaveBeenCalledWith(
-        expect.objectContaining({
           order: { name: 'ASC' },
         }),
       );
@@ -109,20 +69,20 @@ describe('Profession', () => {
 
   describe('find', () => {
     it('should return a Profession', async () => {
-      const repoSpy = jest.spyOn(repo, 'findOne');
-      const profession = await service.find('some-uuid');
+      const profession = professionFactory.build({ id: 'some-uuid' });
+      const repoSpy = jest.spyOn(repo, 'findOne').mockResolvedValue(profession);
 
-      expect(profession).toEqual(profession);
+      expect(service.find('some-uuid')).resolves.toEqual(profession);
       expect(repoSpy).toHaveBeenCalledWith('some-uuid');
     });
   });
 
   describe('findBySlug', () => {
     it('should return a profession', async () => {
-      const repoSpy = jest.spyOn(repo, 'findOne');
-      const profession = await service.findBySlug('some-slug');
+      const profession = professionFactory.build({ slug: 'some-slug' });
+      const repoSpy = jest.spyOn(repo, 'findOne').mockResolvedValue(profession);
 
-      expect(profession).toEqual(profession);
+      expect(service.findBySlug('some-slug')).resolves.toEqual(profession);
       expect(repoSpy).toHaveBeenCalledWith({ where: { slug: 'some-slug' } });
     });
   });

--- a/views/admin/professions/edit.njk
+++ b/views/admin/professions/edit.njk
@@ -11,7 +11,7 @@
       <span class="govuk-caption-l">{{ 'professions.form.captions.edit' | t }}</span>
       <h1 class="govuk-heading-l">{{ ('professions.form.headings.edit' | t({professionName: profession.name})) }}</h1>
 
-      <form method="post" action="/admin/professions/{{ profession.slug }}/edit">
+      <form method="post" action="/admin/professions/{{ profession.id }}/edit">
         {{
           govukButton({
             id: "submit-button",

--- a/views/admin/professions/show.njk
+++ b/views/admin/professions/show.njk
@@ -14,7 +14,7 @@
         text: ('professions.admin.editProfession' | t),
         classes: "govuk-button",
         id: "edit-button",
-        href: "/admin/professions/" + profession.slug + "/edit"
+        href: "/admin/professions/" + profession.id + "/edit"
       }) }}
       </aside>
     </div>


### PR DESCRIPTION
# Changes in this PR

This mostly refactors the tests for controllers used in the "Add/edit a profession" journey to make them more in line with how we're currently doing things (not setting up test context in a `beforeEach`, not worrying about the returned values from the `i18nService` and preferring `mockResolvedValue` over `mockImplementation` where relevant. This paves the way for new behaviour to be added now we're adding versioning to this.

I've refactored the `ProfessionsService` tests here too, as we'll be adding some more functionality to this too.

This also refactors the "edit" journey to use an `id` instead of the `slug`, as that's what we're doing for the Organisations journey and it feels sensible to be consistent here.

This PR also tweaks the backLink decorator to handle upper case letters, as we'll be adding multiple `id`s to URLs in the version journey (namely `professionId` and `versionId`).

Opening these changes in their own PR to keep the main one from being a long read and a very time-consuming effort to review.
