### PR TITLE
Rebase the oldest PR set to automerge on merge

### DIFF
--- a/.github/workflows/automatic-rebase.yml
+++ b/.github/workflows/automatic-rebase.yml
@@ -2,9 +2,6 @@ on:
   issue_comment:
     types:
       - created
-  pull_request_target:
-    types:
-      - auto_merge_enabled
 
 env:
   AUTO_REBASE_PERSONAL_ACCESS_TOKEN: ${{ secrets.AUTO_REBASE_PERSONAL_ACCESS_TOKEN }}

--- a/.github/workflows/rebase-automerged.yml
+++ b/.github/workflows/rebase-automerged.yml
@@ -1,0 +1,40 @@
+name: Rebase Automerged
+
+on:
+  push:
+    branches:
+      - main
+env:
+  AUTO_REBASE_PERSONAL_ACCESS_TOKEN: ${{ secrets.AUTO_REBASE_PERSONAL_ACCESS_TOKEN }}
+jobs:
+  fetch_oldest_pr_awaiting_automerge:
+    runs-on: ubuntu-latest
+    outputs:
+      pr_numbers: ${{ steps.get-all-awaiting-pr-numbers.outputs.pr_numbers }}
+    steps:
+      - name: Get all awaiting PR numbers
+        id: get-all-awaiting-pr-numbers
+        run: |
+          PR_NUMBER=$(curl https://api.github.com/repos/UKGovernmentBEIS/regulated-professions-register/pulls\?state\=open | jq -c '[.[] | select(.auto_merge!=null) | .number] | first')
+          echo "::set-output name=pr_number::$PR_NUMBER"
+  trigger_rebase_action:
+    if: ${{ needs.fetch_oldest_pr_awaiting_automerge.outputs.pr_number != '' }}
+    env:
+      PR_NUMBER: ${{ needs.fetch_oldest_pr_awaiting_automerge.outputs.pr_number }}
+    needs: fetch_oldest_pr_awaiting_automerge
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get the latest ref for ${{ env.PR_NUMBER }}
+        run: |
+          PR_DATA=$(curl https://api.github.com/repos/UKGovernmentBEIS/regulated-professions-register/pulls/$PR_NUMBER)
+          printf 'ref=%q\n' "$(echo "$PR_DATA" | jq -r .head.ref)" >> "$GITHUB_ENV"
+      - name: Checkout the latest code for ${{ env.PR_NUMBER }}
+        uses: actions/checkout@v2
+        with:
+          token: ${{ env.AUTO_REBASE_PERSONAL_ACCESS_TOKEN }}
+          fetch-depth: 0
+          ref: ${{ env.ref }}
+      - name: Automatic Rebase
+        uses: cirrus-actions/rebase@1.5
+        env:
+          GITHUB_TOKEN: ${{ env.AUTO_REBASE_PERSONAL_ACCESS_TOKEN }}


### PR DESCRIPTION
This adds an action to run on every merge to `main` that gets the oldesr PR that’s set to automerge and rebases is against `main`. This is useful when we have a bunch of PRs we want to merge, and will allow us to ‘fire and forget’ without having to constantly nurse a bunch of PRs through to completion (which is especially painful for Dependabot PRs!)