### PR TITLE
(2042) Fetch versions with organisations on the public facing site

### DIFF
--- a/cypress/integration/organisations/search/search.spec.ts
+++ b/cypress/integration/organisations/search/search.spec.ts
@@ -24,7 +24,7 @@ describe('Searching an organisation', () => {
     });
   });
 
-  it.skip('I can click an organisation to be taken to its details page', () => {
+  it('I can click an organisation to be taken to its details page', () => {
     cy.get('a').contains('General Medical Council').click();
     cy.checkAccessibility();
     cy.url().should(

--- a/cypress/integration/organisations/search/search.spec.ts
+++ b/cypress/integration/organisations/search/search.spec.ts
@@ -1,4 +1,4 @@
-describe.skip('Searching an organisation', () => {
+describe('Searching an organisation', () => {
   beforeEach(() => {
     cy.visitAndCheckAccessibility('/');
 
@@ -24,7 +24,7 @@ describe.skip('Searching an organisation', () => {
     });
   });
 
-  it('I can click an organisation to be taken to its details page', () => {
+  it.skip('I can click an organisation to be taken to its details page', () => {
     cy.get('a').contains('General Medical Council').click();
     cy.checkAccessibility();
     cy.url().should(

--- a/cypress/integration/organisations/show.spec.ts
+++ b/cypress/integration/organisations/show.spec.ts
@@ -1,4 +1,4 @@
-describe.skip('Showing organisations', () => {
+describe('Showing organisations', () => {
   beforeEach(() => {
     cy.visitAndCheckAccessibility('/');
 
@@ -14,12 +14,13 @@ describe.skip('Showing organisations', () => {
     cy.readFile('./seeds/test/professions.json').then((professions) => {
       cy.readFile('./seeds/test/organisations.json').then((organisations) => {
         const organisation = organisations[0];
+        const version = organisation.versions[0];
 
         cy.get('a').contains(organisation.name).click();
 
         cy.get('body').should('contain', organisation.name);
-        cy.get('body').should('contain', organisation.email);
-        cy.get('body').should('contain', organisation.contactUrl);
+        cy.get('body').should('contain', version.email);
+        cy.get('body').should('contain', version.contactUrl);
 
         const professionsForOrganisation = professions.filter(
           (profession: any) =>

--- a/src/organisations/organisation-versions.service.spec.ts
+++ b/src/organisations/organisation-versions.service.spec.ts
@@ -111,6 +111,7 @@ describe('OrganisationVersionsService', () => {
       const queryBuilder = createMock<SelectQueryBuilder<OrganisationVersion>>({
         leftJoinAndSelect: () => queryBuilder,
         where: () => queryBuilder,
+        orderBy: () => queryBuilder,
         getMany: async () => versions,
       });
 
@@ -147,6 +148,8 @@ describe('OrganisationVersionsService', () => {
           status: OrganisationVersionStatus.Live,
         },
       );
+
+      expect(queryBuilder.orderBy).toHaveBeenCalledWith('organisation.name');
     });
   });
 

--- a/src/organisations/organisation-versions.service.ts
+++ b/src/organisations/organisation-versions.service.ts
@@ -43,6 +43,7 @@ export class OrganisationVersionsService {
       .where('organisationVersion.status = :status', {
         status: OrganisationVersionStatus.Live,
       })
+      .orderBy('organisation.name')
       .getMany();
 
     return versions.map((version) =>

--- a/src/organisations/organisation-versions.service.ts
+++ b/src/organisations/organisation-versions.service.ts
@@ -5,6 +5,7 @@ import {
   OrganisationVersion,
   OrganisationVersionStatus,
 } from './organisation-version.entity';
+import { Organisation } from './organisation.entity';
 
 @Injectable()
 export class OrganisationVersionsService {
@@ -37,6 +38,21 @@ export class OrganisationVersionsService {
     });
   }
 
+  async allLive(): Promise<Organisation[]> {
+    const versions = await this.repository
+      .createQueryBuilder('organisationVersion')
+      .leftJoinAndSelect('organisationVersion.organisation', 'organisation')
+      .leftJoinAndSelect('organisation.professions', 'professions')
+      .leftJoinAndSelect('professions.industries', 'industries')
+      .where('organisationVersion.status = :status', {
+        status: OrganisationVersionStatus.Live,
+      })
+      .getMany();
+
+    return versions.map((version) =>
+      Organisation.withVersion(version.organisation, version),
+    );
+  }
   async confirm(version: OrganisationVersion): Promise<OrganisationVersion> {
     version.status = OrganisationVersionStatus.Draft;
 

--- a/src/organisations/organisation-versions.service.ts
+++ b/src/organisations/organisation-versions.service.ts
@@ -1,4 +1,4 @@
-import { Repository, In } from 'typeorm';
+import { Repository, In, SelectQueryBuilder } from 'typeorm';
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import {
@@ -39,11 +39,7 @@ export class OrganisationVersionsService {
   }
 
   async allLive(): Promise<Organisation[]> {
-    const versions = await this.repository
-      .createQueryBuilder('organisationVersion')
-      .leftJoinAndSelect('organisationVersion.organisation', 'organisation')
-      .leftJoinAndSelect('organisation.professions', 'professions')
-      .leftJoinAndSelect('professions.industries', 'industries')
+    const versions = await this.versionsWithJoins()
       .where('organisationVersion.status = :status', {
         status: OrganisationVersionStatus.Live,
       })
@@ -53,9 +49,32 @@ export class OrganisationVersionsService {
       Organisation.withVersion(version.organisation, version),
     );
   }
+
+  async findLiveBySlug(slug: string): Promise<Organisation> {
+    const version = await this.versionsWithJoins()
+      .where(
+        'organisationVersion.status = :status AND organisation.slug = :slug',
+        {
+          status: OrganisationVersionStatus.Live,
+          slug: slug,
+        },
+      )
+      .getOne();
+
+    return Organisation.withVersion(version.organisation, version);
+  }
+
   async confirm(version: OrganisationVersion): Promise<OrganisationVersion> {
     version.status = OrganisationVersionStatus.Draft;
 
     return this.repository.save(version);
+  }
+
+  private versionsWithJoins(): SelectQueryBuilder<OrganisationVersion> {
+    return this.repository
+      .createQueryBuilder('organisationVersion')
+      .leftJoinAndSelect('organisationVersion.organisation', 'organisation')
+      .leftJoinAndSelect('organisation.professions', 'professions')
+      .leftJoinAndSelect('professions.industries', 'industries');
   }
 }

--- a/src/organisations/organisations.controller.ts
+++ b/src/organisations/organisations.controller.ts
@@ -1,14 +1,14 @@
 import { Controller, Get, Render, Param } from '@nestjs/common';
 import { I18nService } from 'nestjs-i18n';
 
-import { OrganisationsService } from './organisations.service';
+import { OrganisationVersionsService } from './organisation-versions.service';
 import { ShowTemplate } from './interfaces/show-template.interface';
 import { OrganisationSummaryPresenter } from './presenters/organisation-summary.presenter';
 import { BackLink } from '../common/decorators/back-link.decorator';
 @Controller()
 export class OrganisationsController {
   constructor(
-    private readonly organisationsService: OrganisationsService,
+    private readonly organisationVersionsService: OrganisationVersionsService,
     private readonly i18nService: I18nService,
   ) {}
 
@@ -16,8 +16,9 @@ export class OrganisationsController {
   @Render('organisations/show')
   @BackLink('/regulatory-authorities/search')
   async show(@Param('slug') slug: string): Promise<ShowTemplate> {
-    const organisation =
-      await this.organisationsService.findBySlugWithProfessions(slug);
+    const organisation = await this.organisationVersionsService.findLiveBySlug(
+      slug,
+    );
 
     const organisationSummaryPresenter = new OrganisationSummaryPresenter(
       organisation,

--- a/src/organisations/presenters/organisation-summary.presenter.spec.ts
+++ b/src/organisations/presenters/organisation-summary.presenter.spec.ts
@@ -49,7 +49,11 @@ describe('OrganisationSummaryPresenter', () => {
 
       beforeEach(() => {
         organisation = organisationFactory.build({
-          professions: professionsFactory.buildList(2),
+          professions: [
+            professionsFactory.build({ confirmed: true }),
+            professionsFactory.build({ confirmed: true }),
+            professionsFactory.build({ confirmed: false }),
+          ],
         });
       });
 

--- a/src/organisations/presenters/organisation-summary.presenter.ts
+++ b/src/organisations/presenters/organisation-summary.presenter.ts
@@ -22,9 +22,11 @@ export class OrganisationSummaryPresenter {
       );
     }
 
-    const professionPresenters = this.organisation.professions.map(
-      (profession) => new ProfessionPresenter(profession, this.i18nService),
-    );
+    const professionPresenters = this.organisation.professions
+      .filter((profession) => profession.confirmed)
+      .map(
+        (profession) => new ProfessionPresenter(profession, this.i18nService),
+      );
 
     return {
       organisation: this.organisation,

--- a/src/organisations/search/search.controller.spec.ts
+++ b/src/organisations/search/search.controller.spec.ts
@@ -8,7 +8,8 @@ import organisationFactory from '../../testutils/factories/organisation';
 import professionFactory from '../../testutils/factories/profession';
 import { I18nService } from 'nestjs-i18n';
 import { createMockI18nService } from '../../testutils/create-mock-i18n-service';
-import { OrganisationsService } from '../organisations.service';
+import { OrganisationVersionsService } from '../organisation-versions.service';
+
 import { IndustriesService } from '../../industries/industries.service';
 
 const industry1 = industryFactory.build({
@@ -46,15 +47,15 @@ const organisation2 = organisationFactory.build({
 const industries = [industry1, industry2, industry3];
 
 describe('SearchController', () => {
-  let organisationsService: DeepMocked<OrganisationsService>;
+  let organisationVersionsService: DeepMocked<OrganisationVersionsService>;
   let industriesService: DeepMocked<IndustriesService>;
   let i18nService: DeepMocked<I18nService>;
 
   let controller: SearchController;
 
   beforeEach(async () => {
-    organisationsService = createMock<OrganisationsService>();
-    organisationsService.allWithProfessions.mockResolvedValue([
+    organisationVersionsService = createMock<OrganisationVersionsService>();
+    organisationVersionsService.allLive.mockResolvedValue([
       organisation1,
       organisation2,
     ]);
@@ -67,8 +68,8 @@ describe('SearchController', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         {
-          provide: OrganisationsService,
-          useValue: organisationsService,
+          provide: OrganisationVersionsService,
+          useValue: organisationVersionsService,
         },
         {
           provide: IndustriesService,
@@ -105,15 +106,14 @@ describe('SearchController', () => {
       expect(result).toEqual(expected);
     });
 
-    it('should request organisations populated with professions from `OrganisationsService`', async () => {
+    it('should request organisations populated with professions from `OrganisationVersionsService`', async () => {
       await controller.create({
         keywords: '',
         industries: [],
         nations: [],
       });
 
-      expect(organisationsService.allWithProfessions).toHaveBeenCalled();
-      expect(organisationsService.all).not.toHaveBeenCalled();
+      expect(organisationVersionsService.allLive).toHaveBeenCalled();
     });
   });
 

--- a/src/organisations/search/search.controller.ts
+++ b/src/organisations/search/search.controller.ts
@@ -3,7 +3,8 @@ import { I18nService } from 'nestjs-i18n';
 import { IndustriesService } from '../../industries/industries.service';
 import { Nation } from '../../nations/nation';
 import { OrganisationsFilterHelper } from '../helpers/organisations-filter.helper';
-import { OrganisationsService } from '../organisations.service';
+import { OrganisationVersionsService } from '../organisation-versions.service';
+
 import { FilterDto } from './dto/filter.dto';
 
 import { IndexTemplate } from './interfaces/index-template.interface';
@@ -14,7 +15,7 @@ import { createFilterInput } from '../../helpers/create-filter-input.helper';
 @Controller('regulatory-authorities/search')
 export class SearchController {
   constructor(
-    private readonly organisationsService: OrganisationsService,
+    private readonly organisationVersionsService: OrganisationVersionsService,
     private readonly industriesService: IndustriesService,
     private readonly i18nService: I18nService,
   ) {}
@@ -37,8 +38,7 @@ export class SearchController {
     const allNations = Nation.all();
     const allIndustries = await this.industriesService.all();
 
-    const allOrganisations =
-      await this.organisationsService.allWithProfessions();
+    const allOrganisations = await this.organisationVersionsService.allLive();
 
     const filterInput = createFilterInput({
       ...filter,


### PR DESCRIPTION
This updates the public side of the site to fetch the latest live version of an organisation when searching and viewing. As with #178, this PRs base is the `organisation-versioning` branch, which we will merge into main when all the organisation versioning work is complete.