### PR TITLE
(2125) Rename "Publish now" to "Save as draft" when editing a profession

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Revised text describing each role to reflect role differences between regulatory authority users and central users
 - Enforce that users cannot perform actions outside their role
 - Preserve line breaks of any data entered in a multi-line text field
+- Fix incorrect "Publish now" button that should be saving as draft
 
 ## [release-002] - 2022-02-01
 

--- a/cypress/integration/admin/professions/edit.spec.ts
+++ b/cypress/integration/admin/professions/edit.spec.ts
@@ -72,7 +72,7 @@ describe('Editing an existing profession', () => {
         'The Trade Marks Act 1994',
       );
 
-      cy.translate('professions.form.button.publishNow').then((buttonText) => {
+      cy.translate('professions.form.button.saveAsDraft').then((buttonText) => {
         cy.get(buttonText).should('not.exist');
       });
 
@@ -175,7 +175,7 @@ describe('Editing an existing profession', () => {
         'Updated legislation',
       );
 
-      cy.translate('professions.form.button.publishNow').then((buttonText) => {
+      cy.translate('professions.form.button.saveAsDraft').then((buttonText) => {
         cy.get('button').contains(buttonText).click();
       });
 

--- a/src/i18n/en/professions.json
+++ b/src/i18n/en/professions.json
@@ -89,7 +89,8 @@
     "button": {
       "create": "Create profession",
       "edit": "Yes, continue",
-      "publishNow": "Publish now"
+      "publishNow": "Publish now",
+      "saveAsDraft": "Save as draft"
     },
     "select": {
       "topLevelInformation": {

--- a/views/admin/professions/check-your-answers.njk
+++ b/views/admin/professions/check-your-answers.njk
@@ -15,7 +15,6 @@
         <h1 class="govuk-heading-l">{{ ("professions.form.headings.checkAnswers" | t) }}</h1>
       {% endif %}
 
-      <form method="post" action="confirmation">
         <h2 class="govuk-heading-m">{{ ("professions.form.headings.topLevelInformation" | t) }}</h2>
 
         {% set selectedNationsSummaryListHtml %}
@@ -481,16 +480,17 @@
         }}
 
         {% if not edit and not confirmed %}
-          {{
-            govukButton({
-              id: "submit-button",
-              type: "Submit",
-              preventDoubleClick: true,
-              text: ("professions.form.button.create" | t)
-            })
-          }}
+          <form method="post" action="confirmation">
+            {{
+              govukButton({
+                id: "submit-button",
+                type: "Submit",
+                preventDoubleClick: true,
+                text: ("professions.form.button.create" | t)
+              })
+            }}
+          </form>
         {% endif %}
-      </form>
 
     </div>
 

--- a/views/admin/professions/check-your-answers.njk
+++ b/views/admin/professions/check-your-answers.njk
@@ -480,17 +480,7 @@
           })
         }}
 
-        {% if edit %}
-        {% elif confirmed %}
-          {{
-            govukButton({
-              id: "submit-button",
-              type: "Submit",
-              preventDoubleClick: true,
-              text: ("professions.form.button.publishNow" | t)
-            })
-          }}
-        {% else %}
+        {% if not edit and not confirmed %}
           {{
             govukButton({
               id: "submit-button",
@@ -504,7 +494,23 @@
 
     </div>
 
-    <div class="govuk-grid-column-one-third"></div>
+    <div class="govuk-grid-column-one-third">
+      {% if not edit and confirmed %}
+        <aside class="app-related-items rpr-internal__details-page-sidebar" role="complementary">
+          <form method="post" action="confirmation">
+            {{
+              govukButton({
+                id: "submit-button",
+                classes: "govuk-button--secondary",
+                type: "Submit",
+                preventDoubleClick: true,
+                text: ("professions.form.button.saveAsDraft" | t)
+              })
+            }}
+          </form>
+        </aside>
+      {% endif %}
+    </div>
   </div>
 
 {% endblock %}


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR

Renames Publish now button to Save as draft when editing a profession, as this is what it was really doing. We also move it into an `<aside>` at the top of the page, as users missed this button in research.

We may want to add a "Publish now" button when editing, but this can come in future if there's a need for it.

Also stops rendering a form without a submit button when not creating a new profession.

## Screenshots of UI changes

![image](https://user-images.githubusercontent.com/19826940/154309308-6c92f965-3bfa-4cce-9ce1-d431c98bb536.png)

