### PR TITLE
(2039) Create a version when editing an Organisation

### DIFF
--- a/cypress/integration/admin/organisations/edit.spec.ts
+++ b/cypress/integration/admin/organisations/edit.spec.ts
@@ -145,9 +145,9 @@ describe('Editing organisations', () => {
 
       cy.checkAccessibility();
 
-      cy.translate('organisations.admin.form.headings.confirmation').then(
+      cy.translate('organisations.admin.edit.confirmation.heading').then(
         (confirmationText) => {
-          cy.get('html').contains(confirmationText).click();
+          cy.get('html').should('contain', confirmationText);
         },
       );
     });

--- a/cypress/integration/admin/organisations/edit.spec.ts
+++ b/cypress/integration/admin/organisations/edit.spec.ts
@@ -1,4 +1,4 @@
-describe.skip('Editing organisations', () => {
+describe('Editing organisations', () => {
   context('When I am logged in as admin', () => {
     beforeEach(() => {
       cy.loginAuth0('admin');
@@ -9,20 +9,34 @@ describe.skip('Editing organisations', () => {
 
       cy.readFile('./seeds/test/organisations.json').then((organisations) => {
         const organisation = organisations[0];
+        const version = organisation.versions[1];
 
-        cy.wrap(organisation).as('organisation');
+        cy.wrap({
+          ...organisation,
+          ...version,
+        }).as('organisation');
 
         cy.contains(organisation.name)
           .parent('tr')
           .within(() => {
             cy.get('a').contains('View details').click();
           });
-        cy.checkAccessibility();
+        cy.checkAccessibility({ 'link-name': { enabled: false } });
 
         cy.translate('organisations.admin.button.edit').then((editButton) => {
           cy.get('a').contains(editButton).click();
           cy.checkAccessibility();
         });
+
+        cy.translate('organisation-versions.admin.new.heading').then(
+          (heading) => {
+            cy.get('body').should('contain', heading);
+
+            cy.translate('app.start').then((startButton) => {
+              cy.get('button').contains(startButton).click();
+            });
+          },
+        );
       });
     });
 
@@ -30,11 +44,6 @@ describe.skip('Editing organisations', () => {
       cy.get('@organisation').then((organisation: any) => {
         cy.translate('organisations.admin.edit.heading').then((editHeading) => {
           cy.get('body').should('contain', editHeading);
-
-          cy.checkInputValue(
-            'organisations.admin.form.label.name',
-            organisation.name,
-          );
 
           cy.checkInputValue(
             'organisations.admin.form.label.alternateName',
@@ -65,8 +74,6 @@ describe.skip('Editing organisations', () => {
     });
 
     it('Shows errors when I input data incorrectly', () => {
-      cy.get('input[name="name"]').invoke('val', '');
-
       cy.get('input[name="contactUrl"]')
         .invoke('val', '')
         .type('this is not a url');
@@ -79,12 +86,6 @@ describe.skip('Editing organisations', () => {
         cy.get('button').contains(buttonText).click();
       });
       cy.checkAccessibility();
-
-      cy.translate('organisations.admin.form.errors.name.empty').then(
-        (error) => {
-          cy.get('body').should('contain', error);
-        },
-      );
 
       cy.translate('organisations.admin.form.errors.email.invalid').then(
         (error) => {
@@ -100,8 +101,6 @@ describe.skip('Editing organisations', () => {
     });
 
     it('allows me to update an organisation', () => {
-      cy.get('input[name="name"]').invoke('val', 'New Name');
-
       cy.get('input[name="alternateName"]')
         .invoke('val', '')
         .type('New Alternate Name');
@@ -122,7 +121,6 @@ describe.skip('Editing organisations', () => {
       });
       cy.checkAccessibility();
 
-      cy.checkSummaryListRowValue('organisations.label.name', 'New Name');
       cy.checkSummaryListRowValue(
         'organisations.label.alternateName',
         'New Alternate Name',

--- a/cypress/integration/admin/organisations/new.spec.ts
+++ b/cypress/integration/admin/organisations/new.spec.ts
@@ -54,6 +54,10 @@ describe('Creating organisations', () => {
     });
 
     it('allows me to create an organisation', () => {
+      cy.translate('organisations.admin.create.heading').then((heading) => {
+        cy.get('html').should('contain', heading);
+      });
+
       cy.get('input[name="name"]').invoke('val', 'New Organisation');
 
       cy.get('input[name="alternateName"]').type('Alternate Name');

--- a/cypress/integration/admin/organisations/new.spec.ts
+++ b/cypress/integration/admin/organisations/new.spec.ts
@@ -100,7 +100,7 @@ describe('Creating organisations', () => {
         cy.get('button').contains(buttonText).click();
       });
 
-      cy.translate('organisations.admin.form.headings.confirmation').then(
+      cy.translate('organisations.admin.create.confirmation.heading').then(
         (confirmationText) => {
           cy.get('html').should('contain', confirmationText);
         },

--- a/seeds/test/organisations.json
+++ b/seeds/test/organisations.json
@@ -11,7 +11,8 @@
         "contactUrl": "def@example.com/contact-us",
         "telephone": "+44 0123 456789",
         "fax": "+44 0123 456780",
-        "status": "live"
+        "status": "live",
+        "created_at": "2022-01-01"
       },
       {
         "alternateName": "",
@@ -21,7 +22,8 @@
         "contactUrl": "def@example.com/contact-us",
         "telephone": "+44 0123 456789",
         "fax": "+44 0123 456780",
-        "status": "draft"
+        "status": "draft",
+        "created_at": "2022-01-02"
       }
     ]
   },

--- a/src/i18n/en/organisation-versions.json
+++ b/src/i18n/en/organisation-versions.json
@@ -1,0 +1,7 @@
+{
+  "admin": {
+    "new": {
+      "heading": "Are you sure you want to edit this organisation?"
+    }
+  }
+}

--- a/src/i18n/en/organisations.json
+++ b/src/i18n/en/organisations.json
@@ -35,6 +35,9 @@
     "edit": {
       "heading": "Amending a regulatory authority"
     },
+    "create": {
+      "heading": "Adding a regulatory authority",
+    },
     "new": {
       "heading": "Are you sure you want to create a new regulatory authority?"
     },

--- a/src/i18n/en/organisations.json
+++ b/src/i18n/en/organisations.json
@@ -33,10 +33,24 @@
       "button": "Filter results"
     },
     "edit": {
-      "heading": "Amending a regulatory authority"
+      "heading": "Amending a regulatory authority",
+      "confirmation": {
+        "heading": "Regulatory authority amended",
+        "body": {
+          "panel": "{name} has been updated",
+          "next": "What happens next?"
+        }
+      }
     },
     "create": {
       "heading": "Adding a regulatory authority",
+      "confirmation": {
+        "heading": "Regulatory authority created",
+        "body": {
+          "panel": "{name} has been created",
+          "next": "What happens next?"
+        }
+      }
     },
     "new": {
       "heading": "Are you sure you want to create a new regulatory authority?"
@@ -76,15 +90,6 @@
         },
         "contactUrl": {
           "invalid": "Please enter a valid contact details web address"
-        }
-      },
-      "headings": {
-        "confirmation": "Regulatory authority amended"
-      },
-      "body": {
-        "confirmation": {
-          "panel": "{name} has been updated",
-          "next": "What happens next?"
         }
       }
     },

--- a/src/organisations/admin/organisation-versions.controller.spec.ts
+++ b/src/organisations/admin/organisation-versions.controller.spec.ts
@@ -1,0 +1,56 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { createMock, DeepMocked } from '@golevelup/ts-jest';
+
+import { OrganisationVersionsController } from './organisation-versions.controller';
+
+import { OrganisationVersionsService } from '../organisation-versions.service';
+import { OrganisationsService } from '../organisations.service';
+
+import organisationFactory from '../../testutils/factories/organisation';
+
+describe('OrganisationVersionsController', () => {
+  let controller: OrganisationVersionsController;
+
+  let organisationVersionsService: DeepMocked<OrganisationVersionsService>;
+  let organisationsService: DeepMocked<OrganisationsService>;
+
+  beforeEach(async () => {
+    organisationsService = createMock<OrganisationsService>();
+    organisationVersionsService = createMock<OrganisationVersionsService>();
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [OrganisationVersionsController],
+      providers: [
+        {
+          provide: OrganisationsService,
+          useValue: organisationsService,
+        },
+        {
+          provide: OrganisationVersionsService,
+          useValue: organisationVersionsService,
+        },
+      ],
+    }).compile();
+
+    controller = module.get<OrganisationVersionsController>(
+      OrganisationVersionsController,
+    );
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  describe('new', () => {
+    it('fetches the organisation', async () => {
+      const organisation = organisationFactory.build();
+      organisationsService.find.mockResolvedValue(organisation);
+
+      const result = await controller.new(organisation.id);
+
+      expect(result).toEqual(organisation);
+
+      expect(organisationsService.find).toHaveBeenCalledWith(organisation.id);
+    });
+  });
+});

--- a/src/organisations/admin/organisation-versions.controller.spec.ts
+++ b/src/organisations/admin/organisation-versions.controller.spec.ts
@@ -1,5 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { createMock, DeepMocked } from '@golevelup/ts-jest';
+import { Response } from 'express';
+import { DeepPartial } from 'fishery';
 
 import { OrganisationVersionsController } from './organisation-versions.controller';
 
@@ -7,6 +9,10 @@ import { OrganisationVersionsService } from '../organisation-versions.service';
 import { OrganisationsService } from '../organisations.service';
 
 import organisationFactory from '../../testutils/factories/organisation';
+import organisationVersionFactory from '../../testutils/factories/organisation-version';
+import userFactory from '../../testutils/factories/user';
+
+import { RequestWithAppSession } from '../../common/interfaces/request-with-app-session.interface';
 
 describe('OrganisationVersionsController', () => {
   let controller: OrganisationVersionsController;
@@ -51,6 +57,41 @@ describe('OrganisationVersionsController', () => {
       expect(result).toEqual(organisation);
 
       expect(organisationsService.find).toHaveBeenCalledWith(organisation.id);
+    });
+  });
+
+  describe('create', () => {
+    it('creates a copy of the latest version of the organisation', async () => {
+      const organisationVersion = organisationVersionFactory.build();
+      const user = userFactory.build();
+
+      const response = createMock<Response>();
+      const request = createMock<RequestWithAppSession>({
+        appSession: {
+          user: user as DeepPartial<any>,
+        },
+      });
+
+      organisationVersionsService.findLatestForOrganisationId.mockResolvedValue(
+        organisationVersion,
+      );
+      organisationVersionsService.save.mockResolvedValue(organisationVersion);
+
+      await controller.create(response, request, 'some-uuid');
+
+      expect(organisationVersionsService.save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: undefined,
+          user: user,
+          created_at: undefined,
+          updated_at: undefined,
+          organisation: organisationVersion.organisation,
+        }),
+      );
+
+      expect(response.redirect).toHaveBeenCalledWith(
+        `/admin/organisations/${organisationVersion.organisation.id}/versions/${organisationVersion.id}/edit`,
+      );
     });
   });
 });

--- a/src/organisations/admin/organisation-versions.controller.ts
+++ b/src/organisations/admin/organisation-versions.controller.ts
@@ -37,4 +37,30 @@ export class OrganisationVersionsController {
 
     return organisation;
   }
+
+  @Post('/:organisationID/versions')
+  async create(
+    @Res() res: Response,
+    @Req() req: RequestWithAppSession,
+    @Param('organisationID') organisationID: string,
+  ): Promise<void> {
+    const latestVersion =
+      await this.organisationsVersionsService.findLatestForOrganisationId(
+        organisationID,
+      );
+
+    const newVersion = {
+      ...latestVersion,
+      id: undefined,
+      user: req.appSession.user,
+      created_at: undefined,
+      updated_at: undefined,
+    } as OrganisationVersion;
+
+    const version = await this.organisationsVersionsService.save(newVersion);
+
+    return res.redirect(
+      `/admin/organisations/${version.organisation.id}/versions/${version.id}/edit`,
+    );
+  }
 }

--- a/src/organisations/admin/organisation-versions.controller.ts
+++ b/src/organisations/admin/organisation-versions.controller.ts
@@ -1,0 +1,40 @@
+import {
+  Controller,
+  UseGuards,
+  Get,
+  Render,
+  Param,
+  Post,
+  Res,
+  Req,
+} from '@nestjs/common';
+import { Response } from 'express';
+
+import { BackLink } from '../../common/decorators/back-link.decorator';
+
+import { AuthenticationGuard } from '../../common/authentication.guard';
+
+import { OrganisationsService } from '../organisations.service';
+import { OrganisationVersionsService } from '../organisation-versions.service';
+
+import { RequestWithAppSession } from '../../common/interfaces/request-with-app-session.interface';
+
+import { OrganisationVersion } from '../organisation-version.entity';
+
+@UseGuards(AuthenticationGuard)
+@Controller('/admin/organisations')
+export class OrganisationVersionsController {
+  constructor(
+    private readonly organisationsService: OrganisationsService,
+    private readonly organisationsVersionsService: OrganisationVersionsService,
+  ) {}
+
+  @Get('/:organisationID/versions/new')
+  @Render('admin/organisations/versions/new')
+  @BackLink('/admin/organisations')
+  async new(@Param('organisationID') organisationID: string) {
+    const organisation = await this.organisationsService.find(organisationID);
+
+    return organisation;
+  }
+}

--- a/src/organisations/admin/organisations.controller.spec.ts
+++ b/src/organisations/admin/organisations.controller.spec.ts
@@ -445,7 +445,7 @@ describe('OrganisationsController', () => {
 
             expect(response.render).toHaveBeenCalledWith(
               'admin/organisations/complete',
-              organisation,
+              { ...organisation, action: 'create' },
             );
           });
         });
@@ -482,7 +482,7 @@ describe('OrganisationsController', () => {
 
             expect(response.render).toHaveBeenCalledWith(
               'admin/organisations/complete',
-              organisation,
+              { ...organisation, action: 'edit' },
             );
           });
         });

--- a/src/organisations/admin/organisations.controller.ts
+++ b/src/organisations/admin/organisations.controller.ts
@@ -185,12 +185,17 @@ export class OrganisationsController {
     organisation: Organisation,
     version: OrganisationVersion,
   ): Promise<void> {
+    let action: string;
+
     if (!organisation.slug) {
+      action = 'create';
       await this.organisationsService.setSlug(organisation);
+    } else {
+      action = 'edit';
     }
     await this.organisationsVersionsService.confirm(version);
 
-    res.render('admin/organisations/complete', organisation);
+    res.render('admin/organisations/complete', { ...organisation, action });
   }
 
   async showReviewPage(

--- a/src/organisations/organisation-versions.service.ts
+++ b/src/organisations/organisation-versions.service.ts
@@ -1,4 +1,4 @@
-import { Repository } from 'typeorm';
+import { Repository, In } from 'typeorm';
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import {
@@ -19,6 +19,22 @@ export class OrganisationVersionsService {
 
   async find(id: string): Promise<OrganisationVersion> {
     return this.repository.findOne(id);
+  }
+
+  async findLatestForOrganisationId(
+    organisationId: string,
+  ): Promise<OrganisationVersion> {
+    return this.repository.findOne({
+      where: {
+        organisation: { id: organisationId },
+        status: In([
+          OrganisationVersionStatus.Draft,
+          OrganisationVersionStatus.Live,
+        ]),
+      },
+      order: { created_at: 'DESC' },
+      relations: ['organisation'],
+    });
   }
 
   async confirm(version: OrganisationVersion): Promise<OrganisationVersion> {

--- a/src/organisations/organisations.module.ts
+++ b/src/organisations/organisations.module.ts
@@ -7,6 +7,8 @@ import { OrganisationVersion } from './organisation-version.entity';
 import { OrganisationsService } from './organisations.service';
 import { OrganisationVersionsService } from './organisation-versions.service';
 import { OrganisationsController as AdminOrganisationsController } from './admin/organisations.controller';
+import { OrganisationVersionsController as AdminOrganisationVersionsController } from './admin/organisation-versions.controller';
+
 import { SearchController } from './search/search.controller';
 import { OrganisationsController } from './organisations.controller';
 
@@ -18,6 +20,7 @@ import { OrganisationsController } from './organisations.controller';
   ],
   controllers: [
     AdminOrganisationsController,
+    AdminOrganisationVersionsController,
     SearchController,
     OrganisationsController,
   ],

--- a/src/organisations/organisations.seeder.ts
+++ b/src/organisations/organisations.seeder.ts
@@ -26,6 +26,7 @@ type SeedOrganisationVersion = {
   telephone: string;
   fax: string;
   status: string;
+  created_at: string;
 };
 
 @Injectable()
@@ -82,6 +83,10 @@ export class OrganisationsSeeder implements Seeder {
               organisation: org,
               status: status,
             } as OrganisationVersion;
+
+            if (item.created_at) {
+              newVersion.created_at = new Date(item.created_at);
+            }
 
             return { ...existingVersion, ...newVersion };
           }),

--- a/views/admin/organisations/complete.njk
+++ b/views/admin/organisations/complete.njk
@@ -7,14 +7,18 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
+      {% set titleTranslation = "organisations.admin."+ action +".confirmation.heading" %}
+      {% set panelTranslation = "organisations.admin."+ action +".confirmation.body.panel" %}
+      {% set nextTranslation = "organisations.admin."+ action +".confirmation.body.next" %}
+
       {{
         govukPanel({
-          titleText: ("organisations.admin.form.headings.confirmation" | t),
-          html: ("organisations.admin.form.body.confirmation.panel" | t({name: name}) | safe)
+          titleText: (titleTranslation | t),
+          html: (panelTranslation | t({name: name}) | safe)
         })
       }}
 
-      <h2 class="govuk-heading-m">{{ ("organisations.admin.form.body.confirmation.next" | t) }}</h2>
+      <h2 class="govuk-heading-m">{{ (nextTranslation | t) }}</h2>
 
       <p class="govuk-body">
         <a href="/admin">{{ ("app.backToDashboard" | t) }}</a>

--- a/views/admin/organisations/edit.njk
+++ b/views/admin/organisations/edit.njk
@@ -15,7 +15,7 @@
     <div class="govuk-grid-column-two-thirds">
       {% include "../../shared/_errors.njk" %}
 
-      {% set targetUrl = ( currentUrl if errors else "/admin/organisations/"+ id +"/versions/"+ versionId +"?_method=PUT" ) %}
+      {% set targetUrl = ( currentUrl if errors else "/admin/organisations/"+ id +"/versions/" + versionId + "?_method=PUT" ) %}
 
       <form method="post" action="{{ targetUrl }}">
         {{

--- a/views/admin/organisations/edit.njk
+++ b/views/admin/organisations/edit.njk
@@ -18,17 +18,19 @@
       {% set targetUrl = ( currentUrl if errors else "/admin/organisations/"+ id +"/versions/" + versionId + "?_method=PUT" ) %}
 
       <form method="post" action="{{ targetUrl }}">
-        {{
-          govukInput({
-            label: {
-              text: ("organisations.admin.form.label.name" | t),
-              classes: "govuk-label--m"
-            },
-            id: "name",
-            name: "name",
-            value: name
-          })
-        }}
+        {% if slug|length == 0 %}
+          {{
+            govukInput({
+              label: {
+                text: ("organisations.admin.form.label.name" | t),
+                classes: "govuk-label--m"
+              },
+              id: "name",
+              name: "name",
+              value: name
+            })
+          }}
+        {% endif %}
 
         {{
           govukInput({

--- a/views/admin/organisations/edit.njk
+++ b/views/admin/organisations/edit.njk
@@ -7,7 +7,11 @@
 
 {% block content %}
   <h1 class="govuk-heading-xl">
-    {{ "organisations.admin.edit.heading" | t }}
+    {% if slug|length == 0 %}
+      {{ "organisations.admin.create.heading" | t }}
+    {% else %}
+      {{ "organisations.admin.edit.heading" | t }}
+    {% endif %}
   </h1>
 
   <div class="govuk-grid-row">

--- a/views/admin/organisations/show.njk
+++ b/views/admin/organisations/show.njk
@@ -23,7 +23,7 @@
               {{
                 govukButton({
                   text: ("organisations.admin.button.edit" | t),
-                  href: "/admin/organisations/" + organisation.id + "/edit"
+                  href: "/admin/organisations/" + organisation.id + "/versions/new"
                 })
               }}
             </li>

--- a/views/admin/organisations/versions/new.njk
+++ b/views/admin/organisations/versions/new.njk
@@ -1,0 +1,25 @@
+{% extends "base.njk" %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% set bodyClasses = "rpr-internal__page" %}
+
+{% block content %}
+  <h1 class="govuk-heading-xl">
+    {{ "organisation-versions.admin.new.heading" | t }}
+  </h1>
+
+  <div class="govuk-grid-row">
+
+    <div class="govuk-grid-column-full">
+      <form method="post" action="/admin/organisations/{{ id }}/versions">
+        {{ govukButton({
+          id: "submit-button",
+          type: "Submit",
+          text: ("app.start" | t)
+        }) }}
+      </form>
+    </div>
+
+  </div>
+
+{% endblock %}


### PR DESCRIPTION
❗ This PR will merge into the `organisation-version` branch, as some of the functionality is still broken. This will be rectified in the next PR ❗ 

This adds a confirmation page when clicking through to edit an organisation. If the user clicks through, this then creates a new OrganisationVersion, which is a copy of the latest draft or live version, and then sends the user through to the edit page. 

# Screenshots

![image](https://user-images.githubusercontent.com/109774/151574481-2fb29e3c-25ce-438d-8884-677ab7b5c1e1.png)

![image](https://user-images.githubusercontent.com/109774/151574514-441b3b2b-6c0e-46df-8491-99dd1e02ee6c.png)

![image](https://user-images.githubusercontent.com/109774/151574544-44047f2a-f2fb-46cc-a9f4-8c9f4cf26dcb.png)

![image](https://user-images.githubusercontent.com/109774/151574571-1ef6c438-4669-43c0-bade-b2aedd90259b.png)

