### PR TITLE
(2128) Replace "Placeholder regulators" text on index page with real regulator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Setting an organisation on a profession updates immediately, rather than saving as draft
 - Remove redundant fields from Profession, now the values are stored on a Version
 - Simplify nation selection
+- Remove placeholder authority data on index page
 
 ## [release-002] - 2022-02-01
 

--- a/src/professions/search/interfaces/profession-search-result-template.interface.ts
+++ b/src/professions/search/interfaces/profession-search-result-template.interface.ts
@@ -1,6 +1,7 @@
 export interface ProfessionSearchResultTemplate {
   name: string;
   slug: string;
+  organisation: string;
   nations: string;
   industries: string[];
 }

--- a/src/professions/search/profession-search-result.presenter.spec.ts
+++ b/src/professions/search/profession-search-result.presenter.spec.ts
@@ -1,43 +1,33 @@
-import { createMock, DeepMocked } from '@golevelup/ts-jest';
+import { DeepMocked } from '@golevelup/ts-jest';
 import { I18nService } from 'nestjs-i18n';
-import { Industry } from '../../industries/industry.entity';
-import { Profession } from '../profession.entity';
+import { createMockI18nService } from '../../testutils/create-mock-i18n-service';
+import industryFactory from '../../testutils/factories/industry';
+import organisationFactory from '../../testutils/factories/organisation';
+import professionFactory from '../../testutils/factories/profession';
+import { translationOf } from '../../testutils/translation-of';
 import { ProfessionSearchResultPresenter } from './profession-search-result.presenter';
 
 describe('ProfessionSearchResultPresenter', () => {
   let i18nService: DeepMocked<I18nService>;
 
   beforeEach(() => {
-    i18nService = createMock<I18nService>();
-
-    i18nService.translate.mockImplementation(async (text) => {
-      switch (text) {
-        case 'industries.health':
-          return 'Health';
-        case 'industries.law':
-          return 'Law';
-        case 'nations.england':
-          return 'England';
-        case 'nations.wales':
-          return 'Wales';
-        default:
-          return '';
-      }
-    });
+    i18nService = createMockI18nService();
   });
 
   describe('present', () => {
     it('Returns a ProfessionSearchResultTemplate', async () => {
-      const exampleProfession = new Profession(
-        'Example Profession',
-        '',
-        'example-profession',
-      );
-      exampleProfession.occupationLocations = ['GB-ENG', 'GB-WLS'];
-      exampleProfession.industries = [
-        new Industry('industries.health'),
-        new Industry('industries.law'),
-      ];
+      const exampleProfession = professionFactory.build({
+        name: 'Example Profession',
+        slug: 'example-profession',
+        organisation: organisationFactory.build({
+          name: 'Example Organisation',
+        }),
+        occupationLocations: ['GB-ENG', 'GB-WLS'],
+        industries: [
+          industryFactory.build({ id: 'industries.health', name: 'health' }),
+          industryFactory.build({ id: 'industries.law', name: 'law' }),
+        ],
+      });
 
       const result = await new ProfessionSearchResultPresenter(
         exampleProfession,
@@ -47,8 +37,11 @@ describe('ProfessionSearchResultPresenter', () => {
       expect(result).toEqual({
         name: 'Example Profession',
         slug: 'example-profession',
-        nations: 'England, Wales',
-        industries: ['Health', 'Law'],
+        organisation: 'Example Organisation',
+        nations: `${translationOf('nations.england')}, ${translationOf(
+          'nations.wales',
+        )}`,
+        industries: [translationOf('health'), translationOf('law')],
       });
     });
   });

--- a/src/professions/search/profession-search-result.presenter.ts
+++ b/src/professions/search/profession-search-result.presenter.ts
@@ -25,6 +25,7 @@ export class ProfessionSearchResultPresenter {
     return {
       name: this.profession.name,
       slug: this.profession.slug,
+      organisation: this.profession.organisation.name,
       nations,
       industries,
     };

--- a/src/testutils/factories/profession.ts
+++ b/src/testutils/factories/profession.ts
@@ -4,6 +4,7 @@ import {
   Profession,
 } from '../../professions/profession.entity';
 import industryFactory from './industry';
+import organisationFactory from './organisation';
 import qualificationFactory from './qualification';
 
 class ProfessionFactory extends Factory<Profession> {
@@ -43,7 +44,7 @@ export default ProfessionFactory.define(({ sequence }) => ({
   confirmed: false,
   created_at: new Date(),
   legislations: [],
-  organisation: undefined,
+  organisation: organisationFactory.build({ name: 'Example organisation' }),
   regulationSummary: 'Example summary',
   reservedActivities: 'Example activities',
   protectedTitles: 'Example titles',

--- a/views/professions/search/index.njk
+++ b/views/professions/search/index.njk
@@ -46,7 +46,7 @@
                     text: ("professions.search.profession.regulators" | t)
                   },
                   value: {
-                    html: "Placeholder regulators"
+                    text: profession.organisation
                   }
                 },
                 {


### PR DESCRIPTION
# Changes in this PR

Display real Regulatory Authority in index page rather than "placeholder" now that we have that data in the app.

## Screenshots of UI changes

### Before

![image](https://user-images.githubusercontent.com/19826940/153583335-ff12e85e-8b07-4f1c-996b-5a9d28122cbc.png)


### After

![image](https://user-images.githubusercontent.com/19826940/153583182-87ae9e2f-27d1-482a-80e2-16e4975314c7.png)
