### PR TITLE
(2077) Display user who last edited a profession

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - Users can enter a second legislation for a profession
+- Display user who changed a profession on the Admin Profession index page and Profession page itself.
+- Allow BEIS team users to see the "Changed By" field so they can track who has edited data.
 
 ## [release-003] - 2022-02-16
 

--- a/cypress/integration/admin/professions/edit.spec.ts
+++ b/cypress/integration/admin/professions/edit.spec.ts
@@ -1,3 +1,5 @@
+import { format } from 'date-fns';
+
 describe('Editing an existing profession', () => {
   context('when I am not logged in', () => {
     it('I am prompted to log in', () => {
@@ -221,6 +223,11 @@ describe('Editing an existing profession', () => {
 
       cy.checkAccessibility();
       cy.get('[data-cy=changed-by-user]').should('contain', 'Editor');
+      cy.get('[data-cy=last-modified]').should(
+        'contain',
+        format(new Date(), 'dd-MM-yyyy'),
+      );
+
       cy.translate('professions.admin.update.confirmation.heading').then(
         (flashHeading) => {
           cy.translate('professions.admin.update.confirmation.body', {

--- a/cypress/integration/admin/professions/edit.spec.ts
+++ b/cypress/integration/admin/professions/edit.spec.ts
@@ -21,6 +21,12 @@ describe('Editing an existing profession', () => {
         });
 
       cy.checkAccessibility();
+
+      cy.translate('professions.admin.changed.by').then((lastUpdatedText) => {
+        cy.get('[data-cy=changed-by-text]').should('contain', lastUpdatedText);
+      });
+      cy.get('[data-cy=changed-by-user]').should('contain', '');
+
       cy.translate('professions.admin.editProfession').then((buttonText) => {
         cy.contains(buttonText).click();
       });
@@ -214,6 +220,7 @@ describe('Editing an existing profession', () => {
       });
 
       cy.checkAccessibility();
+      cy.get('[data-cy=changed-by-user]').should('contain', 'Editor');
       cy.translate('professions.admin.update.confirmation.heading').then(
         (flashHeading) => {
           cy.translate('professions.admin.update.confirmation.body', {

--- a/cypress/integration/admin/professions/index.spec.ts
+++ b/cypress/integration/admin/professions/index.spec.ts
@@ -52,6 +52,12 @@ describe('Listing professions', () => {
         cy.get('tr').eq(0).should('contain', status);
       });
 
+      cy.translate('professions.admin.tableHeading.lastModified').then(
+        (lastModified) => {
+          cy.get('tr').eq(0).should('contain', lastModified);
+        },
+      );
+
       cy.translate('professions.admin.tableHeading.changedBy').then(
         (changedBy) => {
           cy.get('tr').eq(0).should('not.contain', changedBy);
@@ -173,6 +179,12 @@ describe('Listing professions', () => {
       cy.translate('professions.admin.tableHeading.industry').then(
         (industry) => {
           cy.get('tr').eq(0).should('not.contain', industry);
+        },
+      );
+
+      cy.translate('professions.admin.tableHeading.lastModified').then(
+        (lastModified) => {
+          cy.get('tr').eq(0).should('contain', lastModified);
         },
       );
 

--- a/cypress/integration/admin/professions/index.spec.ts
+++ b/cypress/integration/admin/professions/index.spec.ts
@@ -60,7 +60,7 @@ describe('Listing professions', () => {
 
       cy.translate('professions.admin.tableHeading.changedBy').then(
         (changedBy) => {
-          cy.get('tr').eq(0).should('not.contain', changedBy);
+          cy.get('tr').eq(0).should('contain', changedBy);
         },
       );
     });

--- a/cypress/integration/admin/professions/new.spec.ts
+++ b/cypress/integration/admin/professions/new.spec.ts
@@ -343,6 +343,7 @@ describe('Adding a new profession', () => {
           });
         },
       );
+      cy.get('[data-cy=changed-by-user]').should('contain', 'Registrar');
     });
   });
 });

--- a/cypress/integration/admin/professions/new.spec.ts
+++ b/cypress/integration/admin/professions/new.spec.ts
@@ -1,3 +1,5 @@
+import { format } from 'date-fns';
+
 describe('Adding a new profession', () => {
   context('when I am not logged in', () => {
     it('I am prompted to log in', () => {
@@ -344,6 +346,10 @@ describe('Adding a new profession', () => {
         },
       );
       cy.get('[data-cy=changed-by-user]').should('contain', 'Registrar');
+      cy.get('[data-cy=last-modified]').should(
+        'contain',
+        format(new Date(), 'dd-MM-yyyy'),
+      );
     });
   });
 });

--- a/cypress/integration/admin/professions/publish.spec.ts
+++ b/cypress/integration/admin/professions/publish.spec.ts
@@ -19,6 +19,8 @@ describe('Publishing professions', () => {
         cy.get('h2[data-status]').should('contain', status);
       });
 
+      cy.get('[data-cy=changed-by-user]').should('contain', '');
+
       cy.translate('professions.form.button.publishNow').then(
         (publishButton) => {
           cy.get('button').contains(publishButton).click();
@@ -46,6 +48,13 @@ describe('Publishing professions', () => {
             cy.wrap($row).should('contain', status);
           });
         });
+
+      cy.contains('Gas Safe Engineer')
+        .parent('tr')
+        .within(() => {
+          cy.get('a').contains('View details').click();
+        });
+      cy.get('[data-cy=changed-by-user]').should('contain', 'Editor');
     });
   });
 });

--- a/cypress/integration/admin/professions/publish.spec.ts
+++ b/cypress/integration/admin/professions/publish.spec.ts
@@ -1,3 +1,5 @@
+import { format } from 'date-fns';
+
 describe('Publishing professions', () => {
   context('When I am logged in as an editor', () => {
     beforeEach(() => {
@@ -54,7 +56,13 @@ describe('Publishing professions', () => {
         .within(() => {
           cy.get('a').contains('View details').click();
         });
+      cy.checkAccessibility();
+
       cy.get('[data-cy=changed-by-user]').should('contain', 'Editor');
+      cy.get('[data-cy=last-modified]').should(
+        'contain',
+        format(new Date(), 'dd-MM-yyyy'),
+      );
     });
   });
 });

--- a/src/i18n/en/professions.json
+++ b/src/i18n/en/professions.json
@@ -311,7 +311,8 @@
       "draft": "Draft"
     },
     "changed": {
-      "by": "Changed by"
+      "by": "Changed by",
+      "on": "Last updated"
     },
     "viewDetails": "View details"
   },

--- a/src/i18n/en/professions.json
+++ b/src/i18n/en/professions.json
@@ -310,6 +310,9 @@
       "live": "Live",
       "draft": "Draft"
     },
+    "changed": {
+      "by": "Changed by"
+    },
     "viewDetails": "View details"
   },
   "search": {

--- a/src/professions/admin/list-entry.presenter.spec.ts
+++ b/src/professions/admin/list-entry.presenter.spec.ts
@@ -5,6 +5,10 @@ import industryFactory from '../../testutils/factories/industry';
 import organisationFactory from '../../testutils/factories/organisation';
 import professionFactory from '../../testutils/factories/profession';
 import { translationOf } from '../../testutils/translation-of';
+import userFactory from '../../testutils/factories/user';
+import { ProfessionPresenter } from '../presenters/profession.presenter';
+
+jest.mock('../presenters/profession.presenter');
 
 describe('ListEntryPresenter', () => {
   describe('tableRow', () => {
@@ -21,8 +25,14 @@ describe('ListEntryPresenter', () => {
           industryFactory.build({ name: 'industries.finance' }),
         ],
         status: 'live',
-        updated_at: new Date(2003, 7, 12),
+        changedByUser: userFactory.build({ name: 'Administrator' }),
+        lastModified: new Date('12-08-2003'),
         versionId: 'version-id',
+      });
+
+      (ProfessionPresenter as jest.Mock).mockReturnValue({
+        changedBy: 'Administrator',
+        lastModified: '12-08-2003',
       });
 
       const presenter = new ListEntryPresenter(
@@ -68,8 +78,14 @@ describe('ListEntryPresenter', () => {
           industryFactory.build({ name: 'industries.finance' }),
         ],
         status: 'draft',
-        updated_at: new Date(2003, 7, 12),
+        lastModified: new Date('12-08-2003'),
+        changedByUser: userFactory.build({ name: 'Editor' }),
         versionId: 'version-id',
+      });
+
+      (ProfessionPresenter as jest.Mock).mockReturnValue({
+        changedBy: 'Editor',
+        lastModified: '12-08-2003',
       });
 
       const presenter = new ListEntryPresenter(
@@ -85,7 +101,7 @@ describe('ListEntryPresenter', () => {
           )}`,
         },
         { text: '12-08-2003' },
-        { text: 'Placeholder name' },
+        { text: 'Editor' },
         { text: translationOf('professions.admin.status.draft') },
         {
           html: `<a href="/admin/professions/profession-id/versions/version-id">${translationOf(

--- a/src/professions/admin/list-entry.presenter.spec.ts
+++ b/src/professions/admin/list-entry.presenter.spec.ts
@@ -48,6 +48,7 @@ describe('ListEntryPresenter', () => {
           )}`,
         },
         { text: '12-08-2003' },
+        { text: 'Administrator' },
         { text: 'Example Organisation' },
         {
           text: `${translationOf('industries.law')}, ${translationOf(
@@ -122,6 +123,7 @@ describe('ListEntryPresenter', () => {
         { text: translationOf('professions.admin.tableHeading.profession') },
         { text: translationOf('professions.admin.tableHeading.nations') },
         { text: translationOf('professions.admin.tableHeading.lastModified') },
+        { text: translationOf('professions.admin.tableHeading.changedBy') },
         { text: translationOf('professions.admin.tableHeading.organisation') },
         { text: translationOf('professions.admin.tableHeading.industry') },
         { text: translationOf('professions.admin.tableHeading.status') },

--- a/src/professions/admin/list-entry.presenter.ts
+++ b/src/professions/admin/list-entry.presenter.ts
@@ -65,7 +65,7 @@ export class ListEntryPresenter {
       this.i18nService,
     );
 
-    const instrustries = (
+    const industries = (
       await Promise.all(
         this.profession.industries.map(
           (industry) =>
@@ -90,7 +90,7 @@ export class ListEntryPresenter {
           ? this.profession.organisation.name
           : '',
       },
-      industry: { text: instrustries },
+      industry: { text: industries },
       status: {
         text: await this.i18nService.translate(
           `professions.admin.status.${this.profession.status}`,

--- a/src/professions/admin/list-entry.presenter.ts
+++ b/src/professions/admin/list-entry.presenter.ts
@@ -1,9 +1,9 @@
 import { I18nService } from 'nestjs-i18n';
 import { TableCell } from '../../common/interfaces/table-cell';
 import { TableRow } from '../../common/interfaces/table-row';
-import { formatDate } from '../../common/utils';
 import { stringifyNations } from '../../nations/helpers/stringifyNations';
 import { Nation } from '../../nations/nation';
+import { ProfessionPresenter } from '../presenters/profession.presenter';
 import { Profession } from '../profession.entity';
 import { ProfessionsPresenterView } from './professions.presenter';
 
@@ -60,6 +60,11 @@ export class ListEntryPresenter {
   ) {}
 
   async tableRow(contents: ProfessionsPresenterView): Promise<TableRow> {
+    const presenter = new ProfessionPresenter(
+      this.profession,
+      this.i18nService,
+    );
+
     const nations = await stringifyNations(
       this.profession.occupationLocations.map((code) => Nation.find(code)),
       this.i18nService,
@@ -83,8 +88,8 @@ export class ListEntryPresenter {
     const entries: { [K in Field]: TableCell } = {
       profession: { text: this.profession.name },
       nations: { text: nations },
-      lastModified: { text: formatDate(this.profession.updated_at) },
-      changedBy: { text: 'Placeholder name' },
+      lastModified: { text: presenter.lastModified },
+      changedBy: { text: presenter.changedBy },
       organisation: {
         text: this.profession.organisation
           ? this.profession.organisation.name

--- a/src/professions/admin/list-entry.presenter.ts
+++ b/src/professions/admin/list-entry.presenter.ts
@@ -22,6 +22,7 @@ const fields = {
     'profession',
     'nations',
     'lastModified',
+    'changedBy',
     'organisation',
     'industry',
     'status',

--- a/src/professions/admin/profession-versions.controller.spec.ts
+++ b/src/professions/admin/profession-versions.controller.spec.ts
@@ -198,12 +198,26 @@ describe('ProfessionVersionsController', () => {
       const version = professionVersionFactory.build({
         profession,
       });
+      const user = userFactory.build();
+
+      const req = createMock<RequestWithAppSession>({
+        appSession: {
+          user: user as DeepPartial<any>,
+        },
+      });
 
       professionVersionsService.findByIdWithProfession.mockResolvedValue(
         version,
       );
 
-      const result = await controller.publish(profession.id, version.id);
+      const newVersion = professionVersionFactory.build({
+        profession,
+        user,
+      });
+
+      professionVersionsService.create.mockResolvedValue(newVersion);
+
+      const result = await controller.publish(req, profession.id, version.id);
 
       expect(result).toEqual(profession);
 
@@ -211,7 +225,14 @@ describe('ProfessionVersionsController', () => {
         professionVersionsService.findByIdWithProfession,
       ).toHaveBeenCalledWith(profession.id, version.id);
 
-      expect(professionVersionsService.publish).toHaveBeenCalledWith(version);
+      expect(professionVersionsService.create).toHaveBeenCalledWith(
+        version,
+        user,
+      );
+
+      expect(professionVersionsService.publish).toHaveBeenCalledWith(
+        newVersion,
+      );
     });
   });
 });

--- a/src/professions/admin/profession-versions.controller.spec.ts
+++ b/src/professions/admin/profession-versions.controller.spec.ts
@@ -18,8 +18,10 @@ import { ProfessionVersionsController } from './profession-versions.controller';
 import { ProfessionVersionsService } from '../profession-versions.service';
 import { ProfessionsService } from '../professions.service';
 import { Profession } from '../profession.entity';
+import { ProfessionPresenter } from '../presenters/profession.presenter';
 
 jest.mock('../../organisations/organisation.entity');
+jest.mock('../presenters/profession.presenter');
 
 describe('ProfessionVersionsController', () => {
   let controller: ProfessionVersionsController;
@@ -139,6 +141,8 @@ describe('ProfessionVersionsController', () => {
         version,
       );
 
+      (ProfessionPresenter as jest.Mock).mockReturnValue({});
+
       (Organisation.withLatestLiveVersion as jest.Mock).mockImplementation(
         () => profession.organisation,
       );
@@ -147,6 +151,7 @@ describe('ProfessionVersionsController', () => {
 
       expect(result).toEqual({
         profession: professionWithVersion,
+        presenter: {},
         qualification: new QualificationPresenter(
           professionWithVersion.qualification,
         ),
@@ -190,6 +195,8 @@ describe('ProfessionVersionsController', () => {
           version,
         );
 
+        (ProfessionPresenter as jest.Mock).mockReturnValue({});
+
         (Organisation.withLatestLiveVersion as jest.Mock).mockImplementation(
           () => profession.organisation,
         );
@@ -198,6 +205,7 @@ describe('ProfessionVersionsController', () => {
 
         expect(result).toEqual({
           profession: professionWithVersion,
+          presenter: {},
           qualification: null,
           nations: [translationOf('nations.england')],
           industries: [translationOf('industries.example')],

--- a/src/professions/admin/profession-versions.controller.spec.ts
+++ b/src/professions/admin/profession-versions.controller.spec.ts
@@ -7,7 +7,6 @@ import { Organisation } from '../../organisations/organisation.entity';
 import QualificationPresenter from '../../qualifications/presenters/qualification.presenter';
 import { createMockI18nService } from '../../testutils/create-mock-i18n-service';
 import industryFactory from '../../testutils/factories/industry';
-import legislationFactory from '../../testutils/factories/legislation';
 import professionFactory from '../../testutils/factories/profession';
 import professionVersionFactory from '../../testutils/factories/profession-version';
 import { translationOf } from '../../testutils/translation-of';
@@ -73,23 +72,7 @@ describe('ProfessionVersionsController', () => {
 
   describe('create', () => {
     it('creates a copy of the latest version of the Profession and its Qualification', async () => {
-      const legislation = legislationFactory.build();
-
-      const version = professionVersionFactory.build();
-
-      const updatedQualification = {
-        ...version.qualification,
-        id: undefined,
-        created_at: undefined,
-        updated_at: undefined,
-      };
-
-      const updatedLegislation = {
-        ...legislation,
-        id: undefined,
-        created_at: undefined,
-        updated_at: undefined,
-      };
+      const previousVersion = professionVersionFactory.build();
       const user = userFactory.build();
 
       const res = createMock<Response>();
@@ -100,27 +83,21 @@ describe('ProfessionVersionsController', () => {
       });
 
       professionVersionsService.findLatestForProfessionId.mockResolvedValue(
-        version,
+        previousVersion,
       );
-      professionVersionsService.save.mockResolvedValue(version);
+
+      const newVersion = professionVersionFactory.build();
+      professionVersionsService.create.mockResolvedValue(newVersion);
 
       await controller.create(res, req, 'some-uuid');
 
-      expect(professionVersionsService.save).toHaveBeenCalledWith(
-        expect.objectContaining({
-          id: undefined,
-          status: undefined,
-          created_at: undefined,
-          updated_at: undefined,
-          qualification: updatedQualification,
-          legislations: [updatedLegislation],
-          profession: version.profession,
-          user: user,
-        }),
+      expect(professionVersionsService.create).toHaveBeenCalledWith(
+        previousVersion,
+        user,
       );
 
       expect(res.redirect).toHaveBeenCalledWith(
-        `/admin/professions/${version.profession.id}/versions/${version.id}/check-your-answers?edit=true`,
+        `/admin/professions/${newVersion.profession.id}/versions/${newVersion.id}/check-your-answers?edit=true`,
       );
     });
   });

--- a/src/professions/admin/profession-versions.controller.ts
+++ b/src/professions/admin/profession-versions.controller.ts
@@ -15,14 +15,11 @@ import { I18nService } from 'nestjs-i18n';
 import { AuthenticationGuard } from '../../common/authentication.guard';
 import { BackLink } from '../../common/decorators/back-link.decorator';
 import { RequestWithAppSession } from '../../common/interfaces/request-with-app-session.interface';
-import { Legislation } from '../../legislations/legislation.entity';
 import { Nation } from '../../nations/nation';
 import { Organisation } from '../../organisations/organisation.entity';
 import QualificationPresenter from '../../qualifications/presenters/qualification.presenter';
-import { Qualification } from '../../qualifications/qualification.entity';
 import { UserPermission } from '../../users/user-permission';
 import { ShowTemplate } from '../interfaces/show-template.interface';
-import { ProfessionVersion } from '../profession-version.entity';
 import { Permissions } from '../../common/permissions.decorator';
 import { ProfessionVersionsService } from '../profession-versions.service';
 import { Profession } from '../profession.entity';
@@ -116,34 +113,10 @@ export class ProfessionVersionsController {
         professionId,
       );
 
-    const newQualification = {
-      ...latestVersion.qualification,
-      id: undefined,
-      created_at: undefined,
-      updated_at: undefined,
-    } as Qualification;
-
-    const newLegislations = latestVersion.legislations.map((legislation) => {
-      return {
-        ...legislation,
-        id: undefined,
-        created_at: undefined,
-        updated_at: undefined,
-      } as Legislation;
-    });
-
-    const newVersion = {
-      ...latestVersion,
-      id: undefined,
-      status: undefined,
-      created_at: undefined,
-      updated_at: undefined,
-      user: req.appSession.user,
-      qualification: newQualification,
-      legislations: newLegislations,
-    } as ProfessionVersion;
-
-    const version = await this.professionVersionsService.save(newVersion);
+    const version = await this.professionVersionsService.create(
+      latestVersion,
+      req.appSession.user,
+    );
 
     return res.redirect(
       `/admin/professions/${version.profession.id}/versions/${version.id}/check-your-answers?edit=true`,

--- a/src/professions/admin/profession-versions.controller.ts
+++ b/src/professions/admin/profession-versions.controller.ts
@@ -127,6 +127,7 @@ export class ProfessionVersionsController {
   @Permissions(UserPermission.PublishProfession)
   @Render('admin/professions/publish')
   async publish(
+    @Req() req: RequestWithAppSession,
     @Param('professionId') professionId: string,
     @Param('versionId') versionId: string,
   ): Promise<Profession> {
@@ -135,7 +136,12 @@ export class ProfessionVersionsController {
       versionId,
     );
 
-    await this.professionVersionsService.publish(version);
+    const newVersion = await this.professionVersionsService.create(
+      version,
+      req.appSession.user,
+    );
+
+    await this.professionVersionsService.publish(newVersion);
 
     return version.profession;
   }

--- a/src/professions/admin/profession-versions.controller.ts
+++ b/src/professions/admin/profession-versions.controller.ts
@@ -27,6 +27,7 @@ import { Permissions } from '../../common/permissions.decorator';
 import { ProfessionVersionsService } from '../profession-versions.service';
 import { Profession } from '../profession.entity';
 import { ProfessionsService } from '../professions.service';
+import { ProfessionPresenter } from '../presenters/profession.presenter';
 
 @UseGuards(AuthenticationGuard)
 @Controller('/admin/professions')
@@ -71,6 +72,7 @@ export class ProfessionVersionsController {
     }
 
     const profession = Profession.withVersion(version.profession, version);
+    const presenter = new ProfessionPresenter(profession, this.i18nService);
 
     const organisation = Organisation.withLatestLiveVersion(
       profession.organisation,
@@ -94,6 +96,7 @@ export class ProfessionVersionsController {
 
     return {
       profession,
+      presenter,
       qualification: qualification,
       nations,
       industries,

--- a/src/professions/interfaces/show-template.interface.ts
+++ b/src/professions/interfaces/show-template.interface.ts
@@ -1,9 +1,11 @@
 import { Organisation } from '../../organisations/organisation.entity';
 import QualificationPresenter from '../../qualifications/presenters/qualification.presenter';
+import { ProfessionPresenter } from '../presenters/profession.presenter';
 import { Profession } from '../profession.entity';
 
 export interface ShowTemplate {
   profession: Profession;
+  presenter?: ProfessionPresenter;
   qualification: QualificationPresenter;
   nations: string[];
   industries: string[];

--- a/src/professions/presenters/profession.presenter.spec.ts
+++ b/src/professions/presenters/profession.presenter.spec.ts
@@ -11,9 +11,11 @@ import { multilineOf } from '../../testutils/multiline-of';
 import { createMockI18nService } from '../../testutils/create-mock-i18n-service';
 import { translationOf } from '../../testutils/translation-of';
 import userFactory from '../../testutils/factories/user';
+import { formatDate } from '../../common/utils';
 
 jest.mock('../../nations/helpers/stringifyNations');
 jest.mock('../../helpers/format-multiline-string.helper');
+jest.mock('../../common/utils');
 
 describe('ProfessionPresenter', () => {
   let profession: Profession;
@@ -92,6 +94,24 @@ describe('ProfessionPresenter', () => {
 
         expect(presenter.changedBy).toEqual('');
       });
+    });
+  });
+
+  describe('lastModified', () => {
+    it('should format the lastModified date on a profession', () => {
+      const profession = professionFactory.build({
+        lastModified: new Date('01-01-2022'),
+      });
+
+      const presenter = new ProfessionPresenter(
+        profession,
+        createMockI18nService(),
+      );
+
+      presenter.lastModified;
+      expect(formatDate as jest.Mock).toHaveBeenCalledWith(
+        new Date('01-01-2022'),
+      );
     });
   });
 

--- a/src/professions/presenters/profession.presenter.spec.ts
+++ b/src/professions/presenters/profession.presenter.spec.ts
@@ -10,6 +10,7 @@ import { formatMultilineString } from '../../helpers/format-multiline-string.hel
 import { multilineOf } from '../../testutils/multiline-of';
 import { createMockI18nService } from '../../testutils/create-mock-i18n-service';
 import { translationOf } from '../../testutils/translation-of';
+import userFactory from '../../testutils/factories/user';
 
 jest.mock('../../nations/helpers/stringifyNations');
 jest.mock('../../helpers/format-multiline-string.helper');
@@ -59,6 +60,38 @@ describe('ProfessionPresenter', () => {
       expect(formatMultilineString).toBeCalledWith(
         profession.qualification.level,
       );
+    });
+  });
+
+  describe('changedBy', () => {
+    describe('when the Profession has been edited by a user', () => {
+      it('returns the name of the user', () => {
+        const profession = professionFactory.build({
+          changedByUser: userFactory.build({ name: 'beis-rpr' }),
+        });
+
+        const presenter = new ProfessionPresenter(
+          profession,
+          createMockI18nService(),
+        );
+
+        expect(presenter.changedBy).toEqual('beis-rpr');
+      });
+    });
+
+    describe("when the Profession hasn't yet been edited by a user", () => {
+      it('returns an empty string', () => {
+        const profession = professionFactory.build({
+          changedByUser: undefined,
+        });
+
+        const presenter = new ProfessionPresenter(
+          profession,
+          createMockI18nService(),
+        );
+
+        expect(presenter.changedBy).toEqual('');
+      });
     });
   });
 

--- a/src/professions/presenters/profession.presenter.ts
+++ b/src/professions/presenters/profession.presenter.ts
@@ -51,6 +51,12 @@ export class ProfessionPresenter {
     };
   }
 
+  get changedBy(): string {
+    return this.profession.changedByUser
+      ? this.profession.changedByUser.name
+      : '';
+  }
+
   public async occupationLocations(): Promise<string> {
     return await stringifyNations(
       this.profession.occupationLocations.map((code) => Nation.find(code)),

--- a/src/professions/presenters/profession.presenter.ts
+++ b/src/professions/presenters/profession.presenter.ts
@@ -4,6 +4,7 @@ import { SummaryList } from '../../common/interfaces/summary-list';
 import { stringifyNations } from '../../nations/helpers/stringifyNations';
 import { Nation } from '../../nations/nation';
 import { formatMultilineString } from '../../helpers/format-multiline-string.helper';
+import { formatDate } from '../../common/utils';
 
 export class ProfessionPresenter {
   constructor(
@@ -55,6 +56,10 @@ export class ProfessionPresenter {
     return this.profession.changedByUser
       ? this.profession.changedByUser.name
       : '';
+  }
+
+  get lastModified(): string {
+    return formatDate(this.profession.lastModified);
   }
 
   public async occupationLocations(): Promise<string> {

--- a/src/professions/profession-version.entity.ts
+++ b/src/professions/profession-version.entity.ts
@@ -38,7 +38,7 @@ export class ProfessionVersion {
   @ManyToOne(() => Profession, (profession) => profession.versions)
   profession: Profession;
 
-  @ManyToOne(() => User, (user) => user.organisationVersions)
+  @ManyToOne(() => User, (user) => user.professionVersions)
   user: User;
 
   @Column({

--- a/src/professions/profession-versions.service.spec.ts
+++ b/src/professions/profession-versions.service.spec.ts
@@ -257,6 +257,7 @@ describe('ProfessionVersionsService', () => {
         'professionVersion.profession',
         'professionVersion.industries',
         'profession.organisation',
+        'professionVersion.user',
         'professionVersion.qualification',
         'professionVersion.legislations',
       ]);
@@ -301,6 +302,7 @@ describe('ProfessionVersionsService', () => {
         'professionVersion.profession',
         'profession.organisation',
         'professionVersion.industries',
+        'professionVersion.user',
         'professionVersion.qualification',
         'professionVersion.legislations',
       ]);
@@ -344,6 +346,7 @@ describe('ProfessionVersionsService', () => {
         'professionVersion.profession',
         'professionVersion.industries',
         'profession.organisation',
+        'professionVersion.user',
         'professionVersion.qualification',
         'professionVersion.legislations',
       ]);
@@ -387,6 +390,7 @@ describe('ProfessionVersionsService', () => {
         'professionVersion.profession',
         'professionVersion.industries',
         'profession.organisation',
+        'professionVersion.user',
         'professionVersion.qualification',
         'professionVersion.legislations',
       ]);

--- a/src/professions/profession-versions.service.spec.ts
+++ b/src/professions/profession-versions.service.spec.ts
@@ -17,6 +17,9 @@ import {
 } from './profession-version.entity';
 import professionFactory from '../testutils/factories/profession';
 import { Profession } from './profession.entity';
+import legislationFactory from '../testutils/factories/legislation';
+import userFactory from '../testutils/factories/user';
+import qualificationFactory from '../testutils/factories/qualification';
 
 describe('ProfessionVersionsService', () => {
   let service: ProfessionVersionsService;
@@ -88,6 +91,51 @@ describe('ProfessionVersionsService', () => {
 
       expect(result).toEqual(updatedVersion);
       expect(repoSpy).toHaveBeenCalledWith(updatedVersion);
+    });
+  });
+
+  describe('create', () => {
+    it('creates a copy of an existing version and sets the user', async () => {
+      const legislation = legislationFactory.build();
+      const qualification = qualificationFactory.build();
+      const profession = professionFactory.build();
+
+      const previousVersion = professionVersionFactory.build({
+        profession: profession,
+        legislations: [legislation],
+        qualification: qualification,
+      });
+
+      const newQualification = {
+        ...previousVersion.qualification,
+        id: undefined,
+        created_at: undefined,
+        updated_at: undefined,
+      };
+
+      const newLegislation = {
+        ...legislation,
+        id: undefined,
+        created_at: undefined,
+        updated_at: undefined,
+      };
+      const user = userFactory.build();
+
+      const repoSpy = jest.spyOn(repo, 'save');
+
+      await service.create(previousVersion, user);
+
+      expect(repoSpy).toHaveBeenCalledWith({
+        ...previousVersion,
+        id: undefined,
+        status: undefined,
+        created_at: undefined,
+        updated_at: undefined,
+        qualification: newQualification,
+        legislations: [newLegislation],
+        profession: profession,
+        user: user,
+      });
     });
   });
 

--- a/src/professions/profession-versions.service.ts
+++ b/src/professions/profession-versions.service.ts
@@ -140,6 +140,7 @@ export class ProfessionVersionsService {
       .leftJoinAndSelect('profession.organisation', 'organisation')
       .leftJoinAndSelect('professionVersion.industries', 'industries')
       .leftJoinAndSelect('professionVersion.qualification', 'qualification')
+      .leftJoinAndSelect('professionVersion.user', 'user')
       .leftJoinAndSelect('professionVersion.legislations', 'legislations');
   }
 }

--- a/src/professions/profession-versions.service.ts
+++ b/src/professions/profession-versions.service.ts
@@ -6,6 +6,9 @@ import {
   ProfessionVersionStatus,
 } from './profession-version.entity';
 import { Profession } from './profession.entity';
+import { Legislation } from '../legislations/legislation.entity';
+import { Qualification } from '../qualifications/qualification.entity';
+import { User } from '../users/user.entity';
 
 @Injectable()
 export class ProfessionVersionsService {
@@ -31,6 +34,40 @@ export class ProfessionVersionsService {
     version.status = ProfessionVersionStatus.Draft;
 
     return this.repository.save(version);
+  }
+
+  async create(
+    previousVersion: ProfessionVersion,
+    user: User,
+  ): Promise<ProfessionVersion> {
+    const newQualification = {
+      ...previousVersion.qualification,
+      id: undefined,
+      created_at: undefined,
+      updated_at: undefined,
+    } as Qualification;
+
+    const newLegislations = previousVersion.legislations.map((legislation) => {
+      return {
+        ...legislation,
+        id: undefined,
+        created_at: undefined,
+        updated_at: undefined,
+      } as Legislation;
+    });
+
+    const newVersion = {
+      ...previousVersion,
+      id: undefined,
+      status: undefined,
+      created_at: undefined,
+      updated_at: undefined,
+      user: user,
+      qualification: newQualification,
+      legislations: newLegislations,
+    } as ProfessionVersion;
+
+    return this.save(newVersion);
   }
 
   async publish(version: ProfessionVersion): Promise<ProfessionVersion> {

--- a/src/professions/profession.entity.spec.ts
+++ b/src/professions/profession.entity.spec.ts
@@ -24,6 +24,7 @@ describe('Profession', () => {
         qualification: professionVersion.qualification,
         reservedActivities: professionVersion.reservedActivities,
         legislations: professionVersion.legislations,
+        changedByUser: professionVersion.user,
         status: professionVersion.status,
         versionId: professionVersion.id,
       });

--- a/src/professions/profession.entity.spec.ts
+++ b/src/professions/profession.entity.spec.ts
@@ -25,6 +25,7 @@ describe('Profession', () => {
         reservedActivities: professionVersion.reservedActivities,
         legislations: professionVersion.legislations,
         changedByUser: professionVersion.user,
+        lastModified: professionVersion.updated_at,
         status: professionVersion.status,
         versionId: professionVersion.id,
       });

--- a/src/professions/profession.entity.ts
+++ b/src/professions/profession.entity.ts
@@ -13,6 +13,7 @@ import { Industry } from '../industries/industry.entity';
 import { Legislation } from '../legislations/legislation.entity';
 import { Organisation } from '../organisations/organisation.entity';
 import { Qualification } from '../qualifications/qualification.entity';
+import { User } from '../users/user.entity';
 import {
   ProfessionVersion,
   ProfessionVersionStatus,
@@ -75,6 +76,7 @@ export class Profession {
   regulationUrl?: string;
   reservedActivities?: string;
   legislations?: Legislation[];
+  changedByUser?: User;
   versionId?: string;
   status?: string;
 
@@ -161,6 +163,7 @@ export class Profession {
       protectedTitles: version.protectedTitles,
       regulationUrl: version.regulationUrl,
       legislations: version.legislations,
+      changedByUser: version.user,
       status: version.status,
       versionId: version.id,
     };

--- a/src/professions/profession.entity.ts
+++ b/src/professions/profession.entity.ts
@@ -79,6 +79,7 @@ export class Profession {
   changedByUser?: User;
   versionId?: string;
   status?: string;
+  lastModified?: Date;
 
   constructor(
     name?: string,
@@ -164,6 +165,7 @@ export class Profession {
       regulationUrl: version.regulationUrl,
       legislations: version.legislations,
       changedByUser: version.user,
+      lastModified: version.updated_at,
       status: version.status,
       versionId: version.id,
     };

--- a/src/testutils/factories/profession.ts
+++ b/src/testutils/factories/profession.ts
@@ -54,6 +54,7 @@ export default ProfessionFactory.define(({ sequence }) => ({
   regulationUrl: 'http://example.com/regulations',
   versions: [],
   changedByUser: userFactory.build(),
+  lastModified: new Date(),
   updated_at: new Date(),
   versionId: 'version-id',
 }));

--- a/src/testutils/factories/profession.ts
+++ b/src/testutils/factories/profession.ts
@@ -6,6 +6,7 @@ import {
 import industryFactory from './industry';
 import organisationFactory from './organisation';
 import qualificationFactory from './qualification';
+import userFactory from './user';
 
 class ProfessionFactory extends Factory<Profession> {
   justCreated(id: string) {
@@ -52,6 +53,7 @@ export default ProfessionFactory.define(({ sequence }) => ({
   protectedTitles: 'Example titles',
   regulationUrl: 'http://example.com/regulations',
   versions: [],
+  changedByUser: userFactory.build(),
   updated_at: new Date(),
   versionId: 'version-id',
 }));

--- a/src/testutils/factories/user.ts
+++ b/src/testutils/factories/user.ts
@@ -9,6 +9,7 @@ export default Factory.define<User>(({ sequence }) => ({
   role: Role.Editor,
   externalIdentifier: 'extid|1234567',
   organisationVersions: [],
+  professionVersions: [],
   organisation: undefined,
   serviceOwner: false,
   confirmed: false,

--- a/src/users/user.entity.ts
+++ b/src/users/user.entity.ts
@@ -60,6 +60,12 @@ export class User {
   )
   organisationVersions: OrganisationVersion[];
 
+  @OneToMany(
+    () => ProfessionVersion,
+    (professionVersion) => professionVersion.user,
+  )
+  professionVersions: ProfessionVersion[];
+
   @ManyToOne(() => Organisation, (organisation) => organisation.users, {
     eager: true,
   })

--- a/src/users/user.entity.ts
+++ b/src/users/user.entity.ts
@@ -12,6 +12,7 @@ import {
 import { OrganisationVersion } from '../organisations/organisation-version.entity';
 import { Role } from './role';
 import { Organisation } from '../organisations/organisation.entity';
+import { ProfessionVersion } from '../professions/profession-version.entity';
 
 @Entity({ name: 'users' })
 export class User {

--- a/views/admin/professions/show.njk
+++ b/views/admin/professions/show.njk
@@ -17,6 +17,11 @@
           <span class="govuk-body">{{ ("professions.admin.status." + profession.status) | t }}</span>
         </h2>
 
+        <h2 class="govuk-heading-s" data-cy="last-modified-text">
+          {{ "professions.admin.changed.on" | t }}<br>
+          <span class="govuk-body" data-cy="last-modified">{{ presenter.lastModified }}</span>
+        </h2>
+
         <h2 class="govuk-heading-s" data-cy="changed-by-text">
           {{ "professions.admin.changed.by" | t }}<br>
           <span class="govuk-body" data-cy="changed-by-user">{{ presenter.changedBy }}</span>

--- a/views/admin/professions/show.njk
+++ b/views/admin/professions/show.njk
@@ -17,6 +17,11 @@
           <span class="govuk-body">{{ ("professions.admin.status." + profession.status) | t }}</span>
         </h2>
 
+        <h2 class="govuk-heading-s" data-cy="changed-by-text">
+          {{ "professions.admin.changed.by" | t }}<br>
+          <span class="govuk-body" data-cy="changed-by-user">{{ presenter.changedBy }}</span>
+        </h2>
+
         <ul class="govuk-list">
           {% if profession.status === 'draft' and 'publishProfession' in permissions %}
             <li>


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR

- Fixes incorrect ProfessionEntity -> User relationship.
- Adds the user who last edited the profession to the admin profession page. This will be empty if data hasn't been edited - we may want to iterate this or hide the field entirely, but this is a first step.
- Publishing a profession now creates a duplicate version, setting the user who published on it rather than the user who edited the Profession version.
- Now shows "Changed by" for BEIS editor users, which was previously hidden in the Profession index table. 

## Screenshots of UI changes

### Admin "show" page (organisation admin, after manually updating):

![image](https://user-images.githubusercontent.com/19826940/154291452-13fd72d8-b615-4d59-a2f6-bc3dd990ef95.png)

### Admin "show" page - editor user, showing entry that has not yet been updated:

![image](https://user-images.githubusercontent.com/19826940/154291899-63048512-1070-43eb-9c1e-4c4c5fcb5fe5.png)

### Admin index page (organisation admin, after manually updating):

![image](https://user-images.githubusercontent.com/19826940/154291295-9297f987-296e-4c9f-ac8e-13cc4532b580.png)

### Admin index page (editor user, showing entry that has not yet been updated):

![image](https://user-images.githubusercontent.com/19826940/154291741-f60a6d49-ca7f-4af6-8475-4b6bc6497c8c.png)


