### PR TITLE
Fix destination of legislation back link

### DIFF
--- a/src/professions/admin/dto/legislation.dto.ts
+++ b/src/professions/admin/dto/legislation.dto.ts
@@ -10,4 +10,6 @@ export default class LegislationDto {
     message: 'professions.form.errors.legislation.link.empty',
   })
   link: string;
+
+  change: boolean;
 }

--- a/src/professions/admin/interfaces/legislation.template.ts
+++ b/src/professions/admin/interfaces/legislation.template.ts
@@ -3,5 +3,6 @@ import { Legislation } from '../../../legislations/legislation.entity';
 export interface LegislationTemplate {
   legislation: Legislation | null;
   captionText: string;
+  change: boolean;
   errors?: object;
 }

--- a/src/professions/admin/legislation.controller.spec.ts
+++ b/src/professions/admin/legislation.controller.spec.ts
@@ -40,7 +40,7 @@ describe(LegislationController, () => {
 
       professionsService.find.mockResolvedValue(profession);
 
-      await controller.edit(response, 'profession-id');
+      await controller.edit(response, 'profession-id', false);
 
       expect(response.render).toHaveBeenCalledWith(
         'admin/professions/legislation',
@@ -59,6 +59,7 @@ describe(LegislationController, () => {
         const dto: LegislationDto = {
           link: 'www.legal-legislation.com',
           nationalLegislation: 'Legal Services Act 2008',
+          change: false,
         };
 
         professionsService.find.mockResolvedValue(profession);
@@ -87,6 +88,7 @@ describe(LegislationController, () => {
         const dto: LegislationDto = {
           link: undefined,
           nationalLegislation: undefined,
+          change: false,
         };
 
         professionsService.find.mockResolvedValue(profession);

--- a/src/professions/admin/legislation.controller.ts
+++ b/src/professions/admin/legislation.controller.ts
@@ -4,6 +4,7 @@ import {
   Get,
   Param,
   Post,
+  Query,
   Res,
   UseFilters,
   UseGuards,
@@ -34,10 +35,14 @@ export class LegislationController {
       ? '/admin/professions/:id/check-your-answers'
       : '/admin/professions/:id/qualification-information/edit',
   )
-  async edit(@Res() res: Response, @Param('id') id: string): Promise<void> {
+  async edit(
+    @Res() res: Response,
+    @Param('id') id: string,
+    @Query('change') change: boolean,
+  ): Promise<void> {
     const profession = await this.professionsService.find(id);
 
-    this.renderForm(res, profession.legislation, profession.confirmed);
+    this.renderForm(res, profession.legislation, profession.confirmed, change);
   }
 
   @Post('/:id/legislation')
@@ -79,6 +84,7 @@ export class LegislationController {
         res,
         updatedLegislation,
         profession.confirmed,
+        submittedValues.change,
         errors,
       );
     }
@@ -94,11 +100,13 @@ export class LegislationController {
     res: Response,
     legislation: Legislation,
     isEditing: boolean,
+    change: boolean,
     errors: object | undefined = undefined,
   ): Promise<void> {
     const templateArgs: LegislationTemplate = {
       legislation,
       captionText: ViewUtils.captionText(isEditing),
+      change,
       errors,
     };
 

--- a/views/admin/professions/legislation.njk
+++ b/views/admin/professions/legislation.njk
@@ -15,6 +15,7 @@
       <h1 class="govuk-heading-l">{{ ("professions.form.headings.legislation" | t) }}</h1>
 
       <form method="post" action="./">
+        <input type="hidden" name="change" value="{{ change }}" />
 
         {{
           govukTextarea({


### PR DESCRIPTION
Previously, if invalid information was entered on the legislation page when editing an existing profession, the back link would go to the wrong destination. This fixes that, and brings the legislation page in line with the conventions of the other pages in this flow