### PR TITLE
(2042) Fetch Organisations with a Version on Profession Pages

### DIFF
--- a/src/organisations/organisation.entity.spec.ts
+++ b/src/organisations/organisation.entity.spec.ts
@@ -1,4 +1,5 @@
 import { Organisation } from './organisation.entity';
+import { OrganisationVersionStatus } from './organisation-version.entity';
 
 import organisationFactory from '../testutils/factories/organisation';
 import organisationVersionFactory from '../testutils/factories/organisation-version';
@@ -28,6 +29,32 @@ describe('Organisation', () => {
         versionId: organisationVersion.id,
         status: organisationVersion.status,
       });
+    });
+  });
+
+  describe('withLatestLiveVersion', () => {
+    it('should get the latest live version', () => {
+      const organisationVersion = organisationVersionFactory.build({
+        status: OrganisationVersionStatus.Live,
+        updated_at: new Date(2022, 1, 2),
+      });
+      const organisation = organisationFactory.build({
+        versions: [
+          organisationVersionFactory.build({
+            status: OrganisationVersionStatus.Draft,
+            updated_at: new Date(2022, 1, 1),
+          }),
+          organisationVersion,
+          organisationVersionFactory.build({
+            status: OrganisationVersionStatus.Live,
+            updated_at: new Date(2022, 1, 3),
+          }),
+        ],
+      });
+
+      expect(Organisation.withLatestLiveVersion(organisation)).toEqual(
+        Organisation.withVersion(organisation, organisationVersion),
+      );
     });
   });
 });

--- a/src/organisations/organisation.entity.ts
+++ b/src/organisations/organisation.entity.ts
@@ -58,6 +58,18 @@ export class Organisation {
   versionId?: string;
   status?: OrganisationVersionStatus;
 
+  public static withLatestLiveVersion(
+    organisation: Organisation,
+  ): Organisation {
+    const liveVersions = organisation.versions
+      .filter((v) => v.status == OrganisationVersionStatus.Live)
+      .sort((a, b) => a.updated_at.getTime() - b.updated_at.getTime());
+
+    const latestVersion = liveVersions[0];
+
+    return Organisation.withVersion(organisation, latestVersion);
+  }
+
   public static withVersion(
     organisation: Organisation,
     organisationVersion: OrganisationVersion,

--- a/src/organisations/organisation.entity.ts
+++ b/src/organisations/organisation.entity.ts
@@ -29,6 +29,7 @@ export class Organisation {
   @OneToMany(
     () => OrganisationVersion,
     (organisationVersion) => organisationVersion.organisation,
+    { eager: true },
   )
   versions: OrganisationVersion[];
 

--- a/src/professions/admin/professions.controller.spec.ts
+++ b/src/professions/admin/professions.controller.spec.ts
@@ -75,6 +75,8 @@ const profession3 = professionFactory.build({
 let request: DeepMocked<Request>;
 let i18nService: DeepMocked<I18nService>;
 
+jest.mock('../../organisations/organisation.entity');
+
 describe('ProfessionsController', () => {
   let controller: ProfessionsController;
   let professionsService: DeepMocked<ProfessionsService>;
@@ -338,6 +340,10 @@ describe('ProfessionsController', () => {
 
       professionsService.findBySlug.mockResolvedValue(profession);
 
+      (Organisation.withLatestLiveVersion as jest.Mock).mockImplementation(
+        () => profession.organisation,
+      );
+
       const result = await controller.show('example-slug');
 
       expect(result).toEqual({
@@ -345,6 +351,7 @@ describe('ProfessionsController', () => {
         qualification: new QualificationPresenter(profession.qualification),
         nations: ['Translation of `nations.england`'],
         industries: ['Translation of `industries.example`'],
+        organisation: profession.organisation,
       });
 
       expect(professionsService.findBySlug).toHaveBeenCalledWith(
@@ -370,6 +377,10 @@ describe('ProfessionsController', () => {
 
         professionsService.findBySlug.mockResolvedValue(profession);
 
+        (Organisation.withLatestLiveVersion as jest.Mock).mockImplementation(
+          () => profession.organisation,
+        );
+
         const result = await controller.show('example-slug');
 
         expect(result).toEqual({
@@ -377,6 +388,7 @@ describe('ProfessionsController', () => {
           qualification: null,
           nations: [translationOf('nations.england')],
           industries: [translationOf('industries.example')],
+          organisation: profession.organisation,
         });
       });
     });

--- a/src/professions/admin/professions.controller.ts
+++ b/src/professions/admin/professions.controller.ts
@@ -32,6 +32,7 @@ import { Permissions } from '../../common/permissions.decorator';
 import { BackLink } from '../../common/decorators/back-link.decorator';
 import QualificationPresenter from '../../qualifications/presenters/qualification.presenter';
 import { createFilterInput } from '../../helpers/create-filter-input.helper';
+import { Organisation } from '../../organisations/organisation.entity';
 
 @UseGuards(AuthenticationGuard)
 @Controller('admin/professions')
@@ -74,6 +75,10 @@ export class ProfessionsController {
       );
     }
 
+    const organisation = Organisation.withLatestLiveVersion(
+      profession.organisation,
+    );
+
     const nations = await Promise.all(
       profession.occupationLocations.map(async (code) =>
         Nation.find(code).translatedName(this.i18Service),
@@ -95,6 +100,7 @@ export class ProfessionsController {
       qualification: qualification,
       nations,
       industries,
+      organisation,
     };
   }
 

--- a/src/professions/interfaces/show-template.interface.ts
+++ b/src/professions/interfaces/show-template.interface.ts
@@ -1,3 +1,4 @@
+import { Organisation } from '../../organisations/organisation.entity';
 import QualificationPresenter from '../../qualifications/presenters/qualification.presenter';
 import { Profession } from '../profession.entity';
 
@@ -6,4 +7,5 @@ export interface ShowTemplate {
   qualification: QualificationPresenter;
   nations: string[];
   industries: string[];
+  organisation: Organisation;
 }

--- a/src/professions/professions.controller.spec.ts
+++ b/src/professions/professions.controller.spec.ts
@@ -11,6 +11,10 @@ import { translationOf } from '../testutils/translation-of';
 import { ProfessionsController } from './professions.controller';
 import { ProfessionsService } from './professions.service';
 
+import { Organisation } from '../organisations/organisation.entity';
+
+jest.mock('../organisations/organisation.entity');
+
 describe('ProfessionsController', () => {
   let controller: ProfessionsController;
   let professionsService: DeepMocked<ProfessionsService>;
@@ -46,6 +50,10 @@ describe('ProfessionsController', () => {
 
       professionsService.findBySlug.mockResolvedValue(profession);
 
+      (Organisation.withLatestLiveVersion as jest.Mock).mockImplementation(
+        () => profession.organisation,
+      );
+
       const result = await controller.show('example-slug');
 
       expect(result).toEqual({
@@ -53,6 +61,7 @@ describe('ProfessionsController', () => {
         qualification: new QualificationPresenter(profession.qualification),
         nations: [translationOf('nations.england')],
         industries: [translationOf('industries.example')],
+        organisation: profession.organisation,
       });
 
       expect(professionsService.findBySlug).toBeCalledWith('example-slug');
@@ -76,6 +85,10 @@ describe('ProfessionsController', () => {
 
         professionsService.findBySlug.mockResolvedValue(profession);
 
+        (Organisation.withLatestLiveVersion as jest.Mock).mockImplementation(
+          () => profession.organisation,
+        );
+
         const result = await controller.show('example-slug');
 
         expect(result).toEqual({
@@ -83,6 +96,7 @@ describe('ProfessionsController', () => {
           qualification: null,
           nations: [translationOf('nations.england')],
           industries: [translationOf('industries.example')],
+          organisation: profession.organisation,
         });
       });
     });

--- a/src/professions/professions.controller.ts
+++ b/src/professions/professions.controller.ts
@@ -11,7 +11,7 @@ import QualificationPresenter from '../qualifications/presenters/qualification.p
 import { ShowTemplate } from './interfaces/show-template.interface';
 import { ProfessionsService } from './professions.service';
 import { BackLink } from '../common/decorators/back-link.decorator';
-
+import { Organisation } from '../organisations/organisation.entity';
 @Controller()
 export class ProfessionsController {
   constructor(
@@ -30,6 +30,10 @@ export class ProfessionsController {
         `A profession with ID ${slug} could not be found`,
       );
     }
+
+    const organisation = Organisation.withLatestLiveVersion(
+      profession.organisation,
+    );
 
     const nations = await Promise.all(
       profession.occupationLocations.map(async (code) =>
@@ -52,6 +56,7 @@ export class ProfessionsController {
       qualification: qualification,
       nations,
       industries,
+      organisation,
     };
   }
 }

--- a/views/professions/_profession-details.njk
+++ b/views/professions/_profession-details.njk
@@ -1,6 +1,6 @@
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 
-<span class="govuk-caption-l">{{ profession.organisation.name }}</span>
+<span class="govuk-caption-l">{{ organisation.name }}</span>
 
 <h1 class="govuk-heading-xl">{{ profession.name }}</h1>
 
@@ -53,7 +53,7 @@
         text: ("professions.show.bodies.regulatedAuthority" | t)
       },
       value: {
-        text: profession.organisation.name
+        text: organisation.name
       }
     },
     {
@@ -61,7 +61,7 @@
         text: ("professions.show.bodies.address" | t)
       },
       value: {
-        text: profession.organisation.address
+        text: organisation.address
       }
     },
     {
@@ -69,7 +69,7 @@
         text: ("professions.show.bodies.emailAddress" | t)
       },
       value: {
-        html: ["<a class=\"govuk-link\" href=\"mailto:", (profession.organisation.email | escape), "\">", (profession.organisation.email | escape),  "</a>" ] | join
+        html: ["<a class=\"govuk-link\" href=\"mailto:", (organisation.email | escape), "\">", (organisation.email | escape),  "</a>" ] | join
       }
     },
     {
@@ -77,7 +77,7 @@
         text: ("professions.show.bodies.url" | t)
       },
       value: {
-        html: ["<a class=\"govuk-link\" href=\"", (profession.organisation.url | escape), "\">", (profession.organisation.url | escape),  "</a>" ] | join
+        html: ["<a class=\"govuk-link\" href=\"", (organisation.url | escape), "\">", (organisation.url | escape),  "</a>" ] | join
       }
     },
     {
@@ -85,7 +85,7 @@
         text: ("professions.show.bodies.phoneNumber" | t)
       },
       value: {
-        text: profession.organisation.telephone
+        text: organisation.telephone
       }
     }
   ]


### PR DESCRIPTION
This fixes the remaining failing tests in #199 to make sure we use versions when fetching organisations on professions pages. Hopefully this won't get in your way too much @Gweaton!