### PR TITLE
(2088) Implement Plausible.io analytics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- Add Plausible.io analytics
+
 ### Changed
 
 - Users can enter a second legislation for a profession

--- a/src/common/create-plausible-event.spec.ts
+++ b/src/common/create-plausible-event.spec.ts
@@ -1,0 +1,23 @@
+import axios from 'axios';
+import { createPlausibleEvent } from './create-plausible-event';
+
+jest.mock('axios');
+
+describe('createPlausibleEvent', () => {
+  it('should send a HTTP request to Plausible', async () => {
+    process.env['HOST_URL'] = 'http://example.com';
+
+    createPlausibleEvent('event', 'some/path');
+
+    expect(axios.post).toHaveBeenCalledWith('https://plausible.io/api/event', {
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      data: {
+        name: 'event',
+        url: 'http://example.com/some/path',
+        domain: 'example.com',
+      },
+    });
+  });
+});

--- a/src/common/create-plausible-event.ts
+++ b/src/common/create-plausible-event.ts
@@ -1,0 +1,17 @@
+import axios from 'axios';
+
+export async function createPlausibleEvent(
+  name: string,
+  path: string,
+): Promise<void> {
+  await axios.post('https://plausible.io/api/event', {
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    data: {
+      name: name,
+      url: `${process.env['HOST_URL']}/${path}`,
+      domain: process.env['HOST_URL'].replace(/https?:\/\//, ''),
+    },
+  });
+}

--- a/src/config/nunjucks.config.ts
+++ b/src/config/nunjucks.config.ts
@@ -27,6 +27,11 @@ export const nunjucksConfig = async (
     'encore_entry_script_tags',
     await assetsHelper.entryScriptTags(),
   );
+  env.addGlobal('environment', process.env['NODE_ENV']);
+  env.addGlobal(
+    'site_domain',
+    process.env['HOST_URL'].replace(/https?:\/\//, ''),
+  );
   env.addFilter(
     't',
     async (...args) => {

--- a/src/middleware/authentication.middleware.spec.ts
+++ b/src/middleware/authentication.middleware.spec.ts
@@ -6,11 +6,16 @@ import { createMock } from '@golevelup/ts-jest';
 import { AuthenticationMidleware } from './authentication.middleware';
 import { User } from '../users/user.entity';
 
+import { createPlausibleEvent } from '../common/create-plausible-event';
+
+jest.mock('../common/create-plausible-event');
+
 describe('AuthenticationMidleware', () => {
   let middleware: AuthenticationMidleware;
   let user: User;
 
   beforeEach(async () => {
+    jest.resetAllMocks();
     const app = createMock<NestExpressApplication>({
       select: () => ({
         get: () => ({
@@ -48,6 +53,40 @@ describe('AuthenticationMidleware', () => {
       await expect(async () => {
         await middleware.afterCallback(session);
       }).rejects.toThrowError(ForbiddenException);
+    });
+
+    describe('when the environment is set to production', () => {
+      it('sends an event to Plausible', async () => {
+        process.env['NODE_ENV'] = 'production';
+
+        user = new User('email@example.com', 'name', '212121');
+
+        const session = {
+          id_token:
+            'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.e30.Et9HFtf9R3GEMA0IICOfFMVXY7kkTX1wr4qCyhIf58U',
+        };
+
+        await middleware.afterCallback(session);
+
+        expect(createPlausibleEvent).toHaveBeenCalledWith('login', '/login');
+      });
+    });
+
+    describe('when the environment is not set to production', () => {
+      it('does not send an event to Plausible', async () => {
+        process.env['NODE_ENV'] = 'development';
+
+        user = new User('email@example.com', 'name', '212121');
+
+        const session = {
+          id_token:
+            'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.e30.Et9HFtf9R3GEMA0IICOfFMVXY7kkTX1wr4qCyhIf58U',
+        };
+
+        await middleware.afterCallback(session);
+
+        expect(createPlausibleEvent).not.toHaveBeenCalled();
+      });
     });
   });
 });

--- a/src/middleware/authentication.middleware.ts
+++ b/src/middleware/authentication.middleware.ts
@@ -2,6 +2,7 @@ import { ForbiddenException } from '@nestjs/common';
 import { NestExpressApplication } from '@nestjs/platform-express';
 import { RequestHandler } from 'express';
 import { auth } from 'express-openid-connect';
+import { createPlausibleEvent } from '../common/create-plausible-event';
 
 import jwt_decode from 'jwt-decode';
 
@@ -77,6 +78,10 @@ export class AuthenticationMidleware {
 
     if (user === undefined) {
       throw new ForbiddenException();
+    }
+
+    if (process.env['NODE_ENV'] === 'production') {
+      await createPlausibleEvent('login', '/login');
     }
 
     return {

--- a/views/base.njk
+++ b/views/base.njk
@@ -33,6 +33,10 @@
 {% block head %}
   {{ encore_entry_link_tags }}
 
+  {% if environment === 'production' %}
+    <script defer data-domain="{{ site_domain }}" src="https://plausible.io/js/plausible.js"></script>
+  {% endif %}
+
   {# For Internet Explorer 8, you need to compile specific stylesheet #}
   {# see https://frontend.design-system.service.gov.uk/supporting-ie8/#support-internet-explorer-8 #}
   <!--[if IE 8]>


### PR DESCRIPTION
This uses [Plausible.io](https://plausible.io) to track visits to the service without having to store cookies on a user's machine, or implement a cookie banner. It's also considerably less bloated than Google Analytics.

As well as tracking page views, I've added a custom server side event to track unique logins to the service.