### PR TITLE
(2045) Only show Live Professions on public-facing pages

### DIFF
--- a/cypress/integration/professions/search/search.spec.ts
+++ b/cypress/integration/professions/search/search.spec.ts
@@ -10,12 +10,13 @@ describe('Searching a profession', () => {
     cy.checkAccessibility();
   });
 
-  it('I can view an unfiltered list of professions', () => {
+  it('I can view an unfiltered list of live professions', () => {
     cy.get('body').should('contain', 'Registered Trademark Attorney');
     cy.get('body').should(
       'contain',
       'Secondary School Teacher in State maintained schools (England)',
     );
+    cy.get('body').should('not.contain', 'Gas Safe Engineer');
   });
 
   it('Organisations are sorted alphabetically', () => {

--- a/seeds/development/legislations.json
+++ b/seeds/development/legislations.json
@@ -14,5 +14,9 @@
   {
     "name": "The Education (Induction Arrangements for School Teachers) (England) Regulations 2012/1115 (as amended)",
     "url": "http://www.legislation.gov.uk/2012/1115"
+  },
+  {
+    "name": "Gas Safety (Installation and Use) Regulations 1998",
+    "url": "https://www.legislation.gov.uk/uksi/1998/2451/made"
   }
 ]

--- a/seeds/development/professions.json
+++ b/seeds/development/professions.json
@@ -25,7 +25,7 @@
         "legislations": ["The Trade Marks Act 1994"],
         "organisation": "Law Society of England and Wales",
         "mandatoryRegistration": "voluntary",
-        "status": "draft"
+        "status": "live"
       }
     ]
   },
@@ -50,14 +50,44 @@
         "occupationLocations": ["GB-ENG"],
         "regulationType": "N/A",
         "industries": ["industries.education"],
-        "qualifications": "PS3 - Diploma of post-secondary level (3-4 years) , Art. 11 d",
+        "qualification": "PS3 - Diploma of post-secondary level (3-4 years) , Art. 11 d",
         "reservedActivities": "No information submitted",
         "legislations": [
           "The Education (School Teachers' Qualifications) (England) Regulations 2003/1662 (as amended)"
         ],
         "organisation": "Department for Education",
         "mandatoryRegistration": "mandatory",
-        "status": "unconfirmed"
+        "status": "live"
+      }
+    ]
+  },
+  {
+    "name": "Gas Safe Engineer",
+    "slug": "gas-safe-engineer",
+    "confirmed": true,
+    "alternateName": "Registered Gas Engineer",
+    "description": "Gas Safe Register is the official list of gas engineers in the UK, Isle of Man and Guernsey. Gas installers work on gas appliances and installations.",
+    "occupationLocations": ["GB-ENG", "GB-WLS", "GB-NIR"],
+    "regulationType": "N/A",
+    "industries": ["industries.constructionAndEngineering"],
+    "qualification": "ATT - Attestation of competence , Art. 11 a",
+    "reservedActivities": "Gas Safe Register is the official list of gas engineers in the UK, Isle of Man and Guernsey. To work on gas appliances and installations you must be on the gas safe register. The register exists to protect the public from unsafe gas work (EN)",
+    "legislation": "Gas Safety (Installation and Use) Regulations 1998",
+    "organisation": "Council of Registered Gas Installers",
+    "mandatoryRegistration": "voluntary",
+    "versions": [
+      {
+        "alternateName": "Registered Gas Engineer",
+        "description": "Gas Safe Register is the official list of gas engineers in the UK, Isle of Man and Guernsey. Gas installers work on gas appliances and installations.",
+        "occupationLocations": ["GB-ENG", "GB-WLS", "GB-NIR"],
+        "regulationType": "N/A",
+        "industries": ["industries.constructionAndEngineering"],
+        "qualification": "ATT - Attestation of competence , Art. 11 a",
+        "reservedActivities": "Gas Safe Register is the official list of gas engineers in the UK, Isle of Man and Guernsey. To work on gas appliances and installations you must be on the gas safe register. The register exists to protect the public from unsafe gas work (EN)",
+        "legislations": ["Gas Safety (Installation and Use) Regulations 1998"],
+        "organisation": "Council of Registered Gas Installers",
+        "mandatoryRegistration": "voluntary",
+        "status": "draft"
       }
     ]
   },

--- a/seeds/development/qualifications.json
+++ b/seeds/development/qualifications.json
@@ -24,5 +24,18 @@
     "educationDurationDays": 0,
     "educationDurationHours": 0,
     "mandatoryProfessionalExperience": true
+  },
+  {
+    "level": "ATT - Attestation of competence , Art. 11 a",
+    "methodToObtain": "generalOrVocationalPostSecondaryEducation",
+    "otherMethodToObtain": "",
+    "commonPathToObtain": "generalOrVocationalPostSecondaryEducation",
+    "otherCommonPathToObtain": "",
+    "educationDuration": "3 Year",
+    "educationDurationYears": 3,
+    "educationDurationMonths": 6,
+    "educationDurationDays": 0,
+    "educationDurationHours": 0,
+    "mandatoryProfessionalExperience": false
   }
 ]

--- a/seeds/staging/legislations.json
+++ b/seeds/staging/legislations.json
@@ -14,5 +14,9 @@
   {
     "name": "The Education (Induction Arrangements for School Teachers) (England) Regulations 2012/1115 (as amended)",
     "url": "http://www.legislation.gov.uk/2012/1115"
+  },
+  {
+    "name": "Gas Safety (Installation and Use) Regulations 1998",
+    "url": "https://www.legislation.gov.uk/uksi/1998/2451/made"
   }
 ]

--- a/seeds/staging/professions.json
+++ b/seeds/staging/professions.json
@@ -25,7 +25,7 @@
         "legislations": ["The Trade Marks Act 1994"],
         "organisation": "Law Society of England and Wales",
         "mandatoryRegistration": "voluntary",
-        "status": "draft"
+        "status": "live"
       }
     ]
   },
@@ -50,14 +50,44 @@
         "occupationLocations": ["GB-ENG"],
         "regulationType": "N/A",
         "industries": ["industries.education"],
-        "qualifications": "PS3 - Diploma of post-secondary level (3-4 years) , Art. 11 d",
+        "qualification": "PS3 - Diploma of post-secondary level (3-4 years) , Art. 11 d",
         "reservedActivities": "No information submitted",
         "legislations": [
           "The Education (School Teachers' Qualifications) (England) Regulations 2003/1662 (as amended)"
         ],
         "organisation": "Department for Education",
         "mandatoryRegistration": "mandatory",
-        "status": "unconfirmed"
+        "status": "live"
+      }
+    ]
+  },
+  {
+    "name": "Gas Safe Engineer",
+    "slug": "gas-safe-engineer",
+    "confirmed": true,
+    "alternateName": "Registered Gas Engineer",
+    "description": "Gas Safe Register is the official list of gas engineers in the UK, Isle of Man and Guernsey. Gas installers work on gas appliances and installations.",
+    "occupationLocations": ["GB-ENG", "GB-WLS", "GB-NIR"],
+    "regulationType": "N/A",
+    "industries": ["industries.constructionAndEngineering"],
+    "qualification": "ATT - Attestation of competence , Art. 11 a",
+    "reservedActivities": "Gas Safe Register is the official list of gas engineers in the UK, Isle of Man and Guernsey. To work on gas appliances and installations you must be on the gas safe register. The register exists to protect the public from unsafe gas work (EN)",
+    "legislation": "Gas Safety (Installation and Use) Regulations 1998",
+    "organisation": "Council of Registered Gas Installers",
+    "mandatoryRegistration": "voluntary",
+    "versions": [
+      {
+        "alternateName": "Registered Gas Engineer",
+        "description": "Gas Safe Register is the official list of gas engineers in the UK, Isle of Man and Guernsey. Gas installers work on gas appliances and installations.",
+        "occupationLocations": ["GB-ENG", "GB-WLS", "GB-NIR"],
+        "regulationType": "N/A",
+        "industries": ["industries.constructionAndEngineering"],
+        "qualification": "ATT - Attestation of competence , Art. 11 a",
+        "reservedActivities": "Gas Safe Register is the official list of gas engineers in the UK, Isle of Man and Guernsey. To work on gas appliances and installations you must be on the gas safe register. The register exists to protect the public from unsafe gas work (EN)",
+        "legislations": ["Gas Safety (Installation and Use) Regulations 1998"],
+        "organisation": "Council of Registered Gas Installers",
+        "mandatoryRegistration": "voluntary",
+        "status": "draft"
       }
     ]
   },

--- a/seeds/staging/qualifications.json
+++ b/seeds/staging/qualifications.json
@@ -24,5 +24,18 @@
     "educationDurationDays": 0,
     "educationDurationHours": 0,
     "mandatoryProfessionalExperience": true
+  },
+  {
+    "level": "ATT - Attestation of competence , Art. 11 a",
+    "methodToObtain": "generalOrVocationalPostSecondaryEducation",
+    "otherMethodToObtain": "",
+    "commonPathToObtain": "generalOrVocationalPostSecondaryEducation",
+    "otherCommonPathToObtain": "",
+    "educationDuration": "3 Year",
+    "educationDurationYears": 3,
+    "educationDurationMonths": 6,
+    "educationDurationDays": 0,
+    "educationDurationHours": 0,
+    "mandatoryProfessionalExperience": false
   }
 ]

--- a/seeds/test/legislations.json
+++ b/seeds/test/legislations.json
@@ -14,5 +14,9 @@
   {
     "name": "The Education (Induction Arrangements for School Teachers) (England) Regulations 2012/1115 (as amended)",
     "url": "http://www.legislation.gov.uk/2012/1115"
+  },
+  {
+    "name": "Gas Safety (Installation and Use) Regulations 1998",
+    "url": "https://www.legislation.gov.uk/uksi/1998/2451/made"
   }
 ]

--- a/seeds/test/professions.json
+++ b/seeds/test/professions.json
@@ -25,7 +25,7 @@
         "legislations": ["The Trade Marks Act 1994"],
         "organisation": "Law Society of England and Wales",
         "mandatoryRegistration": "voluntary",
-        "status": "draft"
+        "status": "live"
       }
     ]
   },
@@ -50,14 +50,44 @@
         "occupationLocations": ["GB-ENG"],
         "regulationType": "N/A",
         "industries": ["industries.education"],
-        "qualifications": "PS3 - Diploma of post-secondary level (3-4 years) , Art. 11 d",
+        "qualification": "PS3 - Diploma of post-secondary level (3-4 years) , Art. 11 d",
         "reservedActivities": "No information submitted",
         "legislations": [
           "The Education (School Teachers' Qualifications) (England) Regulations 2003/1662 (as amended)"
         ],
         "organisation": "Department for Education",
         "mandatoryRegistration": "mandatory",
-        "status": "unconfirmed"
+        "status": "live"
+      }
+    ]
+  },
+  {
+    "name": "Gas Safe Engineer",
+    "slug": "gas-safe-engineer",
+    "confirmed": true,
+    "alternateName": "Registered Gas Engineer",
+    "description": "Gas Safe Register is the official list of gas engineers in the UK, Isle of Man and Guernsey. Gas installers work on gas appliances and installations.",
+    "occupationLocations": ["GB-ENG", "GB-WLS", "GB-NIR"],
+    "regulationType": "N/A",
+    "industries": ["industries.constructionAndEngineering"],
+    "qualification": "ATT - Attestation of competence , Art. 11 a",
+    "reservedActivities": "Gas Safe Register is the official list of gas engineers in the UK, Isle of Man and Guernsey. To work on gas appliances and installations you must be on the gas safe register. The register exists to protect the public from unsafe gas work (EN)",
+    "legislation": "Gas Safety (Installation and Use) Regulations 1998",
+    "organisation": "Council of Registered Gas Installers",
+    "mandatoryRegistration": "voluntary",
+    "versions": [
+      {
+        "alternateName": "Registered Gas Engineer",
+        "description": "Gas Safe Register is the official list of gas engineers in the UK, Isle of Man and Guernsey. Gas installers work on gas appliances and installations.",
+        "occupationLocations": ["GB-ENG", "GB-WLS", "GB-NIR"],
+        "regulationType": "N/A",
+        "industries": ["industries.constructionAndEngineering"],
+        "qualification": "ATT - Attestation of competence , Art. 11 a",
+        "reservedActivities": "Gas Safe Register is the official list of gas engineers in the UK, Isle of Man and Guernsey. To work on gas appliances and installations you must be on the gas safe register. The register exists to protect the public from unsafe gas work (EN)",
+        "legislations": ["Gas Safety (Installation and Use) Regulations 1998"],
+        "organisation": "Council of Registered Gas Installers",
+        "mandatoryRegistration": "voluntary",
+        "status": "draft"
       }
     ]
   },

--- a/seeds/test/qualifications.json
+++ b/seeds/test/qualifications.json
@@ -24,5 +24,18 @@
     "educationDurationDays": 0,
     "educationDurationHours": 0,
     "mandatoryProfessionalExperience": true
+  },
+  {
+    "level": "ATT - Attestation of competence , Art. 11 a",
+    "methodToObtain": "generalOrVocationalPostSecondaryEducation",
+    "otherMethodToObtain": "",
+    "commonPathToObtain": "generalOrVocationalPostSecondaryEducation",
+    "otherCommonPathToObtain": "",
+    "educationDuration": "3 Year",
+    "educationDurationYears": 3,
+    "educationDurationMonths": 6,
+    "educationDurationDays": 0,
+    "educationDurationHours": 0,
+    "mandatoryProfessionalExperience": false
   }
 ]

--- a/src/professions/profession-versions.service.spec.ts
+++ b/src/professions/profession-versions.service.spec.ts
@@ -143,26 +143,13 @@ describe('ProfessionVersionsService', () => {
 
       expect(result).toEqual(expectedProfessions);
 
-      expect(queryBuilder.leftJoinAndSelect).toHaveBeenCalledWith(
+      expect(queryBuilder).toHaveJoined([
         'professionVersion.profession',
-        'profession',
-      );
-      expect(queryBuilder.leftJoinAndSelect).toHaveBeenCalledWith(
         'professionVersion.industries',
-        'industries',
-      );
-      expect(queryBuilder.leftJoinAndSelect).toHaveBeenCalledWith(
         'professionVersion.organisation',
-        'organisation',
-      );
-      expect(queryBuilder.leftJoinAndSelect).toHaveBeenCalledWith(
         'professionVersion.qualification',
-        'qualification',
-      );
-      expect(queryBuilder.leftJoinAndSelect).toHaveBeenCalledWith(
         'professionVersion.legislations',
-        'legislations',
-      );
+      ]);
 
       expect(queryBuilder.where).toHaveBeenCalledWith(
         'professionVersion.status = :status',

--- a/src/professions/profession-versions.service.ts
+++ b/src/professions/profession-versions.service.ts
@@ -5,6 +5,7 @@ import {
   ProfessionVersion,
   ProfessionVersionStatus,
 } from './profession-version.entity';
+import { Profession } from './profession.entity';
 
 @Injectable()
 export class ProfessionVersionsService {
@@ -45,5 +46,23 @@ export class ProfessionVersionsService {
       order: { created_at: 'DESC' },
       relations: ['profession'],
     });
+  }
+
+  async allLive(): Promise<Profession[]> {
+    const versions = await this.repository
+      .createQueryBuilder('professionVersion')
+      .leftJoinAndSelect('professionVersion.profession', 'profession')
+      .leftJoinAndSelect('professionVersion.organisation', 'organisation')
+      .leftJoinAndSelect('professionVersion.industries', 'industries')
+      .leftJoinAndSelect('professionVersion.qualification', 'qualification')
+      .leftJoinAndSelect('professionVersion.legislations', 'legislations')
+      .where('professionVersion.status = :status', {
+        status: ProfessionVersionStatus.Live,
+      })
+      .getMany();
+
+    return versions.map((version) =>
+      Profession.withVersion(version.profession, version),
+    );
   }
 }

--- a/src/professions/profession.entity.spec.ts
+++ b/src/professions/profession.entity.spec.ts
@@ -1,0 +1,31 @@
+import professionFactory from '../testutils/factories/profession';
+import professionVersionFactory from '../testutils/factories/profession-version';
+import { Profession } from './profession.entity';
+
+describe('Profession', () => {
+  describe('withVersion', () => {
+    it('should return an entity with a version', () => {
+      const professionVersion = professionVersionFactory.build();
+      const profession = professionFactory.build({
+        versions: [professionVersion, professionVersionFactory.build()],
+      });
+
+      const result = Profession.withVersion(profession, professionVersion);
+
+      expect(result).toEqual({
+        ...profession,
+        alternateName: professionVersion.alternateName,
+        description: professionVersion.description,
+        occupationLocations: professionVersion.occupationLocations,
+        regulationType: professionVersion.regulationType,
+        mandatoryRegistration: professionVersion.mandatoryRegistration,
+        industries: professionVersion.industries,
+        qualification: professionVersion.qualification,
+        reservedActivities: professionVersion.reservedActivities,
+        legislations: professionVersion.legislations,
+        organisation: professionVersion.organisation,
+        versionId: professionVersion.id,
+      });
+    });
+  });
+});

--- a/src/professions/profession.entity.ts
+++ b/src/professions/profession.entity.ts
@@ -105,6 +105,8 @@ export class Profession {
   })
   updated_at: Date;
 
+  versionId?: string;
+
   constructor(
     name?: string,
     alternateName?: string,
@@ -137,5 +139,25 @@ export class Profession {
     this.organisation = organisation || null;
     this.confirmed = confirmed || false;
     this.versions = versions || null;
+  }
+
+  static withVersion(
+    profession: Profession,
+    version: ProfessionVersion,
+  ): Profession {
+    return {
+      ...profession,
+      alternateName: version.alternateName,
+      description: version.description,
+      occupationLocations: version.occupationLocations,
+      regulationType: version.regulationType,
+      mandatoryRegistration: version.mandatoryRegistration,
+      industries: version.industries,
+      qualification: version.qualification,
+      reservedActivities: version.reservedActivities,
+      legislations: version.legislations,
+      organisation: version.organisation,
+      versionId: version.id,
+    };
   }
 }

--- a/src/professions/professions.controller.spec.ts
+++ b/src/professions/professions.controller.spec.ts
@@ -7,9 +7,9 @@ import { createMockI18nService } from '../testutils/create-mock-i18n-service';
 import industryFactory from '../testutils/factories/industry';
 import professionFactory from '../testutils/factories/profession';
 import { translationOf } from '../testutils/translation-of';
+import { ProfessionVersionsService } from './profession-versions.service';
 
 import { ProfessionsController } from './professions.controller';
-import { ProfessionsService } from './professions.service';
 
 import { Organisation } from '../organisations/organisation.entity';
 
@@ -17,18 +17,18 @@ jest.mock('../organisations/organisation.entity');
 
 describe('ProfessionsController', () => {
   let controller: ProfessionsController;
-  let professionsService: DeepMocked<ProfessionsService>;
+  let professionVersionsService: DeepMocked<ProfessionVersionsService>;
   let i18nService: DeepMocked<I18nService>;
 
   beforeEach(async () => {
-    professionsService = createMock<ProfessionsService>();
+    professionVersionsService = createMock<ProfessionVersionsService>();
     i18nService = createMockI18nService();
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         {
-          provide: ProfessionsService,
-          useValue: professionsService,
+          provide: ProfessionVersionsService,
+          useValue: professionVersionsService,
         },
         { provide: I18nService, useValue: i18nService },
       ],
@@ -48,7 +48,7 @@ describe('ProfessionsController', () => {
         industries: [industry],
       });
 
-      professionsService.findBySlug.mockResolvedValue(profession);
+      professionVersionsService.findLiveBySlug.mockResolvedValue(profession);
 
       (Organisation.withLatestLiveVersion as jest.Mock).mockImplementation(
         () => profession.organisation,
@@ -64,11 +64,13 @@ describe('ProfessionsController', () => {
         organisation: profession.organisation,
       });
 
-      expect(professionsService.findBySlug).toBeCalledWith('example-slug');
+      expect(professionVersionsService.findLiveBySlug).toBeCalledWith(
+        'example-slug',
+      );
     });
 
     it('should throw an error when the slug does not match a profession', () => {
-      professionsService.findBySlug.mockResolvedValue(null);
+      professionVersionsService.findLiveBySlug.mockResolvedValue(null);
 
       expect(async () => {
         await controller.show('example-invalid-slug');
@@ -83,7 +85,7 @@ describe('ProfessionsController', () => {
           industries: [industryFactory.build({ name: 'industries.example' })],
         });
 
-        professionsService.findBySlug.mockResolvedValue(profession);
+        professionVersionsService.findLiveBySlug.mockResolvedValue(profession);
 
         (Organisation.withLatestLiveVersion as jest.Mock).mockImplementation(
           () => profession.organisation,

--- a/src/professions/professions.controller.ts
+++ b/src/professions/professions.controller.ts
@@ -9,13 +9,14 @@ import { I18nService } from 'nestjs-i18n';
 import { Nation } from '../nations/nation';
 import QualificationPresenter from '../qualifications/presenters/qualification.presenter';
 import { ShowTemplate } from './interfaces/show-template.interface';
-import { ProfessionsService } from './professions.service';
 import { BackLink } from '../common/decorators/back-link.decorator';
 import { Organisation } from '../organisations/organisation.entity';
+import { ProfessionVersionsService } from './profession-versions.service';
+
 @Controller()
 export class ProfessionsController {
   constructor(
-    private professionsService: ProfessionsService,
+    private professionVersionsService: ProfessionVersionsService,
     private readonly i18nService: I18nService,
   ) {}
 
@@ -23,7 +24,9 @@ export class ProfessionsController {
   @Render('professions/show')
   @BackLink('/professions/search')
   async show(@Param('slug') slug: string): Promise<ShowTemplate> {
-    const profession = await this.professionsService.findBySlug(slug);
+    const profession = await this.professionVersionsService.findLiveBySlug(
+      slug,
+    );
 
     if (!profession) {
       throw new NotFoundException(

--- a/src/professions/search/search.controller.spec.ts
+++ b/src/professions/search/search.controller.spec.ts
@@ -3,21 +3,21 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { I18nService } from 'nestjs-i18n';
 import { Nation } from '../../nations/nation';
 import { IndustriesService } from '../../industries/industries.service';
-import { ProfessionsService } from '../professions.service';
 import { SearchController } from './search.controller';
 import { SearchPresenter } from './search.presenter';
 import industryFactory from '../../testutils/factories/industry';
 import professionFactory from '../../testutils/factories/profession';
 import { createMockI18nService } from '../../testutils/create-mock-i18n-service';
+import { ProfessionVersionsService } from '../profession-versions.service';
 
 describe('SearchController', () => {
   let controller: SearchController;
-  let professionsService: DeepMocked<ProfessionsService>;
+  let professionVersionsService: DeepMocked<ProfessionVersionsService>;
   let industriesService: DeepMocked<IndustriesService>;
   let i18nService: DeepMocked<I18nService>;
 
   beforeEach(async () => {
-    professionsService = createMock<ProfessionsService>();
+    professionVersionsService = createMock<ProfessionVersionsService>();
     industriesService = createMock<IndustriesService>();
 
     i18nService = createMockI18nService();
@@ -25,8 +25,8 @@ describe('SearchController', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         {
-          provide: ProfessionsService,
-          useValue: professionsService,
+          provide: ProfessionVersionsService,
+          useValue: professionVersionsService,
         },
         {
           provide: IndustriesService,
@@ -56,7 +56,7 @@ describe('SearchController', () => {
         name: 'Trademark Attorney',
         industries: [industry2, industry3],
       });
-      professionsService.allConfirmed.mockResolvedValue([
+      professionVersionsService.allLive.mockResolvedValue([
         schoolTeacher,
         trademarkAttorney,
       ]);
@@ -85,8 +85,7 @@ describe('SearchController', () => {
         nations: [],
       });
 
-      expect(professionsService.allConfirmed).toHaveBeenCalled();
-      expect(professionsService.all).not.toHaveBeenCalled();
+      expect(professionVersionsService.allLive).toHaveBeenCalled();
     });
   });
 
@@ -106,7 +105,7 @@ describe('SearchController', () => {
         name: 'Trademark Attorney',
         industries: [industry2, industry3],
       });
-      professionsService.allConfirmed.mockResolvedValue([
+      professionVersionsService.allLive.mockResolvedValue([
         schoolTeacher,
         trademarkAttorney,
       ]);
@@ -149,7 +148,7 @@ describe('SearchController', () => {
         industries: [industry2, industry3],
         occupationLocations: ['GB-WLS'],
       });
-      professionsService.allConfirmed.mockResolvedValue([
+      professionVersionsService.allLive.mockResolvedValue([
         professionRegulatedInEngland,
         professionRegulatedInWales,
       ]);
@@ -191,7 +190,7 @@ describe('SearchController', () => {
         name: 'Trademark Attorney',
         industries: [lawIndustry],
       });
-      professionsService.allConfirmed.mockResolvedValue([
+      professionVersionsService.allLive.mockResolvedValue([
         schoolTeacher,
         trademarkAttorney,
       ]);
@@ -232,7 +231,7 @@ describe('SearchController', () => {
         name: 'Trademark Attorney',
         industries: [industry2, industry3],
       });
-      professionsService.allConfirmed.mockResolvedValue([
+      professionVersionsService.allLive.mockResolvedValue([
         schoolTeacher,
         trademarkAttorney,
       ]);
@@ -273,7 +272,7 @@ describe('SearchController', () => {
         industries: [industry2],
       });
 
-      professionsService.allConfirmed.mockResolvedValue([
+      professionVersionsService.allLive.mockResolvedValue([
         schoolTeacher,
         trademarkAttorney,
       ]);

--- a/src/professions/search/search.controller.ts
+++ b/src/professions/search/search.controller.ts
@@ -2,18 +2,18 @@ import { Body, Controller, Get, Post, Render } from '@nestjs/common';
 import { I18nService } from 'nestjs-i18n';
 import { IndustriesService } from '../../industries/industries.service';
 import { Nation } from '../../nations/nation';
-import { ProfessionsService } from '../professions.service';
 import { FilterDto } from './dto/filter.dto';
 import { ProfessionsFilterHelper } from '../helpers/professions-filter.helper';
 import { IndexTemplate } from './interfaces/index-template.interface';
 import { SearchPresenter } from './search.presenter';
 import { BackLink } from '../../common/decorators/back-link.decorator';
 import { createFilterInput } from '../../helpers/create-filter-input.helper';
+import { ProfessionVersionsService } from '../profession-versions.service';
 
 @Controller('professions/search')
 export class SearchController {
   constructor(
-    private readonly professionsService: ProfessionsService,
+    private readonly professionVersionsService: ProfessionVersionsService,
     private readonly industriesService: IndustriesService,
     private readonly i18nService: I18nService,
   ) {}
@@ -36,7 +36,7 @@ export class SearchController {
     const allNations = Nation.all();
     const allIndustries = await this.industriesService.all();
 
-    const allProfessions = await this.professionsService.allConfirmed();
+    const allProfessions = await this.professionVersionsService.allLive();
 
     const filterInput = createFilterInput({
       ...filter,

--- a/views/professions/_profession-details.njk
+++ b/views/professions/_profession-details.njk
@@ -171,32 +171,35 @@
 
 {% endif %}
 
-{% if profession.legislation %}
+{% if profession.legislations %}
 
 <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
 <h2 class="govuk-heading-m rpr-details__section-title">{{ "professions.show.legislation.heading" | t}}</h2>
 
-{{ govukSummaryList({
-  classes: 'govuk-summary-list--no-border',
-  rows: [
-    {
-      key: {
-        text: ( "professions.show.legislation.nationalLegislation" | t)
+{% for legislation in profession.legislations %}
+  {{ govukSummaryList({
+    classes: 'govuk-summary-list--no-border',
+    rows: [
+      {
+        key: {
+          text: ( "professions.show.legislation.nationalLegislation" | t) + " " + loop.index
+        },
+        value: {
+          text: legislation.name
+        }
       },
-      value: {
-        text: profession.legislation.name
+      {
+        key: {
+          text: ( "professions.show.legislation.legislationLink" | t) + " " + loop.index
+        },
+        value: {
+          html: ["<a class=\"govuk-link\" href=\"", (legislation.url | escape), "\">", (legislation.url | escape),  "</a>" ] | join
+        }
       }
-    },
-    {
-      key: {
-        text: ( "professions.show.legislation.legislationLink" | t)
-      },
-      value: {
-        html: ["<a class=\"govuk-link\" href=\"", (profession.legislation.url | escape), "\">", (profession.legislation.url | escape),  "</a>" ] | join
-      }
-    }
-  ]
-}) }}
+    ]
+  }) }}
+{% endfor %}
+
 
 {% endif %}


### PR DESCRIPTION
# Changes in this PR

- Adds a new seeded profession so we have more to play with locally.
- Only displays Professions with a live ProfessionVersion in the list of Professions on the public-facing site.
- Updates the "show" profession page to support displaying more than one Legislation (even though we only capture one at the moment). This will be iterated on in future designs being worked on at the moment.
