### PR TITLE
(2065) Format line breaks in data presented to user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Simplify nation selection
 - Remove placeholder authority data on index page
 - Revised text describing each role to reflect role differences between regulatory authority users and central users
+- Preserve line breaks of any data entered in a multi-line text field
 
 ## [release-002] - 2022-02-01
 

--- a/seeds/development/organisations.json
+++ b/seeds/development/organisations.json
@@ -5,7 +5,7 @@
     "versions": [
       {
         "alternateName": "",
-        "address": "123 Example Street, London, EC1 1AB",
+        "address": "123 Example Street\nLondon\nEC1 1AB",
         "url": "https://www.gov.uk/guidance/early-years-qualifications-finder#overseas-qualifications",
         "email": "dfe@example.com",
         "contactUrl": "def@example.com/contact-us",
@@ -15,7 +15,7 @@
       },
       {
         "alternateName": "",
-        "address": "345 Example Street, London, EC1 1AB",
+        "address": "345 Example Street\nLondon\nEC1 1AB",
         "url": "https://www.gov.uk/guidance/early-years-qualifications-finder#overseas-qualifications",
         "email": "old@example.com",
         "contactUrl": "def@example.com/contact-us",
@@ -31,7 +31,7 @@
     "versions": [
       {
         "alternateName": "",
-        "address": "123 Fake Street, London, EC1 1AB",
+        "address": "123 Fake Street\nLondon\nEC1 1AB",
         "url": "www.corgi-gas-safety.com",
         "email": "gas@example.com",
         "contactUrl": "gas@example.com/contact-us",
@@ -47,7 +47,7 @@
     "versions": [
       {
         "alternateName": "",
-        "address": "456 Example Street, London, EC1 1AB",
+        "address": "456 Example Street\nLondon\nEC1 1AB",
         "url": "www.lawsociety.org.uk",
         "email": "law@example.com",
         "contactUrl": "law@example.com/contact-us",
@@ -63,7 +63,7 @@
     "versions": [
       {
         "alternateName": "",
-        "address": "456 Fake Street, London, EC1 1AB",
+        "address": "456 Fake Street\nLondon\nEC1 1AB",
         "url": "www.gmc.com",
         "email": "gmc@example.com",
         "contactUrl": "gmc@example.com/contact-us",

--- a/seeds/staging/organisations.json
+++ b/seeds/staging/organisations.json
@@ -5,7 +5,7 @@
     "versions": [
       {
         "alternateName": "",
-        "address": "123 Example Street, London, EC1 1AB",
+        "address": "123 Example Street\nLondon\nEC1 1AB",
         "url": "https://www.gov.uk/guidance/early-years-qualifications-finder#overseas-qualifications",
         "email": "dfe@example.com",
         "contactUrl": "def@example.com/contact-us",
@@ -15,7 +15,7 @@
       },
       {
         "alternateName": "",
-        "address": "345 Example Street, London, EC1 1AB",
+        "address": "345 Example Street\nLondon\nEC1 1AB",
         "url": "https://www.gov.uk/guidance/early-years-qualifications-finder#overseas-qualifications",
         "email": "old@example.com",
         "contactUrl": "def@example.com/contact-us",
@@ -31,7 +31,7 @@
     "versions": [
       {
         "alternateName": "",
-        "address": "123 Fake Street, London, EC1 1AB",
+        "address": "123 Fake Street\nLondon\nEC1 1AB",
         "url": "www.corgi-gas-safety.com",
         "email": "gas@example.com",
         "contactUrl": "gas@example.com/contact-us",
@@ -47,7 +47,7 @@
     "versions": [
       {
         "alternateName": "",
-        "address": "456 Example Street, London, EC1 1AB",
+        "address": "456 Example Street\nLondon\nEC1 1AB",
         "url": "www.lawsociety.org.uk",
         "email": "law@example.com",
         "contactUrl": "law@example.com/contact-us",
@@ -63,7 +63,7 @@
     "versions": [
       {
         "alternateName": "",
-        "address": "456 Fake Street, London, EC1 1AB",
+        "address": "456 Fake Street\nLondon\nEC1 1AB",
         "url": "www.gmc.com",
         "email": "gmc@example.com",
         "contactUrl": "gmc@example.com/contact-us",

--- a/seeds/test/organisations.json
+++ b/seeds/test/organisations.json
@@ -5,7 +5,7 @@
     "versions": [
       {
         "alternateName": "",
-        "address": "123 Example Street, London, EC1 1AB",
+        "address": "123 Example Street\nLondon\nEC1 1AB",
         "url": "https://www.gov.uk/guidance/early-years-qualifications-finder#overseas-qualifications",
         "email": "dfe@example.com",
         "contactUrl": "def@example.com/contact-us",
@@ -16,7 +16,7 @@
       },
       {
         "alternateName": "DFE",
-        "address": "345 Example Street, London, EC1 1AB",
+        "address": "345 Example Street\nLondon\nEC1 1AB",
         "url": "https://www.gov.uk/guidance/early-years-qualifications-finder#overseas-qualifications",
         "email": "old@example.com",
         "contactUrl": "def@example.com/contact-us",
@@ -33,7 +33,7 @@
     "versions": [
       {
         "alternateName": "CORGI",
-        "address": "123 Fake Street, London, EC1 1AB",
+        "address": "123 Fake Street\nLondon\nEC1 1AB",
         "url": "www.corgi-gas-safety.com",
         "email": "gas@example.com",
         "contactUrl": "gas@example.com/contact-us",
@@ -49,7 +49,7 @@
     "versions": [
       {
         "alternateName": "LSEW",
-        "address": "456 Example Street, London, EC1 1AB",
+        "address": "456 Example Street\nLondon\nEC1 1AB",
         "url": "www.lawsociety.org.uk",
         "email": "law@example.com",
         "contactUrl": "law@example.com/contact-us",
@@ -65,7 +65,7 @@
     "versions": [
       {
         "alternateName": "GMC",
-        "address": "456 Fake Street, London, EC1 1AB",
+        "address": "456 Fake Street\nLondon\nEC1 1AB",
         "url": "www.gmc.com",
         "email": "gmc@example.com",
         "contactUrl": "gmc@example.com/contact-us",

--- a/src/config/nunjucks.config.ts
+++ b/src/config/nunjucks.config.ts
@@ -5,6 +5,7 @@ import { NestExpressApplication } from '@nestjs/platform-express';
 import * as nunjucks from 'nunjucks';
 
 import { AssetsHelper } from '../helpers/assets.helper';
+import { formatMultilineString } from '../helpers/format-multiline-string.helper';
 import { I18nHelper } from '../helpers/i18n.helper';
 
 export const nunjucksConfig = async (
@@ -65,6 +66,12 @@ export const nunjucksConfig = async (
     },
     true,
   );
+
+  env.addFilter('multiline', (text, classes) => {
+    return new nunjucks.runtime.SafeString(
+      formatMultilineString(text, classes),
+    );
+  });
 
   return env;
 };

--- a/src/helpers/format-multiline-string.helper.spec.ts
+++ b/src/helpers/format-multiline-string.helper.spec.ts
@@ -1,0 +1,94 @@
+import { escapeOf } from '../testutils/escape-of';
+import { escape } from './escape.helper';
+import { formatMultilineString } from './format-multiline-string.helper';
+jest.mock('./escape.helper');
+
+describe('formatMultilineString', () => {
+  describe('when the string is a single line', () => {
+    it('wraps the string in a paragraph', () => {
+      (escape as jest.Mock).mockImplementation(escapeOf);
+
+      const input = 'example line';
+      const expected = `<p class="example-class">${escapeOf(
+        'example line',
+      )}</p>`;
+
+      expect(formatMultilineString(input, 'example-class')).toEqual(expected);
+
+      expect(escape).toBeCalledTimes(1);
+    });
+  });
+
+  describe('when the string contains non-consecutive new-lines', () => {
+    it('replaces the new-lines with line-break tags', () => {
+      (escape as jest.Mock).mockImplementation(escapeOf);
+
+      const input = 'example line 1\nexample line 2\rexample line 3';
+      const expected = `<p class="example-class">${escapeOf(
+        'example line 1',
+      )}<br />${escapeOf('example line 2')}<br />${escapeOf(
+        'example line 3',
+      )}</p>`;
+
+      expect(formatMultilineString(input, 'example-class')).toEqual(expected);
+
+      expect(escape).toBeCalledTimes(3);
+    });
+  });
+
+  describe('when the string contains CR LF sequences', () => {
+    it('it treats them as a single new-line', () => {
+      (escape as jest.Mock).mockImplementation(escapeOf);
+
+      const input = 'example line 1\r\nexample line 2';
+
+      const expected = `<p class="example-class">${escapeOf(
+        'example line 1',
+      )}<br />${escapeOf('example line 2')}</p>`;
+
+      expect(formatMultilineString(input, 'example-class')).toEqual(expected);
+
+      expect(escape).toBeCalledTimes(2);
+    });
+  });
+
+  describe('when the string contains consecutive new-lines', () => {
+    it('begins an new paragraph', () => {
+      (escape as jest.Mock).mockImplementation(escapeOf);
+
+      const input =
+        'example paragraph 1\n\nexample paragraph 2\nline 2 paragraph 2';
+
+      const expected = `<p class="example-class">${escapeOf(
+        'example paragraph 1',
+      )}</p><p class="example-class">${escapeOf(
+        'example paragraph 2',
+      )}<br />${escapeOf('line 2 paragraph 2')}</p>`;
+
+      expect(formatMultilineString(input, 'example-class')).toEqual(expected);
+
+      expect(escape).toBeCalledTimes(3);
+    });
+  });
+
+  describe('when the string starts and ends with whitespace', () => {
+    it('the whitespace is ignored', () => {
+      (escape as jest.Mock).mockImplementation(escapeOf);
+
+      const input =
+        '   \n\n \r\n    \nexample paragraph 1\n\nexample paragraph 2\n\n  \r';
+
+      const expected = `<p class="example-class">${escapeOf(
+        'example paragraph 1',
+      )}</p><p class="example-class">${escapeOf('example paragraph 2')}</p>`;
+
+      expect(formatMultilineString(input, 'example-class')).toEqual(expected);
+
+      expect(escape).toBeCalledTimes(2);
+    });
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+});

--- a/src/helpers/format-multiline-string.helper.ts
+++ b/src/helpers/format-multiline-string.helper.ts
@@ -1,0 +1,31 @@
+import { escape } from './escape.helper';
+
+export function formatMultilineString(text: string, classes = ''): string {
+  text = santiseLineBreaks(text);
+
+  const paragraphs = text.split('\n\n');
+
+  const linesByParagraph = paragraphs.map((paragraph) =>
+    paragraph.split('\n').map((line) => escape(line)),
+  );
+
+  const htmlLinesByParagraph = linesByParagraph.map((lines) =>
+    lines.join('<br />'),
+  );
+
+  const htmlParagraphs = `<p class="${classes}">${htmlLinesByParagraph.join(
+    `</p><p class="${classes}">`,
+  )}</p>`;
+
+  return htmlParagraphs;
+}
+
+function santiseLineBreaks(text: string): string {
+  text = text.trim();
+
+  text = text.replace(/(\r\n)/g, '\n');
+  text = text.replace(/(\r)/g, '\n');
+  text = text.replace(/(\n){2,}/g, '\n\n');
+
+  return text;
+}

--- a/src/organisations/presenters/organisation.presenter.spec.ts
+++ b/src/organisations/presenters/organisation.presenter.spec.ts
@@ -1,6 +1,3 @@
-import { DeepMocked } from '@golevelup/ts-jest';
-
-import { I18nService } from 'nestjs-i18n';
 import { OrganisationPresenter } from './organisation.presenter';
 import { Organisation } from '../organisation.entity';
 import { Industry } from '../../industries/industry.entity';
@@ -22,8 +19,6 @@ describe('OrganisationPresenter', () => {
   let industries: Industry[];
   let professions: Profession[];
 
-  const i18nService: DeepMocked<I18nService> = createMockI18nService();
-
   describe('tableRow', () => {
     describe('when all relations are present', () => {
       describe('when the professions share one industry', () => {
@@ -40,6 +35,7 @@ describe('OrganisationPresenter', () => {
         });
 
         it('returns the table row data', async () => {
+          const i18nService = createMockI18nService();
           (escape as jest.Mock).mockImplementation(escapeOf);
 
           const presenter = new OrganisationPresenter(
@@ -92,6 +88,7 @@ describe('OrganisationPresenter', () => {
         });
 
         it('returns the table row data', async () => {
+          const i18nService = createMockI18nService();
           (escape as jest.Mock).mockImplementation(escapeOf);
 
           const presenter = new OrganisationPresenter(
@@ -124,6 +121,7 @@ describe('OrganisationPresenter', () => {
       });
 
       it('should raise an error', async () => {
+        const i18nService = createMockI18nService();
         const presenter = new OrganisationPresenter(organisation, i18nService);
 
         expect(async () => {
@@ -142,6 +140,7 @@ describe('OrganisationPresenter', () => {
       });
 
       it('should raise an error', async () => {
+        const i18nService = createMockI18nService();
         const presenter = new OrganisationPresenter(organisation, i18nService);
 
         expect(async () => {
@@ -156,7 +155,9 @@ describe('OrganisationPresenter', () => {
   describe('summaryList', () => {
     describe('when all fields are present', () => {
       it('should return all fields', async () => {
+        const i18nService = createMockI18nService();
         (escape as jest.Mock).mockImplementation(escapeOf);
+
         organisation = organisationFactory.withVersion().build();
 
         const presenter = new OrganisationPresenter(organisation, i18nService);
@@ -212,6 +213,7 @@ describe('OrganisationPresenter', () => {
     describe('when a field is missing', () => {
       describe('when removeBlank is true', () => {
         it('should filter out empty fields', async () => {
+          const i18nService = createMockI18nService();
           (escape as jest.Mock).mockImplementation(escapeOf);
 
           organisation = organisationFactory
@@ -237,6 +239,7 @@ describe('OrganisationPresenter', () => {
 
       describe('when removeBlank is false', () => {
         it('keeps empty rows intact', async () => {
+          const i18nService = createMockI18nService();
           (escape as jest.Mock).mockImplementation(escapeOf);
 
           organisation = organisationFactory
@@ -265,6 +268,7 @@ describe('OrganisationPresenter', () => {
 
     describe('when includeName is true', () => {
       it('should include the name of the organisation', async () => {
+        const i18nService = createMockI18nService();
         (escape as jest.Mock).mockImplementation(escapeOf);
 
         organisation = organisationFactory
@@ -289,6 +293,7 @@ describe('OrganisationPresenter', () => {
 
     describe('when includeActions is true', () => {
       it('should include an actions column', async () => {
+        const i18nService = createMockI18nService();
         (escape as jest.Mock).mockImplementation(escapeOf);
 
         const version = organisationVersionFactory.build();
@@ -319,6 +324,7 @@ describe('OrganisationPresenter', () => {
 
     describe('when classes are specified', () => {
       it('should return the specified class', async () => {
+        const i18nService = createMockI18nService();
         (escape as jest.Mock).mockImplementation(escapeOf);
 
         const presenter = new OrganisationPresenter(organisation, i18nService);
@@ -331,6 +337,7 @@ describe('OrganisationPresenter', () => {
 
   describe('address', () => {
     it('breaks the address into lines', () => {
+      const i18nService = createMockI18nService();
       (escape as jest.Mock).mockImplementation(escapeOf);
 
       organisation = organisationFactory.build({
@@ -349,6 +356,7 @@ describe('OrganisationPresenter', () => {
 
   describe('email', () => {
     it('makes the email into a link', () => {
+      const i18nService = createMockI18nService();
       (escape as jest.Mock).mockImplementation(escapeOf);
 
       organisation = organisationFactory.build({
@@ -369,6 +377,7 @@ describe('OrganisationPresenter', () => {
 
   describe('contactUrl', () => {
     it('makes the url into a link', () => {
+      const i18nService = createMockI18nService();
       (escape as jest.Mock).mockImplementation(escapeOf);
 
       organisation = organisationFactory.build({
@@ -385,5 +394,9 @@ describe('OrganisationPresenter', () => {
 
       expect(escape).toBeCalledWith('http://www.example.com');
     });
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
   });
 });

--- a/src/organisations/presenters/organisation.presenter.spec.ts
+++ b/src/organisations/presenters/organisation.presenter.spec.ts
@@ -11,8 +11,11 @@ import professionFactory from '../../testutils/factories/profession';
 import industryFactory from '../../testutils/factories/industry';
 import { escape } from '../../helpers/escape.helper';
 import { escapeOf } from '../../testutils/escape-of';
+import { formatMultilineString } from '../../helpers/format-multiline-string.helper';
+import { multilineOf } from '../../testutils/multiline-of';
 
 jest.mock('../../helpers/escape.helper');
+jest.mock('../../helpers/format-multiline-string.helper');
 
 describe('OrganisationPresenter', () => {
   let organisation: Organisation;
@@ -336,9 +339,9 @@ describe('OrganisationPresenter', () => {
   });
 
   describe('address', () => {
-    it('breaks the address into lines', () => {
+    it('formats the address as a multi-line string', () => {
       const i18nService = createMockI18nService();
-      (escape as jest.Mock).mockImplementation(escapeOf);
+      (formatMultilineString as jest.Mock).mockImplementation(multilineOf);
 
       organisation = organisationFactory.build({
         address: '123 Fake Street, London, SW1A 1AA',
@@ -347,10 +350,12 @@ describe('OrganisationPresenter', () => {
       const presenter = new OrganisationPresenter(organisation, i18nService);
 
       expect(presenter.address()).toEqual(
-        `${escapeOf('123 Fake Street<br /> London<br /> SW1A 1AA')}`,
+        `${multilineOf('123 Fake Street, London, SW1A 1AA')}`,
       );
 
-      expect(escape).toBeCalledWith('123 Fake Street, London, SW1A 1AA');
+      expect(formatMultilineString).toBeCalledWith(
+        '123 Fake Street, London, SW1A 1AA',
+      );
     });
   });
 

--- a/src/organisations/presenters/organisation.presenter.ts
+++ b/src/organisations/presenters/organisation.presenter.ts
@@ -3,6 +3,7 @@ import { Organisation } from './../organisation.entity';
 import { TableRow } from '../../common/interfaces/table-row';
 import { SummaryList } from '../../common/interfaces/summary-list';
 import { escape } from '../../helpers/escape.helper';
+import { formatMultilineString } from '../../helpers/format-multiline-string.helper';
 
 interface OrganisationSummaryListOptions {
   classes?: string;
@@ -146,7 +147,7 @@ export class OrganisationPresenter {
   }
 
   public address(): string {
-    return escape(this.organisation.address).split(',').join('<br />');
+    return formatMultilineString(this.organisation.address);
   }
 
   public email(): string {

--- a/src/professions/presenters/profession.presenter.spec.ts
+++ b/src/professions/presenters/profession.presenter.spec.ts
@@ -6,10 +6,13 @@ import { stringifyNations } from '../../nations/helpers/stringifyNations';
 
 import professionFactory from '../../testutils/factories/profession';
 import industryFactory from '../../testutils/factories/industry';
+import { formatMultilineString } from '../../helpers/format-multiline-string.helper';
+import { multilineOf } from '../../testutils/multiline-of';
 import { createMockI18nService } from '../../testutils/create-mock-i18n-service';
 import { translationOf } from '../../testutils/translation-of';
 
 jest.mock('../../nations/helpers/stringifyNations');
+jest.mock('../../helpers/format-multiline-string.helper');
 
 describe('ProfessionPresenter', () => {
   let profession: Profession;
@@ -17,6 +20,8 @@ describe('ProfessionPresenter', () => {
   describe('summaryList', () => {
     it('should return a summary list', async () => {
       const i18nService = createMockI18nService();
+      (formatMultilineString as jest.Mock).mockImplementation(multilineOf);
+
       profession = professionFactory.build();
 
       const presenter = new ProfessionPresenter(profession, i18nService);
@@ -45,11 +50,15 @@ describe('ProfessionPresenter', () => {
               text: translationOf('professions.show.qualification.level'),
             },
             value: {
-              text: profession.qualification.level,
+              html: multilineOf(profession.qualification.level),
             },
           },
         ],
       });
+
+      expect(formatMultilineString).toBeCalledWith(
+        profession.qualification.level,
+      );
     });
   });
 

--- a/src/professions/presenters/profession.presenter.spec.ts
+++ b/src/professions/presenters/profession.presenter.spec.ts
@@ -1,6 +1,3 @@
-import { createMock, DeepMocked } from '@golevelup/ts-jest';
-import { I18nService } from 'nestjs-i18n';
-
 import { Profession } from './../profession.entity';
 import { ProfessionPresenter } from './profession.presenter';
 import { Nation } from '../../nations/nation';
@@ -9,19 +6,17 @@ import { stringifyNations } from '../../nations/helpers/stringifyNations';
 
 import professionFactory from '../../testutils/factories/profession';
 import industryFactory from '../../testutils/factories/industry';
+import { createMockI18nService } from '../../testutils/create-mock-i18n-service';
+import { translationOf } from '../../testutils/translation-of';
 
 jest.mock('../../nations/helpers/stringifyNations');
 
 describe('ProfessionPresenter', () => {
   let profession: Profession;
-  const i18nService: DeepMocked<I18nService> = createMock<I18nService>({
-    translate: async (key: string) => {
-      return key;
-    },
-  });
 
   describe('summaryList', () => {
     it('should return a summary list', async () => {
+      const i18nService = createMockI18nService();
       profession = professionFactory.build();
 
       const presenter = new ProfessionPresenter(profession, i18nService);
@@ -31,7 +26,7 @@ describe('ProfessionPresenter', () => {
         rows: [
           {
             key: {
-              text: 'professions.show.overview.nations',
+              text: translationOf('professions.show.overview.nations'),
             },
             value: {
               text: await presenter.occupationLocations(),
@@ -39,7 +34,7 @@ describe('ProfessionPresenter', () => {
           },
           {
             key: {
-              text: 'professions.show.overview.industry',
+              text: translationOf('professions.show.overview.industry'),
             },
             value: {
               text: await presenter.industries(),
@@ -47,7 +42,7 @@ describe('ProfessionPresenter', () => {
           },
           {
             key: {
-              text: 'professions.show.qualification.level',
+              text: translationOf('professions.show.qualification.level'),
             },
             value: {
               text: profession.qualification.level,
@@ -60,6 +55,8 @@ describe('ProfessionPresenter', () => {
 
   describe('occupationLocations', () => {
     it('should pass the locations to stringifyNations', async () => {
+      const i18nService = createMockI18nService();
+
       profession = professionFactory.build({
         occupationLocations: ['GB-ENG', 'GB-SCT', 'GB-WLS', 'GB-NIR'],
       });
@@ -77,6 +74,8 @@ describe('ProfessionPresenter', () => {
 
   describe('industries', () => {
     it('should return a comma-separated list of industry names', async () => {
+      const i18nService = createMockI18nService();
+
       profession = professionFactory.build({
         industries: [
           industryFactory.build({ name: 'foo' }),
@@ -86,7 +85,13 @@ describe('ProfessionPresenter', () => {
 
       const presenter = new ProfessionPresenter(profession, i18nService);
 
-      expect(await presenter.industries()).toEqual('foo, bar');
+      expect(await presenter.industries()).toEqual(
+        `${translationOf('foo')}, ${translationOf('bar')}`,
+      );
     });
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
   });
 });

--- a/src/professions/presenters/profession.presenter.ts
+++ b/src/professions/presenters/profession.presenter.ts
@@ -3,6 +3,7 @@ import { Profession } from '../profession.entity';
 import { SummaryList } from '../../common/interfaces/summary-list';
 import { stringifyNations } from '../../nations/helpers/stringifyNations';
 import { Nation } from '../../nations/nation';
+import { formatMultilineString } from '../../helpers/format-multiline-string.helper';
 
 export class ProfessionPresenter {
   constructor(
@@ -41,8 +42,8 @@ export class ProfessionPresenter {
             ),
           },
           value: {
-            text: this.profession.qualification
-              ? this.profession.qualification.level
+            html: this.profession.qualification
+              ? formatMultilineString(this.profession.qualification.level)
               : null,
           },
         },

--- a/src/qualifications/presenters/qualification.presenter.spec.ts
+++ b/src/qualifications/presenters/qualification.presenter.spec.ts
@@ -90,4 +90,8 @@ describe(QualificationPresenter, () => {
       });
     });
   });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
 });

--- a/src/qualifications/presenters/qualification.presenter.spec.ts
+++ b/src/qualifications/presenters/qualification.presenter.spec.ts
@@ -1,11 +1,17 @@
 import { MethodToObtain } from '../qualification.entity';
 import qualificationFactory from '../../testutils/factories/qualification';
 import QualificationPresenter from './qualification.presenter';
+import { formatMultilineString } from '../../helpers/format-multiline-string.helper';
+import { multilineOf } from '../../testutils/multiline-of';
+
+jest.mock('../../helpers/format-multiline-string.helper');
 
 describe(QualificationPresenter, () => {
   describe('methodToObtainQualification', () => {
     describe('when the method to ObtainQualification is "others"', () => {
       it('returns the other text value', () => {
+        (formatMultilineString as jest.Mock).mockImplementation(multilineOf);
+
         const qualification = qualificationFactory.build({
           methodToObtain: MethodToObtain.Others,
           otherMethodToObtain: 'other value',
@@ -13,7 +19,11 @@ describe(QualificationPresenter, () => {
 
         const presenter = new QualificationPresenter(qualification);
 
-        expect(presenter.methodToObtainQualification).toEqual('other value');
+        expect(presenter.methodToObtainQualification).toEqual(
+          multilineOf('other value'),
+        );
+
+        expect(formatMultilineString).toBeCalledWith('other value');
       });
     });
 
@@ -36,6 +46,8 @@ describe(QualificationPresenter, () => {
   describe('mostCommonPathToObtainQualification', () => {
     describe('when the method to ObtainQualification is "others"', () => {
       it('returns the other text value', () => {
+        (formatMultilineString as jest.Mock).mockImplementation(multilineOf);
+
         const qualification = qualificationFactory.build({
           commonPathToObtain: MethodToObtain.Others,
           otherCommonPathToObtain: 'other value',
@@ -44,8 +56,10 @@ describe(QualificationPresenter, () => {
         const presenter = new QualificationPresenter(qualification);
 
         expect(presenter.mostCommonPathToObtainQualification).toEqual(
-          'other value',
+          multilineOf('other value'),
         );
+
+        expect(formatMultilineString).toBeCalledWith('other value');
       });
     });
 

--- a/src/qualifications/presenters/qualification.presenter.ts
+++ b/src/qualifications/presenters/qualification.presenter.ts
@@ -1,3 +1,4 @@
+import { formatMultilineString } from '../../helpers/format-multiline-string.helper';
 import { MethodToObtain, Qualification } from '../qualification.entity';
 
 export default class QualificationPresenter {
@@ -7,12 +8,12 @@ export default class QualificationPresenter {
 
   readonly methodToObtainQualification: string =
     this.qualification.methodToObtain === MethodToObtain.Others
-      ? this.qualification.otherMethodToObtain
+      ? formatMultilineString(this.qualification.otherMethodToObtain)
       : `professions.methodsToObtainQualification.${this.qualification.methodToObtain}`;
 
   readonly mostCommonPathToObtainQualification: string =
     this.qualification.commonPathToObtain === MethodToObtain.Others
-      ? this.qualification.otherCommonPathToObtain
+      ? formatMultilineString(this.qualification.otherCommonPathToObtain)
       : `professions.methodsToObtainQualification.${this.qualification.commonPathToObtain}`;
 
   readonly duration = this.qualification.educationDuration;

--- a/src/testutils/multiline-of.ts
+++ b/src/testutils/multiline-of.ts
@@ -1,0 +1,3 @@
+export function multilineOf(text: string): string {
+  return `Multiline of '${text}'`;
+}

--- a/views/admin/professions/check-your-answers.njk
+++ b/views/admin/professions/check-your-answers.njk
@@ -299,7 +299,7 @@
                   text: ("professions.form.label.qualificationInformation.methodsToObtainQualification" | t)
                 },
                 value: {
-                  text: (qualification.methodToObtainQualification | t)
+                  html: (qualification.methodToObtainQualification | t)
                 },
                 actions: {
                   items: [
@@ -316,7 +316,7 @@
                   text: ("professions.form.label.qualificationInformation.mostCommonPathToObtainQualification" | t)
                 },
                 value: {
-                  text: (qualification.mostCommonPathToObtainQualification | t)
+                  html: (qualification.mostCommonPathToObtainQualification | t)
                 },
                 actions: {
                   items: [

--- a/views/admin/professions/check-your-answers.njk
+++ b/views/admin/professions/check-your-answers.njk
@@ -377,7 +377,7 @@
                   text: ("professions.form.label.legislation.nationalLegislation" | t)
                 },
                 value: {
-                  text: legislation.name
+                  html: legislation.name | multiline
                 },
                 actions: {
                   items: [

--- a/views/admin/professions/check-your-answers.njk
+++ b/views/admin/professions/check-your-answers.njk
@@ -282,7 +282,7 @@
                   text: ("professions.form.label.qualificationInformation.qualificationLevel" | t)
                 },
                 value: {
-                  text: qualification.level
+                  html: qualification.level | multiline
                 },
                 actions: {
                   items: [

--- a/views/admin/professions/check-your-answers.njk
+++ b/views/admin/professions/check-your-answers.njk
@@ -204,7 +204,7 @@
                   text: ("professions.form.label.regulatedActivities.regulationSummary" | t)
                 },
                 value: {
-                  text: regulationSummary
+                  html: regulationSummary | multiline
                 },
                 actions: {
                   items: [
@@ -221,7 +221,7 @@
                   text: ("professions.form.label.regulatedActivities.reservedActivities" | t)
                 },
                 value: {
-                  text: reservedActivities
+                  html: reservedActivities | multiline
                 },
                 actions: {
                   items: [
@@ -238,7 +238,7 @@
                   text: ("professions.form.label.regulatedActivities.protectedTitles" | t)
                 },
                 value: {
-                  text: protectedTitles
+                  html: protectedTitles | multiline
                 },
                 actions: {
                   items: [

--- a/views/professions/_profession-details.njk
+++ b/views/professions/_profession-details.njk
@@ -61,7 +61,7 @@
         text: ("professions.show.bodies.address" | t)
       },
       value: {
-        text: organisation.address
+        html: organisation.address | multiline
       }
     },
     {

--- a/views/professions/_profession-details.njk
+++ b/views/professions/_profession-details.njk
@@ -154,7 +154,7 @@
         text: ("professions.show.qualification.methods" | t)
       },
       value: {
-        text: qualification.methodToObtainQualification | t
+        html: qualification.methodToObtainQualification | t
       }
     },
     {
@@ -162,7 +162,7 @@
         text: ("professions.show.qualification.commonPath" | t)
       },
       value: {
-        text: qualification.mostCommonPathToObtainQualification | t
+        html: qualification.mostCommonPathToObtainQualification | t
       }
     },
     {

--- a/views/professions/_profession-details.njk
+++ b/views/professions/_profession-details.njk
@@ -146,7 +146,7 @@
         text: ("professions.show.qualification.level" | t)
       },
       value: {
-        text: qualification.level
+        html: qualification.level | multiline
       }
     },
     {

--- a/views/professions/_profession-details.njk
+++ b/views/professions/_profession-details.njk
@@ -201,7 +201,7 @@
           text: ( "professions.show.legislation.nationalLegislation" | t) + " " + loop.index
         },
         value: {
-          text: legislation.name
+          html: legislation.name | multiline
         }
       },
       {

--- a/views/professions/_profession-details.njk
+++ b/views/professions/_profession-details.njk
@@ -98,18 +98,18 @@
 
   <div>
     <h3 class="govuk-heading-s">{{ "professions.show.regulatedActivities.regulationSummary" | t }}</h3>
-    <p class="govuk-body">{{ profession.description | escape }}</p>
+    {{ profession.description | multiline('govuk-body') }}
   </div>
 
   <div>
     <h3 class="govuk-heading-s">{{ "professions.show.regulatedActivities.reservedActivities" | t }}</h3>
-    <p class="govuk-body">{{ profession.reservedActivities | escape }}</p>
+    {{ profession.reservedActivities | multiline('govuk-body') }}
   </div>
 
   {% if profession.protectedTitles %}
     <div>
       <h3 class="govuk-heading-s">{{ "professions.show.regulatedActivities.protectedTitles" | t }}</h3>
-      <p class="govuk-body">{{ profession.protectedTitles | escape }}</p>
+      {{ profession.protectedTitles | multiline('govuk-body') }}
     </div>
   {% endif %}
 


### PR DESCRIPTION
# Changes in this PR

Any data that the user enters in a multi-line text field, will now be presented back as the user would naturally expect, with new lines preserved.

## Screenshots of UI changes

### Before
![localhost_3000_admin_professions_863278ef-ca98-466b-8445-a56f536b1538_versions_5d333f32-a15a-4972-92b3-45022678ff9e](https://user-images.githubusercontent.com/94137563/154127372-d40d47c8-67f8-4d4b-9dca-fb851611c6ea.png)

### After
![localhost_3000_admin_professions_5817a78b-263b-4fd2-ba8b-6aac022ddd84_versions_ef2ff443-c027-4b4a-8e6d-363a454c2150](https://user-images.githubusercontent.com/94137563/154127392-360be331-85d0-4d80-b2a7-24e4bb837e49.png)
