### PR TITLE
(2106) Add fields to qualifications page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Protected titles and and a URL for further information on regulations can be entered when adding a profession
 - Allow second regulator to be chosen
 - Add registration page and fields
+- Add extra qualification recognition fields
 
 ### Changed
 

--- a/cypress/integration/admin/professions/edit.spec.ts
+++ b/cypress/integration/admin/professions/edit.spec.ts
@@ -194,6 +194,100 @@ describe('Editing an existing profession', () => {
       );
     });
 
+    it('hides the UK recognition fields if the organisation covers the whole of the UK', () => {
+      cy.visitAndCheckAccessibility('/admin/professions');
+
+      cy.get('table')
+        .contains('tr', 'Gas Safe Engineer')
+        .within(() => {
+          cy.contains('View details').click();
+        });
+
+      cy.translate('professions.admin.editProfession').then((buttonText) => {
+        cy.contains(buttonText).click();
+      });
+
+      cy.translate('professions.form.captions.edit').then((editCaption) => {
+        cy.get('body').contains(editCaption);
+      });
+
+      cy.translate('professions.form.button.edit').then((buttonText) => {
+        cy.get('button').contains(buttonText).click();
+      });
+
+      cy.clickSummaryListRowAction(
+        'professions.form.label.topLevelInformation.nations',
+        'Change',
+      );
+
+      cy.translate('app.unitedKingdom').then((uk) => {
+        cy.get('label').contains(uk).click();
+      });
+
+      cy.translate('app.continue').then((buttonText) => {
+        cy.get('button').contains(buttonText).click();
+      });
+
+      cy.translate(
+        'professions.form.label.qualificationInformation.ukRecognition',
+      ).then((ukRecognition) => {
+        cy.contains('.govuk-summary-list__row', ukRecognition).should(
+          'be.visible',
+        );
+      });
+
+      cy.clickSummaryListRowAction(
+        'professions.form.label.qualificationInformation.methodsToObtainQualification',
+        'Change',
+      );
+
+      cy.translate(
+        'professions.form.label.qualificationInformation.ukRecognition',
+      ).then((ukRecognition) => {
+        cy.get('body').should('not.contain', ukRecognition);
+      });
+
+      cy.translate('app.continue').then((buttonText) => {
+        cy.get('button').contains(buttonText).click();
+      });
+
+      cy.clickSummaryListRowAction(
+        'professions.form.label.topLevelInformation.nations',
+        'Change',
+      );
+
+      cy.translate(
+        'professions.form.label.topLevelInformation.certainNations',
+      ).then((certainNations) => {
+        cy.get('label').contains(certainNations).click();
+      });
+
+      cy.get('[type="checkbox"]').uncheck('GB-SCT');
+
+      cy.translate('app.continue').then((buttonText) => {
+        cy.get('button').contains(buttonText).click();
+      });
+
+      cy.translate(
+        'professions.form.label.qualificationInformation.ukRecognition',
+      ).then((ukRecognition) => {
+        cy.contains('.govuk-summary-list__row', ukRecognition).should(
+          'be.visible',
+        );
+      });
+
+      cy.clickSummaryListRowAction(
+        'professions.form.label.qualificationInformation.methodsToObtainQualification',
+        'Change',
+      );
+
+      cy.translate(
+        'professions.form.label.qualificationInformation.ukRecognition',
+      ).then((ukRecognition) => {
+        cy.get('body').should('contain', ukRecognition);
+      });
+    });
+
     it('Selecting UK sets the nations to all UK nations', () => {
       cy.visitAndCheckAccessibility('/admin/professions');
 

--- a/cypress/integration/admin/professions/new.spec.ts
+++ b/cypress/integration/admin/professions/new.spec.ts
@@ -161,6 +161,15 @@ describe('Adding a new profession', () => {
       ).check();
       cy.get('textarea[name="level"]').type('An example Qualification level');
 
+      cy.get('input[name="ukRecognition"]').type('Recognition in the UK');
+      cy.get('input[name="ukRecognitionUrl"]').type('http://example.com/uk');
+      cy.get('input[name="otherCountriesRecognition"]').type(
+        'Recognition in other countries',
+      );
+      cy.get('input[name="otherCountriesRecognitionUrl"]').type(
+        'http://example.com/other',
+      );
+
       cy.translate('app.continue').then((buttonText) => {
         cy.get('button').contains(buttonText).click();
       });

--- a/cypress/integration/admin/professions/new.spec.ts
+++ b/cypress/integration/admin/professions/new.spec.ts
@@ -297,6 +297,26 @@ describe('Adding a new profession', () => {
       });
 
       cy.checkSummaryListRowValue(
+        'professions.form.label.qualificationInformation.ukRecognition',
+        'Recognition in the UK',
+      );
+
+      cy.checkSummaryListRowValue(
+        'professions.form.label.qualificationInformation.ukRecognitionUrl',
+        'http://example.com/uk',
+      );
+
+      cy.checkSummaryListRowValue(
+        'professions.form.label.qualificationInformation.otherCountriesRecognition',
+        'Recognition in other countries',
+      );
+
+      cy.checkSummaryListRowValue(
+        'professions.form.label.qualificationInformation.otherCountriesRecognitionUrl',
+        'http://example.com/other',
+      );
+
+      cy.checkSummaryListRowValue(
         'professions.form.label.legislation.nationalLegislation',
         'National legislation description',
       );

--- a/cypress/integration/admin/professions/new.spec.ts
+++ b/cypress/integration/admin/professions/new.spec.ts
@@ -145,13 +145,13 @@ describe('Adding a new profession', () => {
       cy.translate('professions.form.captions.add').then((addCaption) => {
         cy.get('body').contains(addCaption);
       });
-      cy.get('textarea[name="level"]').type('An example Qualification level');
       cy.get(
         'input[name="methodToObtainQualification"][value="others"]',
       ).check();
       cy.get('textarea[name="otherMethodToObtainQualification"]').type(
         'Another method',
       );
+
       cy.get(
         'input[name="mostCommonPathToObtainQualification"][value="generalSecondaryEducation"]',
       ).check();
@@ -159,6 +159,8 @@ describe('Adding a new profession', () => {
       cy.get(
         'input[name="mandatoryProfessionalExperience"][value="1"]',
       ).check();
+      cy.get('textarea[name="level"]').type('An example Qualification level');
+
       cy.translate('app.continue').then((buttonText) => {
         cy.get('button').contains(buttonText).click();
       });

--- a/src/db/migrate/1644855571433-AddRecognitionFieldsToQualifications.ts
+++ b/src/db/migrate/1644855571433-AddRecognitionFieldsToQualifications.ts
@@ -1,0 +1,37 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddRecognitionFieldsToQualifications1644855571433
+  implements MigrationInterface
+{
+  name = 'AddRecognitionFieldsToQualifications1644855571433';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "qualifications" ADD "ukRecognition" character varying`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "qualifications" ADD "ukRecognitionUrl" character varying`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "qualifications" ADD "otherCountriesRecognition" character varying`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "qualifications" ADD "otherCountriesRecognitionUrl" character varying`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "qualifications" DROP COLUMN "otherCountriesRecognitionUrl"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "qualifications" DROP COLUMN "otherCountriesRecognition"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "qualifications" DROP COLUMN "ukRecognitionUrl"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "qualifications" DROP COLUMN "ukRecognition"`,
+    );
+  }
+}

--- a/src/helpers/nations.helper.spec.ts
+++ b/src/helpers/nations.helper.spec.ts
@@ -1,0 +1,27 @@
+import { allNations, isUK } from './nations.helper';
+
+describe('nations.helper', () => {
+  describe('allNations', () => {
+    it('returns all nations', () => {
+      expect(allNations()).toEqual(['GB-ENG', 'GB-SCT', 'GB-WLS', 'GB-NIR']);
+    });
+  });
+
+  describe('isUK', () => {
+    describe('when the nations list contains all UK nations', () => {
+      it('returns true', () => {
+        const nations = ['GB-ENG', 'GB-SCT', 'GB-WLS', 'GB-NIR'];
+
+        expect(isUK(nations)).toBeTruthy();
+      });
+    });
+
+    describe('when the nations list does not contain all UK nations', () => {
+      it('returns false', () => {
+        const nations = ['GB-ENG', 'GB-WLS'];
+
+        expect(isUK(nations)).toBeFalsy();
+      });
+    });
+  });
+});

--- a/src/helpers/nations.helper.ts
+++ b/src/helpers/nations.helper.ts
@@ -1,0 +1,14 @@
+import { Nation } from './../nations/nation';
+
+export function allNations(): string[] {
+  return Nation.all().map((nation) => nation.code);
+}
+
+export function isUK(nationCodes: string[]) {
+  const nations = allNations();
+
+  return (
+    nationCodes.length === nations.length &&
+    nationCodes.every((e, i) => e === nations[i])
+  );
+}

--- a/src/i18n/en/professions.json
+++ b/src/i18n/en/professions.json
@@ -46,7 +46,11 @@
         "methodsToObtainQualification": "Method to obtain qualification",
         "mostCommonPathToObtainQualification": "Most common path to obtain qualification",
         "duration": "Duration of qualification",
-        "mandatoryProfessionalExperience": "Existence of mandatory professional experience"
+        "mandatoryProfessionalExperience": "Existence of mandatory professional experience",
+        "ukRecognition": "Recognition of qualifications in the UK",
+        "ukRecognitionUrl": "More about recognition within the UK",
+        "otherCountriesRecognition": "Recognition of qualifications from other countries",
+        "otherCountriesRecognitionUrl": "More about recognition in other countries"
       },
       "legislation": {
         "nationalLegislation": "National legislation",
@@ -59,6 +63,10 @@
       },
       "registration": {
         "registrationUrl": "Please enter a link"
+      },
+      "qualificationInformation": {
+        "ukRecognitionUrl": "Please enter a link",
+        "otherCountriesRecognitionUrl": "Please enter a link"
       }
     },
     "details": {
@@ -147,6 +155,12 @@
         },
         "mandatoryProfessionalExperience": {
           "empty": "Select whether existence of professional experience is mandatory"
+        },
+        "ukRecognitionUrl": {
+          "invalid": "Please enter a valid website address"
+        },
+        "otherCountriesRecognitionUrl": {
+          "invalid": "Please enter a valid website address"
         }
       },
       "legislation": {

--- a/src/organisations/admin/dto/organisation.dto.ts
+++ b/src/organisations/admin/dto/organisation.dto.ts
@@ -15,7 +15,7 @@ export class OrganisationDto {
       message: 'organisations.admin.form.errors.email.invalid',
     },
   )
-  @ValidateIf((e) => e.email !== undefined)
+  @ValidateIf((e) => e.email)
   email: string;
 
   @IsUrl(
@@ -32,7 +32,7 @@ export class OrganisationDto {
       message: 'organisations.admin.form.errors.contactUrl.invalid',
     },
   )
-  @ValidateIf((e) => e.contactUrl !== undefined)
+  @ValidateIf((e) => e.contactUrl)
   contactUrl: string;
 
   telephone: string;

--- a/src/professions/admin/check-your-answers.controller.ts
+++ b/src/professions/admin/check-your-answers.controller.ts
@@ -21,6 +21,7 @@ import ViewUtils from './viewUtils';
 import { BackLink } from '../../common/decorators/back-link.decorator';
 import { ProfessionVersionsService } from '../profession-versions.service';
 import { isConfirmed } from '../../helpers/is-confirmed';
+import { isUK } from '../../helpers/nations.helper';
 @UseGuards(AuthenticationGuard)
 @Controller('admin/professions')
 export class CheckYourAnswersController {
@@ -92,6 +93,7 @@ export class CheckYourAnswersController {
       legislation: version.legislations[0],
       confirmed: isConfirmed(draftProfession),
       captionText: ViewUtils.captionText(isConfirmed(draftProfession)),
+      isUK: isUK(version.occupationLocations),
       edit: Boolean(edit),
     };
   }

--- a/src/professions/admin/dto/qualification-information.dto.ts
+++ b/src/professions/admin/dto/qualification-information.dto.ts
@@ -1,4 +1,4 @@
-import { IsNotEmpty, ValidateIf } from 'class-validator';
+import { IsNotEmpty, ValidateIf, IsUrl } from 'class-validator';
 import { MethodToObtain } from '../../../qualifications/qualification.entity';
 
 export class QualificationInformationDto {
@@ -45,6 +45,29 @@ export class QualificationInformationDto {
       'professions.form.errors.qualification.mandatoryProfessionalExperience.empty',
   })
   mandatoryProfessionalExperience: string;
+
+  ukRecognition: string;
+
+  @IsUrl(
+    {},
+    {
+      message: 'professions.form.errors.qualification.ukRecognitionUrl.invalid',
+    },
+  )
+  @ValidateIf((e) => e.ukRecognitionUrl)
+  ukRecognitionUrl: string;
+
+  otherCountriesRecognition: string;
+
+  @IsUrl(
+    {},
+    {
+      message:
+        'professions.form.errors.qualification.otherCountriesRecognitionUrl.invalid',
+    },
+  )
+  @ValidateIf((e) => e.otherCountriesRecognitionUrl)
+  otherCountriesRecognitionUrl: string;
 
   change: boolean;
 }

--- a/src/professions/admin/dto/registration.dto.ts
+++ b/src/professions/admin/dto/registration.dto.ts
@@ -15,6 +15,6 @@ export class RegistrationDto {
       message: 'professions.form.errors.registrationUrl.invalid',
     },
   )
-  @ValidateIf((e) => e.registrationUrl !== '')
+  @ValidateIf((e) => e.registrationUrl)
   registrationUrl: string;
 }

--- a/src/professions/admin/interfaces/check-your-answers.template.ts
+++ b/src/professions/admin/interfaces/check-your-answers.template.ts
@@ -19,6 +19,7 @@ export interface CheckYourAnswersTemplate {
   qualification: QualificationPresenter;
   legislation: Legislation;
   captionText: string;
+  isUK: boolean;
   confirmed: boolean;
   edit: boolean;
 }

--- a/src/professions/admin/interfaces/qualification-information.template.ts
+++ b/src/professions/admin/interfaces/qualification-information.template.ts
@@ -6,6 +6,10 @@ export interface QualificationInformationTemplate {
   mostCommonPathToObtainQualificationRadioButtonArgs: RadioButtonArgs[];
   duration: string;
   mandatoryProfessionalExperienceRadioButtonArgs: RadioButtonArgs[];
+  ukRecognition: string;
+  ukRecognitionUrl: string;
+  otherCountriesRecognition: string;
+  otherCountriesRecognitionUrl: string;
   captionText: string;
   change: boolean;
   errors: object | undefined;

--- a/src/professions/admin/interfaces/qualification-information.template.ts
+++ b/src/professions/admin/interfaces/qualification-information.template.ts
@@ -11,6 +11,7 @@ export interface QualificationInformationTemplate {
   otherCountriesRecognition: string;
   otherCountriesRecognitionUrl: string;
   captionText: string;
+  isUK: boolean;
   change: boolean;
   errors: object | undefined;
 }

--- a/src/professions/admin/qualification-information.controller.spec.ts
+++ b/src/professions/admin/qualification-information.controller.spec.ts
@@ -113,6 +113,10 @@ describe(QualificationInformationController, () => {
             otherMostCommonPathToObtainQualification: '',
             duration: '3.0 Years',
             mandatoryProfessionalExperience: '1',
+            ukRecognition: 'ukRecognition',
+            ukRecognitionUrl: 'http://example.com/uk',
+            otherCountriesRecognition: 'otherCountriesRecognition',
+            otherCountriesRecognitionUrl: 'http://example.com/other',
             change: false,
           };
 
@@ -133,6 +137,10 @@ describe(QualificationInformationController, () => {
                 level: 'Qualification level',
                 mandatoryProfessionalExperience: true,
                 methodToObtain: 'degreeLevel',
+                ukRecognition: 'ukRecognition',
+                ukRecognitionUrl: 'http://example.com/uk',
+                otherCountriesRecognition: 'otherCountriesRecognition',
+                otherCountriesRecognitionUrl: 'http://example.com/other',
               }),
             }),
           );
@@ -161,6 +169,10 @@ describe(QualificationInformationController, () => {
             otherMostCommonPathToObtainQualification: '',
             duration: '3.0 Years',
             mandatoryProfessionalExperience: '1',
+            ukRecognition: 'ukRecognition',
+            ukRecognitionUrl: 'http://example.com/uk',
+            otherCountriesRecognition: 'otherCountriesRecognition',
+            otherCountriesRecognitionUrl: 'http://example.com/other',
             change: true,
           };
 
@@ -181,6 +193,10 @@ describe(QualificationInformationController, () => {
                 level: 'Qualification level',
                 mandatoryProfessionalExperience: true,
                 methodToObtain: 'degreeLevel',
+                ukRecognition: 'ukRecognition',
+                ukRecognitionUrl: 'http://example.com/uk',
+                otherCountriesRecognition: 'otherCountriesRecognition',
+                otherCountriesRecognitionUrl: 'http://example.com/other',
               }),
             }),
           );
@@ -211,6 +227,10 @@ describe(QualificationInformationController, () => {
           duration: '',
           mandatoryProfessionalExperience: undefined,
           change: false,
+          ukRecognition: '',
+          ukRecognitionUrl: 'not a url',
+          otherCountriesRecognition: '',
+          otherCountriesRecognitionUrl: 'not a url',
         };
 
         professionsService.findWithVersions.mockResolvedValue(profession);
@@ -241,6 +261,12 @@ describe(QualificationInformationController, () => {
               },
               mostCommonPathToObtainQualification: {
                 text: 'professions.form.errors.qualification.mostCommonPathToObtain.empty',
+              },
+              ukRecognitionUrl: {
+                text: 'professions.form.errors.qualification.ukRecognitionUrl.invalid',
+              },
+              otherCountriesRecognitionUrl: {
+                text: 'professions.form.errors.qualification.otherCountriesRecognitionUrl.invalid',
               },
             },
           }),

--- a/src/professions/admin/qualification-information.controller.spec.ts
+++ b/src/professions/admin/qualification-information.controller.spec.ts
@@ -11,8 +11,12 @@ import { YesNoRadioButtonArgsPresenter } from './yes-no-radio-buttons-presenter'
 import { QualificationInformationDto } from './dto/qualification-information.dto';
 import { QualificationInformationController } from './qualification-information.controller';
 import { ProfessionVersionsService } from '../profession-versions.service';
+import { isUK } from '../../helpers/nations.helper';
+
 import professionVersionFactory from '../../testutils/factories/profession-version';
 import qualificationFactory from '../../testutils/factories/qualification';
+
+jest.mock('../../helpers/nations.helper');
 
 describe(QualificationInformationController, () => {
   let controller: QualificationInformationController;
@@ -75,6 +79,7 @@ describe(QualificationInformationController, () => {
 
       professionsService.findWithVersions.mockResolvedValue(profession);
       professionVersionsService.findWithProfession.mockResolvedValue(version);
+      (isUK as jest.Mock).mockImplementation(() => false);
 
       await controller.edit(response, 'profession-id', 'version-id', false);
 
@@ -88,6 +93,7 @@ describe(QualificationInformationController, () => {
               version.qualification.mandatoryProfessionalExperience,
               i18nService,
             ).radioButtonArgs(),
+          isUK: false,
         }),
       );
     });
@@ -235,6 +241,7 @@ describe(QualificationInformationController, () => {
 
         professionsService.findWithVersions.mockResolvedValue(profession);
         professionVersionsService.findWithProfession.mockResolvedValue(version);
+        (isUK as jest.Mock).mockImplementation(() => false);
 
         await controller.update(response, 'profession-id', 'version-id', dto);
 
@@ -246,6 +253,7 @@ describe(QualificationInformationController, () => {
                 undefined,
                 i18nService,
               ).radioButtonArgs(),
+            isUK: false,
             errors: {
               level: {
                 text: 'professions.form.errors.qualification.level.empty',

--- a/src/professions/admin/qualification-information.controller.ts
+++ b/src/professions/admin/qualification-information.controller.ts
@@ -109,6 +109,11 @@ export class QualificationInformationController {
           submittedValues.otherMostCommonPathToObtainQualification,
         educationDuration: submittedValues.duration,
         mandatoryProfessionalExperience,
+        ukRecognition: submittedValues.ukRecognition,
+        ukRecognitionUrl: submittedValues.ukRecognitionUrl,
+        otherCountriesRecognition: submittedValues.otherCountriesRecognition,
+        otherCountriesRecognitionUrl:
+          submittedValues.otherCountriesRecognitionUrl,
       },
     };
 
@@ -175,6 +180,10 @@ export class QualificationInformationController {
       mandatoryProfessionalExperienceRadioButtonArgs,
       duration: qualification?.educationDuration,
       captionText: ViewUtils.captionText(isEditing),
+      ukRecognition: qualification?.ukRecognition,
+      ukRecognitionUrl: qualification?.ukRecognitionUrl,
+      otherCountriesRecognition: qualification?.otherCountriesRecognition,
+      otherCountriesRecognitionUrl: qualification?.otherCountriesRecognitionUrl,
       change,
       errors,
     };

--- a/src/professions/admin/qualification-information.controller.ts
+++ b/src/professions/admin/qualification-information.controller.ts
@@ -25,6 +25,8 @@ import { BackLink } from '../../common/decorators/back-link.decorator';
 import ViewUtils from './viewUtils';
 import { ProfessionVersionsService } from '../profession-versions.service';
 import { isConfirmed } from '../../helpers/is-confirmed';
+import { isUK } from '../../helpers/nations.helper';
+import { ProfessionVersion } from '../profession-version.entity';
 
 @UseGuards(AuthenticationGuard)
 @Controller('admin/professions')
@@ -59,6 +61,7 @@ export class QualificationInformationController {
     return this.renderForm(
       res,
       version.qualification,
+      version,
       isConfirmed(profession),
       change,
     );
@@ -123,6 +126,7 @@ export class QualificationInformationController {
       return this.renderForm(
         res,
         updatedQualification,
+        version,
         isConfirmed(profession),
         submittedValues.change,
         errors,
@@ -147,6 +151,7 @@ export class QualificationInformationController {
   private async renderForm(
     res: Response,
     qualification: Qualification | null,
+    version: ProfessionVersion | null,
     isEditing: boolean,
     change: boolean,
     errors: object | undefined = undefined,
@@ -184,6 +189,7 @@ export class QualificationInformationController {
       ukRecognitionUrl: qualification?.ukRecognitionUrl,
       otherCountriesRecognition: qualification?.otherCountriesRecognition,
       otherCountriesRecognitionUrl: qualification?.otherCountriesRecognitionUrl,
+      isUK: isUK(version.occupationLocations),
       change,
       errors,
     };

--- a/src/professions/admin/top-level-information.controller.ts
+++ b/src/professions/admin/top-level-information.controller.ts
@@ -30,6 +30,7 @@ import ViewUtils from './viewUtils';
 import { ProfessionVersionsService } from '../profession-versions.service';
 import { ProfessionVersion } from '../profession-version.entity';
 import { isConfirmed } from '../../helpers/is-confirmed';
+import { allNations, isUK } from '../../helpers/nations.helper';
 @UseGuards(AuthenticationGuard)
 @Controller('admin/professions')
 export class TopLevelInformationController {
@@ -63,7 +64,7 @@ export class TopLevelInformationController {
     );
 
     const coversUK = version.occupationLocations
-      ? this.isUK(version.occupationLocations)
+      ? isUK(version.occupationLocations)
       : null;
 
     return this.renderForm(
@@ -126,7 +127,7 @@ export class TopLevelInformationController {
     }
 
     if (coversUK) {
-      submittedValues.nations = this.allNations();
+      submittedValues.nations = allNations();
     }
 
     const updatedProfession: Profession = {
@@ -199,16 +200,5 @@ export class TopLevelInformationController {
     };
 
     return res.render('admin/professions/top-level-information', templateArgs);
-  }
-
-  private allNations(): string[] {
-    return Nation.all().map((nation) => nation.code);
-  }
-
-  private isUK(nations: Array<string>) {
-    return (
-      nations.length === this.allNations().length &&
-      nations.every((e, i) => e === this.allNations()[i])
-    );
   }
 }

--- a/src/qualifications/presenters/qualification.presenter.spec.ts
+++ b/src/qualifications/presenters/qualification.presenter.spec.ts
@@ -90,4 +90,58 @@ describe(QualificationPresenter, () => {
       });
     });
   });
+
+  describe('ukRecognitionUrl', () => {
+    describe('when a blank string is provided', () => {
+      it('returns null', () => {
+        const qualification = qualificationFactory.build({
+          ukRecognitionUrl: '',
+        });
+
+        const presenter = new QualificationPresenter(qualification);
+
+        expect(presenter.ukRecognitionUrl).toEqual(null);
+      });
+    });
+    describe('when a URL is provided', () => {
+      it('returns a link', () => {
+        const qualification = qualificationFactory.build({
+          ukRecognitionUrl: 'http://example.com',
+        });
+
+        const presenter = new QualificationPresenter(qualification);
+
+        expect(presenter.ukRecognitionUrl).toEqual(
+          '<a class="govuk-link" href="http://example.com">http://example.com</a>',
+        );
+      });
+    });
+  });
+
+  describe('otherCountriesRecognitionUrl', () => {
+    describe('when a blank string is provided', () => {
+      it('returns null', () => {
+        const qualification = qualificationFactory.build({
+          otherCountriesRecognitionUrl: '',
+        });
+
+        const presenter = new QualificationPresenter(qualification);
+
+        expect(presenter.otherCountriesRecognitionUrl).toEqual(null);
+      });
+    });
+    describe('when a URL is provided', () => {
+      it('returns a link', () => {
+        const qualification = qualificationFactory.build({
+          otherCountriesRecognitionUrl: 'http://example.com',
+        });
+
+        const presenter = new QualificationPresenter(qualification);
+
+        expect(presenter.otherCountriesRecognitionUrl).toEqual(
+          '<a class="govuk-link" href="http://example.com">http://example.com</a>',
+        );
+      });
+    });
+  });
 });

--- a/src/qualifications/presenters/qualification.presenter.ts
+++ b/src/qualifications/presenters/qualification.presenter.ts
@@ -1,5 +1,5 @@
 import { MethodToObtain, Qualification } from '../qualification.entity';
-
+import { escape } from '../../helpers/escape.helper';
 export default class QualificationPresenter {
   constructor(private readonly qualification: Qualification) {}
 
@@ -21,4 +21,22 @@ export default class QualificationPresenter {
     .mandatoryProfessionalExperience
     ? 'app.yes'
     : 'app.no';
+
+  readonly ukRecognition = this.qualification.ukRecognition;
+
+  readonly ukRecognitionUrl = this.qualification.ukRecognitionUrl
+    ? `<a class="govuk-link" href="${escape(
+        this.qualification.ukRecognitionUrl,
+      )}">${escape(this.qualification.ukRecognitionUrl)}</a>`
+    : null;
+
+  readonly otherCountriesRecognition =
+    this.qualification.otherCountriesRecognition;
+
+  readonly otherCountriesRecognitionUrl = this.qualification
+    .otherCountriesRecognitionUrl
+    ? `<a class="govuk-link" href="${escape(
+        this.qualification.otherCountriesRecognitionUrl,
+      )}">${escape(this.qualification.otherCountriesRecognitionUrl)}</a>`
+    : null;
 }

--- a/src/qualifications/qualification.entity.ts
+++ b/src/qualifications/qualification.entity.ts
@@ -53,6 +53,18 @@ export class Qualification {
   @Column()
   mandatoryProfessionalExperience: boolean;
 
+  @Column({ nullable: true })
+  ukRecognition: string;
+
+  @Column({ nullable: true })
+  ukRecognitionUrl: string;
+
+  @Column({ nullable: true })
+  otherCountriesRecognition: string;
+
+  @Column({ nullable: true })
+  otherCountriesRecognitionUrl: string;
+
   @CreateDateColumn({
     type: 'timestamp',
     default: () => 'CURRENT_TIMESTAMP(6)',
@@ -78,6 +90,10 @@ export class Qualification {
     educationDurationDays?: number,
     educationDurationHours?: number,
     mandatoryProfessionalExperience?: boolean,
+    ukRecognition?: string,
+    ukRecognitionUrl?: string,
+    otherCountriesRecognition?: string,
+    otherCountriesRecognitionUrl?: string,
   ) {
     this.level = level || '';
     this.methodToObtain = methodToObtain || undefined;
@@ -91,5 +107,9 @@ export class Qualification {
     this.educationDurationHours = educationDurationHours || 0;
     this.mandatoryProfessionalExperience =
       mandatoryProfessionalExperience || true;
+    this.ukRecognition = ukRecognition || '';
+    this.ukRecognitionUrl = ukRecognitionUrl || '';
+    this.otherCountriesRecognition = otherCountriesRecognition || '';
+    this.otherCountriesRecognitionUrl = otherCountriesRecognitionUrl || '';
   }
 }

--- a/src/testutils/factories/qualification.ts
+++ b/src/testutils/factories/qualification.ts
@@ -21,6 +21,10 @@ export default Factory.define<Qualification>(({ sequence }) => ({
     MethodToObtain.GeneralPostSecondaryEducationMandatoryVocational,
   otherMethodToObtain: '',
   professionVersion: undefined,
+  ukRecognition: undefined,
+  ukRecognitionUrl: undefined,
+  otherCountriesRecognition: undefined,
+  otherCountriesRecognitionUrl: undefined,
   created_at: new Date(),
   updated_at: new Date(),
 }));

--- a/views/admin/professions/check-your-answers.njk
+++ b/views/admin/professions/check-your-answers.njk
@@ -361,6 +361,74 @@
                     }
                   ]
                 }
+              },
+              {
+                key: {
+                  text: ("professions.form.label.qualificationInformation.ukRecognition" | t)
+                },
+                value: {
+                  text: qualification.ukRecognition
+                },
+                actions: {
+                  items: [
+                    {
+                      href: "/admin/professions/" + professionId + "/versions/" + versionId + "/qualification-information/edit?change=true",
+                      text: ("app.change" | t),
+                      visuallyHiddenText: ("professions.form.label.qualificationInformation.ukRecognition" | t)
+                    }
+                  ]
+                }
+              },
+              {
+                key: {
+                  text: ("professions.form.label.qualificationInformation.ukRecognitionUrl" | t)
+                },
+                value: {
+                   html: qualification.ukRecognitionUrl | safe
+                },
+                actions: {
+                  items: [
+                    {
+                      href: "/admin/professions/" + professionId + "/versions/" + versionId + "/qualification-information/edit?change=true",
+                      text: ("app.change" | t),
+                      visuallyHiddenText: ("professions.form.label.qualificationInformation.ukRecognitionUrl" | t)
+                    }
+                  ]
+                }
+              },
+              {
+                key: {
+                  text: ("professions.form.label.qualificationInformation.otherCountriesRecognition" | t)
+                },
+                value: {
+                  text: qualification.otherCountriesRecognition
+                },
+                actions: {
+                  items: [
+                    {
+                      href: "/admin/professions/" + professionId + "/versions/" + versionId + "/qualification-information/edit?change=true",
+                      text: ("app.change" | t),
+                      visuallyHiddenText: ("professions.form.label.qualificationInformation.otherCountriesRecognition" | t)
+                    }
+                  ]
+                }
+              },
+              {
+                key: {
+                  text: ("professions.form.label.qualificationInformation.otherCountriesRecognitionUrl" | t)
+                },
+                value: {
+                  html: qualification.otherCountriesRecognitionUrl | safe
+                },
+                actions: {
+                  items: [
+                    {
+                      href: "/admin/professions/" + professionId + "/versions/" + versionId + "/qualification-information/edit?change=true",
+                      text: ("app.change" | t),
+                      visuallyHiddenText: ("professions.form.label.qualificationInformation.otherCountriesRecognitionUrl" | t)
+                    }
+                  ]
+                }
               }
             ]
           })

--- a/views/admin/professions/check-your-answers.njk
+++ b/views/admin/professions/check-your-answers.njk
@@ -279,23 +279,6 @@
             rows: [
               {
                 key: {
-                  text: ("professions.form.label.qualificationInformation.qualificationLevel" | t)
-                },
-                value: {
-                  text: qualification.level
-                },
-                actions: {
-                  items: [
-                    {
-                      href: "/admin/professions/" + professionId + "/versions/" + versionId + "/qualification-information/edit?change=true",
-                      text: ("app.change" | t),
-                      visuallyHiddenText: ("professions.form.label.qualificationInformation.qualificationLevel" | t)
-                    }
-                  ]
-                }
-              },
-              {
-                key: {
                   text: ("professions.form.label.qualificationInformation.methodsToObtainQualification" | t)
                 },
                 value: {
@@ -358,6 +341,23 @@
                       href: "/admin/professions/" + professionId + "/versions/" + versionId + "/qualification-information/edit?change=true",
                       text: ("app.change" | t),
                       visuallyHiddenText: ("professions.form.label.qualificationInformation.mandatoryProfessionalExperience" | t)
+                    }
+                  ]
+                }
+              },
+              {
+                key: {
+                  text: ("professions.form.label.qualificationInformation.qualificationLevel" | t)
+                },
+                value: {
+                  text: qualification.level
+                },
+                actions: {
+                  items: [
+                    {
+                      href: "/admin/professions/" + professionId + "/versions/" + versionId + "/qualification-information/edit?change=true",
+                      text: ("app.change" | t),
+                      visuallyHiddenText: ("professions.form.label.qualificationInformation.qualificationLevel" | t)
                     }
                   ]
                 }

--- a/views/admin/professions/check-your-answers.njk
+++ b/views/admin/professions/check-your-answers.njk
@@ -363,6 +363,7 @@
                 }
               },
               {
+                classes: ("govuk-visually-hidden" if isUK else ""),
                 key: {
                   text: ("professions.form.label.qualificationInformation.ukRecognition" | t)
                 },
@@ -380,6 +381,7 @@
                 }
               },
               {
+                classes: ("govuk-visually-hidden" if isUK else ""),
                 key: {
                   text: ("professions.form.label.qualificationInformation.ukRecognitionUrl" | t)
                 },

--- a/views/admin/professions/qualification-information.njk
+++ b/views/admin/professions/qualification-information.njk
@@ -102,6 +102,8 @@
           })
         }}
 
+        {% if isUK === false %}
+
         <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible" />
 
         {{
@@ -132,6 +134,8 @@
             errorMessage: errors.ukRecognitionUrl | tError
           })
         }}
+
+        {% endif %}
 
         <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible" />
 

--- a/views/admin/professions/qualification-information.njk
+++ b/views/admin/professions/qualification-information.njk
@@ -102,6 +102,68 @@
           })
         }}
 
+        <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible" />
+
+        {{
+          govukInput({
+            label: {
+              text: ("professions.form.label.qualificationInformation.ukRecognition" | t),
+              classes: "govuk-label--m"
+            },
+            id: "ukRecognition",
+            name: "ukRecognition",
+            value: ukRecognition,
+            errorMessage: errors.ukRecognition | tError
+          })
+        }}
+
+        {{
+          govukInput({
+            label: {
+              text: ("professions.form.label.qualificationInformation.ukRecognitionUrl" | t),
+              classes: "govuk-label--m"
+            },
+            id: "ukRecognitionUrl",
+            name: "ukRecognitionUrl",
+            value: ukRecognitionUrl,
+            hint: {
+              text: ("professions.form.hint.qualificationInformation.ukRecognitionUrl" | t)
+            },
+            errorMessage: errors.ukRecognitionUrl | tError
+          })
+        }}
+
+        <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible" />
+
+        {{
+          govukInput({
+            label: {
+              text: ("professions.form.label.qualificationInformation.otherCountriesRecognition" | t),
+              classes: "govuk-label--m"
+            },
+            id: "otherCountriesRecognition",
+            name: "otherCountriesRecognition",
+            value: otherCountriesRecognition,
+            errorMessage: errors.otherCountriesRecognition | tError
+          })
+        }}
+
+        {{
+          govukInput({
+            label: {
+              text: ("professions.form.label.qualificationInformation.otherCountriesRecognitionUrl" | t),
+              classes: "govuk-label--m"
+            },
+            id: "otherCountriesRecognitionUrl",
+            name: "otherCountriesRecognitionUrl",
+            value: otherCountriesRecognitionUrl,
+            hint: {
+              text: ("professions.form.hint.qualificationInformation.otherCountriesRecognitionUrl" | t)
+            },
+            errorMessage: errors.otherCountriesRecognitionUrl | tError
+          })
+        }}
+
         {{
           govukButton({
             id: "submit-button",

--- a/views/admin/professions/qualification-information.njk
+++ b/views/admin/professions/qualification-information.njk
@@ -18,21 +18,6 @@
       <form method="post" action="./">
         <input type="hidden" name="change" value="{{ change }}" />
         {{
-          govukTextarea({
-            label: {
-              text: ("professions.form.label.qualificationInformation.qualificationLevel" | t),
-              classes: "govuk-label--m",
-              isPageHeading: false
-            },
-            id: "level",
-            name: "level",
-            rows: "7",
-            value: level,
-            errorMessage: errors.level | tError
-          })
-        }}
-
-        {{
           govukRadios({
             idPrefix: "methodToObtainQualification",
             name: "methodToObtainQualification",
@@ -99,6 +84,21 @@
             },
             items: mandatoryProfessionalExperienceRadioButtonArgs,
             errorMessage: errors.mandatoryProfessionalExperience | tError
+          })
+        }}
+
+        {{
+          govukTextarea({
+            label: {
+              text: ("professions.form.label.qualificationInformation.qualificationLevel" | t),
+              classes: "govuk-label--m",
+              isPageHeading: false
+            },
+            id: "level",
+            name: "level",
+            rows: "7",
+            value: level,
+            errorMessage: errors.level | tError
           })
         }}
 


### PR DESCRIPTION
This adds four new optional fields to the qualifications page:

* Recognition of qualifications in the UK (string)
* More about recognition within the UK (url)
* Recognition of qualifications from other countries (string)
* More about recognition in other countries (url)

If the profession covers all UK nations, the first two questions are hidden.

I've also rearranged the fields to match the order in the current prototype.

## Screenshots

![image](https://user-images.githubusercontent.com/109774/154071020-a13859c1-93d4-4e8f-ac29-afadb0c68079.png)
![image](https://user-images.githubusercontent.com/109774/154071091-d67e0c76-ab20-4cea-98b6-e55702532e79.png)
