### PR TITLE
(2104) Allow second regulator to be chosen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Allow a draft version to be published
 - Allow draft Professions to be published
 - Protected titles and and a URL for further information on regulations can be entered when adding a profession
+- Allow second regulator to be chosen
 
 ### Changed
 

--- a/cypress/integration/admin/professions/add-a-profession.spec.ts
+++ b/cypress/integration/admin/professions/add-a-profession.spec.ts
@@ -76,6 +76,9 @@ describe('Adding a new profession', () => {
         'Department for Education',
       );
       cy.get('input[name="mandatoryRegistration"][value="mandatory"]').check();
+      cy.get('select[name="additionalRegulatoryBody"]').select(
+        'General Medical Council',
+      );
       cy.translate('app.continue').then((buttonText) => {
         cy.get('button').contains(buttonText).click();
       });

--- a/cypress/integration/admin/professions/add-a-profession.spec.ts
+++ b/cypress/integration/admin/professions/add-a-profession.spec.ts
@@ -174,6 +174,10 @@ describe('Adding a new profession', () => {
 
       cy.get('body').should('contain', 'An example Qualification level');
       cy.get('body').should('contain', 'Another method');
+      cy.checkSummaryListRowValue(
+        'professions.form.label.regulatoryBody.additionalAuthority',
+        'General Medical Council',
+      );
       cy.translate(
         'professions.methodsToObtainQualification.generalSecondaryEducation',
       ).then((method) => {

--- a/cypress/integration/admin/professions/add-a-profession.spec.ts
+++ b/cypress/integration/admin/professions/add-a-profession.spec.ts
@@ -158,38 +158,104 @@ describe('Adding a new profession', () => {
       cy.translate('professions.form.captions.add').then((addCaption) => {
         cy.get('body').contains(addCaption);
       });
-      cy.get('body').should('contain', 'Example Profession');
+
+      cy.checkSummaryListRowValue(
+        'professions.form.label.topLevelInformation.name',
+        'Example Profession',
+      );
+
       cy.translate('nations.england').then((england) => {
+        cy.checkSummaryListRowValue(
+          'professions.form.label.topLevelInformation.nations',
+          england,
+        );
         cy.get('body').should('contain', england);
       });
-      cy.get('body').should('contain', 'Construction & Engineering');
-      cy.get('body').should('contain', 'Department for Education');
+
+      cy.checkSummaryListRowValue(
+        'professions.form.label.topLevelInformation.industry',
+        'Construction & Engineering',
+      );
+
+      cy.checkSummaryListRowValue(
+        'professions.form.label.regulatoryBody.regulatedAuthority',
+        'Department for Education',
+      );
+
       cy.translate(
         'professions.form.radioButtons.mandatoryRegistration.mandatory',
       ).then((mandatoryRegistration) => {
-        cy.get('body').should('contain', mandatoryRegistration);
+        cy.checkSummaryListRowValue(
+          'professions.form.label.regulatoryBody.mandatoryRegistration',
+          mandatoryRegistration,
+        );
       });
-      cy.get('body').should('contain', 'An example activity');
-      cy.get('body').should('contain', 'A summary of the regulation');
 
-      cy.get('body').should('contain', 'An example Qualification level');
-      cy.get('body').should('contain', 'Another method');
       cy.checkSummaryListRowValue(
         'professions.form.label.regulatoryBody.additionalAuthority',
         'General Medical Council',
       );
+
+      cy.checkSummaryListRowValue(
+        'professions.form.label.regulatedActivities.regulationSummary',
+        'A summary of the regulation',
+      );
+
+      cy.checkSummaryListRowValue(
+        'professions.form.label.regulatedActivities.reservedActivities',
+        'An example activity',
+      );
+
+      cy.checkSummaryListRowValue(
+        'professions.form.label.regulatedActivities.protectedTitles',
+        'An example protected title',
+      );
+
+      cy.checkSummaryListRowValue(
+        'professions.form.label.regulatedActivities.regulationUrl',
+        'https://example.com/regulation',
+      );
+
+      cy.checkSummaryListRowValue(
+        'professions.form.label.qualificationInformation.qualificationLevel',
+        'An example Qualification level',
+      );
+
+      cy.checkSummaryListRowValue(
+        'professions.form.label.qualificationInformation.methodsToObtainQualification',
+        'Another method',
+      );
+
       cy.translate(
         'professions.methodsToObtainQualification.generalSecondaryEducation',
       ).then((method) => {
-        cy.get('body').should('contain', method);
-      });
-      cy.get('body').should('contain', '4.0 Years');
-      cy.translate('app.yes').then((yes) => {
-        cy.get('body').should('contain', yes);
+        cy.checkSummaryListRowValue(
+          'professions.form.label.qualificationInformation.mostCommonPathToObtainQualification',
+          method,
+        );
       });
 
-      cy.get('body').should('contain', 'National legislation description');
-      cy.get('body').should('contain', 'www.example-legislation.com');
+      cy.checkSummaryListRowValue(
+        'professions.form.label.qualificationInformation.duration',
+        '4.0 Years',
+      );
+
+      cy.translate('app.yes').then((yes) => {
+        cy.checkSummaryListRowValue(
+          'professions.form.label.qualificationInformation.mandatoryProfessionalExperience',
+          yes,
+        );
+      });
+
+      cy.checkSummaryListRowValue(
+        'professions.form.label.legislation.nationalLegislation',
+        'National legislation description',
+      );
+
+      cy.checkSummaryListRowValue(
+        'professions.form.label.legislation.link',
+        'www.example-legislation.com',
+      );
 
       cy.translate('professions.form.button.create').then((buttonText) => {
         cy.get('button').contains(buttonText).click();

--- a/cypress/integration/admin/user/new.ts
+++ b/cypress/integration/admin/user/new.ts
@@ -98,6 +98,8 @@ describe('Creating a new user', () => {
       cy.get('button').click();
 
       cy.get('input[name="serviceOwner"][value="0"]').check();
+      cy.get('select[name="organisation"]').select('Department for Education');
+
       cy.get('button').click();
 
       cy.get('input[name="name"]').type('Example Name');
@@ -117,6 +119,8 @@ describe('Creating a new user', () => {
       cy.checkAccessibility();
 
       cy.get('input[name="serviceOwner"][value="0"]').check();
+      cy.get('select[name="organisation"]').select('Department for Education');
+
       cy.get('button').click();
 
       cy.get('input[name="name"]').type('Example Name');

--- a/package-lock.json
+++ b/package-lock.json
@@ -67,6 +67,7 @@
         "eslint-plugin-prettier": "^4.0.0",
         "fishery": "^2.1.0",
         "jest": "^27.5.1",
+        "jest-when": "^3.5.1",
         "prettier": "^2.5.1",
         "puppeteer": "^13.3.1",
         "source-map-support": "^0.5.20",
@@ -11902,6 +11903,15 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jest-when": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/jest-when/-/jest-when-3.5.1.tgz",
+      "integrity": "sha512-o+HiaIVCg1IC95sMDKHU9G5v5N5l3UHqXvJpf0PgAMThZeQo4Hf5Sgoj+wpCBRGg4/KtzSAZZZEKNiLqE0i4eQ==",
+      "dev": true,
+      "peerDependencies": {
+        "jest": ">= 25"
       }
     },
     "node_modules/jest-worker": {
@@ -27971,6 +27981,13 @@
           }
         }
       }
+    },
+    "jest-when": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/jest-when/-/jest-when-3.5.1.tgz",
+      "integrity": "sha512-o+HiaIVCg1IC95sMDKHU9G5v5N5l3UHqXvJpf0PgAMThZeQo4Hf5Sgoj+wpCBRGg4/KtzSAZZZEKNiLqE0i4eQ==",
+      "dev": true,
+      "requires": {}
     },
     "jest-worker": {
       "version": "27.5.1",

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "eslint-plugin-prettier": "^4.0.0",
     "fishery": "^2.1.0",
     "jest": "^27.5.1",
+    "jest-when": "^3.5.1",
     "prettier": "^2.5.1",
     "puppeteer": "^13.3.1",
     "source-map-support": "^0.5.20",

--- a/seeds/development/professions.json
+++ b/seeds/development/professions.json
@@ -11,6 +11,7 @@
     "reservedActivities": "England and Wales: the exercise of a right of audience; the conduct of litigation; reserved instrument activities; probate activities; the administration of oaths (see section 12 Legal Services Act 2007).",
     "legislation": "The Trade Marks Act 1994",
     "organisation": "Law Society of England and Wales",
+    "additionalOrganisation": null,
     "mandatoryRegistration": "voluntary",
     "versions": [
       {
@@ -41,6 +42,7 @@
     "reservedActivities": "No information submitted",
     "legislation": "The Education (School Teachers' Qualifications) (England) Regulations 2003/1662 (as amended)",
     "organisation": "Department for Education",
+    "additionalOrganisation": null,
     "mandatoryRegistration": "mandatory",
     "versions": [
       {
@@ -72,6 +74,7 @@
     "reservedActivities": "Gas Safe Register is the official list of gas engineers in the UK, Isle of Man and Guernsey. To work on gas appliances and installations you must be on the gas safe register. The register exists to protect the public from unsafe gas work (EN)",
     "legislation": "Gas Safety (Installation and Use) Regulations 1998",
     "organisation": "Council of Registered Gas Installers",
+    "additionalOrganisation": null,
     "mandatoryRegistration": "voluntary",
     "versions": [
       {

--- a/seeds/staging/professions.json
+++ b/seeds/staging/professions.json
@@ -11,6 +11,7 @@
     "reservedActivities": "England and Wales: the exercise of a right of audience; the conduct of litigation; reserved instrument activities; probate activities; the administration of oaths (see section 12 Legal Services Act 2007).",
     "legislation": "The Trade Marks Act 1994",
     "organisation": "Law Society of England and Wales",
+    "additionalOrganisation": null,
     "mandatoryRegistration": "voluntary",
     "versions": [
       {
@@ -41,6 +42,7 @@
     "reservedActivities": "No information submitted",
     "legislation": "The Education (School Teachers' Qualifications) (England) Regulations 2003/1662 (as amended)",
     "organisation": "Department for Education",
+    "additionalOrganisation": null,
     "mandatoryRegistration": "mandatory",
     "versions": [
       {
@@ -72,6 +74,7 @@
     "reservedActivities": "Gas Safe Register is the official list of gas engineers in the UK, Isle of Man and Guernsey. To work on gas appliances and installations you must be on the gas safe register. The register exists to protect the public from unsafe gas work (EN)",
     "legislation": "Gas Safety (Installation and Use) Regulations 1998",
     "organisation": "Council of Registered Gas Installers",
+    "additionalOrganisation": null,
     "mandatoryRegistration": "voluntary",
     "versions": [
       {

--- a/seeds/test/professions.json
+++ b/seeds/test/professions.json
@@ -11,6 +11,7 @@
     "reservedActivities": "England and Wales: the exercise of a right of audience; the conduct of litigation; reserved instrument activities; probate activities; the administration of oaths (see section 12 Legal Services Act 2007).",
     "legislation": "The Trade Marks Act 1994",
     "organisation": "Law Society of England and Wales",
+    "additionalOrganisation": null,
     "mandatoryRegistration": "voluntary",
     "versions": [
       {
@@ -41,6 +42,7 @@
     "reservedActivities": "No information submitted",
     "legislation": "The Education (School Teachers' Qualifications) (England) Regulations 2003/1662 (as amended)",
     "organisation": "Department for Education",
+    "additionalOrganisation": null,
     "mandatoryRegistration": "mandatory",
     "versions": [
       {
@@ -72,6 +74,7 @@
     "reservedActivities": "Gas Safe Register is the official list of gas engineers in the UK, Isle of Man and Guernsey. To work on gas appliances and installations you must be on the gas safe register. The register exists to protect the public from unsafe gas work (EN)",
     "legislation": "Gas Safety (Installation and Use) Regulations 1998",
     "organisation": "Council of Registered Gas Installers",
+    "additionalOrganisation": null,
     "mandatoryRegistration": "voluntary",
     "versions": [
       {

--- a/src/db/migrate/1644579174098-AddAdditionalOrganisationToProfessions.ts
+++ b/src/db/migrate/1644579174098-AddAdditionalOrganisationToProfessions.ts
@@ -1,0 +1,25 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddAdditionalOrganisationToProfessions1644579174098
+  implements MigrationInterface
+{
+  name = 'AddAdditionalOrganisationToProfessions1644579174098';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "professions" ADD "additionalOrganisationId" uuid`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "professions" ADD CONSTRAINT "FK_86e53b1b0a4604ede6ba4f743c5" FOREIGN KEY ("additionalOrganisationId") REFERENCES "organisations"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "professions" DROP CONSTRAINT "FK_86e53b1b0a4604ede6ba4f743c5"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "professions" DROP COLUMN "additionalOrganisationId"`,
+    );
+  }
+}

--- a/src/i18n/en/professions.json
+++ b/src/i18n/en/professions.json
@@ -27,7 +27,8 @@
       },
       "regulatoryBody": {
         "regulatedAuthority": "Which body regulates this profession?",
-        "mandatoryRegistration": "Is registration mandatory with professional bodies?"
+        "mandatoryRegistration": "Is registration mandatory with professional bodies?",
+        "additionalAuthority": "Is there another regulator associated with this profession?"
       },
       "regulatedActivities": {
         "regulationSummary": "Regulation summary",

--- a/src/i18n/en/professions.json
+++ b/src/i18n/en/professions.json
@@ -102,6 +102,9 @@
       "industries": {
         "empty": "Select at least one industry"
       },
+      "regulatoryBody": {
+        "empty": "Select a regulatory authority for the profession"
+      },
       "mandatoryRegistration": {
         "empty": "Select whether registration with the regulatory authority is mandatory"
       },

--- a/src/professions/admin/check-your-answers.controller.ts
+++ b/src/professions/admin/check-your-answers.controller.ts
@@ -78,6 +78,9 @@ export class CheckYourAnswersController {
       nations: selectedNations,
       industries: industryNames,
       organisation: draftProfession.organisation.name,
+      additionalOrganisation: draftProfession.additionalOrganisation
+        ? draftProfession.additionalOrganisation.name
+        : null,
       mandatoryRegistration: version.mandatoryRegistration,
       regulationSummary: version.description,
       reservedActivities: version.reservedActivities,

--- a/src/professions/admin/dto/regulatory-body.dto.ts
+++ b/src/professions/admin/dto/regulatory-body.dto.ts
@@ -7,6 +7,8 @@ export class RegulatoryBodyDto {
   })
   regulatoryBody: string;
 
+  additionalRegulatoryBody: string;
+
   @IsNotEmpty({
     message: 'professions.form.errors.mandatoryRegistration.empty',
   })

--- a/src/professions/admin/dto/regulatory-body.dto.ts
+++ b/src/professions/admin/dto/regulatory-body.dto.ts
@@ -2,7 +2,9 @@ import { IsNotEmpty } from 'class-validator';
 import { MandatoryRegistration } from '../../profession.entity';
 
 export class RegulatoryBodyDto {
-  @IsNotEmpty()
+  @IsNotEmpty({
+    message: 'professions.form.errors.regulatoryBody.empty',
+  })
   regulatoryBody: string;
 
   @IsNotEmpty({

--- a/src/professions/admin/interfaces/check-your-answers.template.ts
+++ b/src/professions/admin/interfaces/check-your-answers.template.ts
@@ -8,6 +8,7 @@ export interface CheckYourAnswersTemplate {
   professionId: string;
   versionId: string;
   organisation: string;
+  additionalOrganisation: string;
   mandatoryRegistration: string;
   regulationSummary: string;
   reservedActivities: string;

--- a/src/professions/admin/interfaces/regulatory-body.template.ts
+++ b/src/professions/admin/interfaces/regulatory-body.template.ts
@@ -3,6 +3,7 @@ import { SelectItemArgs } from '../../../common/interfaces/select-item-args.inte
 
 export interface RegulatoryBodyTemplate {
   regulatedAuthoritiesSelectArgs: SelectItemArgs[];
+  additionalRegulatedAuthoritiesSelectArgs: SelectItemArgs[];
   mandatoryRegistrationRadioButtonArgs: RadioButtonArgs[];
   change: boolean;
   captionText: string;

--- a/src/professions/admin/regulated-authorities-select-presenter.spec.ts
+++ b/src/professions/admin/regulated-authorities-select-presenter.spec.ts
@@ -8,13 +8,18 @@ describe(RegulatedAuthoritiesSelectPresenter, () => {
   exampleOrganisation2.id = 'org2-id';
 
   describe('selectArgs', () => {
-    it('should return no selected item when called with an empty list of selected Organisations', async () => {
+    it('should return no selected item when called no selected Organisation', async () => {
       const presenter = new RegulatedAuthoritiesSelectPresenter(
         [exampleOrganisation1, exampleOrganisation2],
         null,
       );
 
       expect(presenter.selectArgs()).toEqual([
+        {
+          text: '--- Please Select ---',
+          value: '',
+          selected: null,
+        },
         {
           text: 'Example Organisation 1',
           value: 'org1-id',
@@ -28,13 +33,18 @@ describe(RegulatedAuthoritiesSelectPresenter, () => {
       ]);
     });
 
-    it('should return some checked checkbox arguments when called with a non-empty list of Nations', async () => {
+    it('should return a selected option when called with a selected Organisation', async () => {
       const presenter = new RegulatedAuthoritiesSelectPresenter(
         [exampleOrganisation1, exampleOrganisation2],
         exampleOrganisation1,
       );
 
       expect(presenter.selectArgs()).toEqual([
+        {
+          text: '--- Please Select ---',
+          value: '',
+          selected: null,
+        },
         {
           text: 'Example Organisation 1',
           value: 'org1-id',

--- a/src/professions/admin/regulated-authorities-select-presenter.ts
+++ b/src/professions/admin/regulated-authorities-select-presenter.ts
@@ -8,12 +8,24 @@ export class RegulatedAuthoritiesSelectPresenter {
   ) {}
 
   selectArgs(): SelectItemArgs[] {
-    return this.allOrganisations.map((organisation) => ({
-      text: organisation.name,
-      value: organisation.id,
-      selected: this.selectedOrganisation
-        ? this.selectedOrganisation.id === organisation.id
-        : false,
-    }));
+    const options = [
+      {
+        text: '--- Please Select ---',
+        value: '',
+        selected: null,
+      },
+    ];
+
+    this.allOrganisations.forEach((organisation) =>
+      options.push({
+        text: organisation.name,
+        value: organisation.id,
+        selected: this.selectedOrganisation
+          ? this.selectedOrganisation.id === organisation.id
+          : false,
+      }),
+    );
+
+    return options;
   }
 }

--- a/src/professions/admin/regulatory-body.controller.spec.ts
+++ b/src/professions/admin/regulatory-body.controller.spec.ts
@@ -186,8 +186,8 @@ describe(RegulatoryBodyController, () => {
 
     describe('when required parameters are not entered', () => {
       it('does not update the profession, and re-renders the regulatory body form page with errors', async () => {
-        const regulatoryBodyDtoWithoutMandatoryRegistration = {
-          regulatoryBody: 'example-org-id',
+        const invalidDto = {
+          regulatoryBody: null,
           mandatoryRegistration: undefined,
         };
 
@@ -195,7 +195,7 @@ describe(RegulatoryBodyController, () => {
           response,
           'profession-id',
           'version-id',
-          regulatoryBodyDtoWithoutMandatoryRegistration,
+          invalidDto,
         );
 
         expect(professionVersionsService.save).not.toHaveBeenCalled();
@@ -204,6 +204,9 @@ describe(RegulatoryBodyController, () => {
           'admin/professions/regulatory-body',
           expect.objectContaining({
             errors: {
+              regulatoryBody: {
+                text: 'professions.form.errors.regulatoryBody.empty',
+              },
               mandatoryRegistration: {
                 text: 'professions.form.errors.mandatoryRegistration.empty',
               },

--- a/src/professions/admin/regulatory-body.controller.ts
+++ b/src/professions/admin/regulatory-body.controller.ts
@@ -68,6 +68,7 @@ export class RegulatoryBodyController {
     return this.renderForm(
       res,
       profession.organisation,
+      profession.additionalOrganisation,
       selectedMandatoryRegistration,
       isConfirmed(profession),
       change,
@@ -102,6 +103,13 @@ export class RegulatoryBodyController {
       ? await this.organisationsService.find(submittedValues.regulatoryBody)
       : null;
 
+    const selectedAdditionalOrganisation =
+      submittedValues.additionalRegulatoryBody
+        ? await this.organisationsService.find(
+            submittedValues.additionalRegulatoryBody,
+          )
+        : null;
+
     const selectedMandatoryRegistration = submittedValues.mandatoryRegistration;
 
     const profession = await this.professionsService.findWithVersions(
@@ -113,6 +121,7 @@ export class RegulatoryBodyController {
       return this.renderForm(
         res,
         selectedOrganisation,
+        selectedAdditionalOrganisation,
         selectedMandatoryRegistration,
         isConfirmed(profession),
         regulatoryBodyDto.change,
@@ -123,6 +132,7 @@ export class RegulatoryBodyController {
     const updatedProfession: Profession = {
       ...profession,
       organisation: selectedOrganisation,
+      additionalOrganisation: selectedAdditionalOrganisation,
     };
 
     const updatedVersion: ProfessionVersion = {
@@ -149,6 +159,7 @@ export class RegulatoryBodyController {
   private async renderForm(
     res: Response,
     selectedRegulatoryAuthority: Organisation | null,
+    selectedAdditionalRegulatoryAuthority: Organisation | null,
     mandatoryRegistration: MandatoryRegistration | null,
     isEditing: boolean,
     change: boolean,
@@ -162,6 +173,12 @@ export class RegulatoryBodyController {
         selectedRegulatoryAuthority,
       ).selectArgs();
 
+    const additionalRegulatedAuthoritiesSelectArgs =
+      new RegulatedAuthoritiesSelectPresenter(
+        regulatedAuthorities,
+        selectedAdditionalRegulatoryAuthority,
+      ).selectArgs();
+
     const mandatoryRegistrationRadioButtonArgs =
       await new MandatoryRegistrationRadioButtonsPresenter(
         mandatoryRegistration,
@@ -171,6 +188,7 @@ export class RegulatoryBodyController {
     const templateArgs: RegulatoryBodyTemplate = {
       regulatedAuthoritiesSelectArgs,
       mandatoryRegistrationRadioButtonArgs,
+      additionalRegulatedAuthoritiesSelectArgs,
       captionText: ViewUtils.captionText(isEditing),
       change,
       errors,

--- a/src/professions/admin/regulatory-body.controller.ts
+++ b/src/professions/admin/regulatory-body.controller.ts
@@ -98,9 +98,9 @@ export class RegulatoryBodyController {
 
     const submittedValues: RegulatoryBodyDto = regulatoryBodyDto;
 
-    const selectedOrganisation = await this.organisationsService.find(
-      submittedValues.regulatoryBody,
-    );
+    const selectedOrganisation = submittedValues.regulatoryBody
+      ? await this.organisationsService.find(submittedValues.regulatoryBody)
+      : null;
 
     const selectedMandatoryRegistration = submittedValues.mandatoryRegistration;
 

--- a/src/professions/profession.entity.ts
+++ b/src/professions/profession.entity.ts
@@ -7,6 +7,7 @@ import {
   OneToMany,
   PrimaryGeneratedColumn,
   UpdateDateColumn,
+  JoinColumn,
 } from 'typeorm';
 import { Industry } from '../industries/industry.entity';
 import { Legislation } from '../legislations/legislation.entity';
@@ -35,6 +36,10 @@ export class Profession {
     eager: true,
   })
   organisation: Organisation;
+
+  @ManyToOne(() => Organisation, { eager: true })
+  @JoinColumn()
+  additionalOrganisation: Organisation;
 
   @Index({ unique: true, where: '"slug" IS NOT NULL' })
   @Column({ nullable: true })

--- a/src/professions/professions.seeder.ts
+++ b/src/professions/professions.seeder.ts
@@ -30,6 +30,7 @@ type SeedProfession = {
   regulationUrl: string;
   legislation: string;
   organisation: string;
+  additionalOrganisation: string;
   mandatoryRegistration: MandatoryRegistration;
   confirmed: boolean;
   versions: SeedVersion[];
@@ -80,6 +81,13 @@ export class ProfessionsSeeder implements Seeder {
           where: { name: seedProfession.organisation },
         });
 
+        const additionalOrganisation =
+          seedProfession.additionalOrganisation !== null
+            ? await this.organisationRepository.findOne({
+                where: { name: seedProfession.additionalOrganisation },
+              })
+            : null;
+
         const existingProfession = await this.professionsRepository.findOne({
           slug: seedProfession.slug,
         });
@@ -89,6 +97,7 @@ export class ProfessionsSeeder implements Seeder {
           alternateName: seedProfession.alternateName,
           slug: seedProfession.slug,
           organisation: organisation,
+          additionalOrganisation: additionalOrganisation,
         } as Profession;
 
         const savedProfession = await this.professionsRepository.save({

--- a/src/testutils/factories/profession.ts
+++ b/src/testutils/factories/profession.ts
@@ -22,6 +22,7 @@ class ProfessionFactory extends Factory<Profession> {
       qualification: undefined,
       legislations: undefined,
       organisation: undefined,
+      additionalOrganisation: undefined,
       reservedActivities: undefined,
     });
   }
@@ -45,6 +46,7 @@ export default ProfessionFactory.define(({ sequence }) => ({
   created_at: new Date(),
   legislations: [],
   organisation: organisationFactory.build({ name: 'Example organisation' }),
+  additionalOrganisation: undefined,
   regulationSummary: 'Example summary',
   reservedActivities: 'Example activities',
   protectedTitles: 'Example titles',

--- a/src/users/organisation/dto/organisation.dto.ts
+++ b/src/users/organisation/dto/organisation.dto.ts
@@ -1,4 +1,4 @@
-import { IsNotEmpty } from 'class-validator';
+import { IsNotEmpty, ValidateIf } from 'class-validator';
 
 export class OrganisationDto {
   @IsNotEmpty({
@@ -9,6 +9,7 @@ export class OrganisationDto {
   @IsNotEmpty({
     message: 'users.form.errors.organisation.empty',
   })
+  @ValidateIf((e) => e.serviceOwner === '0')
   organisation: string;
 
   change: string;

--- a/src/users/organisation/organisation.controller.ts
+++ b/src/users/organisation/organisation.controller.ts
@@ -94,9 +94,11 @@ export class OrganisationController {
         ? undefined
         : Boolean(Number(submittedValues.serviceOwner));
 
-    const organisation = serviceOwner
-      ? undefined
-      : await this.organisationsService.find(submittedValues.organisation);
+    const organisation = submittedValues.organisation
+      ? serviceOwner
+        ? undefined
+        : await this.organisationsService.find(submittedValues.organisation)
+      : undefined;
 
     if (!validator.valid()) {
       const errors = new ValidationFailedError(validator.errors).fullMessages();

--- a/views/admin/professions/check-your-answers.njk
+++ b/views/admin/professions/check-your-answers.njk
@@ -129,6 +129,23 @@
                     }
                   ]
                 }
+              },
+              {
+                key: {
+                  text: ("professions.form.label.regulatoryBody.additionalAuthority" | t)
+                },
+                value: {
+                  text: (additionalOrganisation if (additionalOrganisation|length) else ("app.no" | t))
+                },
+                actions: {
+                  items: [
+                    {
+                      href: "/admin/professions/" + professionId + "/versions/" + versionId + "/regulatory-body/edit?change=true",
+                      text: ("app.change" | t),
+                      visuallyHiddenText: ("professions.form.label.regulatoryBody.additionalAuthority" | t)
+                    }
+                  ]
+                }
               }
             ]
           })

--- a/views/admin/professions/regulatory-body.njk
+++ b/views/admin/professions/regulatory-body.njk
@@ -27,7 +27,8 @@
             },
             id: "regulatoryBody",
             name: "regulatoryBody",
-            items: regulatedAuthoritiesSelectArgs
+            items: regulatedAuthoritiesSelectArgs,
+            errorMessage: errors.regulatoryBody | tError
           })
         }}
 

--- a/views/admin/professions/regulatory-body.njk
+++ b/views/admin/professions/regulatory-body.njk
@@ -52,6 +52,19 @@
         }}
 
         {{
+          govukSelect({
+            label: {
+              text: ("professions.form.label.regulatoryBody.additionalAuthority" | t),
+              classes: "govuk-label--m",
+              isPageHeading: false
+            },
+            id: "additionalRegulatoryBody",
+            name: "additionalRegulatoryBody",
+            items: additionalRegulatedAuthoritiesSelectArgs
+          })
+        }}
+
+        {{
           govukButton({
             id: "submit-button",
             type: "Submit",


### PR DESCRIPTION
This adds an optional `additionalOrganisation` field to the Profession entity to allow a secondary organisation to be applied to an organisation.

# Screenshots

![image](https://user-images.githubusercontent.com/109774/153620198-f41d9f5c-e2cf-4a66-84f8-f33d528f6408.png)

![image](https://user-images.githubusercontent.com/109774/153620250-31361dd2-2fba-4b8e-a127-a714dbe59852.png)

![image](https://user-images.githubusercontent.com/109774/153620288-cc1bb89a-fe2f-4351-b1ab-6a7006025274.png)
