### PR TITLE
(2123) Move Organisation to top level Profession

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Users are assigned a role rather than a list of permissions
 - All roles may edit professions
 - Only service admistrators may create professions
+- Setting an organisation on a profession updates immediately, rather than saving as draft
 
 ## [release-002] - 2022-02-01
 

--- a/src/db/migrate/1644488372923-RemoveOrganisationFromProfessionVersion.ts
+++ b/src/db/migrate/1644488372923-RemoveOrganisationFromProfessionVersion.ts
@@ -1,0 +1,25 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class RemoveOrganisationFromProfessionVersion1644488372923
+  implements MigrationInterface
+{
+  name = 'RemoveOrganisationFromProfessionVersion1644488372923';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "professionVersions" DROP CONSTRAINT "FK_5ad0bb58fc31ea3e6c249739e42"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "professionVersions" DROP COLUMN "organisationId"`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "professionVersions" ADD "organisationId" uuid`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "professionVersions" ADD CONSTRAINT "FK_5ad0bb58fc31ea3e6c249739e42" FOREIGN KEY ("organisationId") REFERENCES "organisations"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    );
+  }
+}

--- a/src/professions/admin/check-your-answers.controller.spec.ts
+++ b/src/professions/admin/check-your-answers.controller.spec.ts
@@ -57,6 +57,9 @@ describe('CheckYourAnswersController', () => {
         const profession = professionFactory.build({
           id: 'profession-id',
           name: 'Gas Safe Engineer',
+          organisation: organisationFactory.build({
+            name: 'Council of Gas Registered Engineers',
+          }),
           slug: null,
         });
         professionsService.findWithVersions.mockResolvedValue(profession);
@@ -66,9 +69,6 @@ describe('CheckYourAnswersController', () => {
           industries: [
             industryFactory.build({ name: 'industries.construction' }),
           ],
-          organisation: organisationFactory.build({
-            name: 'Council of Gas Registered Engineers',
-          }),
           mandatoryRegistration: MandatoryRegistration.Voluntary,
           description: 'A description of the regulation',
           reservedActivities: 'Some reserved activities',

--- a/src/professions/admin/check-your-answers.controller.ts
+++ b/src/professions/admin/check-your-answers.controller.ts
@@ -78,7 +78,7 @@ export class CheckYourAnswersController {
       name: draftProfession.name,
       nations: selectedNations,
       industries: industryNames,
-      organisation: version.organisation.name,
+      organisation: draftProfession.organisation.name,
       mandatoryRegistration: version.mandatoryRegistration,
       description: version.description,
       reservedActivities: version.reservedActivities,

--- a/src/professions/admin/regulatory-body.controller.spec.ts
+++ b/src/professions/admin/regulatory-body.controller.spec.ts
@@ -91,10 +91,10 @@ describe(RegulatoryBodyController, () => {
         });
         const profession = professionFactory.build({
           id: 'profession-id',
+          organisation: organisation,
         });
         const version = professionVersionFactory.build({
           profession: profession,
-          organisation: organisation,
           mandatoryRegistration: MandatoryRegistration.Mandatory,
         });
 
@@ -139,7 +139,6 @@ describe(RegulatoryBodyController, () => {
         const version = professionVersionFactory.build({
           id: 'version-id',
           profession: profession,
-          organisation: organisationFactory.build(),
           mandatoryRegistration: MandatoryRegistration.Mandatory,
         });
 
@@ -164,10 +163,16 @@ describe(RegulatoryBodyController, () => {
           regulatoryBodyDto,
         );
 
+        expect(professionsService.save).toHaveBeenCalledWith(
+          expect.objectContaining({
+            id: 'profession-id',
+            organisation: newOrganisation,
+          }),
+        );
+
         expect(professionVersionsService.save).toHaveBeenCalledWith(
           expect.objectContaining({
             id: 'version-id',
-            organisation: newOrganisation,
             mandatoryRegistration: MandatoryRegistration.Voluntary,
             profession: profession,
           }),
@@ -213,11 +218,11 @@ describe(RegulatoryBodyController, () => {
         it('redirects to check your answers on submit', async () => {
           const profession = professionFactory.build({
             id: 'profession-id',
+            organisation: organisationFactory.build(),
           });
           const version = professionVersionFactory.build({
             id: 'version-id',
             profession: profession,
-            organisation: organisationFactory.build(),
             mandatoryRegistration: MandatoryRegistration.Mandatory,
           });
 
@@ -242,15 +247,6 @@ describe(RegulatoryBodyController, () => {
             regulatoryBodyDtoWithChangeParam,
           );
 
-          expect(professionVersionsService.save).toHaveBeenCalledWith(
-            expect.objectContaining({
-              id: 'version-id',
-              organisation: organisation,
-              mandatoryRegistration: MandatoryRegistration.Voluntary,
-              profession: profession,
-            }),
-          );
-
           expect(response.redirect).toHaveBeenCalledWith(
             '/admin/professions/profession-id/versions/version-id/check-your-answers',
           );
@@ -259,11 +255,14 @@ describe(RegulatoryBodyController, () => {
 
       describe('when false or missing', () => {
         it('continues to the next step in the journey', async () => {
-          const profession = professionFactory.build({ id: 'profession-id' });
+          const organisation = organisationFactory.build();
+          const profession = professionFactory.build({
+            id: 'profession-id',
+            organisation: organisation,
+          });
           const version = professionVersionFactory.build({
             id: 'version-id',
             profession: profession,
-            organisation: organisationFactory.build(),
             mandatoryRegistration: MandatoryRegistration.Mandatory,
           });
 
@@ -278,7 +277,6 @@ describe(RegulatoryBodyController, () => {
             change: false,
           };
 
-          const organisation = organisationFactory.build();
           organisationsService.find.mockResolvedValue(organisation);
 
           await controller.update(
@@ -286,15 +284,6 @@ describe(RegulatoryBodyController, () => {
             'profession-id',
             'version-id',
             regulatoryBodyDtoWithFalseChangeParam,
-          );
-
-          expect(professionVersionsService.save).toHaveBeenCalledWith(
-            expect.objectContaining({
-              id: 'version-id',
-              organisation: organisation,
-              mandatoryRegistration: MandatoryRegistration.Voluntary,
-              profession: profession,
-            }),
           );
 
           expect(response.redirect).toHaveBeenCalledWith(

--- a/src/professions/admin/regulatory-body.controller.ts
+++ b/src/professions/admin/regulatory-body.controller.ts
@@ -30,6 +30,7 @@ import {
   MandatoryRegistration,
   ProfessionVersion,
 } from '../profession-version.entity';
+import { Profession } from '../profession.entity';
 @UseGuards(AuthenticationGuard)
 @Controller('admin/professions')
 export class RegulatoryBodyController {
@@ -65,7 +66,7 @@ export class RegulatoryBodyController {
 
     return this.renderForm(
       res,
-      version.organisation,
+      profession.organisation,
       selectedMandatoryRegistration,
       profession.slug !== null,
       change,
@@ -118,14 +119,19 @@ export class RegulatoryBodyController {
       );
     }
 
+    const updatedProfession: Profession = {
+      ...profession,
+      organisation: selectedOrganisation,
+    };
+
     const updatedVersion: ProfessionVersion = {
       ...version,
       ...{
-        organisation: selectedOrganisation,
         mandatoryRegistration: selectedMandatoryRegistration,
       },
     };
 
+    await this.professionsService.save(updatedProfession);
     await this.professionVersionsService.save(updatedVersion);
 
     if (regulatoryBodyDto.change) {

--- a/src/professions/profession-version.entity.ts
+++ b/src/professions/profession-version.entity.ts
@@ -13,7 +13,6 @@ import {
 } from 'typeorm';
 import { Industry } from '../industries/industry.entity';
 import { Legislation } from '../legislations/legislation.entity';
-import { Organisation } from '../organisations/organisation.entity';
 import { Qualification } from '../qualifications/qualification.entity';
 import { User } from '../users/user.entity';
 import { Profession } from './profession.entity';
@@ -84,11 +83,6 @@ export class ProfessionVersion {
     { eager: true, cascade: true },
   )
   legislations: Legislation[];
-
-  @ManyToOne(() => Organisation, (organisation) => organisation.professions, {
-    eager: true,
-  })
-  organisation: Organisation;
 
   @CreateDateColumn({
     type: 'timestamp',

--- a/src/professions/profession-versions.service.spec.ts
+++ b/src/professions/profession-versions.service.spec.ts
@@ -256,7 +256,7 @@ describe('ProfessionVersionsService', () => {
       expect(queryBuilder).toHaveJoined([
         'professionVersion.profession',
         'professionVersion.industries',
-        'professionVersion.organisation',
+        'profession.organisation',
         'professionVersion.qualification',
         'professionVersion.legislations',
       ]);
@@ -299,7 +299,7 @@ describe('ProfessionVersionsService', () => {
 
       expect(queryBuilder).toHaveJoined([
         'professionVersion.profession',
-        'professionVersion.organisation',
+        'profession.organisation',
         'professionVersion.industries',
         'professionVersion.qualification',
         'professionVersion.legislations',
@@ -343,7 +343,7 @@ describe('ProfessionVersionsService', () => {
       expect(queryBuilder).toHaveJoined([
         'professionVersion.profession',
         'professionVersion.industries',
-        'professionVersion.organisation',
+        'profession.organisation',
         'professionVersion.qualification',
         'professionVersion.legislations',
       ]);
@@ -386,7 +386,7 @@ describe('ProfessionVersionsService', () => {
       expect(queryBuilder).toHaveJoined([
         'professionVersion.profession',
         'professionVersion.industries',
-        'professionVersion.organisation',
+        'profession.organisation',
         'professionVersion.qualification',
         'professionVersion.legislations',
       ]);

--- a/src/professions/profession-versions.service.ts
+++ b/src/professions/profession-versions.service.ts
@@ -137,7 +137,7 @@ export class ProfessionVersionsService {
     return this.repository
       .createQueryBuilder('professionVersion')
       .leftJoinAndSelect('professionVersion.profession', 'profession')
-      .leftJoinAndSelect('professionVersion.organisation', 'organisation')
+      .leftJoinAndSelect('profession.organisation', 'organisation')
       .leftJoinAndSelect('professionVersion.industries', 'industries')
       .leftJoinAndSelect('professionVersion.qualification', 'qualification')
       .leftJoinAndSelect('professionVersion.legislations', 'legislations');

--- a/src/professions/profession.entity.spec.ts
+++ b/src/professions/profession.entity.spec.ts
@@ -24,7 +24,6 @@ describe('Profession', () => {
         qualification: professionVersion.qualification,
         reservedActivities: professionVersion.reservedActivities,
         legislations: professionVersion.legislations,
-        organisation: professionVersion.organisation,
         status: professionVersion.status,
         versionId: professionVersion.id,
       });

--- a/src/professions/profession.entity.ts
+++ b/src/professions/profession.entity.ts
@@ -196,7 +196,6 @@ export class Profession {
       qualification: version.qualification,
       reservedActivities: version.reservedActivities,
       legislations: version.legislations,
-      organisation: version.organisation,
       status: version.status,
       versionId: version.id,
     };

--- a/src/professions/professions.seeder.ts
+++ b/src/professions/professions.seeder.ts
@@ -170,10 +170,6 @@ export class ProfessionsSeeder implements Seeder {
               );
             }
 
-            const organisation = await this.organisationRepository.findOne({
-              where: { name: version.organisation },
-            });
-
             const newVersion = {
               alternateName: version.alternateName,
               description: version.description,
@@ -185,7 +181,6 @@ export class ProfessionsSeeder implements Seeder {
               industries: industries,
               legislations: legislations,
               qualification: qualification,
-              organisation: organisation,
               status: version.status as ProfessionVersionStatus,
               profession: profession,
             } as ProfessionVersion;

--- a/src/testutils/factories/profession-version.ts
+++ b/src/testutils/factories/profession-version.ts
@@ -6,7 +6,6 @@ import {
 } from '../../professions/profession-version.entity';
 import industryFactory from './industry';
 import legislationFactory from './legislation';
-import organisationFactory from './organisation';
 import professionFactory from './profession';
 import qualificationFactory from './qualification';
 import userFactory from './user';
@@ -23,7 +22,6 @@ class ProfessionVersionFactory extends Factory<ProfessionVersion> {
       industries: undefined,
       qualification: undefined,
       legislations: undefined,
-      organisation: undefined,
       reservedActivities: undefined,
       profession: undefined,
       user: undefined,
@@ -46,7 +44,6 @@ export default ProfessionVersionFactory.define(({ sequence }) => ({
   qualifications: [],
   qualification: qualificationFactory.build(),
   legislations: legislationFactory.buildList(1),
-  organisation: organisationFactory.build(),
   reservedActivities: 'Stuff',
   profession: professionFactory.build(),
   user: userFactory.build(),


### PR DESCRIPTION
# Changes in this PR

Stores the Organisation on the top level profession, rather than versioning it.

This means that updating the Regulatory Body on a Profession in the edit
journey will update the profession immediately, and won't go through the
publishing step. This is a known risk, which we will mitigate with
permissions, and/or not allowing users to edit the Organisation at all.

A workaround for this is to add a new profession and copy the existing
values on the new Profession when creating it, so it shouldn't be a huge
issue.

Editing an organisation on a profession is something that will happen
very rarely, and non-"national admin" users shouldn't be allowed to do
this anyway.

The main driver behind this decision was the complex relationship
between ProfessionVersions, Organisations and Professions, that didn't
really make logical sense, but it brought the issues around permissions
here to light.
