### PR TITLE
(2049) Only show draft & live Professions to admins

### DIFF
--- a/cypress/integration/admin/professions/index.spec.ts
+++ b/cypress/integration/admin/professions/index.spec.ts
@@ -70,10 +70,6 @@ describe('Listing professions', () => {
         });
 
       cy.checkAccessibility();
-      cy.url().should(
-        'contain',
-        'professions/secondary-school-teacher-in-state-maintained-schools-england',
-      );
     });
 
     it('I can filter by keyword', () => {

--- a/cypress/integration/admin/professions/index.spec.ts
+++ b/cypress/integration/admin/professions/index.spec.ts
@@ -5,12 +5,27 @@ describe('Listing professions', () => {
       cy.visitAndCheckAccessibility('/admin/professions');
     });
 
-    it('I can view an unfiltered list of profession', () => {
-      cy.get('body').should('contain', 'Registered Trademark Attorney');
-      cy.get('body').should(
-        'contain',
-        'Secondary School Teacher in State maintained schools (England)',
-      );
+    it('I can view an unfiltered list of draft and live Professions', () => {
+      cy.get('tr')
+        .contains('Registered Trademark Attorney')
+        .then(($header) => {
+          const $row = $header.parent();
+          cy.wrap($row).contains('Live');
+        });
+      cy.get('tr')
+        .contains(
+          'Secondary School Teacher in State maintained schools (England)',
+        )
+        .then(($header) => {
+          const $row = $header.parent();
+          cy.wrap($row).contains('Live');
+        });
+      cy.get('tr')
+        .contains('Gas Safe Engineer')
+        .then(($header) => {
+          const $row = $header.parent();
+          cy.wrap($row).contains('Draft');
+        });
     });
 
     it('Professions are sorted alphabetically', () => {
@@ -18,10 +33,6 @@ describe('Listing professions', () => {
         const names = elements.map((_, element) => element.innerText).toArray();
         cy.wrap(names).should('deep.equal', names.sort());
       });
-    });
-
-    it('The list page does not show draft professions', () => {
-      cy.get('body').should('not.contain', 'Draft Profession');
     });
 
     it('The list page contains the expected columns', () => {
@@ -36,6 +47,10 @@ describe('Listing professions', () => {
           cy.get('tr').eq(0).should('contain', industry);
         },
       );
+
+      cy.translate('professions.admin.tableHeading.status').then((status) => {
+        cy.get('tr').eq(0).should('contain', status);
+      });
 
       cy.translate('professions.admin.tableHeading.changedBy').then(
         (changedBy) => {

--- a/cypress/integration/professions/show.spec.ts
+++ b/cypress/integration/professions/show.spec.ts
@@ -1,4 +1,4 @@
-describe.skip('Showing a profession', () => {
+describe('Showing a profession', () => {
   it('I can view a profession', () => {
     cy.visitAndCheckAccessibility('/professions/registered-trademark-attorney');
 

--- a/src/i18n/en/professions.json
+++ b/src/i18n/en/professions.json
@@ -235,7 +235,8 @@
       "actions": "Actions"
     },
     "status": {
-      "published": "Published"
+      "live": "Live",
+      "draft": "Draft"
     },
     "viewDetails": "View details"
   },

--- a/src/organisations/interfaces/show-template.interface.ts
+++ b/src/organisations/interfaces/show-template.interface.ts
@@ -7,6 +7,8 @@ export interface ShowTemplate {
   professions: {
     name: string;
     slug: string;
+    id: string;
+    versionId: string;
     summaryList: SummaryList;
   }[];
 }

--- a/src/organisations/organisation-versions.service.spec.ts
+++ b/src/organisations/organisation-versions.service.spec.ts
@@ -63,7 +63,7 @@ describe('OrganisationVersionsService', () => {
   });
 
   describe('findByIdWithOrganisation', () => {
-    it('returns an Organisation witha version', async () => {
+    it('returns an Organisation with a version', async () => {
       const organisationVersion = organisationVersionFactory.build();
       const queryBuilder = createMock<SelectQueryBuilder<OrganisationVersion>>({
         leftJoinAndSelect: () => queryBuilder,
@@ -90,8 +90,17 @@ describe('OrganisationVersionsService', () => {
       expect(queryBuilder).toHaveJoined([
         'organisationVersion.organisation',
         'organisation.professions',
-        'professions.industries',
       ]);
+
+      expect(queryBuilder.leftJoinAndSelect).toHaveBeenCalledWith(
+        'professions.versions',
+        'professionVersions',
+      );
+
+      expect(queryBuilder.leftJoinAndSelect).toHaveBeenCalledWith(
+        'professionVersions.industries',
+        'industries',
+      );
 
       expect(queryBuilder.where).toHaveBeenCalledWith({
         organisation: { id: 'org-uuid' },
@@ -168,8 +177,17 @@ describe('OrganisationVersionsService', () => {
       expect(queryBuilder).toHaveJoined([
         'organisationVersion.organisation',
         'organisation.professions',
-        'professions.industries',
       ]);
+
+      expect(queryBuilder.leftJoinAndSelect).toHaveBeenCalledWith(
+        'professions.versions',
+        'professionVersions',
+      );
+
+      expect(queryBuilder.leftJoinAndSelect).toHaveBeenCalledWith(
+        'professionVersions.industries',
+        'industries',
+      );
 
       expect(queryBuilder.where).toHaveBeenCalledWith(
         'organisationVersion.status = :status',
@@ -208,8 +226,17 @@ describe('OrganisationVersionsService', () => {
       expect(queryBuilder).toHaveJoined([
         'organisationVersion.organisation',
         'organisation.professions',
-        'professions.industries',
       ]);
+
+      expect(queryBuilder.leftJoinAndSelect).toHaveBeenCalledWith(
+        'professions.versions',
+        'professionVersions',
+      );
+
+      expect(queryBuilder.leftJoinAndSelect).toHaveBeenCalledWith(
+        'professionVersions.industries',
+        'industries',
+      );
 
       expect(queryBuilder.distinctOn).toHaveBeenCalledWith([
         'organisationVersion.organisation',
@@ -256,8 +283,17 @@ describe('OrganisationVersionsService', () => {
       expect(queryBuilder).toHaveJoined([
         'organisationVersion.organisation',
         'organisation.professions',
-        'professions.industries',
       ]);
+
+      expect(queryBuilder.leftJoinAndSelect).toHaveBeenCalledWith(
+        'professions.versions',
+        'professionVersions',
+      );
+
+      expect(queryBuilder.leftJoinAndSelect).toHaveBeenCalledWith(
+        'professionVersions.industries',
+        'industries',
+      );
 
       expect(queryBuilder.where).toHaveBeenCalledWith(
         'organisationVersion.status = :status AND organisation.slug = :slug',

--- a/src/organisations/organisation-versions.service.ts
+++ b/src/organisations/organisation-versions.service.ts
@@ -107,6 +107,7 @@ export class OrganisationVersionsService {
       .createQueryBuilder('organisationVersion')
       .leftJoinAndSelect('organisationVersion.organisation', 'organisation')
       .leftJoinAndSelect('organisation.professions', 'professions')
-      .leftJoinAndSelect('professions.industries', 'industries');
+      .leftJoinAndSelect('professions.versions', 'professionVersions')
+      .leftJoinAndSelect('professionVersions.industries', 'industries');
   }
 }

--- a/src/organisations/organisation.entity.spec.ts
+++ b/src/organisations/organisation.entity.spec.ts
@@ -3,14 +3,24 @@ import { OrganisationVersionStatus } from './organisation-version.entity';
 
 import organisationFactory from '../testutils/factories/organisation';
 import organisationVersionFactory from '../testutils/factories/organisation-version';
+import professionFactory from '../testutils/factories/profession';
+import { Profession } from '../professions/profession.entity';
+
+jest.mock('../professions/profession.entity');
 
 describe('Organisation', () => {
   describe('withVersion', () => {
     it('should return an entity with a version', () => {
+      const profession = professionFactory.build();
       const organisationVersion = organisationVersionFactory.build();
       const organisation = organisationFactory.build({
         versions: [organisationVersion, organisationVersionFactory.build()],
+        professions: [profession],
       });
+
+      (Profession.withLatestLiveOrDraftVersion as jest.Mock).mockImplementation(
+        () => profession,
+      );
 
       const result = Organisation.withVersion(
         organisation,
@@ -28,6 +38,42 @@ describe('Organisation', () => {
         fax: organisationVersion.fax,
         versionId: organisationVersion.id,
         status: organisationVersion.status,
+        professions: [profession],
+      });
+    });
+
+    describe('when there are no Live or Draft Professions', () => {
+      it('sets the professions field to an empty array', () => {
+        const profession = professionFactory.build();
+
+        const organisationVersion = organisationVersionFactory.build();
+        const organisation = organisationFactory.build({
+          versions: [organisationVersion, organisationVersionFactory.build()],
+          professions: [profession],
+        });
+
+        (
+          Profession.withLatestLiveOrDraftVersion as jest.Mock
+        ).mockImplementation(() => null);
+
+        const result = Organisation.withVersion(
+          organisation,
+          organisationVersion,
+        );
+
+        expect(result).toEqual({
+          ...organisation,
+          alternateName: organisationVersion.alternateName,
+          address: organisationVersion.address,
+          url: organisationVersion.url,
+          email: organisationVersion.email,
+          contactUrl: organisationVersion.contactUrl,
+          telephone: organisationVersion.telephone,
+          fax: organisationVersion.fax,
+          versionId: organisationVersion.id,
+          status: organisationVersion.status,
+          professions: [],
+        });
       });
     });
   });

--- a/src/organisations/organisation.entity.ts
+++ b/src/organisations/organisation.entity.ts
@@ -75,6 +75,10 @@ export class Organisation {
     organisation: Organisation,
     organisationVersion: OrganisationVersion,
   ): Organisation {
+    const professions = (organisation.professions || [])
+      .map((profession) => Profession.withLatestLiveOrDraftVersion(profession))
+      .filter(Boolean);
+
     return {
       ...organisation,
       alternateName: organisationVersion.alternateName,
@@ -86,6 +90,7 @@ export class Organisation {
       fax: organisationVersion.fax,
       versionId: organisationVersion.id,
       status: organisationVersion.status,
+      professions: professions,
     } as Organisation;
   }
 

--- a/src/organisations/presenters/organisation-summary.presenter.spec.ts
+++ b/src/organisations/presenters/organisation-summary.presenter.spec.ts
@@ -45,19 +45,21 @@ describe('OrganisationSummaryPresenter', () => {
 
   describe('present', () => {
     describe('when all relations are present on the organisation', () => {
-      let organisation: Organisation;
-
-      beforeEach(() => {
-        organisation = organisationFactory.build({
+      it("should return template variables contraining an organisation's summary", async () => {
+        const organisation = organisationFactory.build({
           professions: [
-            professionsFactory.build({ confirmed: true }),
-            professionsFactory.build({ confirmed: true }),
-            professionsFactory.build({ confirmed: false }),
+            professionsFactory.build({
+              confirmed: true,
+            }),
+            professionsFactory.build({
+              confirmed: true,
+            }),
+            professionsFactory.build({
+              confirmed: false,
+            }),
           ],
         });
-      });
 
-      it("should return tempalate variables contraining an organisation's summary", async () => {
         const presenter = new OrganisationSummaryPresenter(
           organisation,
           i18nService,
@@ -69,11 +71,15 @@ describe('OrganisationSummaryPresenter', () => {
           professions: [
             {
               name: organisation.professions[0].name,
+              id: organisation.professions[0].id,
+              versionId: organisation.professions[0].versionId,
               slug: organisation.professions[0].slug,
               summaryList: mockSummaryList(),
             },
             {
               name: organisation.professions[1].name,
+              id: organisation.professions[1].id,
+              versionId: organisation.professions[1].versionId,
               slug: organisation.professions[1].slug,
               summaryList: mockSummaryList(),
             },

--- a/src/organisations/presenters/organisation-summary.presenter.ts
+++ b/src/organisations/presenters/organisation-summary.presenter.ts
@@ -38,6 +38,8 @@ export class OrganisationSummaryPresenter {
           return {
             name: presenter.profession.name,
             slug: presenter.profession.slug,
+            id: presenter.profession.id,
+            versionId: presenter.profession.versionId,
             summaryList: await presenter.summaryList(),
           };
         }),

--- a/src/professions/admin/list-entry.presenter.spec.ts
+++ b/src/professions/admin/list-entry.presenter.spec.ts
@@ -20,6 +20,7 @@ describe('ListEntryPresenter', () => {
           industryFactory.build({ name: 'industries.law' }),
           industryFactory.build({ name: 'industries.finance' }),
         ],
+        status: 'live',
         updated_at: new Date(2003, 7, 12),
       });
 
@@ -42,7 +43,7 @@ describe('ListEntryPresenter', () => {
             'industries.finance',
           )}`,
         },
-        { text: translationOf('professions.admin.status.published') },
+        { text: translationOf('professions.admin.status.live') },
         {
           html: `<a href="/admin/professions/example-profession">${translationOf(
             'professions.admin.viewDetails',
@@ -65,6 +66,7 @@ describe('ListEntryPresenter', () => {
           industryFactory.build({ name: 'industries.law' }),
           industryFactory.build({ name: 'industries.finance' }),
         ],
+        status: 'draft',
         updated_at: new Date(2003, 7, 12),
       });
 
@@ -82,7 +84,7 @@ describe('ListEntryPresenter', () => {
         },
         { text: '12-08-2003' },
         { text: 'Placeholder name' },
-        { text: translationOf('professions.admin.status.published') },
+        { text: translationOf('professions.admin.status.draft') },
         {
           html: `<a href="/admin/professions/example-profession">${translationOf(
             'professions.admin.viewDetails',

--- a/src/professions/admin/list-entry.presenter.spec.ts
+++ b/src/professions/admin/list-entry.presenter.spec.ts
@@ -11,7 +11,7 @@ describe('ListEntryPresenter', () => {
     it('returns a table row when called with `overview`', () => {
       const profession = professionFactory.build({
         name: 'Example Profession',
-        slug: 'example-profession',
+        id: 'profession-id',
         occupationLocations: ['GB-SCT', 'GB-NIR'],
         organisation: organisationFactory.build({
           name: 'Example Organisation',
@@ -22,6 +22,7 @@ describe('ListEntryPresenter', () => {
         ],
         status: 'live',
         updated_at: new Date(2003, 7, 12),
+        versionId: 'version-id',
       });
 
       const presenter = new ListEntryPresenter(
@@ -45,7 +46,7 @@ describe('ListEntryPresenter', () => {
         },
         { text: translationOf('professions.admin.status.live') },
         {
-          html: `<a href="/admin/professions/example-profession">${translationOf(
+          html: `<a href="/admin/professions/profession-id/versions/version-id">${translationOf(
             'professions.admin.viewDetails',
           )}</a>`,
         },
@@ -57,7 +58,7 @@ describe('ListEntryPresenter', () => {
     it('returns a table row when called with `single-organisation`', () => {
       const profession = professionFactory.build({
         name: 'Example Profession',
-        slug: 'example-profession',
+        id: 'profession-id',
         occupationLocations: ['GB-SCT', 'GB-NIR'],
         organisation: organisationFactory.build({
           name: 'Example Organisation',
@@ -68,6 +69,7 @@ describe('ListEntryPresenter', () => {
         ],
         status: 'draft',
         updated_at: new Date(2003, 7, 12),
+        versionId: 'version-id',
       });
 
       const presenter = new ListEntryPresenter(
@@ -86,7 +88,7 @@ describe('ListEntryPresenter', () => {
         { text: 'Placeholder name' },
         { text: translationOf('professions.admin.status.draft') },
         {
-          html: `<a href="/admin/professions/example-profession">${translationOf(
+          html: `<a href="/admin/professions/profession-id/versions/version-id">${translationOf(
             'professions.admin.viewDetails',
           )}</a>`,
         },

--- a/src/professions/admin/list-entry.presenter.ts
+++ b/src/professions/admin/list-entry.presenter.ts
@@ -2,6 +2,7 @@ import { I18nService } from 'nestjs-i18n';
 import { TableCell } from '../../common/interfaces/table-cell';
 import { TableRow } from '../../common/interfaces/table-row';
 import { formatDate } from '../../common/utils';
+import { escape } from '../../helpers/escape.helper';
 import { stringifyNations } from '../../nations/helpers/stringifyNations';
 import { Nation } from '../../nations/nation';
 import { Profession } from '../profession.entity';
@@ -74,9 +75,9 @@ export class ListEntryPresenter {
       )
     ).join(', ');
 
-    const viewDetails = `<a href="/admin/professions/${
-      this.profession.slug
-    }">${await this.i18nService.translate(
+    const viewDetails = `<a href="/admin/professions/${escape(
+      this.profession.slug,
+    )}">${await this.i18nService.translate(
       'professions.admin.viewDetails',
     )}</a>`;
 
@@ -93,7 +94,7 @@ export class ListEntryPresenter {
       industry: { text: instrustries },
       status: {
         text: await this.i18nService.translate(
-          'professions.admin.status.published',
+          `professions.admin.status.${this.profession.status}`,
         ),
       },
       actions: { html: viewDetails },

--- a/src/professions/admin/list-entry.presenter.ts
+++ b/src/professions/admin/list-entry.presenter.ts
@@ -2,7 +2,6 @@ import { I18nService } from 'nestjs-i18n';
 import { TableCell } from '../../common/interfaces/table-cell';
 import { TableRow } from '../../common/interfaces/table-row';
 import { formatDate } from '../../common/utils';
-import { escape } from '../../helpers/escape.helper';
 import { stringifyNations } from '../../nations/helpers/stringifyNations';
 import { Nation } from '../../nations/nation';
 import { Profession } from '../profession.entity';
@@ -75,9 +74,9 @@ export class ListEntryPresenter {
       )
     ).join(', ');
 
-    const viewDetails = `<a href="/admin/professions/${escape(
-      this.profession.slug,
-    )}">${await this.i18nService.translate(
+    const viewDetails = `<a href="/admin/professions/${
+      this.profession.id
+    }/versions/${this.profession.versionId}">${await this.i18nService.translate(
       'professions.admin.viewDetails',
     )}</a>`;
 

--- a/src/professions/admin/professions.controller.spec.ts
+++ b/src/professions/admin/professions.controller.spec.ts
@@ -95,9 +95,11 @@ describe('ProfessionsController', () => {
     industriesService = createMock<IndustriesService>();
     i18nService = createMockI18nService();
 
-    professionsService.allConfirmed.mockImplementation(async () => {
-      return [profession1, profession2, profession3];
-    });
+    professionVersionsService.allDraftOrLive.mockResolvedValue([
+      profession1,
+      profession2,
+      profession3,
+    ]);
 
     organisationsService.all.mockImplementation(async () => {
       return organisations;

--- a/src/professions/admin/professions.controller.spec.ts
+++ b/src/professions/admin/professions.controller.spec.ts
@@ -17,9 +17,6 @@ import { ProfessionsPresenter } from './professions.presenter';
 import industryFactory from '../../testutils/factories/industry';
 import organisationFactory from '../../testutils/factories/organisation';
 import professionFactory from '../../testutils/factories/profession';
-import { NotFoundException } from '@nestjs/common';
-import QualificationPresenter from '../../qualifications/presenters/qualification.presenter';
-import { translationOf } from '../../testutils/translation-of';
 import { ProfessionVersionsService } from '../profession-versions.service';
 import professionVersion from '../../testutils/factories/profession-version';
 
@@ -364,69 +361,6 @@ describe('ProfessionsController', () => {
         ).present('single-organisation');
 
         expect(result).toEqual(expected);
-      });
-    });
-  });
-
-  describe('show', () => {
-    it('should return populated template params', async () => {
-      const profession = professionFactory.build({
-        occupationLocations: ['GB-ENG'],
-        industries: [industryFactory.build({ name: 'industries.example' })],
-      });
-
-      professionsService.findBySlug.mockResolvedValue(profession);
-
-      (Organisation.withLatestLiveVersion as jest.Mock).mockImplementation(
-        () => profession.organisation,
-      );
-
-      const result = await controller.show('example-slug');
-
-      expect(result).toEqual({
-        profession: profession,
-        qualification: new QualificationPresenter(profession.qualification),
-        nations: ['Translation of `nations.england`'],
-        industries: ['Translation of `industries.example`'],
-        organisation: profession.organisation,
-      });
-
-      expect(professionsService.findBySlug).toHaveBeenCalledWith(
-        'example-slug',
-      );
-    });
-
-    it('should throw an error when the slug does not match a profession', () => {
-      professionsService.findBySlug.mockResolvedValue(undefined);
-
-      expect(async () => {
-        await controller.show('example-invalid-slug');
-      }).rejects.toThrowError(NotFoundException);
-    });
-
-    describe('when the Profession has no qualification set', () => {
-      it('passes a null value for the qualification', async () => {
-        const profession = professionFactory.build({
-          qualification: null,
-          occupationLocations: ['GB-ENG'],
-          industries: [industryFactory.build({ name: 'industries.example' })],
-        });
-
-        professionsService.findBySlug.mockResolvedValue(profession);
-
-        (Organisation.withLatestLiveVersion as jest.Mock).mockImplementation(
-          () => profession.organisation,
-        );
-
-        const result = await controller.show('example-slug');
-
-        expect(result).toEqual({
-          profession: profession,
-          qualification: null,
-          nations: [translationOf('nations.england')],
-          industries: [translationOf('industries.example')],
-          organisation: profession.organisation,
-        });
       });
     });
   });

--- a/src/professions/admin/professions.controller.ts
+++ b/src/professions/admin/professions.controller.ts
@@ -123,7 +123,8 @@ export class ProfessionsController {
     const allOrganisations = await this.organisationsService.all();
     const allIndustries = await this.industriesService.all();
 
-    const allProfessions = await this.professionsService.allConfirmed();
+    const allProfessions =
+      await this.professionVersionsService.allDraftOrLive();
 
     const user = request['appSession'].user as User;
 

--- a/src/professions/admin/professions.controller.ts
+++ b/src/professions/admin/professions.controller.ts
@@ -1,8 +1,6 @@
 import {
   Controller,
   Get,
-  NotFoundException,
-  Param,
   Post,
   Query,
   Render,
@@ -26,11 +24,8 @@ import { User } from '../../users/user.entity';
 import { FilterDto } from './dto/filter.dto';
 import { OrganisationsService } from '../../organisations/organisations.service';
 import { Profession } from '../profession.entity';
-import { ShowTemplate } from '../interfaces/show-template.interface';
 import { BackLink } from '../../common/decorators/back-link.decorator';
-import QualificationPresenter from '../../qualifications/presenters/qualification.presenter';
 import { createFilterInput } from '../../helpers/create-filter-input.helper';
-import { Organisation } from '../../organisations/organisation.entity';
 import { ProfessionVersionsService } from '../profession-versions.service';
 import { ProfessionVersion } from '../profession-version.entity';
 
@@ -72,47 +67,6 @@ export class ProfessionsController {
     @Query() query: FilterDto = null,
   ): Promise<IndexTemplate> {
     return this.createListEntries(query || new FilterDto(), request);
-  }
-
-  @Get('/:slug')
-  @Render('admin/professions/show')
-  @BackLink('/admin/professions')
-  async show(@Param('slug') slug: string): Promise<ShowTemplate> {
-    const profession = await this.professionsService.findBySlug(slug);
-
-    if (!profession) {
-      throw new NotFoundException(
-        `A profession with ID ${slug} could not be found`,
-      );
-    }
-
-    const organisation = Organisation.withLatestLiveVersion(
-      profession.organisation,
-    );
-
-    const nations = await Promise.all(
-      profession.occupationLocations.map(async (code) =>
-        Nation.find(code).translatedName(this.i18Service),
-      ),
-    );
-
-    const industries = await Promise.all(
-      profession.industries.map(
-        async (industry) => await this.i18Service.translate(industry.name),
-      ),
-    );
-
-    const qualification = profession.qualification
-      ? new QualificationPresenter(profession.qualification)
-      : null;
-
-    return {
-      profession,
-      qualification: qualification,
-      nations,
-      industries,
-      organisation,
-    };
   }
 
   private async createListEntries(

--- a/src/professions/profession-versions.controller.spec.ts
+++ b/src/professions/profession-versions.controller.spec.ts
@@ -1,22 +1,33 @@
 import { createMock, DeepMocked } from '@golevelup/ts-jest';
+import { NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { Response } from 'express';
+import { I18nService } from 'nestjs-i18n';
+import { Organisation } from '../organisations/organisation.entity';
+import QualificationPresenter from '../qualifications/presenters/qualification.presenter';
+import { createMockI18nService } from '../testutils/create-mock-i18n-service';
+import industryFactory from '../testutils/factories/industry';
 import legislationFactory from '../testutils/factories/legislation';
 import professionFactory from '../testutils/factories/profession';
 import professionVersionFactory from '../testutils/factories/profession-version';
+import { translationOf } from '../testutils/translation-of';
 import { ProfessionVersionsController } from './profession-versions.controller';
 import { ProfessionVersionsService } from './profession-versions.service';
 import { ProfessionsService } from './professions.service';
+
+jest.mock('../organisations/organisation.entity');
 
 describe('ProfessionVersionsController', () => {
   let controller: ProfessionVersionsController;
 
   let professionVersionsService: DeepMocked<ProfessionVersionsService>;
   let professionsService: DeepMocked<ProfessionsService>;
+  let i18nService: DeepMocked<I18nService>;
 
   beforeEach(async () => {
     professionsService = createMock<ProfessionsService>();
     professionVersionsService = createMock<ProfessionVersionsService>();
+    i18nService = createMockI18nService();
 
     const module: TestingModule = await Test.createTestingModule({
       controllers: [ProfessionVersionsController],
@@ -28,6 +39,10 @@ describe('ProfessionVersionsController', () => {
         {
           provide: ProfessionVersionsService,
           useValue: professionVersionsService,
+        },
+        {
+          provide: I18nService,
+          useValue: i18nService,
         },
       ],
     }).compile();
@@ -93,6 +108,75 @@ describe('ProfessionVersionsController', () => {
       expect(response.redirect).toHaveBeenCalledWith(
         `/admin/professions/${version.profession.id}/versions/${version.id}/check-your-answers?edit=true`,
       );
+    });
+  });
+
+  describe('show', () => {
+    it('should return populated template params', async () => {
+      const profession = professionFactory.build({
+        occupationLocations: ['GB-ENG'],
+        industries: [industryFactory.build({ name: 'industries.example' })],
+      });
+
+      professionVersionsService.findByIdWithProfession.mockResolvedValue(
+        profession,
+      );
+
+      (Organisation.withLatestLiveVersion as jest.Mock).mockImplementation(
+        () => profession.organisation,
+      );
+
+      const result = await controller.show('profession-id', 'version-id');
+
+      expect(result).toEqual({
+        profession: profession,
+        qualification: new QualificationPresenter(profession.qualification),
+        nations: ['Translation of `nations.england`'],
+        industries: ['Translation of `industries.example`'],
+        organisation: profession.organisation,
+      });
+
+      expect(
+        professionVersionsService.findByIdWithProfession,
+      ).toHaveBeenCalledWith('profession-id', 'version-id');
+    });
+
+    it('should throw an error when the slug does not match a profession', () => {
+      professionVersionsService.findByIdWithProfession.mockResolvedValue(
+        undefined,
+      );
+
+      expect(async () => {
+        await controller.show('profession-id', 'version-id');
+      }).rejects.toThrowError(NotFoundException);
+    });
+
+    describe('when the Profession has no qualification set', () => {
+      it('passes a null value for the qualification', async () => {
+        const profession = professionFactory.build({
+          qualification: null,
+          occupationLocations: ['GB-ENG'],
+          industries: [industryFactory.build({ name: 'industries.example' })],
+        });
+
+        professionVersionsService.findByIdWithProfession.mockResolvedValue(
+          profession,
+        );
+
+        (Organisation.withLatestLiveVersion as jest.Mock).mockImplementation(
+          () => profession.organisation,
+        );
+
+        const result = await controller.show('profession-id', 'version-id');
+
+        expect(result).toEqual({
+          profession: profession,
+          qualification: null,
+          nations: [translationOf('nations.england')],
+          industries: [translationOf('industries.example')],
+          organisation: profession.organisation,
+        });
+      });
     });
   });
 });

--- a/src/professions/profession-versions.service.spec.ts
+++ b/src/professions/profession-versions.service.spec.ts
@@ -252,4 +252,46 @@ describe('ProfessionVersionsService', () => {
       );
     });
   });
+
+  describe('findByIdWithProfession', () => {
+    it('returns an Profession with a version', async () => {
+      const version = professionVersionFactory.build();
+      const queryBuilder = createMock<SelectQueryBuilder<ProfessionVersion>>({
+        leftJoinAndSelect: () => queryBuilder,
+        where: () => queryBuilder,
+        getOne: async () => version,
+      });
+
+      jest
+        .spyOn(repo, 'createQueryBuilder')
+        .mockImplementation(() => queryBuilder);
+
+      const result = await service.findByIdWithProfession(
+        'profession-uuid',
+        'version-uuid',
+      );
+
+      expect(result).toEqual(
+        Profession.withVersion(version.profession, version),
+      );
+
+      expect(queryBuilder).toHaveJoined([
+        'professionVersion.profession',
+        'professionVersion.industries',
+        'professionVersion.organisation',
+        'professionVersion.qualification',
+        'professionVersion.legislations',
+      ]);
+
+      expect(queryBuilder.leftJoinAndSelect).toHaveBeenCalledWith(
+        'organisation.versions',
+        'organisationVersions',
+      );
+
+      expect(queryBuilder.where).toHaveBeenCalledWith({
+        profession: { id: 'profession-uuid' },
+        id: 'version-uuid',
+      });
+    });
+  });
 });

--- a/src/professions/profession-versions.service.ts
+++ b/src/professions/profession-versions.service.ts
@@ -60,6 +60,23 @@ export class ProfessionVersionsService {
     );
   }
 
+  async allDraftOrLive(): Promise<Profession[]> {
+    const versions = await this.versionsWithJoins()
+      .distinctOn(['professionVersion.profession'])
+      .where('professionVersion.status IN(:...status)', {
+        status: [ProfessionVersionStatus.Live, ProfessionVersionStatus.Draft],
+      })
+      .orderBy(
+        'professionVersion.profession, professionVersion.created_at',
+        'DESC',
+      )
+      .getMany();
+
+    return versions.map((version) =>
+      Profession.withVersion(version.profession, version),
+    );
+  }
+
   async findLiveBySlug(slug: string): Promise<Profession> {
     const version = await this.versionsWithJoins()
       .leftJoinAndSelect('organisation.versions', 'organisationVersions')

--- a/src/professions/profession-versions.service.ts
+++ b/src/professions/profession-versions.service.ts
@@ -89,6 +89,18 @@ export class ProfessionVersionsService {
     return Profession.withVersion(version.profession, version);
   }
 
+  async findByIdWithProfession(
+    professionId: string,
+    id: string,
+  ): Promise<Profession> {
+    const version = await this.versionsWithJoins()
+      .leftJoinAndSelect('organisation.versions', 'organisationVersions')
+      .where({ profession: { id: professionId }, id })
+      .getOne();
+
+    return Profession.withVersion(version.profession, version);
+  }
+
   private versionsWithJoins(): SelectQueryBuilder<ProfessionVersion> {
     return this.repository
       .createQueryBuilder('professionVersion')

--- a/src/professions/profession.entity.spec.ts
+++ b/src/professions/profession.entity.spec.ts
@@ -1,5 +1,6 @@
 import professionFactory from '../testutils/factories/profession';
 import professionVersionFactory from '../testutils/factories/profession-version';
+import { ProfessionVersionStatus } from './profession-version.entity';
 import { Profession } from './profession.entity';
 
 describe('Profession', () => {
@@ -26,6 +27,94 @@ describe('Profession', () => {
         organisation: professionVersion.organisation,
         status: professionVersion.status,
         versionId: professionVersion.id,
+      });
+    });
+  });
+
+  describe('withLatestLiveVersion', () => {
+    it('should get the latest live version', () => {
+      const professionVersion = professionVersionFactory.build({
+        status: ProfessionVersionStatus.Live,
+        updated_at: new Date(2022, 1, 3),
+      });
+      const profession = professionFactory.build({
+        versions: [
+          professionVersionFactory.build({
+            status: ProfessionVersionStatus.Draft,
+            updated_at: new Date(2022, 1, 1),
+          }),
+          professionVersion,
+          professionVersionFactory.build({
+            status: ProfessionVersionStatus.Live,
+            updated_at: new Date(2022, 1, 2),
+          }),
+        ],
+      });
+
+      expect(Profession.withLatestLiveVersion(profession)).toEqual(
+        Profession.withVersion(profession, professionVersion),
+      );
+    });
+
+    describe('when there is no Live version', () => {
+      it('returns null', () => {
+        const profession = professionFactory.build({
+          versions: [
+            professionVersionFactory.build({
+              status: ProfessionVersionStatus.Draft,
+            }),
+            professionVersionFactory.build({
+              status: ProfessionVersionStatus.Draft,
+            }),
+          ],
+        });
+
+        expect(Profession.withLatestLiveVersion(profession)).toEqual(null);
+      });
+    });
+  });
+
+  describe('withLatestLiveOrDraftVersion', () => {
+    it('should get the latest live or draft version', () => {
+      const professionVersion = professionVersionFactory.build({
+        status: ProfessionVersionStatus.Draft,
+        updated_at: new Date(2022, 1, 3),
+      });
+      const profession = professionFactory.build({
+        versions: [
+          professionVersionFactory.build({
+            status: ProfessionVersionStatus.Live,
+            updated_at: new Date(2022, 1, 1),
+          }),
+          professionVersion,
+          professionVersionFactory.build({
+            status: ProfessionVersionStatus.Draft,
+            updated_at: new Date(2022, 1, 2),
+          }),
+        ],
+      });
+
+      expect(Profession.withLatestLiveOrDraftVersion(profession)).toEqual(
+        Profession.withVersion(profession, professionVersion),
+      );
+    });
+
+    describe('when there are no Live or Draft versions', () => {
+      it('returns null', () => {
+        const profession = professionFactory.build({
+          versions: [
+            professionVersionFactory.build({
+              status: ProfessionVersionStatus.Unconfirmed,
+            }),
+            professionVersionFactory.build({
+              status: ProfessionVersionStatus.Unconfirmed,
+            }),
+          ],
+        });
+
+        expect(Profession.withLatestLiveOrDraftVersion(profession)).toEqual(
+          null,
+        );
       });
     });
   });

--- a/src/professions/profession.entity.spec.ts
+++ b/src/professions/profession.entity.spec.ts
@@ -24,6 +24,7 @@ describe('Profession', () => {
         reservedActivities: professionVersion.reservedActivities,
         legislations: professionVersion.legislations,
         organisation: professionVersion.organisation,
+        status: professionVersion.status,
         versionId: professionVersion.id,
       });
     });

--- a/src/professions/profession.entity.ts
+++ b/src/professions/profession.entity.ts
@@ -16,7 +16,10 @@ import {
 } from 'typeorm';
 import { Industry } from '../industries/industry.entity';
 import { Organisation } from '../organisations/organisation.entity';
-import { ProfessionVersion } from './profession-version.entity';
+import {
+  ProfessionVersion,
+  ProfessionVersionStatus,
+} from './profession-version.entity';
 
 export enum MandatoryRegistration {
   Mandatory = 'mandatory',
@@ -140,6 +143,42 @@ export class Profession {
     this.organisation = organisation || null;
     this.confirmed = confirmed || false;
     this.versions = versions || null;
+  }
+
+  public static withLatestLiveVersion(
+    profession: Profession,
+  ): Profession | null {
+    const liveVersions = profession.versions
+      .filter((v) => v.status === ProfessionVersionStatus.Live)
+      .sort((a, b) => b.updated_at.getTime() - a.updated_at.getTime());
+
+    const latestVersion = liveVersions[0];
+
+    if (!latestVersion) {
+      return null;
+    }
+
+    return Profession.withVersion(profession, latestVersion);
+  }
+
+  public static withLatestLiveOrDraftVersion(
+    profession: Profession,
+  ): Profession | null {
+    const draftAndLiveVersions = profession.versions
+      .filter(
+        (v) =>
+          v.status === ProfessionVersionStatus.Live ||
+          v.status === ProfessionVersionStatus.Draft,
+      )
+      .sort((a, b) => b.updated_at.getTime() - a.updated_at.getTime());
+
+    const latestVersion = draftAndLiveVersions[0];
+
+    if (!latestVersion) {
+      return null;
+    }
+
+    return Profession.withVersion(profession, latestVersion);
   }
 
   static withVersion(

--- a/src/professions/profession.entity.ts
+++ b/src/professions/profession.entity.ts
@@ -106,6 +106,7 @@ export class Profession {
   updated_at: Date;
 
   versionId?: string;
+  status?: string;
 
   constructor(
     name?: string,
@@ -157,6 +158,7 @@ export class Profession {
       reservedActivities: version.reservedActivities,
       legislations: version.legislations,
       organisation: version.organisation,
+      status: version.status,
       versionId: version.id,
     };
   }

--- a/src/testutils/factories/profession.ts
+++ b/src/testutils/factories/profession.ts
@@ -51,4 +51,5 @@ export default ProfessionFactory.define(({ sequence }) => ({
   reservedActivities: 'Stuff',
   versions: [],
   updated_at: new Date(),
+  versionId: 'version-id',
 }));

--- a/views/admin/organisations/show.njk
+++ b/views/admin/organisations/show.njk
@@ -6,7 +6,7 @@
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      {% set professionPagePrefix = "admin/professions"%}
+      {% set admin = true %}
       {% include "../../organisations/shared/_organisation.njk" %}
     </div>
     <div class="govuk-grid-column-one-third">

--- a/views/organisations/shared/_organisation.njk
+++ b/views/organisations/shared/_organisation.njk
@@ -11,7 +11,11 @@
 {% for profession in professions %}
   <div class="rpr-listing__ra-container">
     <h3>
-      <a class="govuk-link govuk-heading-m rpr-listing__profession-title" class="govuk-link" href="/{{professionPagePrefix}}/{{ profession.slug }}">
+      {% if admin %}
+      <a class="govuk-link govuk-heading-m rpr-listing__profession-title" class="govuk-link" href="/admin/professions/{{ profession.id }}/versions/{{ profession.versionId }}">
+      {% else %}
+      <a class="govuk-link govuk-heading-m rpr-listing__profession-title" class="govuk-link" href="/professions/{{ profession.slug }}">
+      {% endif %}
         {{ profession.name }}
       </a>
     </h3>

--- a/views/organisations/show.njk
+++ b/views/organisations/show.njk
@@ -6,7 +6,6 @@
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-    {% set professionPagePrefix = "professions"%}
       {% include "./shared/_organisation.njk" %}
     </div>
     <div class="govuk-grid-column-one-third">


### PR DESCRIPTION
# Changes in this PR

Displays draft and live professions to admins on the index page, updating the Profession entity to use its latest version's `status` field, which is now displayed in the table.

## Note, this is based off #205 so reviewing starts from commit [46e176d](https://github.com/UKGovernmentBEIS/regulated-professions-register/pull/207/commits/46e176da9ea8465f0de002f37491be16ff23e4af).

## Screenshots of UI changes

![image](https://user-images.githubusercontent.com/19826940/152566505-e4396107-bf49-4a47-b661-36a7cc1d97a8.png)
