### PR TITLE
Add a health check endpoint

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -75,3 +75,14 @@ jobs:
       - uses: actions/checkout@v2
       - name: Deploy latest code to Staging
         run: script/deploy-terraform
+  check_and_notify:
+    needs: deploy_to_production
+    if: startsWith(github.ref, 'refs/tags/release')
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v2
+      - name: Notifying the team of a successful deploy
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        run: script/deploy-notification

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,12 @@ COPY --from=dependencies ${DEPS_HOME}/package.json ${APP_HOME}/package.json
 COPY --from=dependencies ${DEPS_HOME}/package-lock.json ${APP_HOME}/package-lock.json
 COPY --from=dependencies ${DEPS_HOME}/node_modules ${APP_HOME}/node_modules
 
+ARG current_sha
+ARG time_of_build
+
+ENV CURRENT_SHA=$current_sha
+ENV TIME_OF_BUILD=$time_of_build
+
 RUN mkdir -p ${APP_HOME}
 WORKDIR ${APP_HOME}
 

--- a/script/deploy-notification
+++ b/script/deploy-notification
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+printf "Waiting for deploy."
+current_sha=$(git rev-parse HEAD)
+
+while :
+do
+  printf "."
+  deployed_sha=$(curl -s https://beis-rpr-prod.london.cloudapps.digital/health-check | jq -r '.git_sha')
+  if [ "$deployed_sha" = "$current_sha" ]; then
+    break
+  fi
+  sleep 10
+done
+
+echo "Sending Slack notification!"
+
+curl -s -X POST --data-urlencode "payload={\"text\": \"<!here> :badgerbadger: The latest release of the Regulated Professions Register has been deployed to production :badgerbadger:\"}" "$SLACK_WEBHOOK_URL"
+

--- a/src/app.controller.spec.ts
+++ b/src/app.controller.spec.ts
@@ -33,8 +33,34 @@ describe('AppController', () => {
   });
 
   describe('healthCheck', () => {
+    const OLD_ENV = process.env;
+
+    beforeEach(async () => {
+      jest.resetModules();
+      process.env = { ...OLD_ENV };
+    });
+
+    afterAll(() => {
+      process.env = OLD_ENV;
+    });
+
     it('should return OK', () => {
       expect(appController.healthCheck()).toEqual({ status: 'OK' });
+    });
+
+    describe('when the deployment variables are set', () => {
+      beforeEach(async () => {
+        process.env['CURRENT_SHA'] = 'b9c73f88';
+        process.env['TIME_OF_BUILD'] = '2020-01-01T00:00:00Z';
+      });
+
+      it('should return the sha and the time it was built', () => {
+        expect(appController.healthCheck()).toEqual({
+          status: 'OK',
+          git_sha: 'b9c73f88',
+          built_at: '2020-01-01T00:00:00Z',
+        });
+      });
     });
   });
 });

--- a/src/app.controller.spec.ts
+++ b/src/app.controller.spec.ts
@@ -31,4 +31,10 @@ describe('AppController', () => {
       });
     });
   });
+
+  describe('healthCheck', () => {
+    it('should return OK', () => {
+      expect(appController.healthCheck()).toEqual({ status: 'OK' });
+    });
+  });
 });

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -25,6 +25,8 @@ export class AppController {
   healthCheck() {
     return {
       status: 'OK',
+      git_sha: process.env['CURRENT_SHA'],
+      built_at: process.env['TIME_OF_BUILD'],
     };
   }
 }

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -20,4 +20,11 @@ export class AppController {
       name: req.oidc.user.nickname,
     };
   }
+
+  @Get('/health-check')
+  healthCheck() {
+    return {
+      status: 'OK',
+    };
+  }
 }


### PR DESCRIPTION
This adds a health check endpoint to that app, so we can monitor it for uptime in a way that doesn't put unnecessary load on the app. I've also taken the opportunity to add `CURRENT_SHA` and `TIME_OF_BUILD` env vars, so we can notify the team when a production deploy has been successful. I've added the Slack Webhook url to the secrets.