### PR TITLE
Release 002

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+## [release-002] - 2022-02-01
+
 ### Added
 
 - Add more granular database fields for storing the duration of a qualification
@@ -60,4 +62,5 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Make validation errors more human readable
 
 [unreleased]: https://github.com/UKGovernmentBEIS/regulated-professions-register/compare/release-001...HEAD
+[release-002]: https://github.com/UKGovernmentBEIS/regulated-professions-register/compare/release001...release-002
 [release-001]: https://github.com/UKGovernmentBEIS/regulated-professions-register/compare/release...release-001


### PR DESCRIPTION
### Added

- Add more granular database fields for storing the duration of a qualification
- Add a service owner boolean to a user
- Define new user permissions
- List Regulatory Authorities
- Add page for adding a new qualification to a profession
- Show Regulatory Authorities to an admin
- Add page for setting legislation information on a profession
- Add a public-facing Regulatory Authorities search page that allows for filtering professions by keywords, nations, and industries
- Allow Regulatory Authorities to be edited
- Update start page
- Add public-facing Regulatory Authority pages
- Allow Professions to be edited
- Display real data on "view profession" pages
- Add back link from internal professions page to index page
- Add filters to internal Regulatory Authorities page

### Changed

- No longer display previous values on a profession when rendering form errors
- Use enums for storing methods to obtain and common paths to obtain a qualification
- Require users to be logged in to be able to add a profession
- Change roles to permissions
- Update entities on seed, rather than replacing them
- Take users from internal organisations page to internal profession page via link, rather than to public-facing page
- Move back link to under phase banner
- Fix obvious accessibility issues