### PR TITLE
Don't render missing qualifications on CYA page

### DIFF
--- a/src/professions/admin/check-your-answers.controller.spec.ts
+++ b/src/professions/admin/check-your-answers.controller.spec.ts
@@ -108,6 +108,30 @@ describe('CheckYourAnswersController', () => {
         expect(professionsService.find).toHaveBeenCalledWith('profession-id');
       });
     });
+
+    describe('when the profession has no qualification', () => {
+      it('passes a `null` qualification value to the template', async () => {
+        const profession = professionFactory.build({
+          qualification: undefined,
+          organisation: organisationFactory.build(),
+        });
+
+        professionsService.find.mockResolvedValue(profession);
+
+        const request: Request = createMockRequest(
+          'http://example.com/some/path',
+          'example.com',
+        );
+
+        const templateParams = await controller.show(
+          request,
+          'profession-id',
+          false,
+        );
+
+        expect(templateParams.qualification).toEqual(null);
+      });
+    });
   });
 
   afterEach(() => {

--- a/src/professions/admin/check-your-answers.controller.ts
+++ b/src/professions/admin/check-your-answers.controller.ts
@@ -55,6 +55,10 @@ export class CheckYourAnswersController {
       ),
     );
 
+    const qualification = draftProfession.qualification
+      ? new QualificationPresenter(draftProfession.qualification)
+      : null;
+
     return {
       professionId: id,
       name: draftProfession.name,
@@ -64,7 +68,7 @@ export class CheckYourAnswersController {
       mandatoryRegistration: draftProfession.mandatoryRegistration,
       description: draftProfession.description,
       reservedActivities: draftProfession.reservedActivities,
-      qualification: new QualificationPresenter(draftProfession.qualification),
+      qualification: qualification,
       legislation: draftProfession.legislation,
       confirmed: Boolean(draftProfession.confirmed),
       captionText: ViewUtils.captionText(draftProfession.confirmed),

--- a/views/admin/professions/check-your-answers.njk
+++ b/views/admin/professions/check-your-answers.njk
@@ -177,6 +177,7 @@
           })
         }}
 
+        {% if qualification %}
         <h2 class="govuk-heading-m">{{ ("professions.form.headings.qualificationInformation" | t) }}</h2>
 
         {{
@@ -270,6 +271,7 @@
             ]
           })
         }}
+        {% endif %}
 
         <h2 class="govuk-heading-m">{{ ("professions.form.headings.legislation" | t) }}</h2>
 


### PR DESCRIPTION
# Changes in this PR

Stops creating a `QualificationPresenter` with `null` on the Check your answers page when a Qualification doesn't exist on a Profession. Instead, we pass `null` to the template and use that to determine whether to render the section of the page or not. This was missed when we started allowing null Qualifications, meaning editing a Profession without a Qualification would throw an error when trying to render the page.

## Screenshots of UI changes

### After (Don't render Qualification section)

![image](https://user-images.githubusercontent.com/19826940/151375651-cc28cec9-6180-4db1-bdd8-793c1be1c813.png)

