### PR TITLE
Release 004

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+### Changed
+
+## [release-004] - 2022-02-21
+
+### Added
+
 - Add Plausible.io analytics
 
 ### Changed


### PR DESCRIPTION
### Added

- Add Plausible.io analytics

### Changed

- Users can enter a second legislation for a profession
- Display user who changed a profession on the Admin Profession index page and Profession page itself.
- Display name of user who last edited an organisation and modified date to admins
- Allow BEIS team users to see the "Changed By" field so they can track who has edited data.
- Change edit button wording depending on entity status
- Show a confirmation banner when publishing entities