### PR TITLE
Add cdn-route

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -50,6 +50,8 @@ jobs:
       TF_VAR_rollbar_token: ${{ secrets.PROD_ROLLBAR_TOKEN }}
       TF_VAR_basic_auth_username: ${{ secrets.PROD_BASIC_AUTH_USERNAME }}
       TF_VAR_basic_auth_password: ${{ secrets.PROD_BASIC_AUTH_PASSWORD }}
+      TF_VAR_custom_domain: ${{ secrets.PROD_CUSTOM_DOMAIN }}
+      TF_VAR_custom_hostname: ${{ secrets.PROD_CUSTOM_HOSTNAME }}
     steps:
       - uses: actions/checkout@v2
       - name: Deploy latest code to Production
@@ -75,6 +77,8 @@ jobs:
       TF_VAR_rollbar_token: ${{ secrets.STAGING_ROLLBAR_TOKEN }}
       TF_VAR_basic_auth_username: ${{ secrets.STAGING_BASIC_AUTH_USERNAME }}
       TF_VAR_basic_auth_password: ${{ secrets.STAGING_BASIC_AUTH_PASSWORD }}
+      TF_VAR_custom_domain: ${{ secrets.STAGING_CUSTOM_DOMAIN }}
+      TF_VAR_custom_hostname: ${{ secrets.STAGING_CUSTOM_HOSTNAME }}
     steps:
       - uses: actions/checkout@v2
       - name: Deploy latest code to Staging

--- a/doc/architecture/decisions/0016-add-cdn-route.md
+++ b/doc/architecture/decisions/0016-add-cdn-route.md
@@ -1,0 +1,20 @@
+# 16. Add CDN route
+
+Date: 2022-02-22
+
+## Status
+
+Accepted
+
+## Context
+
+The apps need to be hosted on a custom domain, behind CloudFront
+
+## Decision
+
+We will create a cdn-route on GPaas, which will create a CloudFront endpoint with the custom domain
+This will also generate the TLS certificates
+
+## Consequences
+
+We may need to configure the cdn-route to forward particular headers or cookies, if they are configured to not be forwarded to the application

--- a/terraform/app.tf
+++ b/terraform/app.tf
@@ -34,5 +34,8 @@ resource "cloudfoundry_app" "beis-rpr-app" {
   routes {
     route = cloudfoundry_route.beis-rpr-route.id
   }
+  routes {
+    route = cloudfoundry_route.beis-rpr-custom-domain-route.id
+  }
 
 }

--- a/terraform/cdn-route.tf
+++ b/terraform/cdn-route.tf
@@ -1,0 +1,12 @@
+data "cloudfoundry_service" "cdn_route" {
+  name = "cdn-route"
+}
+
+resource "cloudfoundry_service_instance" "cdn_route" {
+  name         = "beis-rpr-${var.environment}-cdn-route"
+  space        = cloudfoundry_space.space.id
+  service_plan = data.cloudfoundry_service.cdn_route.service_plans["cdn-route"]
+  json_params  = <<EOF
+{"domain": "${var.custom_hostname}.${var.custom_domain}"}
+EOF
+}

--- a/terraform/domains.tf
+++ b/terraform/domains.tf
@@ -2,3 +2,8 @@
 data "cloudfoundry_domain" "default" {
   name = "london.cloudapps.digital"
 }
+
+# Get data for the custom domain on the PaaS
+data "cloudfoundry_domain" "custom" {
+  name = "${var.custom_domain}"
+}

--- a/terraform/routes.tf
+++ b/terraform/routes.tf
@@ -5,3 +5,11 @@ resource "cloudfoundry_route" "beis-rpr-route" {
   space    = cloudfoundry_space.space.id
   hostname = "beis-rpr-${var.environment}"
 }
+
+# Create a route for the app using the default domain
+# and useful hostname provided from tfvars (which allows us to easily set www for prod)
+resource "cloudfoundry_route" "beis-rpr-custom-domain-route" {
+  domain   = data.cloudfoundry_domain.custom.id
+  space    = cloudfoundry_space.space.id
+  hostname = var.custom_hostname
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -78,3 +78,12 @@ variable "basic_auth_password" {
   description = "The password we use for basic authentication if we want to hide the site from the public"
 }
 
+variable "custom_domain" {
+  type        = string
+  description = "Name of custom domain created in the cf org"
+}
+
+variable "custom_hostname" {
+  type        = string
+  description = "Custom hostname (prepended to custom_domain for the app and cdn-route)"
+}


### PR DESCRIPTION
Creates a cdn-route, and maps it to the app using the custom domain

This introduces 2 new tfvars:

```
custom_domain (the apex domain of where the app will be hosted)
custom_hostname (the subdomain, eg. www or staging)
```

We'll need to confirm the domain names are OK and add them as secrets before this is merged. 