### PR TITLE
Tidy up Dockerfile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,18 +35,20 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v2
 
-      - id: cache-docker
-        uses: actions/cache@v2
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@master
+
+      - name: Build and push
+        uses: docker/build-push-action@v2
         with:
-          path: /tmp/docker-save
-          key: docker-save-${{ hashFiles('Dockerfile', 'package-lock.json') }}
-
-      - if: steps.cache-docker.outputs.cache-hit == 'true'
-        name: Load cached Docker image
-        run: docker load -i /tmp/docker-save/snapshot.tar || true
-
-      - name: Build
-        run: script/ci/cibuild
+          context: .
+          push: false
+          load: true
+          tags: app_test:latest
+          build-args: NODE_ENV=test
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Test
         id: test
@@ -67,8 +69,3 @@ jobs:
           name: end-to-end-test-videos
           path: cypress/videos/
           retention-days: 14
-
-      - if: always() && steps.cache-docker.outputs.cache-hit != 'true'
-        name: Prepare Docker cache
-        run: mkdir -p /tmp/docker-save && docker save app_test:latest -o
-          /tmp/docker-save/snapshot.tar && ls -lh /tmp/docker-save

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,10 +5,14 @@ FROM node:16 as base
 
 ENV APP_HOME /srv/app
 ENV DEPS_HOME /deps
+ENV TEST_HOME /srv/test
 
 ARG NODE_ENV
 ENV NODE_ENV ${NODE_ENV:-production}
 
+# ------------------------------------------------------------------------------
+# Dependencies
+# ------------------------------------------------------------------------------
 FROM base AS dependencies
 
 RUN mkdir -p ${DEPS_HOME}
@@ -22,14 +26,16 @@ RUN npm ci
 # ------------------------------------------------------------------------------
 # Web
 # ------------------------------------------------------------------------------
-FROM dependencies AS web
+FROM base AS web
+
+COPY --from=dependencies ${DEPS_HOME}/package.json ${APP_HOME}/package.json
+COPY --from=dependencies ${DEPS_HOME}/package-lock.json ${APP_HOME}/package-lock.json
+COPY --from=dependencies ${DEPS_HOME}/node_modules ${APP_HOME}/node_modules
 
 RUN mkdir -p ${APP_HOME}
 WORKDIR ${APP_HOME}
 
 COPY . ${APP_HOME}
-
-RUN cp -R $DEPS_HOME/node_modules $APP_HOME/node_modules
 
 RUN if [ "$NODE_ENV" = "production" ]; then \
   npm run build:assets:prod && \
@@ -48,8 +54,10 @@ CMD ["node", "dist/main"]
 # ------------------------------------------------------------------------------
 # Test
 # ------------------------------------------------------------------------------
-FROM web AS test
+FROM base AS test
 
+RUN mkdir -p ${TEST_HOME}
+WORKDIR ${TEST_HOME}
 
 RUN apt-get update && apt-get install -y --fix-missing --no-install-recommends \
   libgtk2.0-0 \
@@ -63,3 +71,10 @@ RUN apt-get update && apt-get install -y --fix-missing --no-install-recommends \
   libxtst6 \
   xauth \
   xvfb
+
+COPY --from=dependencies ${DEPS_HOME}/package.json ${TEST_HOME}/package.json
+COPY --from=dependencies ${DEPS_HOME}/package-lock.json ${TEST_HOME}/package-lock.json
+COPY --from=dependencies ${DEPS_HOME}/node_modules ${TEST_HOME}/node_modules
+COPY --from=dependencies /root/.cache/Cypress /root/.cache/Cypress
+
+COPY --from=web ${APP_HOME} ${TEST_HOME}

--- a/script/ci/cibuild
+++ b/script/ci/cibuild
@@ -7,4 +7,6 @@ set -e
 
 cd "$(dirname "$0")/../.."
 
+docker build --target dependencies -t app_dependencies:latest .
+docker build --target web -t app_web:latest .
 docker-compose -f docker-compose.ci.yml -p app build


### PR DESCRIPTION
This tweaks the Dockerfile so we can do caching properly. All of the layers now inherit from the base layer and we only copy what we need from the dependency layer, ensuring that we cache as much as is humanly possible.

The only things that should not be cached when running CI are the test dependencies. This should keep Docker build times down to a couple of minutes at the most, as long as the package.json or Dockerfile doesn’t change.