### PR TITLE
(2166) Allow admins to edit blank professions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Remove Qualification Level from admin organisation list
 - Remove deprecated fields from Qualification
 - Move Sectors filter above the Nations filter
+- Allow admin users to edit blank Qualifications when no values have been set from a data import
 
 ## [release-004] - 2022-02-21
 

--- a/cypress/integration/admin/organisations/index.spec.ts
+++ b/cypress/integration/admin/organisations/index.spec.ts
@@ -42,7 +42,7 @@ describe('Listing organisations', () => {
                 );
 
                 professionsForOrganisation.forEach((profession: any) => {
-                  profession.industries.forEach((industry: any) => {
+                  profession.versions[0].industries.forEach((industry: any) => {
                     cy.translate(industry).then((industry) => {
                       cy.wrap($row).should('contain', industry);
                     });

--- a/cypress/integration/admin/professions/edit.spec.ts
+++ b/cypress/integration/admin/professions/edit.spec.ts
@@ -411,6 +411,141 @@ describe('Editing an existing profession', () => {
         });
       });
     });
+
+    context('when no Qualification has been set on the Profession', () => {
+      it('allows users to update Qualification values', () => {
+        cy.visitAndCheckAccessibility('/admin/professions');
+
+        cy.get('table')
+          .contains('tr', 'Orthodontic Therapist')
+          .within(() => {
+            cy.contains('View details').click();
+          });
+
+        cy.checkAccessibility();
+
+        cy.translate('professions.form.headings.qualifications').then(
+          (qualifications) => {
+            cy.get('body').should('not.contain', qualifications);
+          },
+        );
+
+        cy.translate('professions.admin.button.edit.draft').then(
+          (buttonText) => {
+            cy.contains(buttonText).click();
+          },
+        );
+
+        cy.checkAccessibility();
+
+        cy.translate('professions.form.button.edit').then((buttonText) => {
+          cy.get('button').contains(buttonText).click();
+        });
+
+        cy.checkAccessibility();
+
+        cy.checkSummaryListRowValue(
+          'professions.form.label.qualifications.routesToObtain',
+          '',
+        );
+        cy.checkSummaryListRowValue(
+          'professions.form.label.qualifications.mostCommonRouteToObtain',
+          '',
+        );
+        cy.checkSummaryListRowValue(
+          'professions.form.label.qualifications.duration',
+          '',
+        );
+        cy.checkSummaryListRowValue(
+          'professions.form.label.qualifications.mandatoryProfessionalExperience',
+          '',
+        );
+        cy.checkSummaryListRowValue(
+          'professions.form.label.qualifications.moreInformationUrl',
+          '',
+        );
+
+        cy.clickSummaryListRowAction(
+          'professions.form.label.qualifications.qualificationLevel',
+          'Change',
+        );
+
+        cy.checkAccessibility();
+
+        cy.get('textarea[name="routesToObtain"]').type(
+          'General secondary education',
+        );
+        cy.get('textarea[name="mostCommonRouteToObtain"]').type(
+          'A 4 year degree',
+        );
+        cy.get('input[name="duration"]').type('4.0 Years');
+        cy.get(
+          'input[name="mandatoryProfessionalExperience"][value="1"]',
+        ).check();
+        cy.get('textarea[name="level"]').type('An example Qualification level');
+        cy.get('input[name="moreInformationUrl"]').type(
+          'http://example.com/more-info',
+        );
+
+        cy.get('input[name="otherCountriesRecognition"]').type(
+          'Recognition in other countries',
+        );
+        cy.get('input[name="otherCountriesRecognitionUrl"]').type(
+          'http://example.com/other',
+        );
+
+        cy.translate('app.continue').then((buttonText) => {
+          cy.get('button').contains(buttonText).click();
+        });
+
+        cy.checkAccessibility();
+
+        cy.checkSummaryListRowValue(
+          'professions.form.label.qualifications.qualificationLevel',
+          'An example Qualification level',
+        );
+
+        cy.checkSummaryListRowValue(
+          'professions.form.label.qualifications.routesToObtain',
+          'General secondary education',
+        );
+
+        cy.checkSummaryListRowValue(
+          'professions.form.label.qualifications.mostCommonRouteToObtain',
+          'A 4 year degree',
+        );
+
+        cy.checkSummaryListRowValue(
+          'professions.form.label.qualifications.duration',
+          '4.0 Years',
+        );
+
+        cy.translate('app.yes').then((yes) => {
+          cy.checkSummaryListRowValue(
+            'professions.form.label.qualifications.mandatoryProfessionalExperience',
+            yes,
+          );
+        });
+
+        cy.checkSummaryListRowValue(
+          'professions.form.label.qualifications.moreInformationUrl',
+          'http://example.com/more-info',
+        );
+
+        cy.translate('professions.form.button.saveAsDraft').then(
+          (buttonText) => {
+            cy.get('button').contains(buttonText).click();
+          },
+        );
+
+        cy.checkAccessibility();
+
+        cy.checkSummaryListRowValue(
+          'professions.form.label.qualifications.moreInformationUrl',
+          'http://example.com/more-info',
+        );
+      });
+    });
   });
 
   context('when I am logged in as a registrar', () => {

--- a/seeds/test/legislations.json
+++ b/seeds/test/legislations.json
@@ -18,5 +18,9 @@
   {
     "name": "Gas Safety (Installation and Use) Regulations 1998",
     "url": "https://www.legislation.gov.uk/uksi/1998/2451/made"
+  },
+  {
+    "name": "Dentists Act 1984",
+    "url": "https://www.legislation.gov.uk/ukpga/1984/24"
   }
 ]

--- a/seeds/test/professions.json
+++ b/seeds/test/professions.json
@@ -97,5 +97,26 @@
         "keywords": "Adviser, heating,Connector, coupling,Consultant, heating,Contractor, plumbing,Converter,Craftsman, distribution,Craftsman, governor,Craftsman, transmission,Craftsman,Engineer, biomass,Engineer, domestic,Engineer, field,Engineer, Gas, British,Engineer, gas, domestic,Engineer, gas, emergency,Engineer, gas, technical,Engineer, gas,Engineer, gas and heating,Engineer, gas and water,Engineer, heat and domestic,Engineer, heating, central,Engineer, heating, gas,Engineer, heating,Engineer, heating and lighting,Engineer, heating and plumbing,Engineer, heating and ventilating,Engineer, installation, gas,Engineer, installation,Engineer, mains,Engineer, maintenance,Engineer, plumber and gas,Engineer, plumbing,Engineer, plumbing and heating,Engineer, pump, heat,Engineer, safe, gas,Engineer, sanitary,Engineer, service, gas,Engineer, service,Engineer, service,Engineer, service,Engineer, technical, gas,Engineer, technical,Engineer, thermal,Engineer, thermal and acoustic,Engineer, ventilating,Engineer, ventilation,Engineer, ventilation,Engineer, water, hot,Erector, mains, gas,Fitter, bathroom,Fitter, burner,Fitter, district,Fitter, engineer's, heating,Fitter, engineer's, sanitary,Fitter, fire, gas,Fitter, gas,Fitter, governor,Fitter, heating,Fitter, heating and ventilation,Fitter, kitchen and bathroom,Fitter, maintenance,Fitter, maintenance,Fitter, maintenance,Fitter, sanitary,Fitter, sprinkler,Fitter, steam,Fitter, steam and hot water,Fitter, stove,Fitter, ventilation,Fitter, water,Fitter,Fitter,Fitter,Fitter-welder,Fixer, appliances,Fixer, meter,Fixer, meter,Fixer, ventilator,Inserter, ferrule,Installer, bathroom,Installer, heating,Installer, meter,Installer, meter,Installer, pump, heat,Installer,Jointer, pipe, sprinkler,Linesman, gas,Man, maintenance,Man, service, sales,Man, service,Man, service,Mender,Pewterer,Plumber,Plumber and decorator,Plumber and gasfitter,Plumber-welder,Repairer, stove,Repairer,Technician, gas,Technician, network,Technician, network,Technician, plumbing,Technician, service,Worker, gas, maintenance"
       }
     ]
+  },
+  {
+    "name": "Orthodontic Therapist",
+    "slug": "orthodontic-therapist",
+    "organisation": "General Medical Council",
+    "additionalOrganisation": null,
+    "versions": [
+      {
+        "alternateName": "Orthodontic Auxiliary",
+        "description": "Orthodontic therapists are registered dental professionals who carry out certain parts of orthodontic treatment under prescription from a dentist.",
+        "occupationLocations": ["GB-ENG", "GB-SCT", "GB-WLS", "GB-NIR"],
+        "regulationType": "N/A",
+        "industries": ["industries.health"],
+        "reservedActivities": "",
+        "legislations": ["Dentists Act 1984"],
+        "mandatoryRegistration": "voluntary",
+        "status": "draft",
+        "socCode": 3213,
+        "keywords": "Associate, nursing"
+      }
+    ]
   }
 ]

--- a/src/db/migrate/1645530015829-MakeAllQualificationFieldsNullable.ts
+++ b/src/db/migrate/1645530015829-MakeAllQualificationFieldsNullable.ts
@@ -1,0 +1,31 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class MakeAllQualificationFieldsNullable1645530015829
+  implements MigrationInterface
+{
+  name = 'MakeAllQualificationFieldsNullable1645530015829';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "qualifications" ALTER COLUMN "level" DROP NOT NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "qualifications" ALTER COLUMN "educationDuration" DROP NOT NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "qualifications" ALTER COLUMN "mandatoryProfessionalExperience" DROP NOT NULL`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "qualifications" ALTER COLUMN "mandatoryProfessionalExperience" SET NOT NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "qualifications" ALTER COLUMN "educationDuration" SET NOT NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "qualifications" ALTER COLUMN "level" SET NOT NULL`,
+    );
+  }
+}

--- a/src/professions/admin/check-your-answers.controller.spec.ts
+++ b/src/professions/admin/check-your-answers.controller.spec.ts
@@ -142,30 +142,6 @@ describe('CheckYourAnswersController', () => {
       });
     });
 
-    describe('when the profession has no qualification', () => {
-      it('passes a `null` qualification value to the template', async () => {
-        const profession = professionFactory.build({
-          organisation: organisationFactory.build(),
-        });
-
-        const version = professionVersionFactory.build({
-          qualification: undefined,
-          profession: profession,
-        });
-
-        professionsService.findWithVersions.mockResolvedValue(profession);
-        professionVersionsService.findWithProfession.mockResolvedValue(version);
-
-        const templateParams = await controller.show(
-          'profession-id',
-          'version-id',
-          'false',
-        );
-
-        expect(templateParams.qualification).toEqual(null);
-      });
-    });
-
     describe('when the profession has only one legislation', () => {
       it('the legislations array passed to the template is padded to length 2', async () => {
         const legislation = legislationFactory.build({
@@ -178,7 +154,6 @@ describe('CheckYourAnswersController', () => {
         });
 
         const version = professionVersionFactory.build({
-          qualification: undefined,
           legislations: [legislation],
         });
 

--- a/src/professions/admin/check-your-answers.controller.ts
+++ b/src/professions/admin/check-your-answers.controller.ts
@@ -68,9 +68,10 @@ export class CheckYourAnswersController {
       ),
     );
 
-    const qualification = version.qualification
-      ? new QualificationPresenter(version.qualification, this.i18nService)
-      : null;
+    const qualification = new QualificationPresenter(
+      version.qualification,
+      this.i18nService,
+    );
 
     const legislations = [version.legislations[0], version.legislations[1]];
 

--- a/src/qualifications/presenters/qualification.presenter.spec.ts
+++ b/src/qualifications/presenters/qualification.presenter.spec.ts
@@ -78,6 +78,21 @@ describe(QualificationPresenter, () => {
         expect(presenter.mandatoryProfessionalExperience).toEqual('app.no');
       });
     });
+
+    describe('when not set at all on a blank Qualification', () => {
+      it('returns an empty string', () => {
+        const qualification = qualificationFactory.build({
+          mandatoryProfessionalExperience: null,
+        });
+
+        const presenter = new QualificationPresenter(
+          qualification,
+          createMockI18nService(),
+        );
+
+        expect(presenter.mandatoryProfessionalExperience).toEqual('');
+      });
+    });
   });
 
   describe('moreInformationUrl', () => {

--- a/src/qualifications/presenters/qualification.presenter.ts
+++ b/src/qualifications/presenters/qualification.presenter.ts
@@ -21,10 +21,15 @@ export default class QualificationPresenter {
 
   readonly duration = this.qualification.educationDuration;
 
-  readonly mandatoryProfessionalExperience = this.qualification
-    .mandatoryProfessionalExperience
-    ? 'app.yes'
-    : 'app.no';
+  get mandatoryProfessionalExperience(): string {
+    if (this.qualification.mandatoryProfessionalExperience === null) {
+      return '';
+    }
+
+    return this.qualification.mandatoryProfessionalExperience
+      ? 'app.yes'
+      : 'app.no';
+  }
 
   readonly moreInformationUrl = this.qualification.url
     ? `<a class="govuk-link" href="${escape(this.qualification.url)}">${escape(

--- a/src/qualifications/qualification.entity.ts
+++ b/src/qualifications/qualification.entity.ts
@@ -11,7 +11,7 @@ export class Qualification {
   @PrimaryGeneratedColumn('uuid')
   id: string;
 
-  @Column()
+  @Column({ nullable: true })
   level: string;
 
   @Column({ nullable: true })
@@ -20,10 +20,10 @@ export class Qualification {
   @Column({ nullable: true })
   mostCommonRouteToObtain: string;
 
-  @Column()
+  @Column({ nullable: true })
   educationDuration: string;
 
-  @Column()
+  @Column({ nullable: true })
   mandatoryProfessionalExperience: boolean;
 
   @Column({ nullable: true })


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR

Allows admins to edit blank professions, when one hasn't been created by a data import. This is done by clicking "change" next to the blank label on the CYA page.

As part of this, we make qualification fields nullable.

