### PR TITLE
(2112) User listing is filtered by organisation

### DIFF
--- a/cypress/integration/admin/user/index.spec.ts
+++ b/cypress/integration/admin/user/index.spec.ts
@@ -1,0 +1,43 @@
+describe('Listing professions', () => {
+  context('When I am logged in as a service admin', () => {
+    beforeEach(() => {
+      cy.loginAuth0();
+    });
+
+    it('All users are listed', () => {
+      cy.visitAndCheckAccessibility('/admin/users');
+
+      cy.readFile('./seeds/test/users.json').then((users) => {
+        users.forEach((user) => {
+          cy.get('tbody th').should('contain', user.name);
+          cy.get('tbody td').should('contain', user.email);
+        });
+
+        cy.get('tbody tr').should('have.length', users.length);
+      });
+    });
+  });
+
+  context('When I am logged in as an organisation admin', () => {
+    beforeEach(() => {
+      cy.loginAuth0('orgadmin');
+    });
+
+    it('Users for the organisation are listed', () => {
+      cy.visitAndCheckAccessibility('/admin/users');
+
+      cy.readFile('./seeds/test/users.json').then((users) => {
+        const organisationUsers = users.filter(
+          (user) => user.organisation === 'Department for Education',
+        );
+
+        organisationUsers.forEach((user) => {
+          cy.get('tbody th').should('contain', user.name);
+          cy.get('tbody td').should('contain', user.email);
+        });
+
+        cy.get('tbody tr').should('have.length', organisationUsers.length);
+      });
+    });
+  });
+});

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -78,9 +78,13 @@ function login(role: string) {
 /**
  * Login with Auth0.
  */
-Cypress.Commands.add('loginAuth0', (role = 'admin') => {
-  return cy.session(`logged in user with ${role} role`, () => {
-    login(role).then(({ cookies, callbackUrl }) => {
+Cypress.Commands.add('loginAuth0', (user = 'admin') => {
+  // For organisation level users, we use a cache-breaker string to prevent
+  // a stale user organisation being used across database refreshes
+  const sessionName = user.startsWith('org') ? crypto.randomUUID() : 'default';
+
+  return cy.session(`logged as user ${user} (${sessionName})`, () => {
+    login(user).then(({ cookies, callbackUrl }) => {
       cookies
         .map(createCookie)
         .forEach((c: any) => cy.setCookie(c.name, c.value, c.options));

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -41,8 +41,13 @@ export class UsersController {
   @Permissions(UserPermission.CreateUser, UserPermission.EditUser)
   @Render('admin/users/index')
   @BackLink('/admin')
-  async index(): Promise<IndexTemplate> {
-    const users = await this.usersService.where({ confirmed: true });
+  async index(@Req() req: Request): Promise<IndexTemplate> {
+    const actingUser = req['appSession'].user;
+
+    const users = await (actingUser.serviceOwner
+      ? this.usersService.allConfirmed()
+      : this.usersService.allConfirmedForOrganisation(actingUser.organisation));
+
     const usersPresenter = new UsersPresenter(users);
 
     return {

--- a/src/users/users.service.spec.ts
+++ b/src/users/users.service.spec.ts
@@ -60,17 +60,6 @@ describe('UsersService', () => {
     });
   });
 
-  describe('where', () => {
-    it('should search for a user given a query', async () => {
-      const query = { email: 'foo@bar.com' };
-      const repoSpy = jest.spyOn(repo, 'find');
-      const post = await service.where(query);
-
-      expect(post).toEqual(userArray);
-      expect(repoSpy).toHaveBeenCalledWith({ where: query });
-    });
-  });
-
   describe('allConfirmed', () => {
     it('should return all confirmed users', async () => {
       const repoSpy = jest.spyOn(repo, 'find');

--- a/src/users/users.service.spec.ts
+++ b/src/users/users.service.spec.ts
@@ -6,6 +6,7 @@ import userFactory from '../testutils/factories/user';
 
 import { User } from './user.entity';
 import { UsersService } from './users.service';
+import organisationFactory from '../testutils/factories/organisation';
 
 const user = userFactory.build();
 const userArray = userFactory.buildList(2);
@@ -67,6 +68,30 @@ describe('UsersService', () => {
 
       expect(post).toEqual(userArray);
       expect(repoSpy).toHaveBeenCalledWith({ where: query });
+    });
+  });
+
+  describe('allConfirmed', () => {
+    it('should return all confirmed users', async () => {
+      const repoSpy = jest.spyOn(repo, 'find');
+      const posts = await service.allConfirmed();
+
+      expect(posts).toEqual(userArray);
+      expect(repoSpy).toHaveBeenCalledWith({ where: { confirmed: true } });
+    });
+  });
+
+  describe('allConfirmedForOrganisation', () => {
+    it('should return all confirmed users', async () => {
+      const organisation = organisationFactory.build();
+
+      const repoSpy = jest.spyOn(repo, 'find');
+      const posts = await service.allConfirmedForOrganisation(organisation);
+
+      expect(posts).toEqual(userArray);
+      expect(repoSpy).toHaveBeenCalledWith({
+        where: { confirmed: true, organisation },
+      });
     });
   });
 

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -3,6 +3,7 @@ import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 
 import { User } from './user.entity';
+import { Organisation } from '../organisations/organisation.entity';
 
 @Injectable()
 export class UsersService {
@@ -18,6 +19,16 @@ export class UsersService {
 
   where(query: FindConditions<User>): Promise<User[]> {
     return this.repository.find({ where: query });
+  }
+
+  allConfirmed(): Promise<User[]> {
+    return this.repository.find({ where: { confirmed: true } });
+  }
+
+  allConfirmedForOrganisation(organisation: Organisation): Promise<User[]> {
+    return this.repository.find({
+      where: { confirmed: true, organisation },
+    });
   }
 
   find(id: string): Promise<User> {

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -1,4 +1,4 @@
-import { Connection, Repository, FindConditions, DeleteResult } from 'typeorm';
+import { Connection, Repository, DeleteResult } from 'typeorm';
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 
@@ -15,10 +15,6 @@ export class UsersService {
 
   all(): Promise<User[]> {
     return this.repository.find();
-  }
-
-  where(query: FindConditions<User>): Promise<User[]> {
-    return this.repository.find({ where: query });
   }
 
   allConfirmed(): Promise<User[]> {


### PR DESCRIPTION
# Changes in this PR

The manager users page filters the user list by organisation when logged in as an organisation-level user

## Screenshots of UI changes

### Before

![localhost_3000_admin_users](https://user-images.githubusercontent.com/94137563/153201202-2f40dcdf-fee2-4b6e-85fe-656a6a44a820.png)

### After

![localhost_3000_admin_users (1)](https://user-images.githubusercontent.com/94137563/153201209-238ef21b-094c-42f8-a306-33d559a7532a.png)
