### PR TITLE
(2108) Add an optional second Legislation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+
+### Changed
+
+- Users can enter a second legislation for a profession
+
 ## [release-003] - 2022-02-16
 
 ### Added

--- a/cypress/integration/admin/professions/edit.spec.ts
+++ b/cypress/integration/admin/professions/edit.spec.ts
@@ -170,9 +170,43 @@ describe('Editing an existing profession', () => {
       cy.translate('app.continue').then((buttonText) => {
         cy.get('button').contains(buttonText).click();
       });
-      cy.checkSummaryListRowValue(
+      cy.checkIndexedSummaryListRowValue(
         'professions.form.label.legislation.nationalLegislation',
         'Updated legislation',
+        1,
+      );
+
+      cy.clickSummaryListRowAction(
+        'professions.form.label.legislation.nationalLegislation',
+        'Change',
+      );
+      cy.checkAccessibility();
+      cy.translate('professions.form.captions.edit').then((editCaption) => {
+        cy.get('body').contains(editCaption);
+      });
+      cy.get('textarea[name="secondNationalLegislation"]').type(
+        'Second legislation',
+      );
+      cy.get('input[name="secondLink"]').type(
+        'http://www.example.com/legislation',
+      );
+      cy.translate('app.continue').then((buttonText) => {
+        cy.get('button').contains(buttonText).click();
+      });
+      cy.checkIndexedSummaryListRowValue(
+        'professions.form.label.legislation.nationalLegislation',
+        'Updated legislation',
+        1,
+      );
+      cy.checkIndexedSummaryListRowValue(
+        'professions.form.label.legislation.nationalLegislation',
+        'Second legislation',
+        2,
+      );
+      cy.checkIndexedSummaryListRowValue(
+        'professions.form.label.legislation.link',
+        'http://www.example.com/legislation',
+        2,
       );
 
       cy.translate('professions.form.button.saveAsDraft').then((buttonText) => {

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -144,6 +144,20 @@ Cypress.Commands.add(
 );
 
 Cypress.Commands.add(
+  'checkIndexedSummaryListRowValue',
+  (key: string, value: string, index: number) => {
+    return cy.translate(key).then((label) => {
+      cy.get('.govuk-summary-list__key')
+        .contains(label + ' ' + index)
+        .siblings('.govuk-summary-list__value')
+        .then(($summaryListValue) => {
+          cy.wrap($summaryListValue).should('contain', value);
+        });
+    });
+  },
+);
+
+Cypress.Commands.add(
   'checkSummaryListRowMultilineValue',
   (key: string, lines: string[]) => {
     return cy.translate(key).then((label) => {

--- a/cypress/support/index.ts
+++ b/cypress/support/index.ts
@@ -44,6 +44,11 @@ declare global {
       checkInputValue(label: string, value: string): Chainable<string>;
       checkTextareaValue(label: string, value: string): Chainable<string>;
       checkSummaryListRowValue(key: string, value: string): Chainable<string>;
+      checkIndexedSummaryListRowValue(
+        key: string,
+        value: string,
+        index: number,
+      ): Chainable<string>;
       checkSummaryListRowMultilineValue(
         key: string,
         lines: string[],

--- a/src/i18n/en/professions.json
+++ b/src/i18n/en/professions.json
@@ -169,7 +169,7 @@
           "empty": "Enter the national legislation"
         },
         "link": {
-          "empty": "Enter a link to the registration"
+          "invalid": "Enter a valid link to the legislation"
         }
       }
     }

--- a/src/i18n/en/professions.json
+++ b/src/i18n/en/professions.json
@@ -54,7 +54,9 @@
       },
       "legislation": {
         "nationalLegislation": "National legislation",
-        "link": "Legislation link"
+        "link": "Legislation link",
+        "secondNationalLegislation": "Second national legislation (optional)",
+        "secondLink": "Second legislation link (optional)"
       }
     },
     "hint": {
@@ -172,6 +174,12 @@
           "empty": "Enter the national legislation"
         },
         "link": {
+          "invalid": "Enter a valid link to the legislation"
+        },
+        "secondNationalLegislation": {
+          "empty": "Enter a second national legislation"
+        },
+        "secondLink": {
           "invalid": "Enter a valid link to the legislation"
         }
       }

--- a/src/i18n/en/professions.json
+++ b/src/i18n/en/professions.json
@@ -67,6 +67,9 @@
       "qualificationInformation": {
         "ukRecognitionUrl": "Please enter a link",
         "otherCountriesRecognitionUrl": "Please enter a link"
+      },
+      "legislation": {
+        "link": "Please enter a link"
       }
     },
     "details": {

--- a/src/professions/admin/check-your-answers.controller.spec.ts
+++ b/src/professions/admin/check-your-answers.controller.spec.ts
@@ -84,7 +84,7 @@ describe('CheckYourAnswersController', () => {
         const templateParams = await controller.show(
           'profession-id',
           'version-id',
-          false,
+          'false',
         );
         expect(templateParams.name).toEqual('Gas Safe Engineer');
         expect(templateParams.nations).toEqual([
@@ -147,7 +147,7 @@ describe('CheckYourAnswersController', () => {
         const templateParams = await controller.show(
           'profession-id',
           'version-id',
-          false,
+          'false',
         );
 
         expect(templateParams.qualification).toEqual(null);

--- a/src/professions/admin/check-your-answers.controller.spec.ts
+++ b/src/professions/admin/check-your-answers.controller.spec.ts
@@ -47,9 +47,15 @@ describe('CheckYourAnswersController', () => {
     describe('when a Profession has been created with the persisted ID', () => {
       it('fetches the draft Profession from the persisted ID, and renders the answers on the page', async () => {
         const qualification = qualificationFactory.build();
-        const legislation = legislationFactory.build({
+
+        const legislation1 = legislationFactory.build({
           url: 'www.gas-legislation.com',
           name: 'Gas Safety Legislation',
+        });
+
+        const legislation2 = legislationFactory.build({
+          url: 'www.another-gas-legislation.com',
+          name: 'Another Gas Safety Legislation',
         });
 
         const profession = professionFactory.build({
@@ -75,7 +81,7 @@ describe('CheckYourAnswersController', () => {
           registrationRequirements: 'Requirements',
           registrationUrl: 'https://example.com/requirement',
           profession: profession,
-          legislations: [legislation],
+          legislations: [legislation1, legislation2],
           qualification: qualification,
         });
 
@@ -116,11 +122,17 @@ describe('CheckYourAnswersController', () => {
         expect(templateParams.qualification).toEqual(
           new QualificationPresenter(qualification),
         );
-        expect(templateParams.legislation.url).toEqual(
+        expect(templateParams.legislations[0].url).toEqual(
           'www.gas-legislation.com',
         );
-        expect(templateParams.legislation.name).toEqual(
+        expect(templateParams.legislations[0].name).toEqual(
           'Gas Safety Legislation',
+        );
+        expect(templateParams.legislations[1].url).toEqual(
+          'www.another-gas-legislation.com',
+        );
+        expect(templateParams.legislations[1].name).toEqual(
+          'Another Gas Safety Legislation',
         );
         expect(templateParams.confirmed).toEqual(false);
 
@@ -151,6 +163,35 @@ describe('CheckYourAnswersController', () => {
         );
 
         expect(templateParams.qualification).toEqual(null);
+      });
+    });
+
+    describe('when the profession has only one legislation', () => {
+      it('the legislations array passed to the template is padded to length 2', async () => {
+        const legislation = legislationFactory.build({
+          url: 'www.gas-legislation.com',
+          name: 'Gas Safety Legislation',
+        });
+
+        const profession = professionFactory.build({
+          organisation: organisationFactory.build(),
+        });
+
+        const version = professionVersionFactory.build({
+          qualification: undefined,
+          legislations: [legislation],
+        });
+
+        professionsService.findWithVersions.mockResolvedValue(profession);
+        professionVersionsService.findWithProfession.mockResolvedValue(version);
+
+        const templateParams = await controller.show(
+          'profession-id',
+          'version-id',
+          'false',
+        );
+
+        expect(templateParams.legislations).toEqual([legislation, undefined]);
       });
     });
   });

--- a/src/professions/admin/check-your-answers.controller.ts
+++ b/src/professions/admin/check-your-answers.controller.ts
@@ -73,8 +73,8 @@ export class CheckYourAnswersController {
       : null;
 
     return {
-      professionId: professionId,
-      versionId: versionId,
+      professionId,
+      versionId,
       name: draftProfession.name,
       nations: selectedNations,
       industries: industryNames,
@@ -89,8 +89,8 @@ export class CheckYourAnswersController {
       reservedActivities: version.reservedActivities,
       protectedTitles: version.protectedTitles,
       regulationUrl: version.regulationUrl,
-      qualification: qualification,
       legislation: version.legislations[0],
+      qualification,
       confirmed: isConfirmed(draftProfession),
       captionText: ViewUtils.captionText(isConfirmed(draftProfession)),
       isUK: isUK(version.occupationLocations),

--- a/src/professions/admin/check-your-answers.controller.ts
+++ b/src/professions/admin/check-your-answers.controller.ts
@@ -38,7 +38,7 @@ export class CheckYourAnswersController {
   async show(
     @Param('professionId') professionId: string,
     @Param('versionId') versionId: string,
-    @Query('edit') edit: boolean,
+    @Query('edit') edit: string,
   ): Promise<CheckYourAnswersTemplate> {
     const draftProfession = await this.professionsService.findWithVersions(
       professionId,
@@ -94,7 +94,7 @@ export class CheckYourAnswersController {
       confirmed: isConfirmed(draftProfession),
       captionText: ViewUtils.captionText(isConfirmed(draftProfession)),
       isUK: isUK(version.occupationLocations),
-      edit: Boolean(edit),
+      edit: edit === 'true',
     };
   }
 }

--- a/src/professions/admin/check-your-answers.controller.ts
+++ b/src/professions/admin/check-your-answers.controller.ts
@@ -72,6 +72,8 @@ export class CheckYourAnswersController {
       ? new QualificationPresenter(version.qualification)
       : null;
 
+    const legislations = [version.legislations[0], version.legislations[1]];
+
     return {
       professionId,
       versionId,
@@ -89,8 +91,8 @@ export class CheckYourAnswersController {
       reservedActivities: version.reservedActivities,
       protectedTitles: version.protectedTitles,
       regulationUrl: version.regulationUrl,
-      legislation: version.legislations[0],
       qualification,
+      legislations,
       confirmed: isConfirmed(draftProfession),
       captionText: ViewUtils.captionText(isConfirmed(draftProfession)),
       isUK: isUK(version.occupationLocations),

--- a/src/professions/admin/dto/legislation.dto.ts
+++ b/src/professions/admin/dto/legislation.dto.ts
@@ -1,4 +1,4 @@
-import { IsNotEmpty, IsUrl } from 'class-validator';
+import { IsNotEmpty, IsUrl, ValidateIf } from 'class-validator';
 
 export default class LegislationDto {
   @IsNotEmpty({
@@ -13,6 +13,22 @@ export default class LegislationDto {
     },
   )
   link: string;
+
+  @IsNotEmpty({
+    message:
+      'professions.form.errors.legislation.secondNationalLegislation.empty',
+  })
+  @ValidateIf((e) => e.secondLink || e.secondNationalLegislation)
+  secondNationalLegislation?: string;
+
+  @IsUrl(
+    {},
+    {
+      message: 'professions.form.errors.legislation.secondLink.invalid',
+    },
+  )
+  @ValidateIf((e) => e.secondLink || e.secondNationalLegislation)
+  secondLink?: string;
 
   change: string;
 }

--- a/src/professions/admin/dto/legislation.dto.ts
+++ b/src/professions/admin/dto/legislation.dto.ts
@@ -1,4 +1,4 @@
-import { IsNotEmpty } from 'class-validator';
+import { IsNotEmpty, IsUrl } from 'class-validator';
 
 export default class LegislationDto {
   @IsNotEmpty({
@@ -6,9 +6,12 @@ export default class LegislationDto {
   })
   nationalLegislation: string;
 
-  @IsNotEmpty({
-    message: 'professions.form.errors.legislation.link.empty',
-  })
+  @IsUrl(
+    {},
+    {
+      message: 'professions.form.errors.legislation.link.invalid',
+    },
+  )
   link: string;
 
   change: boolean;

--- a/src/professions/admin/dto/legislation.dto.ts
+++ b/src/professions/admin/dto/legislation.dto.ts
@@ -14,5 +14,5 @@ export default class LegislationDto {
   )
   link: string;
 
-  change: boolean;
+  change: string;
 }

--- a/src/professions/admin/interfaces/check-your-answers.template.ts
+++ b/src/professions/admin/interfaces/check-your-answers.template.ts
@@ -17,7 +17,7 @@ export interface CheckYourAnswersTemplate {
   protectedTitles: string;
   regulationUrl: string;
   qualification: QualificationPresenter;
-  legislation: Legislation;
+  legislations: Legislation[];
   captionText: string;
   isUK: boolean;
   confirmed: boolean;

--- a/src/professions/admin/interfaces/legislation.template.ts
+++ b/src/professions/admin/interfaces/legislation.template.ts
@@ -2,6 +2,7 @@ import { Legislation } from '../../../legislations/legislation.entity';
 
 export interface LegislationTemplate {
   legislation: Legislation | null;
+  secondLegislation: Legislation | null;
   captionText: string;
   change: boolean;
   errors?: object;

--- a/src/professions/admin/legislation.controller.spec.ts
+++ b/src/professions/admin/legislation.controller.spec.ts
@@ -53,7 +53,7 @@ describe(LegislationController, () => {
       professionsService.findWithVersions.mockResolvedValue(profession);
       professionVersionsService.findWithProfession.mockResolvedValue(version);
 
-      await controller.edit(response, 'profession-id', 'version-id', false);
+      await controller.edit(response, 'profession-id', 'version-id', 'false');
 
       expect(response.render).toHaveBeenCalledWith(
         'admin/professions/legislation',
@@ -76,7 +76,7 @@ describe(LegislationController, () => {
         const dto: LegislationDto = {
           link: 'www.legal-legislation.com',
           nationalLegislation: 'Legal Services Act 2008',
-          change: false,
+          change: 'false',
         };
 
         professionsService.findWithVersions.mockResolvedValue(profession);
@@ -113,7 +113,7 @@ describe(LegislationController, () => {
         const dto: LegislationDto = {
           link: undefined,
           nationalLegislation: undefined,
-          change: false,
+          change: 'false',
         };
 
         professionsService.findWithVersions.mockResolvedValue(profession);

--- a/src/professions/admin/legislation.controller.spec.ts
+++ b/src/professions/admin/legislation.controller.spec.ts
@@ -128,7 +128,7 @@ describe(LegislationController, () => {
           expect.objectContaining({
             errors: {
               link: {
-                text: 'professions.form.errors.legislation.link.empty',
+                text: 'professions.form.errors.legislation.link.invalid',
               },
               nationalLegislation: {
                 text: 'professions.form.errors.legislation.nationalLegislation.empty',

--- a/src/professions/admin/legislation.controller.spec.ts
+++ b/src/professions/admin/legislation.controller.spec.ts
@@ -36,31 +36,69 @@ describe(LegislationController, () => {
   });
 
   describe('edit', () => {
-    it('renders the Legislation page, passing in any values on the Profession that have already been set', async () => {
-      const legislation = legislationFactory.build({
-        name: 'Legal Services Act 2007',
-        url: 'www.example.com',
+    describe('when the Profession contains a single legislation', () => {
+      it('renders the Legislation page, passing in any values on the Profession that have already been set', async () => {
+        const legislation = legislationFactory.build({
+          name: 'Legal Services Act 2007',
+          url: 'www.example.com',
+        });
+        const profession = professionFactory.build({
+          id: 'profession-id',
+        });
+
+        const version = professionVersionFactory.build({
+          id: 'version-id',
+          legislations: [legislation],
+        });
+
+        professionsService.findWithVersions.mockResolvedValue(profession);
+        professionVersionsService.findWithProfession.mockResolvedValue(version);
+
+        await controller.edit(response, 'profession-id', 'version-id', 'false');
+
+        expect(response.render).toHaveBeenCalledWith(
+          'admin/professions/legislation',
+          expect.objectContaining({
+            legislation: legislation,
+          }),
+        );
       });
-      const profession = professionFactory.build({
-        id: 'profession-id',
+    });
+
+    describe('when the Profession contains a second Legislation', () => {
+      it('renders the Legislation page, passing in any values on the Profession that have already been set', async () => {
+        const legislation1 = legislationFactory.build({
+          name: 'Legal Services Act 2007',
+          url: 'www.example.com',
+        });
+
+        const legislation2 = legislationFactory.build({
+          name: 'Another Legal Services Act 2007',
+          url: 'www.another-example.com',
+        });
+
+        const profession = professionFactory.build({
+          id: 'profession-id',
+        });
+
+        const version = professionVersionFactory.build({
+          id: 'version-id',
+          legislations: [legislation1, legislation2],
+        });
+
+        professionsService.findWithVersions.mockResolvedValue(profession);
+        professionVersionsService.findWithProfession.mockResolvedValue(version);
+
+        await controller.edit(response, 'profession-id', 'version-id', 'false');
+
+        expect(response.render).toHaveBeenCalledWith(
+          'admin/professions/legislation',
+          expect.objectContaining({
+            legislation: legislation1,
+            secondLegislation: legislation2,
+          }),
+        );
       });
-
-      const version = professionVersionFactory.build({
-        id: 'version-id',
-        legislations: [legislation],
-      });
-
-      professionsService.findWithVersions.mockResolvedValue(profession);
-      professionVersionsService.findWithProfession.mockResolvedValue(version);
-
-      await controller.edit(response, 'profession-id', 'version-id', 'false');
-
-      expect(response.render).toHaveBeenCalledWith(
-        'admin/professions/legislation',
-        expect.objectContaining({
-          legislation: legislation,
-        }),
-      );
     });
   });
 
@@ -90,6 +128,49 @@ describe(LegislationController, () => {
               expect.objectContaining({
                 url: 'www.legal-legislation.com',
                 name: 'Legal Services Act 2008',
+              }),
+            ],
+            profession: profession,
+          }),
+        );
+
+        expect(response.redirect).toHaveBeenCalledWith(
+          '/admin/professions/profession-id/versions/version-id/check-your-answers',
+        );
+      });
+    });
+
+    describe('when a second Legislation is entered', () => {
+      it('creates two new Legislations on the Profession and redirects to Check your answers', async () => {
+        const profession = professionFactory.build({ id: 'profession-id' });
+        const version = professionVersionFactory.build({
+          id: 'version-id',
+          profession: profession,
+        });
+
+        const dto: LegislationDto = {
+          link: 'www.legal-legislation.com',
+          nationalLegislation: 'Legal Services Act 2008',
+          secondLink: 'www.another-legal-legislation.com',
+          secondNationalLegislation: 'Another Legal Services Act 2008',
+          change: 'false',
+        };
+
+        professionsService.findWithVersions.mockResolvedValue(profession);
+        professionVersionsService.findWithProfession.mockResolvedValue(version);
+
+        await controller.update(response, 'profession-id', 'version-id', dto);
+
+        expect(professionVersionsService.save).toHaveBeenCalledWith(
+          expect.objectContaining({
+            legislations: [
+              expect.objectContaining({
+                url: 'www.legal-legislation.com',
+                name: 'Legal Services Act 2008',
+              }),
+              expect.objectContaining({
+                url: 'www.another-legal-legislation.com',
+                name: 'Another Legal Services Act 2008',
               }),
             ],
             profession: profession,

--- a/src/professions/admin/legislation.controller.ts
+++ b/src/professions/admin/legislation.controller.ts
@@ -45,7 +45,7 @@ export class LegislationController {
     @Param('professionId') professionId: string,
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     @Param('versionId') versionId: string,
-    @Query('change') change: boolean,
+    @Query('change') change: string,
   ): Promise<void> {
     const profession = await this.professionsService.findWithVersions(
       professionId,
@@ -60,7 +60,7 @@ export class LegislationController {
       res,
       version.legislations[0],
       isConfirmed(profession),
-      change,
+      change === 'true',
     );
   }
 
@@ -111,7 +111,7 @@ export class LegislationController {
         res,
         updatedLegislation,
         isConfirmed(profession),
-        submittedValues.change,
+        submittedValues.change === 'true',
         errors,
       );
     }

--- a/src/professions/admin/legislation.controller.ts
+++ b/src/professions/admin/legislation.controller.ts
@@ -6,7 +6,6 @@ import {
   Post,
   Query,
   Res,
-  UseFilters,
   UseGuards,
 } from '@nestjs/common';
 import { Response, Request } from 'express';
@@ -15,7 +14,6 @@ import { Permissions } from '../../common/permissions.decorator';
 import { Validator } from '../../helpers/validator';
 import { Legislation } from '../../legislations/legislation.entity';
 import { UserPermission } from '../../users/user-permission';
-import { ValidationExceptionFilter } from '../../common/validation/validation-exception.filter';
 import { ValidationFailedError } from '../../common/validation/validation-failed.error';
 import { ProfessionsService } from '../professions.service';
 import LegislationDto from './dto/legislation.dto';
@@ -66,12 +64,6 @@ export class LegislationController {
 
   @Post('/:professionId/versions/:versionId/legislation')
   @Permissions(UserPermission.CreateProfession, UserPermission.EditProfession)
-  @UseFilters(
-    new ValidationExceptionFilter(
-      'admin/professions/legislation',
-      'legislation',
-    ),
-  )
   @BackLink((request: Request) =>
     request.body.change === 'true'
       ? '/admin/professions/:professionId/versions/:versionId/check-your-answers'

--- a/src/professions/admin/legislation.controller.ts
+++ b/src/professions/admin/legislation.controller.ts
@@ -126,6 +126,7 @@ export class LegislationController {
   ): Promise<void> {
     const templateArgs: LegislationTemplate = {
       legislation,
+      secondLegislation: null,
       captionText: ViewUtils.captionText(isEditing),
       change,
       errors,

--- a/src/professions/admin/legislation.controller.ts
+++ b/src/professions/admin/legislation.controller.ts
@@ -57,6 +57,7 @@ export class LegislationController {
     this.renderForm(
       res,
       version.legislations[0],
+      version.legislations[1],
       isConfirmed(profession),
       change === 'true',
     );
@@ -88,11 +89,18 @@ export class LegislationController {
     const submittedValues: LegislationDto = legislationDto;
 
     const updatedLegislation: Legislation = {
-      // We currently need to update one legislation here, but will update multiple in future
       ...version.legislations[0],
       ...{
         name: submittedValues.nationalLegislation,
         url: submittedValues.link,
+      },
+    };
+
+    const updatedSecondLegislation: Legislation = {
+      ...version.legislations[1],
+      ...{
+        name: submittedValues.secondNationalLegislation,
+        url: submittedValues.secondLink,
       },
     };
 
@@ -102,13 +110,20 @@ export class LegislationController {
       return this.renderForm(
         res,
         updatedLegislation,
+        updatedSecondLegislation,
         isConfirmed(profession),
         submittedValues.change === 'true',
         errors,
       );
     }
 
-    version.legislations = [updatedLegislation];
+    const updatedLegislations = [updatedLegislation];
+
+    if (updatedSecondLegislation.name || updatedSecondLegislation.url) {
+      updatedLegislations.push(updatedSecondLegislation);
+    }
+
+    version.legislations = updatedLegislations;
 
     await this.professionVersionsService.save(version);
 
@@ -120,13 +135,14 @@ export class LegislationController {
   private async renderForm(
     res: Response,
     legislation: Legislation,
+    secondLegislation: Legislation,
     isEditing: boolean,
     change: boolean,
     errors: object | undefined = undefined,
   ): Promise<void> {
     const templateArgs: LegislationTemplate = {
       legislation,
-      secondLegislation: null,
+      secondLegislation,
       captionText: ViewUtils.captionText(isEditing),
       change,
       errors,

--- a/views/admin/professions/check-your-answers.njk
+++ b/views/admin/professions/check-your-answers.njk
@@ -438,46 +438,48 @@
 
         <h2 class="govuk-heading-m">{{ ("professions.form.headings.legislation" | t) }}</h2>
 
-        {{
-          govukSummaryList({
-            rows: [
-              {
-                key: {
-                  text: ("professions.form.label.legislation.nationalLegislation" | t)
+        {% for legislation in legislations %}
+          {{
+            govukSummaryList({
+              rows: [
+                {
+                  key: {
+                    html: ("professions.form.label.legislation.nationalLegislation" | t) + "<span class=\"govuk-visually-hidden\"> " + loop.index + "</span>"
+                  },
+                  value: {
+                    text: legislation.name | multiline
+                  },
+                  actions: {
+                    items: [
+                      {
+                        href: "/admin/professions/" + professionId + "/versions/" + versionId + "/legislation/edit?change=true",
+                        text: ("app.change" | t),
+                        visuallyHiddenText: ("professions.form.label.legislation.nationalLegislation" | t) + " " + loop.index
+                      }
+                    ]
+                  }
                 },
-                value: {
-                  html: legislation.name | multiline
-                },
-                actions: {
-                  items: [
-                    {
-                      href: "/admin/professions/" + professionId + "/versions/" + versionId + "/legislation/edit?change=true",
-                      text: ("app.change" | t),
-                      visuallyHiddenText: ("professions.form.label.legislation.nationalLegislation" | t)
-                    }
-                  ]
+                {
+                  key: {
+                    html: ("professions.form.label.legislation.link" | t) + "<span class=\"govuk-visually-hidden\"> " + loop.index + "</span>"
+                  },
+                  value: {
+                    html: ("<a class='govuk-link' href='" + (legislation.url | escape) + "'>" + (legislation.url | escape) + "</a>") if legislation else ""
+                  },
+                  actions: {
+                    items: [
+                      {
+                        href: "/admin/professions/" + professionId + "/versions/" + versionId + "/legislation/edit?change=true",
+                        text: ("app.change" | t),
+                        visuallyHiddenText: ("professions.form.label.legislation.nationalLegislation" | t) + " " + loop.index
+                      }
+                    ]
+                  }
                 }
-              },
-              {
-                key: {
-                  text: ("professions.form.label.legislation.link" | t)
-                },
-                value: {
-                  html: "<a class='govuk-link' href='" + (legislation.url | escape) + "'>" + (legislation.url | escape) + "</a>"
-                },
-                actions: {
-                  items: [
-                    {
-                      href: "/admin/professions/" + professionId + "/versions/" + versionId + "/legislation/edit?change=true",
-                      text: ("app.change" | t),
-                      visuallyHiddenText: ("professions.form.label.legislation.nationalLegislation" | t)
-                    }
-                  ]
-                }
-              }
-            ]
-          })
-        }}
+              ]
+            })
+          }}
+        {% endfor %}
 
         {% if not edit and not confirmed %}
           <form method="post" action="confirmation">

--- a/views/admin/professions/legislation.njk
+++ b/views/admin/professions/legislation.njk
@@ -39,6 +39,9 @@
               classes: "govuk-label--m",
               isPageHeading: false
             },
+            hint: {
+              text: "professions.form.hint.legislation.link" | t
+            },
             id: "link",
             name: "link",
             value: legislation.url,

--- a/views/admin/professions/legislation.njk
+++ b/views/admin/professions/legislation.njk
@@ -50,6 +50,37 @@
         }}
 
         {{
+          govukTextarea({
+            label: {
+              text: ("professions.form.label.legislation.secondNationalLegislation" | t),
+              classes: "govuk-label--m",
+              isPageHeading: false
+            },
+            id: "secondNationalLegislation",
+            name: "secondNationalLegislation",
+            value: secondLegislation.name,
+            errorMessage: errors.secondNationalLegislation | tError
+          })
+        }}
+
+        {{
+          govukInput({
+            label: {
+              text: ("professions.form.label.legislation.secondLink" | t),
+              classes: "govuk-label--m",
+              isPageHeading: false
+            },
+            hint: {
+              text: "professions.form.hint.legislation.link" | t
+            },
+            id: "secondLink",
+            name: "secondLink",
+            value: secondLegislation.url,
+            errorMessage: errors.secondLink | tError
+          })
+        }}
+
+        {{
           govukButton({
             id: "submit-button",
             type: "Submit",

--- a/views/professions/_profession-details.njk
+++ b/views/professions/_profession-details.njk
@@ -198,7 +198,7 @@
     rows: [
       {
         key: {
-          text: ( "professions.show.legislation.nationalLegislation" | t) + " " + loop.index
+          html: ( "professions.show.legislation.nationalLegislation" | t) + "<span class=\"govuk-visually-hidden\"> " + loop.index + "</span>"
         },
         value: {
           html: legislation.name | multiline
@@ -206,7 +206,7 @@
       },
       {
         key: {
-          text: ( "professions.show.legislation.legislationLink" | t) + " " + loop.index
+          html: ( "professions.show.legislation.legislationLink" | t) + "<span class=\"govuk-visually-hidden\"> " + loop.index + "</span>"
         },
         value: {
           html: ["<a class=\"govuk-link\" href=\"", (legislation.url | escape), "\">", (legislation.url | escape),  "</a>" ] | join


### PR DESCRIPTION
# Changes in this PR

A user can now enter a second legislation name and link

## Screenshots of UI changes

### Before
![localhost_3000_admin_professions_29d119c8-e9e5-476e-90a0-c77d1e3654c9_versions_e07a9ede-c6f3-425f-b855-084c036a52ae_legislation_edit_change=true (1)](https://user-images.githubusercontent.com/94137563/154324251-bcd2e47e-97da-473f-9542-2ca5e2a29bf1.png)

### After
![localhost_3000_admin_professions_29d119c8-e9e5-476e-90a0-c77d1e3654c9_versions_e07a9ede-c6f3-425f-b855-084c036a52ae_legislation_edit_change=true](https://user-images.githubusercontent.com/94137563/154324231-e8126ab8-ddc8-4e92-b7ea-9bd13975a20d.png)

