### PR TITLE
(2041) Allow a draft organisation to be published

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+
+- Allow a draft version to be published
+
 ### Changed
 
 - Creating and editing an organisation creates new draft versions

--- a/cypress/integration/admin/organisations/publish.spec.ts
+++ b/cypress/integration/admin/organisations/publish.spec.ts
@@ -18,6 +18,34 @@ describe('Publishing organisations', () => {
       cy.translate('organisations.status.draft').then((status) => {
         cy.get('h2[data-status]').should('contain', status);
       });
+
+      cy.translate('organisations.admin.button.publish').then(
+        (publishButton) => {
+          cy.get('button').contains(publishButton).click();
+        },
+      );
+
+      cy.translate('organisations.admin.publish.confirmation.heading').then(
+        (confirmation) => {
+          cy.get('html').should('contain', confirmation);
+        },
+      );
+
+      cy.translate(
+        'organisations.admin.publish.confirmation.backToDashboard',
+      ).then((backToDashboard) => {
+        cy.get('a').contains(backToDashboard).click();
+      });
+
+      cy.get('tr')
+        .contains('Department for Education')
+        .then(($header) => {
+          const $row = $header.parent();
+
+          cy.translate(`organisations.status.live`).then((status) => {
+            cy.wrap($row).should('contain', status);
+          });
+        });
     });
   });
 });

--- a/cypress/integration/admin/organisations/publish.spec.ts
+++ b/cypress/integration/admin/organisations/publish.spec.ts
@@ -1,0 +1,23 @@
+describe('Publishing organisations', () => {
+  context('When I am logged in as admin', () => {
+    beforeEach(() => {
+      cy.loginAuth0('admin');
+      cy.visitAndCheckAccessibility('/admin');
+    });
+
+    it('Allows me to publish a draft organisation', () => {
+      cy.get('a').contains('Regulatory authorities').click();
+      cy.checkAccessibility();
+
+      cy.contains('Department for Education')
+        .parent('tr')
+        .within(() => {
+          cy.get('a').contains('View details').click();
+        });
+
+      cy.translate('organisations.status.draft').then((status) => {
+        cy.get('h2[data-status]').should('contain', status);
+      });
+    });
+  });
+});

--- a/src/i18n/en/organisations.json
+++ b/src/i18n/en/organisations.json
@@ -99,7 +99,8 @@
     "button": {
       "edit": "Edit this regulatory authority",
       "delete": "Delete this regulatory authority",
-      "amend": "Amend regulatory authority"
+      "amend": "Amend regulatory authority",
+      "publish": "Publish regulatory authority"
     }
   },
   "search": {

--- a/src/i18n/en/organisations.json
+++ b/src/i18n/en/organisations.json
@@ -120,7 +120,8 @@
     }
   },
   "headings": {
-    "professions": "Regulated professions"
+    "professions": "Regulated professions",
+    "status": "Status"
   },
   "label": {
     "name": "Name",

--- a/src/i18n/en/organisations.json
+++ b/src/i18n/en/organisations.json
@@ -56,6 +56,14 @@
         "button": "Add a new regulatory authority"
       }
     },
+    "publish": {
+      "confirmation": {
+        "heading": "Regulatory authority published",
+        "body": "The new regulator <strong>{name}</strong> has been published.",
+        "next": "What happens next?",
+        "backToDashboard": "Back to the dashboard"
+      }
+    },
     "tableHeading": {
       "name": "Name",
       "alternateName": "Alternate name",

--- a/src/organisations/admin/organisation-versions.controller.spec.ts
+++ b/src/organisations/admin/organisation-versions.controller.spec.ts
@@ -9,6 +9,8 @@ import { OrganisationVersionsController } from './organisation-versions.controll
 import { OrganisationVersionsService } from '../organisation-versions.service';
 import { OrganisationsService } from '../organisations.service';
 
+import { Organisation } from '../organisation.entity';
+
 import { OrganisationSummaryPresenter } from '../presenters/organisation-summary.presenter';
 
 import { ShowTemplate } from '../interfaces/show-template.interface';
@@ -111,8 +113,16 @@ describe('OrganisationVersionsController', () => {
   describe('show', () => {
     it('should return variables for the show template', async () => {
       const organisation = organisationFactory.build();
-      organisationVersionsService.findByIdWithOrganisation.mockResolvedValue(
+      const version = organisationVersionFactory.build({
+        organisation: organisation,
+      });
+      const organisationWithVersion = Organisation.withVersion(
         organisation,
+        version,
+      );
+
+      organisationVersionsService.findByIdWithOrganisation.mockResolvedValue(
+        version,
       );
 
       const showTemplate: ShowTemplate = {
@@ -137,7 +147,7 @@ describe('OrganisationVersionsController', () => {
       ).toHaveBeenCalledWith('org-uuid', 'version-uuid');
 
       expect(OrganisationSummaryPresenter).toHaveBeenCalledWith(
-        organisation,
+        organisationWithVersion,
         i18nService,
       );
     });

--- a/src/organisations/admin/organisation-versions.controller.spec.ts
+++ b/src/organisations/admin/organisation-versions.controller.spec.ts
@@ -152,4 +152,27 @@ describe('OrganisationVersionsController', () => {
       );
     });
   });
+
+  describe('publish', () => {
+    it('should publish the current version', async () => {
+      const organisation = organisationFactory.build();
+      const version = organisationVersionFactory.build({
+        organisation: organisation,
+      });
+
+      organisationVersionsService.findByIdWithOrganisation.mockResolvedValue(
+        version,
+      );
+
+      const result = await controller.publish(organisation.id, version.id);
+
+      expect(result).toEqual(organisation);
+
+      expect(
+        organisationVersionsService.findByIdWithOrganisation,
+      ).toHaveBeenCalledWith(organisation.id, version.id);
+
+      expect(organisationVersionsService.publish).toHaveBeenCalledWith(version);
+    });
+  });
 });

--- a/src/organisations/admin/organisation-versions.controller.ts
+++ b/src/organisations/admin/organisation-versions.controller.ts
@@ -4,6 +4,7 @@ import {
   Get,
   Render,
   Param,
+  Put,
   Post,
   Res,
   Req,
@@ -95,5 +96,22 @@ export class OrganisationVersionsController {
     );
 
     return organisationSummaryPresenter.present();
+  }
+
+  @Put(':organisationId/versions/:versionId/publish')
+  @Render('admin/organisations/versions/publish')
+  async publish(
+    @Param('organisationId') organisationId: string,
+    @Param('versionId') versionId: string,
+  ): Promise<Organisation> {
+    const version =
+      await this.organisationVersionsService.findByIdWithOrganisation(
+        organisationId,
+        versionId,
+      );
+
+    await this.organisationVersionsService.publish(version);
+
+    return version.organisation;
   }
 }

--- a/src/organisations/admin/organisation-versions.controller.ts
+++ b/src/organisations/admin/organisation-versions.controller.ts
@@ -21,6 +21,7 @@ import { OrganisationVersionsService } from '../organisation-versions.service';
 import { RequestWithAppSession } from '../../common/interfaces/request-with-app-session.interface';
 
 import { OrganisationVersion } from '../organisation-version.entity';
+import { Organisation } from '../organisation.entity';
 
 import { ShowTemplate } from '../interfaces/show-template.interface';
 
@@ -77,11 +78,16 @@ export class OrganisationVersionsController {
     @Param('organisationId') organisationId: string,
     @Param('versionId') versionId: string,
   ): Promise<ShowTemplate> {
-    const organisation =
+    const version =
       await this.organisationVersionsService.findByIdWithOrganisation(
         organisationId,
         versionId,
       );
+
+    const organisation = Organisation.withVersion(
+      version.organisation,
+      version,
+    );
 
     const organisationSummaryPresenter = new OrganisationSummaryPresenter(
       organisation,

--- a/src/organisations/organisation-versions.service.spec.ts
+++ b/src/organisations/organisation-versions.service.spec.ts
@@ -93,12 +93,7 @@ describe('OrganisationVersionsService', () => {
         'version-uuid',
       );
 
-      expect(result).toEqual(
-        Organisation.withVersion(
-          organisationVersion.organisation,
-          organisationVersion,
-        ),
-      );
+      expect(result).toEqual(organisationVersion);
 
       expect(queryBuilder).toHaveJoined([
         'organisationVersion.organisation',

--- a/src/organisations/organisation-versions.service.ts
+++ b/src/organisations/organisation-versions.service.ts
@@ -26,12 +26,12 @@ export class OrganisationVersionsService {
   async findByIdWithOrganisation(
     organisationId: string,
     id: string,
-  ): Promise<Organisation> {
+  ): Promise<OrganisationVersion> {
     const version = await this.versionsWithJoins()
       .where({ organisation: { id: organisationId }, id })
       .getOne();
 
-    return Organisation.withVersion(version.organisation, version);
+    return version;
   }
 
   async findLatestForOrganisationId(

--- a/src/organisations/organisation-versions.service.ts
+++ b/src/organisations/organisation-versions.service.ts
@@ -1,4 +1,4 @@
-import { Repository, In, SelectQueryBuilder } from 'typeorm';
+import { Repository, In, SelectQueryBuilder, Connection } from 'typeorm';
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import {
@@ -12,6 +12,7 @@ export class OrganisationVersionsService {
   constructor(
     @InjectRepository(OrganisationVersion)
     private repository: Repository<OrganisationVersion>,
+    private connection: Connection,
   ) {}
 
   async save(organisation: OrganisationVersion): Promise<OrganisationVersion> {
@@ -100,6 +101,37 @@ export class OrganisationVersionsService {
     version.status = OrganisationVersionStatus.Draft;
 
     return this.repository.save(version);
+  }
+
+  async publish(version: OrganisationVersion): Promise<OrganisationVersion> {
+    const queryRunner = this.connection.createQueryRunner();
+    const organisation = version.organisation;
+
+    const liveVersion = await this.repository.findOne({
+      organisation,
+      status: OrganisationVersionStatus.Live,
+    });
+
+    await queryRunner.connect();
+    await queryRunner.startTransaction();
+
+    try {
+      if (liveVersion) {
+        liveVersion.status = OrganisationVersionStatus.Archived;
+        await this.repository.save(liveVersion);
+      }
+
+      version.status = OrganisationVersionStatus.Live;
+      await this.repository.save(version);
+
+      await queryRunner.commitTransaction();
+    } catch (err) {
+      await queryRunner.rollbackTransaction();
+    } finally {
+      await queryRunner.release();
+    }
+
+    return version;
   }
 
   private versionsWithJoins(): SelectQueryBuilder<OrganisationVersion> {

--- a/views/admin/organisations/show.njk
+++ b/views/admin/organisations/show.njk
@@ -19,11 +19,23 @@
 
         <nav role="navigation" aria-labelledby="subsection-title">
           <ul class="govuk-list">
+            {% if organisation.status === 'draft' %}
+            <li>
+              <form action="/admin/organisations/{{ organisation.id }}/versions/{{ organisation.versionId }}/publish?_method=PUT" method="post">
+                {{
+                  govukButton({
+                    text: ("organisations.admin.button.publish" | t)
+                  })
+                }}
+              </form>
+            </li>
+            {% endif %}
             <li>
               {{
                 govukButton({
                   text: ("organisations.admin.button.edit" | t),
-                  href: "/admin/organisations/" + organisation.id + "/versions/new"
+                  href: "/admin/organisations/" + organisation.id + "/versions/new",
+                  classes: "govuk-button--secondary"
                 })
               }}
             </li>

--- a/views/admin/organisations/show.njk
+++ b/views/admin/organisations/show.njk
@@ -12,9 +12,9 @@
     <div class="govuk-grid-column-one-third">
       <aside class="app-related-items rpr-internal__details-page-sidebar" role="complementary">
 
-        <h2 class="govuk-heading-s">
-          Status<br>
-          <span class="govuk-body">Published</span>
+        <h2 class="govuk-heading-s" data-status>
+          {{ "organisations.headings.status" | t }}<br>
+          <span class="govuk-body">{{ ("organisations.status." + organisation.status) | t }}</span>
         </h2>
 
         <nav role="navigation" aria-labelledby="subsection-title">

--- a/views/admin/organisations/versions/publish.njk
+++ b/views/admin/organisations/versions/publish.njk
@@ -1,0 +1,25 @@
+{% extends "base.njk" %}
+{% from "govuk/components/panel/macro.njk" import govukPanel %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    {{ govukPanel({
+      titleText: ("organisations.admin.publish.confirmation.heading" | t),
+      html: "organisations.admin.publish.confirmation.body" | t({name: (name | escape)})
+    }) }}
+
+    <h2 class="govuk-heading-m">{{ "organisations.admin.publish.confirmation.next" | t  }}</h3>
+
+    <p class="govuk-body"><a href="/admin/organisations">{{ "organisations.admin.publish.confirmation.backToDashboard" | t }}</a></p>
+
+  </div>
+
+  <div class="govuk-grid-column-one-third">
+
+  </div>
+</div>
+
+
+{% endblock %}


### PR DESCRIPTION
This adds a new "Publish this organisation" button to publish a draft version of an Organisation. The marks the latest live version as archived and then promotes the draft version to live.

## Screenshots

![image](https://user-images.githubusercontent.com/109774/152789567-6f4fe8ab-f99d-495e-97d1-a8b33a2cf644.png)

![image](https://user-images.githubusercontent.com/109774/152789590-ae45513d-99ad-4c7c-8780-0c1a57b0cd5c.png)
