### PR TITLE
(2047) Allow admins to publish Professions

### DIFF
--- a/cypress/integration/admin/organisations/index.spec.ts
+++ b/cypress/integration/admin/organisations/index.spec.ts
@@ -20,8 +20,6 @@ describe('Listing organisations', () => {
               .then(($header) => {
                 const $row = $header.parent();
 
-                console.log($row);
-
                 cy.wrap($row).should('contain', organisation.name);
                 cy.wrap($row).should('contain', latestVersion.alternateName);
 

--- a/cypress/integration/admin/professions/publish.spec.ts
+++ b/cypress/integration/admin/professions/publish.spec.ts
@@ -1,0 +1,23 @@
+describe('Publishing organisations', () => {
+  context('When I am logged in as admin', () => {
+    beforeEach(() => {
+      cy.loginAuth0('admin');
+      cy.visitAndCheckAccessibility('/admin');
+    });
+
+    it('Allows me to publish a draft profession', () => {
+      cy.get('a').contains('Regulated professions').click();
+      cy.checkAccessibility();
+
+      cy.contains('Gas Safe Engineer')
+        .parent('tr')
+        .within(() => {
+          cy.get('a').contains('View details').click();
+        });
+
+      cy.translate('professions.admin.status.draft').then((status) => {
+        cy.get('h2[data-status]').should('contain', status);
+      });
+    });
+  });
+});

--- a/cypress/integration/admin/professions/publish.spec.ts
+++ b/cypress/integration/admin/professions/publish.spec.ts
@@ -18,6 +18,34 @@ describe('Publishing organisations', () => {
       cy.translate('professions.admin.status.draft').then((status) => {
         cy.get('h2[data-status]').should('contain', status);
       });
+
+      cy.translate('professions.form.button.publishNow').then(
+        (publishButton) => {
+          cy.get('button').contains(publishButton).click();
+        },
+      );
+
+      cy.translate('professions.admin.publish.confirmation.heading').then(
+        (confirmation) => {
+          cy.get('html').should('contain', confirmation);
+        },
+      );
+
+      cy.translate(
+        'professions.admin.publish.confirmation.backToDashboard',
+      ).then((backToDashboard) => {
+        cy.get('a').contains(backToDashboard).click();
+      });
+
+      cy.get('tr')
+        .contains('Gas Safe Engineer')
+        .then(($header) => {
+          const $row = $header.parent();
+
+          cy.translate('professions.admin.status.live').then((status) => {
+            cy.wrap($row).should('contain', status);
+          });
+        });
     });
   });
 });

--- a/cypress/integration/organisations/show.spec.ts
+++ b/cypress/integration/organisations/show.spec.ts
@@ -38,4 +38,30 @@ describe('Showing organisations', () => {
       });
     });
   });
+
+  it('Shows the detail of an organisation, with no link to a profession if that profession is in a draft state', () => {
+    cy.readFile('./seeds/test/professions.json').then((professions) => {
+      cy.readFile('./seeds/test/organisations.json').then((organisations) => {
+        const councilOfRegisteredGasInstallers = organisations[1];
+        const version = councilOfRegisteredGasInstallers.versions[0];
+
+        cy.get('a').contains(councilOfRegisteredGasInstallers.name).click();
+
+        cy.checkAccessibility();
+
+        cy.get('body').should('contain', councilOfRegisteredGasInstallers.name);
+        cy.get('body').should('contain', version.email);
+        cy.get('body').should('contain', version.contactUrl);
+
+        const draftProfessionsForOrganisation = professions.filter(
+          (profession: any) =>
+            profession.organisation == councilOfRegisteredGasInstallers.name,
+        );
+
+        draftProfessionsForOrganisation.forEach((draftProfession: any) => {
+          cy.should('not.contain', draftProfession.name);
+        });
+      });
+    });
+  });
 });

--- a/seeds/development/professions.json
+++ b/seeds/development/professions.json
@@ -90,10 +90,5 @@
         "status": "draft"
       }
     ]
-  },
-  {
-    "name": "Draft Profession",
-    "organisation": "Department for Education",
-    "confirmed": false
   }
 ]

--- a/seeds/staging/professions.json
+++ b/seeds/staging/professions.json
@@ -90,10 +90,5 @@
         "status": "draft"
       }
     ]
-  },
-  {
-    "name": "Draft Profession",
-    "organisation": "Department for Education",
-    "confirmed": false
   }
 ]

--- a/seeds/test/professions.json
+++ b/seeds/test/professions.json
@@ -90,10 +90,5 @@
         "status": "draft"
       }
     ]
-  },
-  {
-    "name": "Draft Profession",
-    "organisation": "Department for Education",
-    "confirmed": false
   }
 ]

--- a/src/i18n/en/professions.json
+++ b/src/i18n/en/professions.json
@@ -246,6 +246,14 @@
         "body": "The new profession <strong>{name}</strong> is not published yet."
       }
     },
+    "publish": {
+      "confirmation": {
+        "heading": "Regulated profession published",
+        "body": "The new profession <strong>{name}</strong> has been published.",
+        "next": "What happens next?",
+        "backToDashboard": "Back to the dashboard"
+      }
+    },
     "status": {
       "heading": "Status",
       "live": "Live",

--- a/src/i18n/en/professions.json
+++ b/src/i18n/en/professions.json
@@ -247,6 +247,7 @@
       }
     },
     "status": {
+      "heading": "Status",
       "live": "Live",
       "draft": "Draft"
     },

--- a/src/organisations/admin/organisations.controller.spec.ts
+++ b/src/organisations/admin/organisations.controller.spec.ts
@@ -309,6 +309,7 @@ describe('OrganisationsController', () => {
           const updatedOrganisation = Organisation.withVersion(
             organisation,
             newVersion,
+            true,
           );
 
           expect(OrganisationPresenter).toHaveBeenCalledWith(

--- a/src/organisations/admin/organisations.controller.ts
+++ b/src/organisations/admin/organisations.controller.ts
@@ -147,6 +147,7 @@ export class OrganisationsController {
       const updatedOrganisation = Organisation.withVersion(
         organisation,
         updatedVersion,
+        true,
       );
 
       const organisationPresenter = new OrganisationPresenter(

--- a/src/organisations/organisation-versions.service.spec.ts
+++ b/src/organisations/organisation-versions.service.spec.ts
@@ -63,7 +63,7 @@ describe('OrganisationVersionsService', () => {
   });
 
   describe('findByIdWithOrganisation', () => {
-    it('returns an Organisation with a version', async () => {
+    it('returns an Organisation with a version, fetching its draft and live professions', async () => {
       const organisationVersion = organisationVersionFactory.build();
       const queryBuilder = createMock<SelectQueryBuilder<OrganisationVersion>>({
         leftJoinAndSelect: () => queryBuilder,
@@ -84,6 +84,7 @@ describe('OrganisationVersionsService', () => {
         Organisation.withVersion(
           organisationVersion.organisation,
           organisationVersion,
+          true,
         ),
       );
 
@@ -201,7 +202,7 @@ describe('OrganisationVersionsService', () => {
   });
 
   describe('allDraftOrLive', () => {
-    it('gets all organisations and their latest draft or live version', async () => {
+    it('gets all organisations and their latest draft or live version with draft or live Professions', async () => {
       const versions = organisationVersionFactory.buildList(5);
       const queryBuilder = createMock<SelectQueryBuilder<OrganisationVersion>>({
         leftJoinAndSelect: () => queryBuilder,
@@ -218,7 +219,7 @@ describe('OrganisationVersionsService', () => {
       const result = await service.allDraftOrLive();
 
       const expectedOrganisations = versions.map((version) =>
-        Organisation.withVersion(version.organisation, version),
+        Organisation.withVersion(version.organisation, version, true),
       );
 
       expect(result).toEqual(expectedOrganisations);

--- a/src/organisations/organisation-versions.service.ts
+++ b/src/organisations/organisation-versions.service.ts
@@ -30,7 +30,7 @@ export class OrganisationVersionsService {
       .where({ organisation: { id: organisationId }, id })
       .getOne();
 
-    return Organisation.withVersion(version.organisation, version);
+    return Organisation.withVersion(version.organisation, version, true);
   }
 
   async findLatestForOrganisationId(
@@ -78,7 +78,7 @@ export class OrganisationVersionsService {
       .getMany();
 
     return versions.map((version) =>
-      Organisation.withVersion(version.organisation, version),
+      Organisation.withVersion(version.organisation, version, true),
     );
   }
 

--- a/src/organisations/organisation.entity.spec.ts
+++ b/src/organisations/organisation.entity.spec.ts
@@ -10,7 +10,7 @@ jest.mock('../professions/profession.entity');
 
 describe('Organisation', () => {
   describe('withVersion', () => {
-    it('should return an entity with a version', () => {
+    it('should return an entity with a version and all its live Professions', () => {
       const profession = professionFactory.build();
       const organisationVersion = organisationVersionFactory.build();
       const organisation = organisationFactory.build({
@@ -18,7 +18,7 @@ describe('Organisation', () => {
         professions: [profession],
       });
 
-      (Profession.withLatestLiveOrDraftVersion as jest.Mock).mockImplementation(
+      (Profession.withLatestLiveVersion as jest.Mock).mockImplementation(
         () => profession,
       );
 
@@ -39,6 +39,51 @@ describe('Organisation', () => {
         versionId: organisationVersion.id,
         status: organisationVersion.status,
         professions: [profession],
+      });
+
+      expect(
+        Profession.withLatestLiveOrDraftVersion as jest.Mock,
+      ).not.toHaveBeenCalled();
+    });
+
+    describe('when `showDraftProfessions` is `true`', () => {
+      it('should return an entity with a version and all its live and draft Professions', () => {
+        const profession = professionFactory.build();
+        const organisationVersion = organisationVersionFactory.build();
+        const organisation = organisationFactory.build({
+          versions: [organisationVersion, organisationVersionFactory.build()],
+          professions: [profession],
+        });
+
+        (
+          Profession.withLatestLiveOrDraftVersion as jest.Mock
+        ).mockImplementation(() => profession);
+
+        Profession.withLatestLiveVersion = jest.fn();
+
+        const resultWithDraftProfessions = Organisation.withVersion(
+          organisation,
+          organisationVersion,
+          true,
+        );
+
+        expect(resultWithDraftProfessions).toEqual({
+          ...organisation,
+          alternateName: organisationVersion.alternateName,
+          address: organisationVersion.address,
+          url: organisationVersion.url,
+          email: organisationVersion.email,
+          contactUrl: organisationVersion.contactUrl,
+          telephone: organisationVersion.telephone,
+          fax: organisationVersion.fax,
+          versionId: organisationVersion.id,
+          status: organisationVersion.status,
+          professions: [profession],
+        });
+
+        expect(
+          Profession.withLatestLiveVersion as jest.Mock,
+        ).not.toHaveBeenCalled();
       });
     });
 

--- a/src/organisations/organisation.entity.ts
+++ b/src/organisations/organisation.entity.ts
@@ -74,9 +74,16 @@ export class Organisation {
   public static withVersion(
     organisation: Organisation,
     organisationVersion: OrganisationVersion,
+    showDraftProfessions = false,
   ): Organisation {
     const professions = (organisation.professions || [])
-      .map((profession) => Profession.withLatestLiveOrDraftVersion(profession))
+      .map((profession) => {
+        if (showDraftProfessions === true) {
+          return Profession.withLatestLiveOrDraftVersion(profession);
+        } else {
+          return Profession.withLatestLiveVersion(profession);
+        }
+      })
       .filter(Boolean);
 
     return {

--- a/src/professions/profession-versions.controller.spec.ts
+++ b/src/professions/profession-versions.controller.spec.ts
@@ -18,7 +18,6 @@ import { ProfessionVersionsController } from './profession-versions.controller';
 import { ProfessionVersionsService } from './profession-versions.service';
 import { ProfessionsService } from './professions.service';
 import { Profession } from './profession.entity';
-import qualificationFactory from '../testutils/factories/qualification';
 
 jest.mock('../organisations/organisation.entity');
 

--- a/src/professions/profession-versions.controller.spec.ts
+++ b/src/professions/profession-versions.controller.spec.ts
@@ -207,4 +207,27 @@ describe('ProfessionVersionsController', () => {
       });
     });
   });
+
+  describe('publish', () => {
+    it('should publish the current version', async () => {
+      const profession = professionFactory.build();
+      const version = professionVersionFactory.build({
+        profession,
+      });
+
+      professionVersionsService.findByIdWithProfession.mockResolvedValue(
+        version,
+      );
+
+      const result = await controller.publish(profession.id, version.id);
+
+      expect(result).toEqual(profession);
+
+      expect(
+        professionVersionsService.findByIdWithProfession,
+      ).toHaveBeenCalledWith(profession.id, version.id);
+
+      expect(professionVersionsService.publish).toHaveBeenCalledWith(version);
+    });
+  });
 });

--- a/src/professions/profession-versions.controller.ts
+++ b/src/professions/profession-versions.controller.ts
@@ -4,6 +4,7 @@ import {
   NotFoundException,
   Param,
   Post,
+  Put,
   Render,
   Req,
   Res,
@@ -135,5 +136,21 @@ export class ProfessionVersionsController {
     return res.redirect(
       `/admin/professions/${version.profession.id}/versions/${version.id}/check-your-answers?edit=true`,
     );
+  }
+
+  @Put(':professionId/versions/:versionId/publish')
+  @Render('admin/professions/versions/publish')
+  async publish(
+    @Param('professionId') professionId: string,
+    @Param('versionId') versionId: string,
+  ): Promise<Profession> {
+    const version = await this.professionVersionsService.findByIdWithProfession(
+      professionId,
+      versionId,
+    );
+
+    await this.professionVersionsService.publish(version);
+
+    return version.profession;
   }
 }

--- a/src/professions/profession-versions.controller.ts
+++ b/src/professions/profession-versions.controller.ts
@@ -22,6 +22,7 @@ import { Qualification } from '../qualifications/qualification.entity';
 import { ShowTemplate } from './interfaces/show-template.interface';
 import { ProfessionVersion } from './profession-version.entity';
 import { ProfessionVersionsService } from './profession-versions.service';
+import { Profession } from './profession.entity';
 import { ProfessionsService } from './professions.service';
 
 @UseGuards(AuthenticationGuard)
@@ -49,17 +50,18 @@ export class ProfessionVersionsController {
     @Param('professionId') professionId: string,
     @Param('versionId') versionId: string,
   ): Promise<ShowTemplate> {
-    const profession =
-      await this.professionVersionsService.findByIdWithProfession(
-        professionId,
-        versionId,
-      );
+    const version = await this.professionVersionsService.findByIdWithProfession(
+      professionId,
+      versionId,
+    );
 
-    if (!profession) {
+    if (!version) {
       throw new NotFoundException(
         `A profession with ID ${professionId}, version ${versionId} could not be found`,
       );
     }
+
+    const profession = Profession.withVersion(version.profession, version);
 
     const organisation = Organisation.withLatestLiveVersion(
       profession.organisation,

--- a/src/professions/profession-versions.controller.ts
+++ b/src/professions/profession-versions.controller.ts
@@ -139,7 +139,7 @@ export class ProfessionVersionsController {
   }
 
   @Put(':professionId/versions/:versionId/publish')
-  @Render('admin/professions/versions/publish')
+  @Render('admin/professions/publish')
   async publish(
     @Param('professionId') professionId: string,
     @Param('versionId') versionId: string,

--- a/src/professions/profession-versions.service.spec.ts
+++ b/src/professions/profession-versions.service.spec.ts
@@ -381,9 +381,7 @@ describe('ProfessionVersionsService', () => {
         'version-uuid',
       );
 
-      expect(result).toEqual(
-        Profession.withVersion(version.profession, version),
-      );
+      expect(result).toEqual(version);
 
       expect(queryBuilder).toHaveJoined([
         'professionVersion.profession',

--- a/src/professions/profession-versions.service.ts
+++ b/src/professions/profession-versions.service.ts
@@ -124,13 +124,13 @@ export class ProfessionVersionsService {
   async findByIdWithProfession(
     professionId: string,
     id: string,
-  ): Promise<Profession> {
+  ): Promise<ProfessionVersion> {
     const version = await this.versionsWithJoins()
       .leftJoinAndSelect('organisation.versions', 'organisationVersions')
       .where({ profession: { id: professionId }, id })
       .getOne();
 
-    return Profession.withVersion(version.profession, version);
+    return version;
   }
 
   private versionsWithJoins(): SelectQueryBuilder<ProfessionVersion> {

--- a/views/admin/professions/publish.njk
+++ b/views/admin/professions/publish.njk
@@ -1,0 +1,19 @@
+{% extends "base.njk" %}
+{% from "govuk/components/panel/macro.njk" import govukPanel %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    {{ govukPanel({
+        titleText: ("professions.admin.publish.confirmation.heading" | t),
+        html: "professions.admin.publish.confirmation.body" | t({name: (name | escape)})
+    }) }}
+
+    <h2 class="govuk-heading-m">{{ "professions.admin.publish.confirmation.next" | t  }}</h3>
+
+    <p class="govuk-body"><a href="/admin/professions">{{ "professions.admin.publish.confirmation.backToDashboard" | t }}</a></p>
+  </div>
+</div>
+
+{% endblock %}

--- a/views/admin/professions/show.njk
+++ b/views/admin/professions/show.njk
@@ -11,12 +11,16 @@
     </div>
     <div class="govuk-grid-column-one-third">
       <aside class="app-related-items rpr-internal__details-page-sidebar" role="complementary">
-      {{ govukButton({
-        text: ('professions.admin.editProfession' | t),
-        classes: "govuk-button",
-        id: "edit-button",
-        href: "/admin/professions/" + profession.id + "/versions/edit"
-      }) }}
+        <h2 class="govuk-heading-s" data-status>
+          {{ "professions.admin.status.heading" | t }}<br>
+          <span class="govuk-body">{{ ("professions.admin.status." + profession.status) | t }}</span>
+        </h2>
+        {{ govukButton({
+          text: ('professions.admin.editProfession' | t),
+          classes: "govuk-button",
+          id: "edit-button",
+          href: "/admin/professions/" + profession.id + "/versions/edit"
+        }) }}
       </aside>
     </div>
   </div>

--- a/views/admin/professions/show.njk
+++ b/views/admin/professions/show.njk
@@ -15,12 +15,28 @@
           {{ "professions.admin.status.heading" | t }}<br>
           <span class="govuk-body">{{ ("professions.admin.status." + profession.status) | t }}</span>
         </h2>
-        {{ govukButton({
-          text: ('professions.admin.editProfession' | t),
-          classes: "govuk-button",
-          id: "edit-button",
-          href: "/admin/professions/" + profession.id + "/versions/edit"
-        }) }}
+
+        <ul class="govuk-list">
+          {% if profession.status === 'draft' %}
+            <li>
+                <form action="/admin/professions/{{ profession.id }}/versions/{{ profession.versionId }}/publish?_method=PUT" method="post">
+                  {{ govukButton({
+                    text: ('professions.form.button.publishNow' | t),
+                    classes: "govuk-button",
+                    id: "publish-button"
+                  }) }}
+                </form>
+            </li>
+          {% endif %}
+          <li>
+            {{ govukButton({
+              text: ('professions.admin.editProfession' | t),
+              classes: "govuk-button--secondary",
+              id: "edit-button",
+              href: "/admin/professions/" + profession.id + "/versions/edit"
+            }) }}
+          </li>
+        </ul>
       </aside>
     </div>
   </div>


### PR DESCRIPTION
# Changes in this PR

Adds "Publish now" button to the admin page for viewing professions. This makes a PUT request that calls the controller#publish action to mark the version as published, while archiving the previous "live" version.

This also adds the status of the currently-viewed profession to the page, and a confirmation screen for this journey.

## Screenshots of UI changes

<img width="997" alt="image" src="https://user-images.githubusercontent.com/19826940/153041613-d30ab2e7-1d63-4b42-9f83-8a5c1bc4d673.png">

![image](https://user-images.githubusercontent.com/19826940/153041995-c2aa2da9-9ff7-4339-8b43-f1354c82c5f9.png)
