### PR TITLE
Release 003

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+## [release-003] - 2022-02-16
+
 ### Added
 
 - Allow a draft version to be published
@@ -84,6 +86,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix links in error messages when adding a new profession
 - Make validation errors more human readable
 
-[unreleased]: https://github.com/UKGovernmentBEIS/regulated-professions-register/compare/release-001...HEAD
+[unreleased]: https://github.com/UKGovernmentBEIS/regulated-professions-register/compare/release-003...HEAD
+[release-003]: https://github.com/UKGovernmentBEIS/regulated-professions-register/compare/release002...release-003
 [release-002]: https://github.com/UKGovernmentBEIS/regulated-professions-register/compare/release001...release-002
 [release-001]: https://github.com/UKGovernmentBEIS/regulated-professions-register/compare/release...release-001


### PR DESCRIPTION
### Added

- Allow a draft version to be published
- Allow draft Professions to be published
- Protected titles and and a URL for further information on regulations can be entered when adding a profession
- Allow second regulator to be chosen
- Add registration page and fields

### Changed

- Creating and editing an organisation creates new draft versions
- Creating and editing a profession creates new draft versions
- Users can be assigned to an organisation
- Users are assigned a role rather than a list of permissions
- All roles may edit professions
- Only service admistrators may create professions
- Setting an organisation on a profession updates immediately, rather than saving as draft
- Remove redundant fields from Profession, now the values are stored on a Version
- Simplify nation selection
- Remove placeholder authority data on index page
- Revised text describing each role to reflect role differences between regulatory authority users and central users
- Enforce that users cannot perform actions outside their role