### PR TITLE
Revise permissions required for editing professions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Creating and editing a profession creates new draft versions
 - Users can be assigned to an organisation
 - Users are assigned a role rather than a list of permissions
+- All roles may edit professions
+- Only service admistrators may create professions
 
 ## [release-002] - 2022-02-01
 

--- a/src/professions/admin/check-your-answers.controller.ts
+++ b/src/professions/admin/check-your-answers.controller.ts
@@ -31,7 +31,7 @@ export class CheckYourAnswersController {
   ) {}
 
   @Get(':professionId/versions/:versionId/check-your-answers')
-  @Permissions(UserPermission.CreateProfession)
+  @Permissions(UserPermission.EditProfession)
   @Render('admin/professions/check-your-answers')
   @BackLink((request: Request) => getReferrer(request))
   async show(

--- a/src/professions/admin/confirmation.controller.ts
+++ b/src/professions/admin/confirmation.controller.ts
@@ -17,7 +17,7 @@ export class ConfirmationController {
   ) {}
 
   @Post('/:professionId/versions/:versionId/confirmation')
-  @Permissions(UserPermission.CreateProfession)
+  @Permissions(UserPermission.EditProfession)
   async create(
     @Res() res: Response,
     @Req() req: Request,

--- a/src/professions/admin/legislation.controller.ts
+++ b/src/professions/admin/legislation.controller.ts
@@ -33,7 +33,7 @@ export class LegislationController {
   ) {}
 
   @Get('/:professionId/versions/:versionId/legislation/edit')
-  @Permissions(UserPermission.CreateProfession)
+  @Permissions(UserPermission.EditProfession)
   @BackLink((request: Request) =>
     request.query.change === 'true'
       ? '/admin/professions/:professionId/versions/:versionId/check-your-answers'
@@ -64,7 +64,7 @@ export class LegislationController {
   }
 
   @Post('/:professionId/versions/:versionId/legislation')
-  @Permissions(UserPermission.CreateProfession)
+  @Permissions(UserPermission.EditProfession)
   @UseFilters(
     new ValidationExceptionFilter(
       'admin/professions/legislation',

--- a/src/professions/admin/professions.controller.ts
+++ b/src/professions/admin/professions.controller.ts
@@ -29,6 +29,8 @@ import { createFilterInput } from '../../helpers/create-filter-input.helper';
 import { ProfessionVersionsService } from '../profession-versions.service';
 import { ProfessionVersion } from '../profession-version.entity';
 import { RequestWithAppSession } from '../../common/interfaces/request-with-app-session.interface';
+import { UserPermission } from '../../users/user-permission';
+import { Permissions } from '../../common/permissions.decorator';
 
 @UseGuards(AuthenticationGuard)
 @Controller('admin/professions')
@@ -42,6 +44,7 @@ export class ProfessionsController {
   ) {}
 
   @Post()
+  @Permissions(UserPermission.CreateProfession)
   async create(
     @Res() res: Response,
     @Req() req: RequestWithAppSession,

--- a/src/professions/admin/qualification-information.controller.ts
+++ b/src/professions/admin/qualification-information.controller.ts
@@ -35,7 +35,7 @@ export class QualificationInformationController {
   ) {}
 
   @Get('/:professionId/versions/:versionId/qualification-information/edit')
-  @Permissions(UserPermission.CreateProfession)
+  @Permissions(UserPermission.EditProfession)
   @BackLink((request: Request) =>
     request.query.change === 'true'
       ? '/admin/professions/:professionId/versions/:versionId/check-your-answers'
@@ -64,7 +64,7 @@ export class QualificationInformationController {
   }
 
   @Post('/:professionId/versions/:versionId/qualification-information')
-  @Permissions(UserPermission.CreateProfession)
+  @Permissions(UserPermission.EditProfession)
   @BackLink((request: Request) =>
     request.body.change === 'true'
       ? '/admin/professions/:professionId/versions/:versionId/check-your-answers'

--- a/src/professions/admin/regulated-activities.controller.ts
+++ b/src/professions/admin/regulated-activities.controller.ts
@@ -31,7 +31,7 @@ export class RegulatedActivitiesController {
   ) {}
 
   @Get('/:professionId/versions/:versionId/regulated-activities/edit')
-  @Permissions(UserPermission.CreateProfession)
+  @Permissions(UserPermission.EditProfession)
   @BackLink((request: Request) =>
     request.query.change === 'true'
       ? '/admin/professions/:professionId/versions/:versionId/check-your-answers'
@@ -61,7 +61,7 @@ export class RegulatedActivitiesController {
   }
 
   @Post('/:professionId/versions/:versionId/regulated-activities')
-  @Permissions(UserPermission.CreateProfession)
+  @Permissions(UserPermission.EditProfession)
   @BackLink((request: Request) =>
     request.body.change === 'true'
       ? '/admin/professions/:professionId/versions/:versionId/check-your-answers'

--- a/src/professions/admin/regulatory-body.controller.ts
+++ b/src/professions/admin/regulatory-body.controller.ts
@@ -41,7 +41,7 @@ export class RegulatoryBodyController {
   ) {}
 
   @Get('/:professionId/versions/:versionId/regulatory-body/edit')
-  @Permissions(UserPermission.CreateProfession)
+  @Permissions(UserPermission.EditProfession)
   @BackLink((request: Request) =>
     request.query.change === 'true'
       ? '/admin/professions/:professionId/versions/:versionId/check-your-answers'
@@ -73,7 +73,7 @@ export class RegulatoryBodyController {
   }
 
   @Post('/:professionId/versions/:versionId/regulatory-body')
-  @Permissions(UserPermission.CreateProfession)
+  @Permissions(UserPermission.EditProfession)
   @BackLink((request: Request) =>
     request.body.change === 'true'
       ? '/admin/professions/:professionId/versions/:versionId/check-your-answers'

--- a/src/professions/admin/top-level-information.controller.ts
+++ b/src/professions/admin/top-level-information.controller.ts
@@ -40,7 +40,7 @@ export class TopLevelInformationController {
   ) {}
 
   @Get('/:professionId/versions/:versionId/top-level-information/edit')
-  @Permissions(UserPermission.CreateProfession)
+  @Permissions(UserPermission.EditProfession)
   @BackLink((request: Request) =>
     request.query.change === 'true'
       ? '/admin/professions/:professionId/versions/:versionId/check-your-answers'
@@ -73,7 +73,7 @@ export class TopLevelInformationController {
   }
 
   @Post('/:professionId/versions/:versionId/top-level-information')
-  @Permissions(UserPermission.CreateProfession)
+  @Permissions(UserPermission.EditProfession)
   @BackLink((request: Request) =>
     request.body.change === 'true'
       ? '/admin/professions/:professionId/check-your-answers'

--- a/src/professions/profession-versions.controller.ts
+++ b/src/professions/profession-versions.controller.ts
@@ -15,11 +15,13 @@ import { I18nService } from 'nestjs-i18n';
 import { AuthenticationGuard } from '../common/authentication.guard';
 import { BackLink } from '../common/decorators/back-link.decorator';
 import { RequestWithAppSession } from '../common/interfaces/request-with-app-session.interface';
+import { Permissions } from '../common/permissions.decorator';
 import { Legislation } from '../legislations/legislation.entity';
 import { Nation } from '../nations/nation';
 import { Organisation } from '../organisations/organisation.entity';
 import QualificationPresenter from '../qualifications/presenters/qualification.presenter';
 import { Qualification } from '../qualifications/qualification.entity';
+import { UserPermission } from '../users/user-permission';
 import { ShowTemplate } from './interfaces/show-template.interface';
 import { ProfessionVersion } from './profession-version.entity';
 import { ProfessionVersionsService } from './profession-versions.service';
@@ -94,6 +96,7 @@ export class ProfessionVersionsController {
   }
 
   @Post('/:professionId/versions')
+  @Permissions(UserPermission.EditProfession)
   async create(
     @Res() res: Response,
     @Req() req: RequestWithAppSession,
@@ -139,6 +142,7 @@ export class ProfessionVersionsController {
   }
 
   @Put(':professionId/versions/:versionId/publish')
+  @Permissions(UserPermission.EditProfession)
   @Render('admin/professions/publish')
   async publish(
     @Param('professionId') professionId: string,

--- a/src/users/helpers/get-permissions-from-user.helper.ts
+++ b/src/users/helpers/get-permissions-from-user.helper.ts
@@ -11,6 +11,7 @@ const permissions = {
       UserPermission.CreateOrganisation,
       UserPermission.DeleteOrganisation,
       UserPermission.CreateProfession,
+      UserPermission.EditProfession,
       UserPermission.DeleteProfession,
       UserPermission.UploadDecisionData,
       UserPermission.DownloadDecisionData,
@@ -20,20 +21,22 @@ const permissions = {
       UserPermission.CreateOrganisation,
       UserPermission.DeleteOrganisation,
       UserPermission.CreateProfession,
+      UserPermission.EditProfession,
       UserPermission.DeleteProfession,
     ],
-    [Role.Editor]: [],
+    [Role.Editor]: [UserPermission.EditProfession],
   },
   notServiceOwner: {
     [Role.Administrator]: [
       UserPermission.CreateUser,
       UserPermission.EditUser,
       UserPermission.DeleteUser,
+      UserPermission.EditProfession,
       UserPermission.UploadDecisionData,
       UserPermission.DownloadDecisionData,
       UserPermission.ViewDecisionData,
     ],
-    [Role.Editor]: [],
+    [Role.Editor]: [UserPermission.EditProfession],
   },
 };
 

--- a/src/users/user-permission.ts
+++ b/src/users/user-permission.ts
@@ -6,6 +6,7 @@ export enum UserPermission {
   DeleteOrganisation = 'deleteOrganisation',
   CreateProfession = 'createProfession',
   DeleteProfession = 'deleteProfession',
+  EditProfession = 'editProfession',
   UploadDecisionData = 'uploadDecisionData',
   DownloadDecisionData = 'downloadDecisionData',
   ViewDecisionData = 'viewDecisionData',

--- a/views/admin/professions/show.njk
+++ b/views/admin/professions/show.njk
@@ -17,7 +17,7 @@
         </h2>
 
         <ul class="govuk-list">
-          {% if profession.status === 'draft' %}
+          {% if profession.status === 'draft' and 'editProfession' in permissions %}
             <li>
                 <form action="/admin/professions/{{ profession.id }}/versions/{{ profession.versionId }}/publish?_method=PUT" method="post">
                   {{ govukButton({
@@ -28,14 +28,16 @@
                 </form>
             </li>
           {% endif %}
+          {% if 'editProfession' in permissions %}
           <li>
-            {{ govukButton({
-              text: ('professions.admin.editProfession' | t),
-              classes: "govuk-button--secondary",
-              id: "edit-button",
-              href: "/admin/professions/" + profession.id + "/versions/edit"
-            }) }}
+              {{ govukButton({
+                text: ('professions.admin.editProfession' | t),
+                classes: "govuk-button--secondary",
+                id: "edit-button",
+                href: "/admin/professions/" + profession.id + "/versions/edit"
+              }) }}
           </li>
+          {% endif %}
         </ul>
       </aside>
     </div>


### PR DESCRIPTION
Add a new `EditProfession` permission, granted to all roles, and require this when editing professions. Only require the `CreateProfession` permission when actually creating a profession.

Note this is not the full sweep of professions is the app, so much as the minimum necessary to prevent confusion during user research