### PR TITLE
(2103) Simplify nation selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Only service admistrators may create professions
 - Setting an organisation on a profession updates immediately, rather than saving as draft
 - Remove redundant fields from Profession, now the values are stored on a Version
+- Simplify nation selection
 
 ## [release-002] - 2022-02-01
 

--- a/cypress/integration/admin/professions/add-a-profession.spec.ts
+++ b/cypress/integration/admin/professions/add-a-profession.spec.ts
@@ -33,7 +33,10 @@ describe('Adding a new profession', () => {
         cy.get('button').contains(buttonText).click();
       });
 
-      cy.checkAccessibility();
+      // Conditional radio buttons add an additional `aria-expanded` field,
+      // so ignore that rule on this page
+      cy.checkAccessibility({ 'aria-allowed-attr': { enabled: false } });
+
       cy.translate('professions.form.headings.topLevelInformation').then(
         (heading) => {
           cy.get('body').should('contain', heading);
@@ -43,7 +46,14 @@ describe('Adding a new profession', () => {
         cy.get('body').contains(addCaption);
       });
       cy.get('input[name="name"]').type('Example Profession');
-      cy.get('[type="checkbox"]').check('GB-ENG');
+
+      cy.translate(
+        'professions.form.label.topLevelInformation.certainNations',
+      ).then((certainNations) => {
+        cy.get('label').contains(certainNations).click();
+        cy.get('[type="checkbox"]').check('GB-ENG');
+      });
+
       cy.translate('industries.constructionAndEngineering').then(
         (constructionAndEngineering) => {
           cy.contains(constructionAndEngineering).click();

--- a/cypress/integration/admin/professions/edit-a-profession.spec.ts
+++ b/cypress/integration/admin/professions/edit-a-profession.spec.ts
@@ -94,7 +94,11 @@ describe('Editing an existing profession', () => {
         'professions.form.label.topLevelInformation.name',
         'Change',
       );
-      cy.checkAccessibility();
+
+      // Conditional radio buttons add an additional `aria-expanded` field,
+      // so ignore that rule on this page
+      cy.checkAccessibility({ 'aria-allowed-attr': { enabled: false } });
+
       cy.translate('professions.form.captions.edit').then((editCaption) => {
         cy.get('body').contains(editCaption);
       });

--- a/cypress/integration/admin/professions/edit-a-profession.spec.ts
+++ b/cypress/integration/admin/professions/edit-a-profession.spec.ts
@@ -207,5 +207,70 @@ describe('Editing an existing profession', () => {
         },
       );
     });
+
+    it('Selecting UK sets the nations to all UK nations', () => {
+      cy.visitAndCheckAccessibility('/admin/professions');
+
+      cy.get('table')
+        .contains('tr', 'Gas Safe Engineer')
+        .within(() => {
+          cy.contains('View details').click();
+        });
+
+      cy.checkAccessibility();
+      cy.translate('professions.admin.editProfession').then((buttonText) => {
+        cy.contains(buttonText).click();
+      });
+
+      cy.checkAccessibility();
+      cy.translate('professions.form.captions.edit').then((editCaption) => {
+        cy.get('body').contains(editCaption);
+      });
+
+      cy.translate('professions.form.button.edit').then((buttonText) => {
+        cy.get('button').contains(buttonText).click();
+      });
+
+      cy.clickSummaryListRowAction(
+        'professions.form.label.topLevelInformation.name',
+        'Change',
+      );
+
+      cy.translate('app.unitedKingdom').then((uk) => {
+        cy.get('label').contains(uk).click();
+      });
+
+      cy.translate('app.continue').then((buttonText) => {
+        cy.get('button').contains(buttonText).click();
+      });
+
+      cy.translate('nations.england').then((england) => {
+        cy.checkSummaryListRowValue(
+          'professions.form.label.topLevelInformation.nations',
+          england,
+        );
+      });
+
+      cy.translate('nations.wales').then((wales) => {
+        cy.checkSummaryListRowValue(
+          'professions.form.label.topLevelInformation.nations',
+          wales,
+        );
+      });
+
+      cy.translate('nations.northernIreland').then((northernIreland) => {
+        cy.checkSummaryListRowValue(
+          'professions.form.label.topLevelInformation.nations',
+          northernIreland,
+        );
+      });
+
+      cy.translate('nations.scotland').then((scotland) => {
+        cy.checkSummaryListRowValue(
+          'professions.form.label.topLevelInformation.nations',
+          scotland,
+        );
+      });
+    });
   });
 });

--- a/src/common/interfaces/checkbox-args.interface.ts
+++ b/src/common/interfaces/checkbox-args.interface.ts
@@ -1,0 +1,10 @@
+import { CheckboxItems } from './checkbox-items.interface';
+
+export interface CheckboxArgs {
+  idPrefix: string;
+  name: string;
+  hint: {
+    text: string;
+  };
+  items: CheckboxItems[];
+}

--- a/src/common/interfaces/checkbox-items.interface.ts
+++ b/src/common/interfaces/checkbox-items.interface.ts
@@ -1,4 +1,4 @@
-export interface CheckboxArgs {
+export interface CheckboxItems {
   text: string;
   value: string;
   checked: boolean;

--- a/src/i18n/en/professions.json
+++ b/src/i18n/en/professions.json
@@ -22,6 +22,7 @@
       "topLevelInformation": {
         "name": "Name of regulated profession",
         "nations": "In which nation(s) is this profession regulated?",
+        "certainNations": "Certain Nations",
         "industry": "Industry / sector"
       },
       "regulatoryBody": {

--- a/src/industries/industries-checkbox.presenter.spec.ts
+++ b/src/industries/industries-checkbox.presenter.spec.ts
@@ -38,7 +38,7 @@ describe('IndustriesCheckboxPresenter', () => {
     });
   });
 
-  describe('checkboxArgs', () => {
+  describe('checkboxItems', () => {
     it('should return unchecked checkbox arguments when called with an empty list of checked Indutries', () => {
       const presenter = new IndustriesCheckboxPresenter(
         exampleIndustries,
@@ -46,7 +46,7 @@ describe('IndustriesCheckboxPresenter', () => {
         i18nService,
       );
 
-      expect(presenter.checkboxArgs()).resolves.toEqual([
+      expect(presenter.checkboxItems()).resolves.toEqual([
         {
           text: 'Example Industry 1',
           value: 'example-industry-1',
@@ -72,7 +72,7 @@ describe('IndustriesCheckboxPresenter', () => {
         i18nService,
       );
 
-      expect(presenter.checkboxArgs()).resolves.toEqual([
+      expect(presenter.checkboxItems()).resolves.toEqual([
         {
           text: 'Example Industry 1',
           value: 'example-industry-1',

--- a/src/industries/industries-checkbox.presenter.ts
+++ b/src/industries/industries-checkbox.presenter.ts
@@ -1,5 +1,5 @@
 import { I18nService } from 'nestjs-i18n';
-import { CheckboxArgs } from '../common/interfaces/checkbox-args.interface';
+import { CheckboxItems } from '../common/interfaces/checkbox-items.interface';
 import { Industry } from './industry.entity';
 
 export class IndustriesCheckboxPresenter {
@@ -8,7 +8,7 @@ export class IndustriesCheckboxPresenter {
     private readonly checkedIndustries: Industry[],
     private readonly i18nService: I18nService,
   ) {}
-  async checkboxArgs(): Promise<CheckboxArgs[]> {
+  async checkboxItems(): Promise<CheckboxItems[]> {
     return Promise.all(
       this.allIndustries.map(async (industry) => ({
         text: await this.i18nService.translate(industry.name),

--- a/src/nations/nations-checkbox.presenter.spec.ts
+++ b/src/nations/nations-checkbox.presenter.spec.ts
@@ -1,27 +1,19 @@
-import { createMock, DeepMocked } from '@golevelup/ts-jest';
+import { DeepMocked } from '@golevelup/ts-jest';
 import { I18nService } from 'nestjs-i18n';
 import { Nation } from './nation';
 import { NationsCheckboxPresenter } from './nations-checkbox.presenter';
+import { createMockI18nService } from '../testutils/create-mock-i18n-service';
+import { translationOf } from '../testutils/translation-of';
 
 describe('NationsCheckboxPresenter', () => {
   let i18nService: DeepMocked<I18nService>;
 
   beforeEach(async () => {
-    i18nService = createMock<I18nService>();
-
-    i18nService.translate.mockImplementation(async (text) => {
-      switch (text) {
-        case 'nations.england':
-          return 'England';
-        case 'nations.scotland':
-          return 'Scotland';
-        case 'nations.wales':
-          return 'Wales';
-        case 'nations.northernIreland':
-          return 'Northern Ireland';
-        default:
-          return '';
-      }
+    i18nService = createMockI18nService({
+      'nations.england': 'England',
+      'nations.scotland': 'Scotland',
+      'nations.wales': 'Wales',
+      'nations.northernIreland': 'Northern Ireland',
     });
   });
 
@@ -87,6 +79,46 @@ describe('NationsCheckboxPresenter', () => {
           checked: false,
         },
       ]);
+    });
+  });
+
+  describe('checkboxArgs', () => {
+    it('should return arguments for a group of checkboxes', async () => {
+      const presenter = new NationsCheckboxPresenter(
+        Nation.all(),
+        [],
+        i18nService,
+      );
+
+      expect(await presenter.checkboxArgs('foo', 'foo[]', 'abc.123')).toEqual({
+        name: 'foo[]',
+        hint: {
+          text: translationOf('abc.123'),
+        },
+        idPrefix: 'foo',
+        items: [
+          {
+            text: 'England',
+            value: 'GB-ENG',
+            checked: false,
+          },
+          {
+            text: 'Scotland',
+            value: 'GB-SCT',
+            checked: false,
+          },
+          {
+            text: 'Wales',
+            value: 'GB-WLS',
+            checked: false,
+          },
+          {
+            text: 'Northern Ireland',
+            value: 'GB-NIR',
+            checked: false,
+          },
+        ],
+      });
     });
   });
 });

--- a/src/nations/nations-checkbox.presenter.spec.ts
+++ b/src/nations/nations-checkbox.presenter.spec.ts
@@ -25,7 +25,7 @@ describe('NationsCheckboxPresenter', () => {
     });
   });
 
-  describe('checkboxArgs', () => {
+  describe('checkboxItems', () => {
     it('should return unchecked checkbox arguments when called with an empty list of Nations', async () => {
       const presenter = new NationsCheckboxPresenter(
         Nation.all(),
@@ -33,7 +33,7 @@ describe('NationsCheckboxPresenter', () => {
         i18nService,
       );
 
-      expect(presenter.checkboxArgs()).resolves.toEqual([
+      expect(presenter.checkboxItems()).resolves.toEqual([
         {
           text: 'England',
           value: 'GB-ENG',
@@ -65,7 +65,7 @@ describe('NationsCheckboxPresenter', () => {
         i18nService,
       );
 
-      expect(presenter.checkboxArgs()).resolves.toEqual([
+      expect(presenter.checkboxItems()).resolves.toEqual([
         {
           text: 'England',
           value: 'GB-ENG',

--- a/src/nations/nations-checkbox.presenter.ts
+++ b/src/nations/nations-checkbox.presenter.ts
@@ -1,5 +1,5 @@
 import { I18nService } from 'nestjs-i18n';
-import { CheckboxArgs } from '../common/interfaces/checkbox-args.interface';
+import { CheckboxItems } from '../common/interfaces/checkbox-items.interface';
 import { Nation } from './nation';
 
 export class NationsCheckboxPresenter {
@@ -9,7 +9,7 @@ export class NationsCheckboxPresenter {
     private readonly i18nService: I18nService,
   ) {}
 
-  async checkboxArgs(): Promise<CheckboxArgs[]> {
+  async checkboxItems(): Promise<CheckboxItems[]> {
     return Promise.all(
       this.allNations.map(async (nation) => ({
         text: await nation.translatedName(this.i18nService),

--- a/src/nations/nations-checkbox.presenter.ts
+++ b/src/nations/nations-checkbox.presenter.ts
@@ -1,5 +1,7 @@
 import { I18nService } from 'nestjs-i18n';
 import { CheckboxItems } from '../common/interfaces/checkbox-items.interface';
+import { CheckboxArgs } from '../common/interfaces/checkbox-args.interface';
+
 import { Nation } from './nation';
 
 export class NationsCheckboxPresenter {
@@ -19,5 +21,20 @@ export class NationsCheckboxPresenter {
         ),
       })),
     );
+  }
+
+  async checkboxArgs(
+    idPrefix: string,
+    name: string,
+    hintTranslation: string,
+  ): Promise<CheckboxArgs> {
+    return {
+      idPrefix: idPrefix,
+      name: name,
+      hint: {
+        text: await this.i18nService.translate(hintTranslation),
+      },
+      items: await this.checkboxItems(),
+    };
   }
 }

--- a/src/organisations/admin/interfaces/index-template.interface.ts
+++ b/src/organisations/admin/interfaces/index-template.interface.ts
@@ -1,4 +1,4 @@
-import { CheckboxArgs } from '../../../common/interfaces/checkbox-args.interface';
+import { CheckboxItems } from '../../../common/interfaces/checkbox-items.interface';
 import { Table } from '../../../common/interfaces/table';
 
 export interface IndexTemplate {
@@ -9,5 +9,5 @@ export interface IndexTemplate {
     industries: string[];
   };
 
-  industriesCheckboxArgs: CheckboxArgs[];
+  industriesCheckboxItems: CheckboxItems[];
 }

--- a/src/organisations/admin/organisations.controller.spec.ts
+++ b/src/organisations/admin/organisations.controller.spec.ts
@@ -94,7 +94,7 @@ describe('OrganisationsController', () => {
             keywords: '',
             industries: [],
           },
-          industriesCheckboxArgs: [],
+          industriesCheckboxItems: [],
         };
 
         const organisations = createOrganisations();
@@ -146,7 +146,7 @@ describe('OrganisationsController', () => {
             keywords: '',
             industries: [],
           },
-          industriesCheckboxArgs: [],
+          industriesCheckboxItems: [],
         };
 
         const organisations = createOrganisations();

--- a/src/organisations/admin/presenters/organisations.presenter.spec.ts
+++ b/src/organisations/admin/presenters/organisations.presenter.spec.ts
@@ -8,7 +8,7 @@ import { IndustriesCheckboxPresenter } from '../../../industries/industries-chec
 import { OrganisationPresenter } from '../../presenters/organisation.presenter';
 
 const mockTableRow = jest.fn();
-const mockCheckboxArgs = jest.fn();
+const mockCheckboxItems = jest.fn();
 
 jest.mock('../../presenters/organisation.presenter', () => {
   return {
@@ -24,7 +24,7 @@ jest.mock('../../../industries/industries-checkbox.presenter', () => {
   return {
     IndustriesCheckboxPresenter: jest.fn().mockImplementation(() => {
       return {
-        checkboxArgs: mockCheckboxArgs,
+        checkboxItems: mockCheckboxItems,
       };
     }),
   };
@@ -40,7 +40,7 @@ describe('OrganisationsPresenter', () => {
           },
         ]);
 
-        mockCheckboxArgs.mockReturnValue([
+        mockCheckboxItems.mockReturnValue([
           {
             text: 'Some text',
             value: 'Some value',
@@ -93,12 +93,12 @@ describe('OrganisationsPresenter', () => {
           mockTableRow(),
         ]);
 
-        expect(result.industriesCheckboxArgs).toEqual(mockCheckboxArgs());
+        expect(result.industriesCheckboxItems).toEqual(mockCheckboxItems());
       });
 
       it('returns empty filter data', async () => {
         mockTableRow.mockReturnValue([]);
-        mockCheckboxArgs.mockReturnValue([]);
+        mockCheckboxItems.mockReturnValue([]);
 
         const i18nService = createMockI18nService();
 
@@ -132,7 +132,7 @@ describe('OrganisationsPresenter', () => {
     describe('when called with populated `FilterInput`', () => {
       it('returns populated filter data', async () => {
         mockTableRow.mockReturnValue([]);
-        mockCheckboxArgs.mockReturnValue([]);
+        mockCheckboxItems.mockReturnValue([]);
 
         const i18nService = createMockI18nService();
 

--- a/src/organisations/admin/presenters/organisations.presenter.ts
+++ b/src/organisations/admin/presenters/organisations.presenter.ts
@@ -26,14 +26,14 @@ export class OrganisationsPresenter {
   ) {}
 
   async present(): Promise<IndexTemplate> {
-    const industriesCheckboxArgs = await new IndustriesCheckboxPresenter(
+    const industriesCheckboxItems = await new IndustriesCheckboxPresenter(
       this.allIndustries,
       this.filterInput.industries || [],
       this.i18nService,
-    ).checkboxArgs();
+    ).checkboxItems();
 
     return {
-      industriesCheckboxArgs,
+      industriesCheckboxItems,
       organisationsTable: await this.table(),
       filters: {
         keywords: this.filterInput.keywords || '',

--- a/src/organisations/organisations-checkbox-presenter.spec.ts
+++ b/src/organisations/organisations-checkbox-presenter.spec.ts
@@ -17,11 +17,11 @@ const organisation3 = organisationFactory.build({
 const organisations = [organisation1, organisation2, organisation3];
 
 describe('OrganisationsCheckboxPresenter', () => {
-  describe('checkboxArgs', () => {
+  describe('checkboxItems', () => {
     it('should return unchecked checkbox arguments when called with an empty list of Organisations', () => {
       const presenter = new OrganisationsCheckboxPresenter(organisations, []);
 
-      expect(presenter.checkboxArgs()).toEqual([
+      expect(presenter.checkboxItems()).toEqual([
         {
           text: 'Example Organisation 1',
           value: 'example-organisation-1',
@@ -46,7 +46,7 @@ describe('OrganisationsCheckboxPresenter', () => {
         organisation1,
       ]);
 
-      expect(presenter.checkboxArgs()).toEqual([
+      expect(presenter.checkboxItems()).toEqual([
         {
           text: 'Example Organisation 1',
           value: 'example-organisation-1',

--- a/src/organisations/organisations-checkbox-presenter.ts
+++ b/src/organisations/organisations-checkbox-presenter.ts
@@ -1,4 +1,4 @@
-import { CheckboxArgs } from '../common/interfaces/checkbox-args.interface';
+import { CheckboxItems } from '../common/interfaces/checkbox-items.interface';
 import { Organisation } from './organisation.entity';
 
 export class OrganisationsCheckboxPresenter {
@@ -7,7 +7,7 @@ export class OrganisationsCheckboxPresenter {
     private readonly checkedOrganisations: Organisation[],
   ) {}
 
-  checkboxArgs(): CheckboxArgs[] {
+  checkboxItems(): CheckboxItems[] {
     return this.allOrganisations.map((organisation) => ({
       text: organisation.name,
       value: organisation.id,

--- a/src/organisations/search/interfaces/index-template.interface.ts
+++ b/src/organisations/search/interfaces/index-template.interface.ts
@@ -1,4 +1,4 @@
-import { CheckboxArgs } from 'src/common/interfaces/checkbox-args.interface';
+import { CheckboxItems } from 'src/common/interfaces/checkbox-items.interface';
 import { OrganisationSearchResultTemplate } from './organisation-search-result-template.interface';
 
 export interface IndexTemplate {
@@ -10,7 +10,7 @@ export interface IndexTemplate {
     keywords: string;
   };
 
-  nationsCheckboxArgs: CheckboxArgs[];
+  nationsCheckboxItems: CheckboxItems[];
 
-  industriesCheckboxArgs: CheckboxArgs[];
+  industriesCheckboxItems: CheckboxItems[];
 }

--- a/src/organisations/search/search.presenter.spec.ts
+++ b/src/organisations/search/search.presenter.spec.ts
@@ -64,17 +64,17 @@ describe('SearchPresenter', () => {
 
       const result = await presenter.present();
 
-      const industriesCheckboxArgs = await new IndustriesCheckboxPresenter(
+      const industriesCheckboxItems = await new IndustriesCheckboxPresenter(
         industries,
         [industry2],
         i18nService,
-      ).checkboxArgs();
+      ).checkboxItems();
 
-      const nationsCheckboxArgs = await new NationsCheckboxPresenter(
+      const nationsCheckboxItems = await new NationsCheckboxPresenter(
         Nation.all(),
         [Nation.find('GB-ENG')],
         i18nService,
-      ).checkboxArgs();
+      ).checkboxItems();
 
       const expected: IndexTemplate = {
         filters: {
@@ -82,8 +82,8 @@ describe('SearchPresenter', () => {
           keywords: 'Example Keywords',
           nations: ['nations.england'],
         },
-        industriesCheckboxArgs,
-        nationsCheckboxArgs,
+        industriesCheckboxItems,
+        nationsCheckboxItems,
         organisations: [
           await new OrganisationSearchResultPresenter(organisation1).present(),
           await new OrganisationSearchResultPresenter(organisation2).present(),

--- a/src/organisations/search/search.presenter.ts
+++ b/src/organisations/search/search.presenter.ts
@@ -18,17 +18,17 @@ export class SearchPresenter {
   ) {}
 
   async present(): Promise<IndexTemplate> {
-    const nationsCheckboxArgs = await new NationsCheckboxPresenter(
+    const nationsCheckboxItems = await new NationsCheckboxPresenter(
       this.allNations,
       this.filterInput.nations,
       this.i18nService,
-    ).checkboxArgs();
+    ).checkboxItems();
 
-    const industriesCheckboxArgs = await new IndustriesCheckboxPresenter(
+    const industriesCheckboxItems = await new IndustriesCheckboxPresenter(
       this.allIndustries,
       this.filterInput.industries,
       this.i18nService,
-    ).checkboxArgs();
+    ).checkboxItems();
 
     const displayOrganisations = await Promise.all(
       this.filteredOrganisations.map(async (organisation) =>
@@ -38,8 +38,8 @@ export class SearchPresenter {
 
     return {
       organisations: displayOrganisations,
-      nationsCheckboxArgs,
-      industriesCheckboxArgs,
+      nationsCheckboxItems,
+      industriesCheckboxItems,
       filters: {
         keywords: this.filterInput.keywords,
         nations: this.filterInput.nations.map((nation) => nation.name),

--- a/src/professions/admin/dto/top-level-details.dto.ts
+++ b/src/professions/admin/dto/top-level-details.dto.ts
@@ -1,10 +1,14 @@
-import { IsNotEmpty } from 'class-validator';
+import { IsNotEmpty, ValidateIf, IsIn } from 'class-validator';
 
 export class TopLevelDetailsDto {
   @IsNotEmpty({ message: 'professions.form.errors.name.empty' })
   name: string;
 
+  @IsIn(['1', '0'], { message: 'professions.form.errors.nations.empty' })
+  coversUK: string;
+
   @IsNotEmpty({ message: 'professions.form.errors.nations.empty' })
+  @ValidateIf((e) => e.coversUK === '0')
   nations: string[];
 
   @IsNotEmpty({ message: 'professions.form.errors.industries.empty' })

--- a/src/professions/admin/interfaces/index-template.interface.ts
+++ b/src/professions/admin/interfaces/index-template.interface.ts
@@ -1,4 +1,4 @@
-import { CheckboxArgs } from 'src/common/interfaces/checkbox-args.interface';
+import { CheckboxItems } from 'src/common/interfaces/checkbox-items.interface';
 import { TableRow } from 'src/common/interfaces/table-row';
 import { ProfessionsPresenterView } from '../professions.presenter';
 
@@ -18,8 +18,8 @@ export interface IndexTemplate {
     changedBy: string[];
   };
 
-  nationsCheckboxArgs: CheckboxArgs[];
-  organisationsCheckboxArgs: CheckboxArgs[];
-  industriesCheckboxArgs: CheckboxArgs[];
-  changedByCheckboxArgs: CheckboxArgs[];
+  nationsCheckboxItems: CheckboxItems[];
+  organisationsCheckboxItems: CheckboxItems[];
+  industriesCheckboxItems: CheckboxItems[];
+  changedByCheckboxItems: CheckboxItems[];
 }

--- a/src/professions/admin/interfaces/top-level-details.template.ts
+++ b/src/professions/admin/interfaces/top-level-details.template.ts
@@ -3,6 +3,7 @@ import { CheckboxArgs } from '../../../common/interfaces/checkbox-args.interface
 
 export interface TopLevelDetailsTemplate {
   name: string | null;
+  coversUK: string | null;
   industriesCheckboxItems: CheckboxItems[];
   nationsCheckboxArgs: CheckboxArgs;
   captionText: string;

--- a/src/professions/admin/interfaces/top-level-details.template.ts
+++ b/src/professions/admin/interfaces/top-level-details.template.ts
@@ -3,7 +3,7 @@ import { CheckboxArgs } from '../../../common/interfaces/checkbox-args.interface
 
 export interface TopLevelDetailsTemplate {
   name: string | null;
-  coversUK: string | null;
+  coversUK: boolean | null;
   industriesCheckboxItems: CheckboxItems[];
   nationsCheckboxArgs: CheckboxArgs;
   captionText: string;

--- a/src/professions/admin/interfaces/top-level-details.template.ts
+++ b/src/professions/admin/interfaces/top-level-details.template.ts
@@ -1,9 +1,9 @@
-import { CheckboxArgs } from '../../../common/interfaces/checkbox-args.interface';
+import { CheckboxItems } from '../../../common/interfaces/checkbox-items.interface';
 
 export interface TopLevelDetailsTemplate {
   name: string | null;
-  industriesCheckboxArgs: CheckboxArgs[];
-  nationsCheckboxArgs: CheckboxArgs[];
+  industriesCheckboxItems: CheckboxItems[];
+  nationsCheckboxItems: CheckboxItems[];
   captionText: string;
   change: boolean;
   errors: object | undefined;

--- a/src/professions/admin/interfaces/top-level-details.template.ts
+++ b/src/professions/admin/interfaces/top-level-details.template.ts
@@ -1,9 +1,10 @@
 import { CheckboxItems } from '../../../common/interfaces/checkbox-items.interface';
+import { CheckboxArgs } from '../../../common/interfaces/checkbox-args.interface';
 
 export interface TopLevelDetailsTemplate {
   name: string | null;
   industriesCheckboxItems: CheckboxItems[];
-  nationsCheckboxItems: CheckboxItems[];
+  nationsCheckboxArgs: CheckboxArgs;
   captionText: string;
   change: boolean;
   errors: object | undefined;

--- a/src/professions/admin/professions.presenter.spec.ts
+++ b/src/professions/admin/professions.presenter.spec.ts
@@ -111,21 +111,21 @@ describe('ProfessionsPresenter', () => {
           changedBy: [],
         },
 
-        nationsCheckboxArgs: await new NationsCheckboxPresenter(
+        nationsCheckboxItems: await new NationsCheckboxPresenter(
           nations,
           [Nation.find('GB-ENG')],
           i18nService,
-        ).checkboxArgs(),
-        organisationsCheckboxArgs: await new OrganisationsCheckboxPresenter(
+        ).checkboxItems(),
+        organisationsCheckboxItems: await new OrganisationsCheckboxPresenter(
           organisations,
           [organisation1],
-        ).checkboxArgs(),
-        industriesCheckboxArgs: await new IndustriesCheckboxPresenter(
+        ).checkboxItems(),
+        industriesCheckboxItems: await new IndustriesCheckboxPresenter(
           industries,
           [transportIndustry],
           i18nService,
-        ).checkboxArgs(),
-        changedByCheckboxArgs: [],
+        ).checkboxItems(),
+        changedByCheckboxItems: [],
       };
 
       expect(result).toEqual(expected);
@@ -160,21 +160,21 @@ describe('ProfessionsPresenter', () => {
           changedBy: [],
         },
 
-        nationsCheckboxArgs: await new NationsCheckboxPresenter(
+        nationsCheckboxItems: await new NationsCheckboxPresenter(
           nations,
           [Nation.find('GB-ENG')],
           i18nService,
-        ).checkboxArgs(),
-        organisationsCheckboxArgs: await new OrganisationsCheckboxPresenter(
+        ).checkboxItems(),
+        organisationsCheckboxItems: await new OrganisationsCheckboxPresenter(
           organisations,
           [organisation1],
-        ).checkboxArgs(),
-        industriesCheckboxArgs: await new IndustriesCheckboxPresenter(
+        ).checkboxItems(),
+        industriesCheckboxItems: await new IndustriesCheckboxPresenter(
           industries,
           [transportIndustry],
           i18nService,
-        ).checkboxArgs(),
-        changedByCheckboxArgs: [],
+        ).checkboxItems(),
+        changedByCheckboxItems: [],
       };
 
       expect(result).toEqual(expected);

--- a/src/professions/admin/professions.presenter.ts
+++ b/src/professions/admin/professions.presenter.ts
@@ -31,22 +31,22 @@ export class ProfessionsPresenter {
 
     const headings = await ListEntryPresenter.headings(this.i18nService, view);
 
-    const nationsCheckboxArgs = await new NationsCheckboxPresenter(
+    const nationsCheckboxItems = await new NationsCheckboxPresenter(
       this.allNations,
       this.filterInput.nations || [],
       this.i18nService,
-    ).checkboxArgs();
+    ).checkboxItems();
 
-    const organisationsCheckboxArgs = await new OrganisationsCheckboxPresenter(
+    const organisationsCheckboxItems = await new OrganisationsCheckboxPresenter(
       this.allOrganisations,
       this.filterInput.organisations || [],
-    ).checkboxArgs();
+    ).checkboxItems();
 
-    const industriesCheckboxArgs = await new IndustriesCheckboxPresenter(
+    const industriesCheckboxItems = await new IndustriesCheckboxPresenter(
       this.allIndustries,
       this.filterInput.industries || [],
       this.i18nService,
-    ).checkboxArgs();
+    ).checkboxItems();
 
     const displayProfessions = await Promise.all(
       this.filteredProfessions.map(async (profession) =>
@@ -59,10 +59,10 @@ export class ProfessionsPresenter {
       organisation,
       headings,
       professions: displayProfessions,
-      nationsCheckboxArgs,
-      organisationsCheckboxArgs,
-      industriesCheckboxArgs,
-      changedByCheckboxArgs: [],
+      nationsCheckboxItems,
+      organisationsCheckboxItems,
+      industriesCheckboxItems,
+      changedByCheckboxItems: [],
       filters: {
         keywords: this.filterInput.keywords || '',
         nations: (this.filterInput.nations || []).map((nation) => nation.name),

--- a/src/professions/admin/top-level-information.controller.spec.ts
+++ b/src/professions/admin/top-level-information.controller.spec.ts
@@ -83,6 +83,7 @@ describe('TopLevelInformationController', () => {
           'admin/professions/top-level-information',
           expect.objectContaining({
             name: undefined,
+            coversUK: null,
             industriesCheckboxItems: [
               {
                 text: translationOf('industries.health'),
@@ -165,6 +166,7 @@ describe('TopLevelInformationController', () => {
           'admin/professions/top-level-information',
           expect.objectContaining({
             name: 'Example Profession',
+            coversUK: null,
             industriesCheckboxItems: [
               {
                 text: translationOf('industries.health'),
@@ -230,6 +232,7 @@ describe('TopLevelInformationController', () => {
 
         const topLevelDetailsDto = {
           name: 'Gas Safe Engineer',
+          coversUK: '0',
           nations: ['GB-ENG'],
           industries: ['construction-uuid'],
         };
@@ -275,6 +278,7 @@ describe('TopLevelInformationController', () => {
         const topLevelDetailsDtoWithNoAnswers = {
           name: '',
           nations: undefined,
+          coversUK: null,
           industries: undefined,
         };
 
@@ -292,7 +296,7 @@ describe('TopLevelInformationController', () => {
               name: {
                 text: 'professions.form.errors.name.empty',
               },
-              nations: {
+              coversUK: {
                 text: 'professions.form.errors.nations.empty',
               },
               industries: {
@@ -327,6 +331,7 @@ describe('TopLevelInformationController', () => {
 
           const topLevelDetailsDtoWithChangeParam = {
             name: 'A new profession',
+            coversUK: '0',
             nations: ['GB-ENG'],
             industries: ['construction-uuid'],
             change: true,
@@ -367,6 +372,7 @@ describe('TopLevelInformationController', () => {
           const topLevelDetailsDtoWithoutChangeParam = {
             name: 'A new profession',
             nations: ['GB-ENG'],
+            coversUK: '0',
             industries: ['construction-uuid'],
           };
 

--- a/src/professions/admin/top-level-information.controller.spec.ts
+++ b/src/professions/admin/top-level-information.controller.spec.ts
@@ -95,28 +95,35 @@ describe('TopLevelInformationController', () => {
                 checked: false,
               },
             ],
-            nationsCheckboxItems: [
-              {
-                text: translationOf('nations.england'),
-                value: 'GB-ENG',
-                checked: false,
+            nationsCheckboxArgs: {
+              idPrefix: 'nations',
+              name: 'nations[]',
+              hint: {
+                text: translationOf('professions.form.checkboxes.hint'),
               },
-              {
-                text: translationOf('nations.scotland'),
-                value: 'GB-SCT',
-                checked: false,
-              },
-              {
-                text: translationOf('nations.wales'),
-                value: 'GB-WLS',
-                checked: false,
-              },
-              {
-                text: translationOf('nations.northernIreland'),
-                value: 'GB-NIR',
-                checked: false,
-              },
-            ],
+              items: [
+                {
+                  text: translationOf('nations.england'),
+                  value: 'GB-ENG',
+                  checked: false,
+                },
+                {
+                  text: translationOf('nations.scotland'),
+                  value: 'GB-SCT',
+                  checked: false,
+                },
+                {
+                  text: translationOf('nations.wales'),
+                  value: 'GB-WLS',
+                  checked: false,
+                },
+                {
+                  text: translationOf('nations.northernIreland'),
+                  value: 'GB-NIR',
+                  checked: false,
+                },
+              ],
+            },
           }),
         );
         expect(industriesService.all).toHaveBeenCalled();
@@ -170,28 +177,35 @@ describe('TopLevelInformationController', () => {
                 checked: false,
               },
             ],
-            nationsCheckboxItems: [
-              {
-                text: translationOf('nations.england'),
-                value: 'GB-ENG',
-                checked: true,
+            nationsCheckboxArgs: {
+              idPrefix: 'nations',
+              name: 'nations[]',
+              hint: {
+                text: translationOf('professions.form.checkboxes.hint'),
               },
-              {
-                text: translationOf('nations.scotland'),
-                value: 'GB-SCT',
-                checked: true,
-              },
-              {
-                text: translationOf('nations.wales'),
-                value: 'GB-WLS',
-                checked: false,
-              },
-              {
-                text: translationOf('nations.northernIreland'),
-                value: 'GB-NIR',
-                checked: false,
-              },
-            ],
+              items: [
+                {
+                  text: translationOf('nations.england'),
+                  value: 'GB-ENG',
+                  checked: true,
+                },
+                {
+                  text: translationOf('nations.scotland'),
+                  value: 'GB-SCT',
+                  checked: true,
+                },
+                {
+                  text: translationOf('nations.wales'),
+                  value: 'GB-WLS',
+                  checked: false,
+                },
+                {
+                  text: translationOf('nations.northernIreland'),
+                  value: 'GB-NIR',
+                  checked: false,
+                },
+              ],
+            },
           }),
         );
         expect(industriesService.all).toHaveBeenCalled();

--- a/src/professions/admin/top-level-information.controller.spec.ts
+++ b/src/professions/admin/top-level-information.controller.spec.ts
@@ -83,7 +83,7 @@ describe('TopLevelInformationController', () => {
           'admin/professions/top-level-information',
           expect.objectContaining({
             name: undefined,
-            industriesCheckboxArgs: [
+            industriesCheckboxItems: [
               {
                 text: translationOf('industries.health'),
                 value: 'health-uuid',
@@ -95,7 +95,7 @@ describe('TopLevelInformationController', () => {
                 checked: false,
               },
             ],
-            nationsCheckboxArgs: [
+            nationsCheckboxItems: [
               {
                 text: translationOf('nations.england'),
                 value: 'GB-ENG',
@@ -158,7 +158,7 @@ describe('TopLevelInformationController', () => {
           'admin/professions/top-level-information',
           expect.objectContaining({
             name: 'Example Profession',
-            industriesCheckboxArgs: [
+            industriesCheckboxItems: [
               {
                 text: translationOf('industries.health'),
                 value: 'health-uuid',
@@ -170,7 +170,7 @@ describe('TopLevelInformationController', () => {
                 checked: false,
               },
             ],
-            nationsCheckboxArgs: [
+            nationsCheckboxItems: [
               {
                 text: translationOf('nations.england'),
                 value: 'GB-ENG',

--- a/src/professions/admin/top-level-information.controller.spec.ts
+++ b/src/professions/admin/top-level-information.controller.spec.ts
@@ -296,6 +296,39 @@ describe('TopLevelInformationController', () => {
           '/admin/professions/profession-id/versions/version-id/regulatory-body/edit',
         );
       });
+
+      it('sets all nations when `coversUK` is set to `1`', async () => {
+        const profession = professionFactory
+          .justCreated('profession-id')
+          .build();
+
+        const version = professionVersionFactory.build({
+          id: 'version-id',
+          profession: profession,
+        });
+
+        professionsService.findWithVersions.mockResolvedValue(profession);
+        professionVersionsService.findWithProfession.mockResolvedValue(version);
+
+        const topLevelDetailsDto = {
+          name: 'Gas Safe Engineer',
+          coversUK: '1',
+          industries: ['construction-uuid'],
+        };
+
+        await controller.update(
+          topLevelDetailsDto,
+          response,
+          'profession-id',
+          'version-id',
+        );
+
+        expect(professionVersionsService.save).toHaveBeenCalledWith(
+          expect.objectContaining({
+            occupationLocations: ['GB-ENG', 'GB-SCT', 'GB-WLS', 'GB-NIR'],
+          }),
+        );
+      });
     });
 
     describe('when required parameters are not entered', () => {

--- a/src/professions/admin/top-level-information.controller.spec.ts
+++ b/src/professions/admin/top-level-information.controller.spec.ts
@@ -166,7 +166,7 @@ describe('TopLevelInformationController', () => {
           'admin/professions/top-level-information',
           expect.objectContaining({
             name: 'Example Profession',
-            coversUK: null,
+            coversUK: false,
             industriesCheckboxItems: [
               {
                 text: translationOf('industries.health'),
@@ -211,6 +211,31 @@ describe('TopLevelInformationController', () => {
           }),
         );
         expect(industriesService.all).toHaveBeenCalled();
+      });
+
+      it('should set coversUK to 1 if the profession covers all of the UK', async () => {
+        const profession = professionFactory.build({
+          name: 'Example Profession',
+        });
+
+        const version = professionVersionFactory.build({
+          id: 'version-id',
+          profession: profession,
+          occupationLocations: ['GB-ENG', 'GB-SCT', 'GB-WLS', 'GB-NIR'],
+          industries: [],
+        });
+
+        professionsService.findWithVersions.mockResolvedValue(profession);
+        professionVersionsService.findWithProfession.mockResolvedValue(version);
+
+        await controller.edit(response, 'profession-id', 'version-id', false);
+
+        expect(response.render).toHaveBeenCalledWith(
+          'admin/professions/top-level-information',
+          expect.objectContaining({
+            coversUK: true,
+          }),
+        );
       });
     });
   });

--- a/src/professions/admin/top-level-information.controller.ts
+++ b/src/professions/admin/top-level-information.controller.ts
@@ -62,10 +62,14 @@ export class TopLevelInformationController {
       versionId,
     );
 
+    const coversUK = version.occupationLocations
+      ? this.isUK(version.occupationLocations)
+      : null;
+
     return this.renderForm(
       res,
       profession.name,
-      null,
+      coversUK,
       version.industries || [],
       version.occupationLocations || [],
       isConfirmed(profession),
@@ -190,5 +194,16 @@ export class TopLevelInformationController {
     };
 
     return res.render('admin/professions/top-level-information', templateArgs);
+  }
+
+  private allNations(): string[] {
+    return Nation.all().map((nation) => nation.code);
+  }
+
+  private isUK(nations: Array<string>) {
+    return (
+      nations.length === this.allNations().length &&
+      nations.every((e, i) => e === this.allNations()[i])
+    );
   }
 }

--- a/src/professions/admin/top-level-information.controller.ts
+++ b/src/professions/admin/top-level-information.controller.ts
@@ -158,22 +158,22 @@ export class TopLevelInformationController {
   ): Promise<void> {
     const industries = await this.industriesService.all();
 
-    const industriesCheckboxArgs = await new IndustriesCheckboxPresenter(
+    const industriesCheckboxItems = await new IndustriesCheckboxPresenter(
       industries,
       selectedIndustries,
       this.i18nService,
-    ).checkboxArgs();
+    ).checkboxItems();
 
-    const nationsCheckboxArgs = await new NationsCheckboxPresenter(
+    const nationsCheckboxItems = await new NationsCheckboxPresenter(
       Nation.all(),
       selectedNations.map((nationCode) => Nation.find(nationCode)),
       this.i18nService,
-    ).checkboxArgs();
+    ).checkboxItems();
 
     const templateArgs: TopLevelDetailsTemplate = {
       name,
-      industriesCheckboxArgs,
-      nationsCheckboxArgs,
+      industriesCheckboxItems,
+      nationsCheckboxItems,
       captionText: ViewUtils.captionText(isEditing),
       change,
       errors,

--- a/src/professions/admin/top-level-information.controller.ts
+++ b/src/professions/admin/top-level-information.controller.ts
@@ -97,6 +97,7 @@ export class TopLevelInformationController {
     );
 
     const submittedValues: TopLevelDetailsDto = topLevelDetailsDto;
+    const coversUK = Boolean(Number(submittedValues.coversUK));
 
     const profession = await this.professionsService.findWithVersions(
       professionId,
@@ -122,6 +123,10 @@ export class TopLevelInformationController {
         submittedValues.change,
         errors,
       );
+    }
+
+    if (coversUK) {
+      submittedValues.nations = this.allNations();
     }
 
     const updatedProfession: Profession = {

--- a/src/professions/admin/top-level-information.controller.ts
+++ b/src/professions/admin/top-level-information.controller.ts
@@ -65,6 +65,7 @@ export class TopLevelInformationController {
     return this.renderForm(
       res,
       profession.name,
+      null,
       version.industries || [],
       version.occupationLocations || [],
       isConfirmed(profession),
@@ -110,6 +111,7 @@ export class TopLevelInformationController {
       return this.renderForm(
         res,
         submittedValues.name,
+        submittedValues.coversUK,
         submittedIndustries,
         submittedValues.nations || [],
         isConfirmed(profession),
@@ -150,6 +152,7 @@ export class TopLevelInformationController {
   private async renderForm(
     res: Response,
     name: string,
+    coversUK: string,
     selectedIndustries: Industry[],
     selectedNations: string[],
     isEditing: boolean,
@@ -178,6 +181,7 @@ export class TopLevelInformationController {
 
     const templateArgs: TopLevelDetailsTemplate = {
       name,
+      coversUK,
       industriesCheckboxItems,
       nationsCheckboxArgs,
       captionText: ViewUtils.captionText(isEditing),

--- a/src/professions/admin/top-level-information.controller.ts
+++ b/src/professions/admin/top-level-information.controller.ts
@@ -111,7 +111,7 @@ export class TopLevelInformationController {
       return this.renderForm(
         res,
         submittedValues.name,
-        submittedValues.coversUK,
+        coversUK,
         submittedIndustries,
         submittedValues.nations || [],
         isConfirmed(profession),
@@ -152,7 +152,7 @@ export class TopLevelInformationController {
   private async renderForm(
     res: Response,
     name: string,
-    coversUK: string,
+    coversUK: boolean,
     selectedIndustries: Industry[],
     selectedNations: string[],
     isEditing: boolean,

--- a/src/professions/admin/top-level-information.controller.ts
+++ b/src/professions/admin/top-level-information.controller.ts
@@ -164,16 +164,22 @@ export class TopLevelInformationController {
       this.i18nService,
     ).checkboxItems();
 
-    const nationsCheckboxItems = await new NationsCheckboxPresenter(
+    const nationsCheckboxPresenter = new NationsCheckboxPresenter(
       Nation.all(),
       selectedNations.map((nationCode) => Nation.find(nationCode)),
       this.i18nService,
-    ).checkboxItems();
+    );
+
+    const nationsCheckboxArgs = await nationsCheckboxPresenter.checkboxArgs(
+      'nations',
+      'nations[]',
+      'professions.form.checkboxes.hint',
+    );
 
     const templateArgs: TopLevelDetailsTemplate = {
       name,
       industriesCheckboxItems,
-      nationsCheckboxItems,
+      nationsCheckboxArgs,
       captionText: ViewUtils.captionText(isEditing),
       change,
       errors,

--- a/src/professions/search/interfaces/index-template.interface.ts
+++ b/src/professions/search/interfaces/index-template.interface.ts
@@ -1,4 +1,4 @@
-import { CheckboxArgs } from 'src/common/interfaces/checkbox-args.interface';
+import { CheckboxItems } from 'src/common/interfaces/checkbox-items.interface';
 import { ProfessionSearchResultTemplate } from './profession-search-result-template.interface';
 
 export interface IndexTemplate {
@@ -10,7 +10,7 @@ export interface IndexTemplate {
     keywords: string;
   };
 
-  nationsCheckboxArgs: CheckboxArgs[];
+  nationsCheckboxItems: CheckboxItems[];
 
-  industriesCheckboxArgs: CheckboxArgs[];
+  industriesCheckboxItems: CheckboxItems[];
 }

--- a/src/professions/search/search.presenter.spec.ts
+++ b/src/professions/search/search.presenter.spec.ts
@@ -70,17 +70,17 @@ describe('SearchPresenter', () => {
 
       const result = await presenter.present();
 
-      const industriesCheckboxArgs = await new IndustriesCheckboxPresenter(
+      const industriesCheckboxItems = await new IndustriesCheckboxPresenter(
         industries,
         [industry2],
         i18nService,
-      ).checkboxArgs();
+      ).checkboxItems();
 
-      const nationsCheckboxArgs = await new NationsCheckboxPresenter(
+      const nationsCheckboxItems = await new NationsCheckboxPresenter(
         Nation.all(),
         [Nation.find('GB-ENG')],
         i18nService,
-      ).checkboxArgs();
+      ).checkboxItems();
 
       const expected: IndexTemplate = {
         filters: {
@@ -88,8 +88,8 @@ describe('SearchPresenter', () => {
           keywords: 'Example Keywords',
           nations: ['nations.england'],
         },
-        industriesCheckboxArgs,
-        nationsCheckboxArgs,
+        industriesCheckboxItems,
+        nationsCheckboxItems,
         professions: [
           await new ProfessionSearchResultPresenter(
             profession1,

--- a/src/professions/search/search.presenter.ts
+++ b/src/professions/search/search.presenter.ts
@@ -18,17 +18,17 @@ export class SearchPresenter {
   ) {}
 
   async present(): Promise<IndexTemplate> {
-    const nationsCheckboxArgs = await new NationsCheckboxPresenter(
+    const nationsCheckboxItems = await new NationsCheckboxPresenter(
       this.allNations,
       this.filterInput.nations,
       this.i18nService,
-    ).checkboxArgs();
+    ).checkboxItems();
 
-    const industriesCheckboxArgs = await new IndustriesCheckboxPresenter(
+    const industriesCheckboxItems = await new IndustriesCheckboxPresenter(
       this.allIndustries,
       this.filterInput.industries,
       this.i18nService,
-    ).checkboxArgs();
+    ).checkboxItems();
 
     const displayProfessions = await Promise.all(
       this.filteredProfessions.map(async (profession) =>
@@ -41,8 +41,8 @@ export class SearchPresenter {
 
     return {
       professions: displayProfessions,
-      nationsCheckboxArgs,
-      industriesCheckboxArgs,
+      nationsCheckboxItems,
+      industriesCheckboxItems,
       filters: {
         keywords: this.filterInput.keywords,
         nations: this.filterInput.nations.map((nation) => nation.name),

--- a/views/admin/professions/index.njk
+++ b/views/admin/professions/index.njk
@@ -32,10 +32,10 @@
       <h2 class="govuk-heading-l">{{ "professions.admin.manageHeading" | t }} </h2>
 
       {% if view === 'overview' %}
-        {% set changedByCheckboxArgs = false %}
+        {% set changedByCheckboxItems = false %}
       {% else %}
-        {% set organisationsCheckboxArgs = false %}
-        {% set industriesCheckboxArgs = false %}
+        {% set organisationsCheckboxItems = false %}
+        {% set industriesCheckboxItems = false %}
       {% endif %}
       {% set filterTextPrefix = "professions.admin" %}
       {% include "../../shared/_horizontal-filter.njk" %}

--- a/views/admin/professions/top-level-information.njk
+++ b/views/admin/professions/top-level-information.njk
@@ -3,6 +3,7 @@
 {% from "govuk/components/select/macro.njk" import govukSelect %}
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
 
 {% set bodyClasses = "rpr-internal__page" %}
 
@@ -33,10 +34,16 @@
         })
       }}
 
+      {% set nationHtml %}
+        {{
+          govukCheckboxes(nationsCheckboxArgs)
+        }}
+      {% endset -%}
+
       {{
-        govukCheckboxes({
-          idPrefix: "nations",
-          name: "nations[]",
+        govukRadios({
+          idPrefix: "coversUK",
+          name: "coversUK",
           fieldset: {
             legend: {
               text: ("professions.form.label.topLevelInformation.nations" | t),
@@ -47,8 +54,21 @@
           hint: {
             text: ("professions.form.checkboxes.hint" | t)
           },
-          items: nationsCheckboxItems,
-          errorMessage: errors.nations | tError
+          items: [
+            {
+              value: "1",
+              text: ("app.unitedKingdom" | t),
+              checked: (coversUK === '1')
+            },
+            {
+              value: "0",
+              text: ("professions.form.label.topLevelInformation.certainNations" | t),
+              checked: (coversUK === '0'),
+              conditional: {
+                html: nationHtml
+              }
+            }
+          ]
         })
       }}
 

--- a/views/admin/professions/top-level-information.njk
+++ b/views/admin/professions/top-level-information.njk
@@ -58,12 +58,12 @@
             {
               value: "1",
               text: ("app.unitedKingdom" | t),
-              checked: (coversUK === '1')
+              checked: (coversUK === true)
             },
             {
               value: "0",
               text: ("professions.form.label.topLevelInformation.certainNations" | t),
-              checked: (coversUK === '0'),
+              checked: (coversUK === false),
               conditional: {
                 html: nationHtml
               }

--- a/views/admin/professions/top-level-information.njk
+++ b/views/admin/professions/top-level-information.njk
@@ -47,7 +47,7 @@
           hint: {
             text: ("professions.form.checkboxes.hint" | t)
           },
-          items: nationsCheckboxArgs,
+          items: nationsCheckboxItems,
           errorMessage: errors.nations | tError
         })
       }}
@@ -66,7 +66,7 @@
           hint: {
             text: ("professions.form.checkboxes.hint" | t)
           },
-          items: industriesCheckboxArgs,
+          items: industriesCheckboxItems,
           errorMessage: errors.industries | tError
         })
       }}

--- a/views/shared/_filter.njk
+++ b/views/shared/_filter.njk
@@ -20,7 +20,7 @@
       }) }}
     </div>
 
-    {% if nationsCheckboxArgs %}
+    {% if nationsCheckboxItems %}
       <div class="{{ filterColumnClass }}">
         {{ govukCheckboxes({
           name: "nations[]",
@@ -34,12 +34,12 @@
           hint: {
             text: (filterTextPrefix + ".filter.nations.hint") | t
           },
-          items: nationsCheckboxArgs
+          items: nationsCheckboxItems
         }) }}
       </div>
     {% endif %}
 
-    {% if organisationsCheckboxArgs %}
+    {% if organisationsCheckboxItems %}
       <div class="{{ filterColumnClass }}">
         {{ govukCheckboxes({
           name: "organisations[]",
@@ -53,12 +53,12 @@
           hint: {
             text: (filterTextPrefix + ".filter.organisations.hint") | t
           },
-          items: organisationsCheckboxArgs
+          items: organisationsCheckboxItems
         }) }}
       </div>
     {% endif %}
-      
-    {% if industriesCheckboxArgs %}
+
+    {% if industriesCheckboxItems %}
       <div class="{{ filterColumnClass }}">
         {{ govukCheckboxes({
           name: "industries[]",
@@ -72,12 +72,12 @@
           hint: {
             text: (filterTextPrefix + ".filter.industries.hint") | t
           },
-          items: industriesCheckboxArgs
+          items: industriesCheckboxItems
         }) }}
       </div>
     {% endif %}
 
-    {% if changedByCheckboxArgs %}
+    {% if changedByCheckboxItems %}
       <div class="{{ filterColumnClass }}">
         {{ govukCheckboxes({
           name: "changedBy[]",
@@ -91,7 +91,7 @@
           hint: {
             text: (filterTextPrefix + ".filter.changedBy.hint") | t
           },
-          items: changedByCheckboxArgs
+          items: changedByCheckboxItems
         }) }}
       </div>
     {% endif %}

--- a/views/shared/_horizontal-filter.njk
+++ b/views/shared/_horizontal-filter.njk
@@ -5,16 +5,16 @@
 {% set filterFormMethod = 'get' %}
 
 {% set filterColumns = 1 %}
-  {% if nationsCheckboxArgs %}
+  {% if nationsCheckboxItems %}
   {% set filterColumns = filterColumns + 1 %}
 {% endif %}
-  {% if organisationsCheckboxArgs %}
+  {% if organisationsCheckboxItems %}
   {% set filterColumns = filterColumns + 1 %}
 {% endif %}
-  {% if industriesCheckboxArgs %}
+  {% if industriesCheckboxItems %}
   {% set filterColumns = filterColumns + 1 %}
 {% endif %}
-  {% if nationsCheckboxArgs %}
+  {% if nationsCheckboxItems %}
   {% set filterColumns = filterColumns + 1 %}
 {% endif %}
 


### PR DESCRIPTION
This updates the nation selection part of the Profession edit journey to allow users to select United Kingdom if a profession is regulated across the UK, or "Certain Nations" if the profession is only regulated in particular nation(s)

# Screenshots

![image](https://user-images.githubusercontent.com/109774/153449172-a0acd8df-4398-4136-add9-f912d9d46645.png)

![image](https://user-images.githubusercontent.com/109774/153449214-911c7ef3-e6fc-48ad-a74e-d9d0d3915bc6.png)
 