### PR TITLE
Fix incorrect role descriptions being shown when creating a non-service owner user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Remove redundant fields from Profession, now the values are stored on a Version
 - Simplify nation selection
 - Remove placeholder authority data on index page
+- Revised text describing each role to reflect role differences between regulatory authority users and central users
 
 ## [release-002] - 2022-02-01
 

--- a/cypress/integration/admin/user/new.ts
+++ b/cypress/integration/admin/user/new.ts
@@ -56,7 +56,7 @@ describe('Creating a new user', () => {
       cy.checkAccessibility();
 
       cy.translate(
-        'users.roleDescriptions.managerProfessionsAndOrganisations',
+        'users.roleDescriptions.manageProfessionsAndOrganisations',
       ).then((manageLabel) => {
         cy.get('body').should('contain', manageLabel);
       });
@@ -200,13 +200,13 @@ describe('Creating a new user', () => {
       cy.checkAccessibility();
 
       cy.translate(
-        'users.roleDescriptions.managerProfessionsAndOrganisations',
+        'users.roleDescriptions.manageProfessionsAndOrganisations',
       ).then((manageLabel) => {
         cy.get('body').should('not.contain', manageLabel);
       });
 
       cy.translate(
-        'users.roleDescriptions.managerProfessionsAndOrganisations',
+        'users.roleDescriptions.manageProfessionsAndOrganisations',
       ).then((manageLabel) => {
         cy.get('body').should('not.contain', manageLabel);
       });

--- a/cypress/integration/admin/user/new.ts
+++ b/cypress/integration/admin/user/new.ts
@@ -55,6 +55,18 @@ describe('Creating a new user', () => {
       cy.get('button').click();
       cy.checkAccessibility();
 
+      cy.translate(
+        'users.roleDescriptions.managerProfessionsAndOrganisations',
+      ).then((manageLabel) => {
+        cy.get('body').should('contain', manageLabel);
+      });
+
+      cy.translate(
+        'users.roleDescriptions.editProfessionsAndOrganisations',
+      ).then((editLabel) => {
+        cy.get('body').should('contain', editLabel);
+      });
+
       cy.get('input[name="role"][value="registrar"]').check();
 
       cy.get('button').click();
@@ -186,6 +198,24 @@ describe('Creating a new user', () => {
       cy.get('input[name="email"]').type('organisation@example.com');
       cy.get('button').click();
       cy.checkAccessibility();
+
+      cy.translate(
+        'users.roleDescriptions.managerProfessionsAndOrganisations',
+      ).then((manageLabel) => {
+        cy.get('body').should('not.contain', manageLabel);
+      });
+
+      cy.translate(
+        'users.roleDescriptions.managerProfessionsAndOrganisations',
+      ).then((manageLabel) => {
+        cy.get('body').should('not.contain', manageLabel);
+      });
+
+      cy.translate(
+        'users.roleDescriptions.editProfessionsAndOwnOrganisation',
+      ).then((editLabel) => {
+        cy.get('body').should('contain', editLabel);
+      });
 
       cy.get('input[name="role"][value="editor"]').check();
 

--- a/src/i18n/en/users.json
+++ b/src/i18n/en/users.json
@@ -83,7 +83,8 @@
   "roleDescriptions": {
     "managerUsers": "Onboard and manage users",
     "managerProfessionsAndOrganisations": "Create and link regulators and professions",
-    "editProfessionsAndOrganisations": "Edit information about regulators and professions"
+    "editProfessionsAndOrganisations": "Edit information about regulators and professions",
+    "editProfessionsAndOwnOrganisation": "Edit information about the regulator and its professions"
   },
   "serviceOwnerOrganisation": "Regulatory Professions Register"
 }

--- a/src/i18n/en/users.json
+++ b/src/i18n/en/users.json
@@ -81,8 +81,8 @@
     "editor": "Editor"
   },
   "roleDescriptions": {
-    "managerUsers": "Onboard and manage users",
-    "managerProfessionsAndOrganisations": "Create and link regulators and professions",
+    "manageUsers": "Onboard and manage users",
+    "manageProfessionsAndOrganisations": "Create and link regulators and professions",
     "editProfessionsAndOrganisations": "Edit information about regulators and professions",
     "editProfessionsAndOwnOrganisation": "Edit information about the regulator and its professions"
   },

--- a/src/users/presenters/role-radio-buttons.presenter.spec.ts
+++ b/src/users/presenters/role-radio-buttons.presenter.spec.ts
@@ -27,7 +27,7 @@ describe('RoleRadioButtonsPresenter', () => {
         const result = await presenter.radioButtonArgs();
 
         const registrarHint = `${translationOf(
-          'users.roleDescriptions.managerProfessionsAndOrganisations',
+          'users.roleDescriptions.manageProfessionsAndOrganisations',
         )}<br />${translationOf(
           'users.roleDescriptions.editProfessionsAndOrganisations',
         )}`;
@@ -75,7 +75,7 @@ describe('RoleRadioButtonsPresenter', () => {
         const result = await presenter.radioButtonArgs();
 
         const administratorHint = `${translationOf(
-          'users.roleDescriptions.managerUsers',
+          'users.roleDescriptions.manageUsers',
         )}<br />${translationOf(
           'users.roleDescriptions.editProfessionsAndOwnOrganisation',
         )}`;

--- a/src/users/presenters/role-radio-buttons.presenter.spec.ts
+++ b/src/users/presenters/role-radio-buttons.presenter.spec.ts
@@ -1,44 +1,108 @@
 import { createMockI18nService } from '../../testutils/create-mock-i18n-service';
 import { translationOf } from '../../testutils/translation-of';
+import { getPermissionsFromUser } from '../helpers/get-permissions-from-user.helper';
 import { Role } from '../role';
+import { UserPermission } from '../user-permission';
 import { RoleRadioButtonsPresenter } from './role-radio-buttons.preseter';
+
+jest.mock('../helpers/get-permissions-from-user.helper');
 
 describe('RoleRadioButtonsPresenter', () => {
   describe('radioButtonArgs', () => {
-    it('returns an array of `RadioButtonArg`s with correct hints and checked values', async () => {
-      const presenter = new RoleRadioButtonsPresenter(
-        [Role.Administrator, Role.Registrar, Role.Editor],
-        Role.Registrar,
-        createMockI18nService(),
-      );
+    describe('when we we are presenting roles for a service owner', () => {
+      it('returns an array of `RadioButtonArg`s with correct hints and checked values', async () => {
+        (getPermissionsFromUser as jest.Mock).mockReturnValue([
+          UserPermission.CreateOrganisation,
+          UserPermission.CreateProfession,
+          UserPermission.EditProfession,
+        ]);
 
-      const result = await presenter.radioButtonArgs();
+        const presenter = new RoleRadioButtonsPresenter(
+          [Role.Administrator, Role.Registrar, Role.Editor],
+          true,
+          Role.Registrar,
+          createMockI18nService(),
+        );
 
-      const registrarHint = `${translationOf(
-        'users.roleDescriptions.managerProfessionsAndOrganisations',
-      )}<br />${translationOf(
-        'users.roleDescriptions.editProfessionsAndOrganisations',
-      )}`;
+        const result = await presenter.radioButtonArgs();
 
-      expect(result).toHaveLength(3);
-      expect(result).toMatchObject([
-        {
-          text: translationOf('users.roles.administrator'),
-          value: Role.Administrator,
-          checked: false,
-        },
-        {
-          text: translationOf('users.roles.registrar'),
-          value: Role.Registrar,
-          checked: true,
-          hint: { html: registrarHint },
-        },
-        {
-          text: translationOf('users.roles.editor'),
-          value: Role.Editor,
-          checked: false,
-        },
-      ]);
+        const registrarHint = `${translationOf(
+          'users.roleDescriptions.managerProfessionsAndOrganisations',
+        )}<br />${translationOf(
+          'users.roleDescriptions.editProfessionsAndOrganisations',
+        )}`;
+
+        expect(result).toHaveLength(3);
+        expect(result).toMatchObject([
+          {
+            text: translationOf('users.roles.administrator'),
+            value: Role.Administrator,
+            checked: false,
+          },
+          {
+            text: translationOf('users.roles.registrar'),
+            value: Role.Registrar,
+            checked: true,
+            hint: { html: registrarHint },
+          },
+          {
+            text: translationOf('users.roles.editor'),
+            value: Role.Editor,
+            checked: false,
+          },
+        ]);
+
+        expect(getPermissionsFromUser).toBeCalledWith(
+          expect.objectContaining({ serviceOwner: true }),
+        );
+      });
     });
+
+    describe('when we we are presenting roles for a non-service owner', () => {
+      it('returns an array of `RadioButtonArg`s with correct hints and checked values', async () => {
+        (getPermissionsFromUser as jest.Mock).mockReturnValue([
+          UserPermission.CreateUser,
+          UserPermission.EditProfession,
+        ]);
+
+        const presenter = new RoleRadioButtonsPresenter(
+          [Role.Administrator, Role.Editor],
+          false,
+          Role.Registrar,
+          createMockI18nService(),
+        );
+
+        const result = await presenter.radioButtonArgs();
+
+        const administratorHint = `${translationOf(
+          'users.roleDescriptions.managerUsers',
+        )}<br />${translationOf(
+          'users.roleDescriptions.editProfessionsAndOwnOrganisation',
+        )}`;
+
+        expect(result).toHaveLength(2);
+        expect(result).toMatchObject([
+          {
+            text: translationOf('users.roles.administrator'),
+            value: Role.Administrator,
+            checked: false,
+            hint: { html: administratorHint },
+          },
+          {
+            text: translationOf('users.roles.editor'),
+            value: Role.Editor,
+            checked: false,
+          },
+        ]);
+
+        expect(getPermissionsFromUser).toBeCalledWith(
+          expect.objectContaining({ serviceOwner: false }),
+        );
+      });
+    });
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
   });
 });

--- a/src/users/presenters/role-radio-buttons.preseter.ts
+++ b/src/users/presenters/role-radio-buttons.preseter.ts
@@ -7,15 +7,15 @@ import { User } from '../user.entity';
 
 const descriptions = [
   {
-    serviceOwnerText: 'users.roleDescriptions.managerUsers',
-    nonServiceOwnerText: 'users.roleDescriptions.managerUsers',
+    serviceOwnerText: 'users.roleDescriptions.manageUsers',
+    nonServiceOwnerText: 'users.roleDescriptions.manageUsers',
     permissions: [UserPermission.CreateUser],
   },
   {
     serviceOwnerText:
-      'users.roleDescriptions.managerProfessionsAndOrganisations',
+      'users.roleDescriptions.manageProfessionsAndOrganisations',
     nonServiceOwnerText:
-      'users.roleDescriptions.managerProfessionsAndOrganisations',
+      'users.roleDescriptions.manageProfessionsAndOrganisations',
     permissions: [
       UserPermission.CreateOrganisation,
       UserPermission.CreateProfession,

--- a/src/users/presenters/role-radio-buttons.preseter.ts
+++ b/src/users/presenters/role-radio-buttons.preseter.ts
@@ -1,10 +1,38 @@
 import { I18nService } from 'nestjs-i18n';
 import { RadioButtonArgs } from '../../common/interfaces/radio-button-args.interface';
+import { getPermissionsFromUser } from '../helpers/get-permissions-from-user.helper';
 import { Role } from '../role';
+import { UserPermission } from '../user-permission';
+import { User } from '../user.entity';
+
+const descriptions = [
+  {
+    serviceOwnerText: 'users.roleDescriptions.managerUsers',
+    nonServiceOwnerText: 'users.roleDescriptions.managerUsers',
+    permissions: [UserPermission.CreateUser],
+  },
+  {
+    serviceOwnerText:
+      'users.roleDescriptions.managerProfessionsAndOrganisations',
+    nonServiceOwnerText:
+      'users.roleDescriptions.managerProfessionsAndOrganisations',
+    permissions: [
+      UserPermission.CreateOrganisation,
+      UserPermission.CreateProfession,
+    ],
+  },
+  {
+    serviceOwnerText: 'users.roleDescriptions.editProfessionsAndOrganisations',
+    nonServiceOwnerText:
+      'users.roleDescriptions.editProfessionsAndOwnOrganisation',
+    permissions: [UserPermission.EditProfession],
+  },
+];
 
 export class RoleRadioButtonsPresenter {
   constructor(
     private readonly allRoles: Role[],
+    private readonly serviceOwner: boolean,
     private readonly selectedRole: Role | null,
     private readonly i18nService: I18nService,
   ) {}
@@ -15,33 +43,35 @@ export class RoleRadioButtonsPresenter {
         text: await this.i18nService.translate(`users.roles.${role}`),
         value: role,
         checked: this.selectedRole === role,
-        hint: { html: await this.getHintHtml(role) },
+        hint: { html: await this.getHintHtml(role, this.serviceOwner) },
       })),
     );
   }
 
-  private async getHintHtml(role: Role): Promise<string> {
-    const descriptions = [
-      {
-        text: 'users.roleDescriptions.managerUsers',
-        roles: [Role.Administrator],
-      },
-      {
-        text: 'users.roleDescriptions.managerProfessionsAndOrganisations',
-        roles: [Role.Administrator, Role.Registrar],
-      },
-      {
-        text: 'users.roleDescriptions.editProfessionsAndOrganisations',
-        roles: [Role.Administrator, Role.Registrar, Role.Editor],
-      },
-    ];
+  private async getHintHtml(
+    role: Role,
+    serviceOwner: boolean,
+  ): Promise<string> {
+    const permissions = getPermissionsFromUser({
+      ...new User(),
+      role,
+      serviceOwner,
+    });
 
     const lines = await Promise.all(
       descriptions
-        .filter((description) => description.roles.includes(role))
+        .filter((description) =>
+          description.permissions.every((permission) =>
+            permissions.includes(permission),
+          ),
+        )
         .map(
           (description) =>
-            this.i18nService.translate(description.text) as Promise<string>,
+            this.i18nService.translate(
+              serviceOwner
+                ? description.serviceOwnerText
+                : description.nonServiceOwnerText,
+            ) as Promise<string>,
         ),
     );
 

--- a/src/users/role/role.controller.spec.ts
+++ b/src/users/role/role.controller.spec.ts
@@ -77,6 +77,7 @@ describe('RoleController', () => {
 
       expect(RoleRadioButtonsPresenter).toBeCalledWith(
         expect.anything(),
+        false,
         Role.Registrar,
         i18nService,
       );
@@ -111,6 +112,7 @@ describe('RoleController', () => {
 
       expect(RoleRadioButtonsPresenter).toBeCalledWith(
         [Role.Administrator, Role.Editor],
+        false,
         expect.anything(),
         i18nService,
       );
@@ -127,6 +129,7 @@ describe('RoleController', () => {
 
       expect(RoleRadioButtonsPresenter).toBeCalledWith(
         [Role.Administrator, Role.Registrar, Role.Editor],
+        true,
         expect.anything(),
         i18nService,
       );
@@ -199,6 +202,7 @@ describe('RoleController', () => {
 
       expect(RoleRadioButtonsPresenter).toBeCalledWith(
         [Role.Administrator, Role.Editor],
+        false,
         undefined,
         i18nService,
       );

--- a/src/users/role/role.controller.ts
+++ b/src/users/role/role.controller.ts
@@ -116,6 +116,7 @@ export class RoleController {
   ): Promise<void> {
     const roleRadioButtonArgs = await new RoleRadioButtonsPresenter(
       this.getAllowedRoles(serviceOwner),
+      serviceOwner,
       role,
       this.i18nService,
     ).radioButtonArgs();

--- a/src/users/role/role.controller.ts
+++ b/src/users/role/role.controller.ts
@@ -115,9 +115,7 @@ export class RoleController {
     errors: object | undefined = undefined,
   ): Promise<void> {
     const roleRadioButtonArgs = await new RoleRadioButtonsPresenter(
-      serviceOwner
-        ? [Role.Administrator, Role.Registrar, Role.Editor]
-        : [Role.Administrator, Role.Editor],
+      this.getAllowedRoles(serviceOwner),
       role,
       this.i18nService,
     ).radioButtonArgs();
@@ -130,5 +128,11 @@ export class RoleController {
     };
 
     res.render('admin/users/role/edit', templateArgs);
+  }
+
+  private getAllowedRoles(serviceOwner: boolean): Role[] {
+    return serviceOwner
+      ? [Role.Administrator, Role.Registrar, Role.Editor]
+      : [Role.Administrator, Role.Editor];
   }
 }


### PR DESCRIPTION
Previously the same description for each role was shown regardless of whether we were creating a service owner user or a regulatory body user. We now show slightly differing descriptions to reflect the different permission that a role has dependant on whether or not the user is a service owner