### PR TITLE
(2152) Add confirmation step to publishing a Profession or Organisation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Add "more information url" to Qualification detail entry page
 - Display message in search results when no professions match filter criteria
+- Add a confirmation page before publishing an organisation or a profession
 
 ### Changed
 

--- a/cypress/integration/admin/organisations/edit.spec.ts
+++ b/cypress/integration/admin/organisations/edit.spec.ts
@@ -152,24 +152,20 @@ describe('Editing organisations', () => {
           cy.get('html').should('contain.html', confirmationBody);
         });
 
-        cy.get('tr')
-          .contains(organisation.name)
-          .then(($header) => {
-            const $row = $header.parent();
+        cy.checkSummaryListRowValue(
+          'organisations.label.alternateName',
+          'New Alternate Name',
+        );
 
-            cy.wrap($row).should('contain', 'Alternate Name');
+        cy.translate(`organisations.status.draft`).then((status) => {
+          cy.get('h2[data-status]').should('contain', status);
+        });
 
-            cy.translate(`organisations.status.draft`).then((status) => {
-              cy.wrap($row).should('contain', status);
-            });
-
-            cy.wrap($row).contains('View details').click();
-            cy.get('[data-cy=changed-by-user]').should('contain', 'Editor');
-            cy.get('[data-cy=last-modified]').should(
-              'contain',
-              format(new Date(), 'dd-MM-yyyy'),
-            );
-          });
+        cy.get('[data-cy=changed-by-user]').should('contain', 'Editor');
+        cy.get('[data-cy=last-modified]').should(
+          'contain',
+          format(new Date(), 'dd-MM-yyyy'),
+        );
       });
     });
   });

--- a/cypress/integration/admin/organisations/new.spec.ts
+++ b/cypress/integration/admin/organisations/new.spec.ts
@@ -1,3 +1,5 @@
+import { format } from 'date-fns';
+
 describe('Creating organisations', () => {
   context('when I am logged in without the correct permissions', () => {
     beforeEach(() => {
@@ -123,17 +125,17 @@ describe('Creating organisations', () => {
         cy.get('html').should('contain.html', confirmationBody);
       });
 
-      cy.get('tr')
-        .contains('New Organisation')
-        .then(($header) => {
-          const $row = $header.parent();
+      cy.get('body').should('contain', 'New Organisation');
 
-          cy.wrap($row).should('contain', 'Alternate Name');
+      cy.translate(`organisations.status.draft`).then((status) => {
+        cy.get('h2[data-status]').should('contain', status);
+      });
 
-          cy.translate(`organisations.status.draft`).then((status) => {
-            cy.wrap($row).should('contain', status);
-          });
-        });
+      cy.get('[data-cy=changed-by-user]').should('contain', 'Registrar');
+      cy.get('[data-cy=last-modified]').should(
+        'contain',
+        format(new Date(), 'dd-MM-yyyy'),
+      );
     });
   });
 });

--- a/cypress/integration/admin/organisations/publish.spec.ts
+++ b/cypress/integration/admin/organisations/publish.spec.ts
@@ -23,9 +23,29 @@ describe('Publishing organisations', () => {
 
       cy.translate('organisations.admin.button.publish').then(
         (publishButton) => {
-          cy.get('button').contains(publishButton).click();
+          cy.get('a').contains(publishButton).click();
         },
       );
+
+      cy.checkAccessibility();
+
+      cy.translate('organisations.admin.publish.caption').then(
+        (publishCaption) => {
+          cy.get('body').contains(publishCaption);
+        },
+      );
+
+      cy.translate('organisations.admin.publish.heading', {
+        organisationName: 'Department for Education',
+      }).then((heading) => {
+        cy.contains(heading);
+      });
+
+      cy.translate('organisations.admin.button.publish').then((buttonText) => {
+        cy.get('button').contains(buttonText).click();
+      });
+
+      cy.checkAccessibility();
 
       cy.translate('organisations.admin.publish.confirmation.heading').then(
         (confirmation) => {

--- a/cypress/integration/admin/professions/publish.spec.ts
+++ b/cypress/integration/admin/professions/publish.spec.ts
@@ -25,9 +25,28 @@ describe('Publishing professions', () => {
 
       cy.translate('professions.form.button.publishNow').then(
         (publishButton) => {
-          cy.get('button').contains(publishButton).click();
+          cy.get('a').contains(publishButton).click();
         },
       );
+
+      cy.checkAccessibility();
+      cy.translate('professions.form.captions.publish').then(
+        (publishCaption) => {
+          cy.get('body').contains(publishCaption);
+        },
+      );
+
+      cy.translate('professions.form.headings.publish', {
+        professionName: 'Gas Safe Engineer',
+      }).then((heading) => {
+        cy.contains(heading);
+      });
+
+      cy.translate('professions.form.button.publishNow').then((buttonText) => {
+        cy.get('button').contains(buttonText).click();
+      });
+
+      cy.checkAccessibility();
 
       cy.translate('professions.admin.publish.confirmation.heading').then(
         (confirmation) => {

--- a/src/i18n/en/organisations.json
+++ b/src/i18n/en/organisations.json
@@ -57,6 +57,8 @@
       }
     },
     "publish": {
+      "heading": "Are you sure you want to publish {organisationName}?",
+      "caption": "Publishing an organisation",
       "confirmation": {
         "heading": "Regulatory authority published",
         "body": "The new regulator <strong>{name}</strong> has been published.",

--- a/src/i18n/en/professions.json
+++ b/src/i18n/en/professions.json
@@ -12,11 +12,12 @@
       "regulatedActivities": "Regulation",
       "qualifications": "Qualifications",
       "legislation": "Legislation",
-      "edit": "Are you sure you want to amend {professionName}?"
+      "publish": "Are you sure you want to publish {professionName}?"
     },
     "captions": {
       "add": "Adding a new profession",
-      "edit": "Amending a profession"
+      "edit": "Amending a profession",
+      "publish": "Publishing a profession"
     },
     "editProfession": "Use this section of the site to add a new profession",
     "label": {

--- a/src/organisations/admin/organisation-publication.controller.spec.ts
+++ b/src/organisations/admin/organisation-publication.controller.spec.ts
@@ -1,12 +1,21 @@
 import { DeepMocked, createMock } from '@golevelup/ts-jest';
 import { TestingModule, Test } from '@nestjs/testing';
+import { Response } from 'express';
 import { I18nService } from 'nestjs-i18n';
+import { flashMessage } from '../../common/flash-message';
 import { createMockI18nService } from '../../testutils/create-mock-i18n-service';
+import { createDefaultMockRequest } from '../../testutils/factories/create-default-mock-request';
 import organisationFactory from '../../testutils/factories/organisation';
 import organisationVersionFactory from '../../testutils/factories/organisation-version';
+import userFactory from '../../testutils/factories/user';
+import { translationOf } from '../../testutils/translation-of';
+import { getActingUser } from '../../users/helpers/get-acting-user.helper';
 import { OrganisationVersionsService } from '../organisation-versions.service';
 import { Organisation } from '../organisation.entity';
 import { OrganisationPublicationController } from './organisation-publication.controller';
+
+jest.mock('../../common/flash-message');
+jest.mock('../../users/helpers/get-acting-user.helper');
 
 describe('OrganisationPublicationController', () => {
   let controller: OrganisationPublicationController;
@@ -56,6 +65,61 @@ describe('OrganisationPublicationController', () => {
       expect(result).toEqual({
         organisation: Organisation.withVersion(organisation, version),
       });
+    });
+  });
+
+  describe('create', () => {
+    it('should publish the current version', async () => {
+      const organisation = organisationFactory.build();
+      const version = organisationVersionFactory.build({
+        organisation: organisation,
+      });
+      const user = userFactory.build();
+
+      const req = createDefaultMockRequest();
+      (getActingUser as jest.Mock).mockReturnValue(user);
+
+      const res = createMock<Response>({});
+
+      const flashMock = flashMessage as jest.Mock;
+      flashMock.mockImplementation(() => 'STUB_FLASH_MESSAGE');
+
+      organisationVersionsService.findByIdWithOrganisation.mockResolvedValue(
+        version,
+      );
+
+      const newVersion = organisationVersionFactory.build({
+        organisation,
+        user,
+      });
+
+      organisationVersionsService.create.mockResolvedValue(newVersion);
+
+      await controller.create(req, res, organisation.id, version.id);
+
+      expect(
+        organisationVersionsService.findByIdWithOrganisation,
+      ).toHaveBeenCalledWith(organisation.id, version.id);
+
+      expect(organisationVersionsService.create).toHaveBeenCalledWith(
+        version,
+        user,
+      );
+
+      expect(organisationVersionsService.publish).toHaveBeenCalledWith(
+        newVersion,
+      );
+
+      expect(flashMock).toHaveBeenCalledWith(
+        translationOf('organisations.admin.publish.confirmation.heading'),
+        translationOf('organisations.admin.publish.confirmation.body'),
+      );
+
+      expect(req.flash).toHaveBeenCalledWith('success', 'STUB_FLASH_MESSAGE');
+
+      expect(res.redirect).toHaveBeenCalledWith(
+        `/admin/organisations/${organisation.id}/versions/${newVersion.id}`,
+      );
     });
   });
 });

--- a/src/organisations/admin/organisation-publication.controller.spec.ts
+++ b/src/organisations/admin/organisation-publication.controller.spec.ts
@@ -1,0 +1,61 @@
+import { DeepMocked, createMock } from '@golevelup/ts-jest';
+import { TestingModule, Test } from '@nestjs/testing';
+import { I18nService } from 'nestjs-i18n';
+import { createMockI18nService } from '../../testutils/create-mock-i18n-service';
+import organisationFactory from '../../testutils/factories/organisation';
+import organisationVersionFactory from '../../testutils/factories/organisation-version';
+import { OrganisationVersionsService } from '../organisation-versions.service';
+import { Organisation } from '../organisation.entity';
+import { OrganisationPublicationController } from './organisation-publication.controller';
+
+describe('OrganisationPublicationController', () => {
+  let controller: OrganisationPublicationController;
+
+  let organisationVersionsService: DeepMocked<OrganisationVersionsService>;
+  let i18nService: DeepMocked<I18nService>;
+
+  beforeEach(async () => {
+    organisationVersionsService = createMock<OrganisationVersionsService>();
+    i18nService = createMockI18nService();
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [OrganisationPublicationController],
+      providers: [
+        {
+          provide: OrganisationVersionsService,
+          useValue: organisationVersionsService,
+        },
+        {
+          provide: I18nService,
+          useValue: i18nService,
+        },
+      ],
+    }).compile();
+
+    controller = module.get<OrganisationPublicationController>(
+      OrganisationPublicationController,
+    );
+  });
+
+  describe('new', () => {
+    it('fetches the Profession to render on the page', async () => {
+      const organisation = organisationFactory.build();
+      const version = organisationVersionFactory.build({
+        organisation,
+      });
+
+      organisationVersionsService.findByIdWithOrganisation.mockResolvedValue(
+        version,
+      );
+
+      const result = await controller.new(organisation.id, version.id);
+
+      expect(
+        organisationVersionsService.findByIdWithOrganisation,
+      ).toHaveBeenCalledWith(organisation.id, version.id);
+      expect(result).toEqual({
+        organisation: Organisation.withVersion(organisation, version),
+      });
+    });
+  });
+});

--- a/src/organisations/admin/organisation-publication.controller.ts
+++ b/src/organisations/admin/organisation-publication.controller.ts
@@ -1,6 +1,11 @@
-import { Controller, Get, Param, Render } from '@nestjs/common';
+import { Controller, Get, Param, Put, Render, Req, Res } from '@nestjs/common';
+import { Response } from 'express';
+import { I18nService } from 'nestjs-i18n';
 import { BackLink } from '../../common/decorators/back-link.decorator';
+import { flashMessage } from '../../common/flash-message';
+import { RequestWithAppSession } from '../../common/interfaces/request-with-app-session.interface';
 import { Permissions } from '../../common/permissions.decorator';
+import { getActingUser } from '../../users/helpers/get-acting-user.helper';
 import { UserPermission } from '../../users/user-permission';
 import { OrganisationVersionsService } from '../organisation-versions.service';
 import { Organisation } from '../organisation.entity';
@@ -9,6 +14,7 @@ import { Organisation } from '../organisation.entity';
 export class OrganisationPublicationController {
   constructor(
     private organisationVersionsService: OrganisationVersionsService,
+    private i18nService: I18nService,
   ) {}
 
   @Get('/:organisationId/versions/:versionId/publish')
@@ -31,5 +37,42 @@ export class OrganisationPublicationController {
     );
 
     return { organisation };
+  }
+
+  @Put(':organisationId/versions/:versionId/publish')
+  @Permissions(UserPermission.PublishOrganisation)
+  async create(
+    @Req() req: RequestWithAppSession,
+    @Res() res: Response,
+    @Param('organisationId') organisationId: string,
+    @Param('versionId') versionId: string,
+  ): Promise<void> {
+    const version =
+      await this.organisationVersionsService.findByIdWithOrganisation(
+        organisationId,
+        versionId,
+      );
+
+    const newVersion = await this.organisationVersionsService.create(
+      version,
+      getActingUser(req),
+    );
+
+    await this.organisationVersionsService.publish(newVersion);
+
+    const messageTitle = await this.i18nService.translate(
+      'organisations.admin.publish.confirmation.heading',
+    );
+
+    const messageBody = await this.i18nService.translate(
+      'organisations.admin.publish.confirmation.body',
+      { args: { name: version.organisation.name } },
+    );
+
+    req.flash('success', flashMessage(messageTitle, messageBody));
+
+    res.redirect(
+      `/admin/organisations/${newVersion.organisation.id}/versions/${newVersion.id}`,
+    );
   }
 }

--- a/src/organisations/admin/organisation-publication.controller.ts
+++ b/src/organisations/admin/organisation-publication.controller.ts
@@ -1,0 +1,35 @@
+import { Controller, Get, Param, Render } from '@nestjs/common';
+import { BackLink } from '../../common/decorators/back-link.decorator';
+import { Permissions } from '../../common/permissions.decorator';
+import { UserPermission } from '../../users/user-permission';
+import { OrganisationVersionsService } from '../organisation-versions.service';
+import { Organisation } from '../organisation.entity';
+
+@Controller('/admin/organisations')
+export class OrganisationPublicationController {
+  constructor(
+    private organisationVersionsService: OrganisationVersionsService,
+  ) {}
+
+  @Get('/:organisationId/versions/:versionId/publish')
+  @Permissions(UserPermission.PublishOrganisation)
+  @Render('admin/organisations/publication/new')
+  @BackLink('/admin/organisations/:organisationId/versions/:versionId')
+  async new(
+    @Param('organisationId') organisationId: string,
+    @Param('versionId') versionId: string,
+  ) {
+    const version =
+      await this.organisationVersionsService.findByIdWithOrganisation(
+        organisationId,
+        versionId,
+      );
+
+    const organisation = Organisation.withVersion(
+      version.organisation,
+      version,
+    );
+
+    return { organisation };
+  }
+}

--- a/src/organisations/admin/organisation-versions.controller.spec.ts
+++ b/src/organisations/admin/organisation-versions.controller.spec.ts
@@ -3,8 +3,6 @@ import { createMock, DeepMocked } from '@golevelup/ts-jest';
 import { Response } from 'express';
 import { I18nService } from 'nestjs-i18n';
 
-import { translationOf } from '../../testutils/translation-of';
-
 import { OrganisationVersionsController } from './organisation-versions.controller';
 
 import { OrganisationVersionsService } from '../organisation-versions.service';
@@ -24,13 +22,11 @@ import { createMockI18nService } from '../../testutils/create-mock-i18n-service'
 
 import { OrganisationPresenter } from '../presenters/organisation.presenter';
 
-import { flashMessage } from '../../common/flash-message';
 import { getActingUser } from '../../users/helpers/get-acting-user.helper';
 import { createDefaultMockRequest } from '../../testutils/factories/create-default-mock-request';
 
 jest.mock('../presenters/organisation-summary.presenter');
 jest.mock('../presenters/organisation.presenter');
-jest.mock('../../common/flash-message');
 jest.mock('../../users/helpers/get-acting-user.helper');
 
 describe('OrganisationVersionsController', () => {
@@ -142,61 +138,6 @@ describe('OrganisationVersionsController', () => {
       expect(OrganisationSummaryPresenter).toHaveBeenCalledWith(
         organisationWithVersion,
         i18nService,
-      );
-    });
-  });
-
-  describe('publish', () => {
-    it('should publish the current version', async () => {
-      const organisation = organisationFactory.build();
-      const version = organisationVersionFactory.build({
-        organisation: organisation,
-      });
-      const user = userFactory.build();
-
-      const req = createDefaultMockRequest();
-      (getActingUser as jest.Mock).mockReturnValue(user);
-
-      const res = createMock<Response>({});
-
-      const flashMock = flashMessage as jest.Mock;
-      flashMock.mockImplementation(() => 'STUB_FLASH_MESSAGE');
-
-      organisationVersionsService.findByIdWithOrganisation.mockResolvedValue(
-        version,
-      );
-
-      const newVersion = organisationVersionFactory.build({
-        organisation,
-        user,
-      });
-
-      organisationVersionsService.create.mockResolvedValue(newVersion);
-
-      await controller.publish(req, res, organisation.id, version.id);
-
-      expect(
-        organisationVersionsService.findByIdWithOrganisation,
-      ).toHaveBeenCalledWith(organisation.id, version.id);
-
-      expect(organisationVersionsService.create).toHaveBeenCalledWith(
-        version,
-        user,
-      );
-
-      expect(organisationVersionsService.publish).toHaveBeenCalledWith(
-        newVersion,
-      );
-
-      expect(flashMock).toHaveBeenCalledWith(
-        translationOf('organisations.admin.publish.confirmation.heading'),
-        translationOf('organisations.admin.publish.confirmation.body'),
-      );
-
-      expect(req.flash).toHaveBeenCalledWith('success', 'STUB_FLASH_MESSAGE');
-
-      expect(res.redirect).toHaveBeenCalledWith(
-        `/admin/organisations/${organisation.id}/versions/${newVersion.id}`,
       );
     });
   });

--- a/src/organisations/admin/organisation-versions.controller.ts
+++ b/src/organisations/admin/organisation-versions.controller.ts
@@ -4,7 +4,6 @@ import {
   Get,
   Render,
   Param,
-  Put,
   Post,
   Res,
   Req,
@@ -29,7 +28,6 @@ import { OrganisationSummaryPresenter } from '../presenters/organisation-summary
 import { Permissions } from '../../common/permissions.decorator';
 import { UserPermission } from '../../users/user-permission';
 
-import { flashMessage } from '../../common/flash-message';
 import { getActingUser } from '../../users/helpers/get-acting-user.helper';
 @UseGuards(AuthenticationGuard)
 @Controller('/admin/organisations')
@@ -92,42 +90,5 @@ export class OrganisationVersionsController {
     );
 
     return organisationSummaryPresenter.present();
-  }
-
-  @Put(':organisationId/versions/:versionId/publish')
-  @Permissions(UserPermission.PublishOrganisation)
-  async publish(
-    @Req() req: RequestWithAppSession,
-    @Res() res: Response,
-    @Param('organisationId') organisationId: string,
-    @Param('versionId') versionId: string,
-  ): Promise<void> {
-    const version =
-      await this.organisationVersionsService.findByIdWithOrganisation(
-        organisationId,
-        versionId,
-      );
-
-    const newVersion = await this.organisationVersionsService.create(
-      version,
-      getActingUser(req),
-    );
-
-    await this.organisationVersionsService.publish(newVersion);
-
-    const messageTitle = await this.i18nService.translate(
-      'organisations.admin.publish.confirmation.heading',
-    );
-
-    const messageBody = await this.i18nService.translate(
-      'organisations.admin.publish.confirmation.body',
-      { args: { name: version.organisation.name } },
-    );
-
-    req.flash('success', flashMessage(messageTitle, messageBody));
-
-    res.redirect(
-      `/admin/organisations/${newVersion.organisation.id}/versions/${newVersion.id}`,
-    );
   }
 }

--- a/src/organisations/admin/organisations.controller.spec.ts
+++ b/src/organisations/admin/organisations.controller.spec.ts
@@ -518,7 +518,7 @@ describe('OrganisationsController', () => {
           );
 
           expect(response.redirect).toHaveBeenCalledWith(
-            '/admin/organisations',
+            `/admin/organisations/${organisation.id}/versions/${version.id}`,
           );
         });
       });
@@ -570,7 +570,7 @@ describe('OrganisationsController', () => {
           );
 
           expect(response.redirect).toHaveBeenCalledWith(
-            '/admin/organisations',
+            `/admin/organisations/${organisation.id}/versions/${version.id}`,
           );
         });
       });

--- a/src/organisations/admin/organisations.controller.ts
+++ b/src/organisations/admin/organisations.controller.ts
@@ -220,7 +220,9 @@ export class OrganisationsController {
 
     req.flash('info', flashMessage(messageTitle, messageBody));
 
-    res.redirect('/admin/organisations');
+    res.redirect(
+      `/admin/organisations/${organisation.id}/versions/${version.id}`,
+    );
   }
 
   private async showReviewPage(

--- a/src/organisations/admin/organisations.controller.ts
+++ b/src/organisations/admin/organisations.controller.ts
@@ -124,7 +124,7 @@ export class OrganisationsController {
     UserPermission.EditOrganisation,
   )
   @Render('admin/organisations/edit')
-  @BackLink('/admin/organisations/:id')
+  @BackLink('/admin/organisations/:organisationId/versions/:versionId')
   async edit(
     @Param('organisationId') organisationId: string,
     @Param('versionId') versionId: string,

--- a/src/organisations/organisations.module.ts
+++ b/src/organisations/organisations.module.ts
@@ -11,6 +11,7 @@ import { OrganisationVersionsController as AdminOrganisationVersionsController }
 
 import { SearchController } from './search/search.controller';
 import { OrganisationsController } from './organisations.controller';
+import { OrganisationPublicationController } from './admin/organisation-publication.controller';
 
 @Module({
   providers: [
@@ -23,6 +24,7 @@ import { OrganisationsController } from './organisations.controller';
     AdminOrganisationVersionsController,
     SearchController,
     OrganisationsController,
+    OrganisationPublicationController,
   ],
   imports: [
     TypeOrmModule.forFeature([Organisation]),

--- a/src/professions/admin/profession-publication.controller.spec.ts
+++ b/src/professions/admin/profession-publication.controller.spec.ts
@@ -1,18 +1,31 @@
 import { createMock, DeepMocked } from '@golevelup/ts-jest';
 import { Test, TestingModule } from '@nestjs/testing';
+import { Response } from 'express';
+import { I18nService } from 'nestjs-i18n';
+import { flashMessage } from '../../common/flash-message';
+import { createMockI18nService } from '../../testutils/create-mock-i18n-service';
+import { createDefaultMockRequest } from '../../testutils/factories/create-default-mock-request';
 import professionFactory from '../../testutils/factories/profession';
 import professionVersionFactory from '../../testutils/factories/profession-version';
+import userFactory from '../../testutils/factories/user';
+import { translationOf } from '../../testutils/translation-of';
+import { getActingUser } from '../../users/helpers/get-acting-user.helper';
 import { ProfessionVersionsService } from '../profession-versions.service';
 import { Profession } from '../profession.entity';
 import { ProfessionPublicationController } from './profession-publication.controller';
+
+jest.mock('../../common/flash-message');
+jest.mock('../../users/helpers/get-acting-user.helper');
 
 describe('ProfessionPublicationController', () => {
   let controller: ProfessionPublicationController;
 
   let professionVersionsService: DeepMocked<ProfessionVersionsService>;
+  let i18nService: DeepMocked<I18nService>;
 
   beforeEach(async () => {
     professionVersionsService = createMock<ProfessionVersionsService>();
+    i18nService = createMockI18nService();
 
     const module: TestingModule = await Test.createTestingModule({
       controllers: [ProfessionPublicationController],
@@ -20,6 +33,10 @@ describe('ProfessionPublicationController', () => {
         {
           provide: ProfessionVersionsService,
           useValue: professionVersionsService,
+        },
+        {
+          provide: I18nService,
+          useValue: i18nService,
         },
       ],
     }).compile();
@@ -48,6 +65,61 @@ describe('ProfessionPublicationController', () => {
       expect(result).toEqual({
         profession: Profession.withVersion(profession, version),
       });
+    });
+  });
+
+  describe('create', () => {
+    it('should publish the current version', async () => {
+      const profession = professionFactory.build();
+      const version = professionVersionFactory.build({
+        profession,
+      });
+      const user = userFactory.build();
+
+      const req = createDefaultMockRequest();
+      (getActingUser as jest.Mock).mockReturnValue(user);
+
+      const res = createMock<Response>({});
+
+      const flashMock = flashMessage as jest.Mock;
+      flashMock.mockImplementation(() => 'STUB_FLASH_MESSAGE');
+
+      professionVersionsService.findByIdWithProfession.mockResolvedValue(
+        version,
+      );
+
+      const newVersion = professionVersionFactory.build({
+        profession,
+        user,
+      });
+
+      professionVersionsService.create.mockResolvedValue(newVersion);
+
+      await controller.create(req, res, profession.id, version.id);
+
+      expect(
+        professionVersionsService.findByIdWithProfession,
+      ).toHaveBeenCalledWith(profession.id, version.id);
+
+      expect(professionVersionsService.create).toHaveBeenCalledWith(
+        version,
+        user,
+      );
+
+      expect(professionVersionsService.publish).toHaveBeenCalledWith(
+        newVersion,
+      );
+
+      expect(flashMock).toHaveBeenCalledWith(
+        translationOf('professions.admin.publish.confirmation.heading'),
+        translationOf('professions.admin.publish.confirmation.body'),
+      );
+
+      expect(req.flash).toHaveBeenCalledWith('success', 'STUB_FLASH_MESSAGE');
+
+      expect(res.redirect).toHaveBeenCalledWith(
+        `/admin/professions/${profession.id}/versions/${newVersion.id}`,
+      );
     });
   });
 });

--- a/src/professions/admin/profession-publication.controller.spec.ts
+++ b/src/professions/admin/profession-publication.controller.spec.ts
@@ -1,0 +1,53 @@
+import { createMock, DeepMocked } from '@golevelup/ts-jest';
+import { Test, TestingModule } from '@nestjs/testing';
+import professionFactory from '../../testutils/factories/profession';
+import professionVersionFactory from '../../testutils/factories/profession-version';
+import { ProfessionVersionsService } from '../profession-versions.service';
+import { Profession } from '../profession.entity';
+import { ProfessionPublicationController } from './profession-publication.controller';
+
+describe('ProfessionPublicationController', () => {
+  let controller: ProfessionPublicationController;
+
+  let professionVersionsService: DeepMocked<ProfessionVersionsService>;
+
+  beforeEach(async () => {
+    professionVersionsService = createMock<ProfessionVersionsService>();
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [ProfessionPublicationController],
+      providers: [
+        {
+          provide: ProfessionVersionsService,
+          useValue: professionVersionsService,
+        },
+      ],
+    }).compile();
+
+    controller = module.get<ProfessionPublicationController>(
+      ProfessionPublicationController,
+    );
+  });
+
+  describe('new', () => {
+    it('fetches the Profession to render on the page', async () => {
+      const profession = professionFactory.build();
+      const version = professionVersionFactory.build({
+        profession,
+      });
+
+      professionVersionsService.findByIdWithProfession.mockResolvedValue(
+        version,
+      );
+
+      const result = await controller.new(profession.id, version.id);
+
+      expect(
+        professionVersionsService.findByIdWithProfession,
+      ).toHaveBeenCalledWith(profession.id, version.id);
+      expect(result).toEqual({
+        profession: Profession.withVersion(profession, version),
+      });
+    });
+  });
+});

--- a/src/professions/admin/profession-publication.controller.ts
+++ b/src/professions/admin/profession-publication.controller.ts
@@ -1,0 +1,29 @@
+import { Controller, Get, Param, Render } from '@nestjs/common';
+import { BackLink } from '../../common/decorators/back-link.decorator';
+import { Permissions } from '../../common/permissions.decorator';
+import { UserPermission } from '../../users/user-permission';
+import { ProfessionVersionsService } from '../profession-versions.service';
+import { Profession } from '../profession.entity';
+
+@Controller('/admin/professions')
+export class ProfessionPublicationController {
+  constructor(private professionVersionsService: ProfessionVersionsService) {}
+
+  @Get('/:professionId/versions/:versionId/publish')
+  @Permissions(UserPermission.PublishProfession)
+  @Render('admin/professions/publication/new')
+  @BackLink('/admin/professions/:professionId/versions/:versionId')
+  async new(
+    @Param('professionId') professionId: string,
+    @Param('versionId') versionId: string,
+  ) {
+    const version = await this.professionVersionsService.findByIdWithProfession(
+      professionId,
+      versionId,
+    );
+
+    const profession = Profession.withVersion(version.profession, version);
+
+    return { profession };
+  }
+}

--- a/src/professions/admin/profession-publication.controller.ts
+++ b/src/professions/admin/profession-publication.controller.ts
@@ -1,13 +1,21 @@
-import { Controller, Get, Param, Render } from '@nestjs/common';
+import { Controller, Get, Param, Put, Render, Req, Res } from '@nestjs/common';
+import { Response } from 'express';
+import { I18nService } from 'nestjs-i18n';
 import { BackLink } from '../../common/decorators/back-link.decorator';
+import { flashMessage } from '../../common/flash-message';
+import { RequestWithAppSession } from '../../common/interfaces/request-with-app-session.interface';
 import { Permissions } from '../../common/permissions.decorator';
+import { getActingUser } from '../../users/helpers/get-acting-user.helper';
 import { UserPermission } from '../../users/user-permission';
 import { ProfessionVersionsService } from '../profession-versions.service';
 import { Profession } from '../profession.entity';
 
 @Controller('/admin/professions')
 export class ProfessionPublicationController {
-  constructor(private professionVersionsService: ProfessionVersionsService) {}
+  constructor(
+    private professionVersionsService: ProfessionVersionsService,
+    private i18nService: I18nService,
+  ) {}
 
   @Get('/:professionId/versions/:versionId/publish')
   @Permissions(UserPermission.PublishProfession)
@@ -25,5 +33,41 @@ export class ProfessionPublicationController {
     const profession = Profession.withVersion(version.profession, version);
 
     return { profession };
+  }
+
+  @Put(':professionId/versions/:versionId/publish')
+  @Permissions(UserPermission.PublishProfession)
+  async create(
+    @Req() req: RequestWithAppSession,
+    @Res() res: Response,
+    @Param('professionId') professionId: string,
+    @Param('versionId') versionId: string,
+  ): Promise<void> {
+    const version = await this.professionVersionsService.findByIdWithProfession(
+      professionId,
+      versionId,
+    );
+
+    const newVersion = await this.professionVersionsService.create(
+      version,
+      getActingUser(req),
+    );
+
+    await this.professionVersionsService.publish(newVersion);
+
+    const messageTitle = await this.i18nService.translate(
+      'professions.admin.publish.confirmation.heading',
+    );
+
+    const messageBody = await this.i18nService.translate(
+      'professions.admin.publish.confirmation.body',
+      { args: { name: version.profession.name } },
+    );
+
+    req.flash('success', flashMessage(messageTitle, messageBody));
+
+    res.redirect(
+      `/admin/professions/${newVersion.profession.id}/versions/${newVersion.id}`,
+    );
   }
 }

--- a/src/professions/admin/profession-versions.controller.spec.ts
+++ b/src/professions/admin/profession-versions.controller.spec.ts
@@ -16,13 +16,11 @@ import { ProfessionVersionsService } from '../profession-versions.service';
 import { ProfessionsService } from '../professions.service';
 import { Profession } from '../profession.entity';
 import { ProfessionPresenter } from '../presenters/profession.presenter';
-import { flashMessage } from '../../common/flash-message';
 import { getActingUser } from '../../users/helpers/get-acting-user.helper';
 import { createDefaultMockRequest } from '../../testutils/factories/create-default-mock-request';
 
 jest.mock('../../organisations/organisation.entity');
 jest.mock('../presenters/profession.presenter');
-jest.mock('../../common/flash-message');
 jest.mock('../../users/helpers/get-acting-user.helper');
 
 describe('ProfessionVersionsController', () => {
@@ -177,61 +175,6 @@ describe('ProfessionVersionsController', () => {
           organisation: profession.organisation,
         });
       });
-    });
-  });
-
-  describe('publish', () => {
-    it('should publish the current version', async () => {
-      const profession = professionFactory.build();
-      const version = professionVersionFactory.build({
-        profession,
-      });
-      const user = userFactory.build();
-
-      const req = createDefaultMockRequest();
-      (getActingUser as jest.Mock).mockReturnValue(user);
-
-      const res = createMock<Response>({});
-
-      const flashMock = flashMessage as jest.Mock;
-      flashMock.mockImplementation(() => 'STUB_FLASH_MESSAGE');
-
-      professionVersionsService.findByIdWithProfession.mockResolvedValue(
-        version,
-      );
-
-      const newVersion = professionVersionFactory.build({
-        profession,
-        user,
-      });
-
-      professionVersionsService.create.mockResolvedValue(newVersion);
-
-      await controller.publish(req, res, profession.id, version.id);
-
-      expect(
-        professionVersionsService.findByIdWithProfession,
-      ).toHaveBeenCalledWith(profession.id, version.id);
-
-      expect(professionVersionsService.create).toHaveBeenCalledWith(
-        version,
-        user,
-      );
-
-      expect(professionVersionsService.publish).toHaveBeenCalledWith(
-        newVersion,
-      );
-
-      expect(flashMock).toHaveBeenCalledWith(
-        translationOf('professions.admin.publish.confirmation.heading'),
-        translationOf('professions.admin.publish.confirmation.body'),
-      );
-
-      expect(req.flash).toHaveBeenCalledWith('success', 'STUB_FLASH_MESSAGE');
-
-      expect(res.redirect).toHaveBeenCalledWith(
-        `/admin/professions/${profession.id}/versions/${newVersion.id}`,
-      );
     });
   });
 });

--- a/src/professions/admin/profession-versions.controller.ts
+++ b/src/professions/admin/profession-versions.controller.ts
@@ -4,7 +4,6 @@ import {
   NotFoundException,
   Param,
   Post,
-  Put,
   Render,
   Req,
   Res,
@@ -25,7 +24,6 @@ import { ProfessionVersionsService } from '../profession-versions.service';
 import { Profession } from '../profession.entity';
 import { ProfessionsService } from '../professions.service';
 import { ProfessionPresenter } from '../presenters/profession.presenter';
-import { flashMessage } from '../../common/flash-message';
 import { getActingUser } from '../../users/helpers/get-acting-user.helper';
 
 @UseGuards(AuthenticationGuard)
@@ -114,42 +112,6 @@ export class ProfessionVersionsController {
 
     return res.redirect(
       `/admin/professions/${version.profession.id}/versions/${version.id}/check-your-answers?edit=true`,
-    );
-  }
-
-  @Put(':professionId/versions/:versionId/publish')
-  @Permissions(UserPermission.PublishProfession)
-  async publish(
-    @Req() req: RequestWithAppSession,
-    @Res() res: Response,
-    @Param('professionId') professionId: string,
-    @Param('versionId') versionId: string,
-  ): Promise<void> {
-    const version = await this.professionVersionsService.findByIdWithProfession(
-      professionId,
-      versionId,
-    );
-
-    const newVersion = await this.professionVersionsService.create(
-      version,
-      getActingUser(req),
-    );
-
-    await this.professionVersionsService.publish(newVersion);
-
-    const messageTitle = await this.i18nService.translate(
-      'professions.admin.publish.confirmation.heading',
-    );
-
-    const messageBody = await this.i18nService.translate(
-      'professions.admin.publish.confirmation.body',
-      { args: { name: version.profession.name } },
-    );
-
-    req.flash('success', flashMessage(messageTitle, messageBody));
-
-    res.redirect(
-      `/admin/professions/${newVersion.profession.id}/versions/${newVersion.id}`,
     );
   }
 }

--- a/src/professions/professions.module.ts
+++ b/src/professions/professions.module.ts
@@ -20,6 +20,7 @@ import { ProfessionVersion } from './profession-version.entity';
 import { ProfessionVersionsController } from './admin/profession-versions.controller';
 import { RegistrationController } from './admin/registration.controller';
 import { ScopeController } from './admin/scope.controller';
+import { ProfessionPublicationController } from './admin/profession-publication.controller';
 
 @Module({
   imports: [
@@ -47,6 +48,7 @@ import { ScopeController } from './admin/scope.controller';
     ConfirmationController,
     AdminProfessionsController,
     RegistrationController,
+    ProfessionPublicationController,
   ],
 })
 export class ProfessionsModule {}

--- a/views/admin/organisations/publication/new.njk
+++ b/views/admin/organisations/publication/new.njk
@@ -1,0 +1,24 @@
+{% extends "admin/base.njk" %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% set bodyClasses = "rpr-internal__page" %}
+
+{% block content %}
+  <span class="govuk-caption-l">{{ 'organisations.admin.publish.caption' | t }}</span>
+  <h1 class="govuk-heading-l">{{ ('organisations.admin.publish.heading' | t({organisationName: organisation.name})) }}</h1>
+
+  <div class="govuk-grid-row">
+
+    <div class="govuk-grid-column-full">
+      <form action="/admin/organisations/{{ organisation.id }}/versions/{{ organisation.versionId }}/publish?_method=PUT" method="post">
+        {{
+          govukButton({
+            text: ("organisations.admin.button.publish" | t)
+          })
+        }}
+      </form>
+    </div>
+
+  </div>
+
+{% endblock %}

--- a/views/admin/organisations/show.njk
+++ b/views/admin/organisations/show.njk
@@ -32,13 +32,14 @@
           <ul class="govuk-list">
             {% if organisation.status === 'draft' and 'publishOrganisation' in permissions %}
             <li>
-              <form action="/admin/organisations/{{ organisation.id }}/versions/{{ organisation.versionId }}/publish?_method=PUT" method="post">
-                {{
-                  govukButton({
-                    text: ("organisations.admin.button.publish" | t)
-                  })
-                }}
-              </form>
+              {{
+                govukButton({
+                  text: ("organisations.admin.button.publish" | t),
+                  classes: "govuk-button",
+                  id: "publish-button",
+                  href: "/admin/organisations/" + organisation.id + "/versions/" + organisation.versionId + "/publish"
+                })
+              }}
             </li>
             {% endif %}
             {% if 'editOrganisation' in permissions %}

--- a/views/admin/professions/publication/new.njk
+++ b/views/admin/professions/publication/new.njk
@@ -1,0 +1,27 @@
+{% extends "admin/base.njk" %}
+
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% set bodyClasses = "rpr-internal__page" %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <span class="govuk-caption-l">{{ 'professions.form.captions.publish' | t }}</span>
+      <h1 class="govuk-heading-l">{{ ('professions.form.headings.publish' | t({professionName: profession.name})) }}</h1>
+
+        <form action="/admin/professions/{{ profession.id }}/versions/{{ profession.versionId }}/publish?_method=PUT" method="post">
+          {{
+            govukButton({
+              text: ('professions.form.button.publishNow' | t),
+              classes: "govuk-button",
+              id: "publish-button"
+            })
+          }}
+        </form>
+
+    </div>
+  </div>
+
+{% endblock %}

--- a/views/admin/professions/show.njk
+++ b/views/admin/professions/show.njk
@@ -30,13 +30,14 @@
         <ul class="govuk-list">
           {% if profession.status === 'draft' and 'publishProfession' in permissions %}
             <li>
-                <form action="/admin/professions/{{ profession.id }}/versions/{{ profession.versionId }}/publish?_method=PUT" method="post">
-                  {{ govukButton({
-                    text: ('professions.form.button.publishNow' | t),
-                    classes: "govuk-button",
-                    id: "publish-button"
-                  }) }}
-                </form>
+              {{
+                govukButton({
+                  text: ('professions.form.button.publishNow' | t),
+                  classes: "govuk-button",
+                  id: "publish-button",
+                  href: "/admin/professions/" + profession.id + "/versions/" + profession.versionId + "/publish"
+                })
+              }}
             </li>
           {% endif %}
           {% if 'editProfession' in permissions %}


### PR DESCRIPTION
# Changes in this PR

- Adds an "are you sure you want to publish x" screen when admins click "Publish this x" for both Professions and Organisations.
- Fixes an incorrect back link.
- Makes the end of editing an organisation take you back to the newly-updated organisation page, as it does for publishing and the profession journey.

## Screenshots of UI changes

### Publishing an organisation

![image](https://user-images.githubusercontent.com/19826940/155341078-ae63e2d4-1c8d-45d4-87cf-2580b4650b98.png)

### Publishing a profession

![image](https://user-images.githubusercontent.com/19826940/155341174-9bc3743d-0df4-465f-b4b8-a0b5a9a85bb7.png)

### After editing an organisation (no longer on the Organisation index page)

![image](https://user-images.githubusercontent.com/19826940/155341348-0f59b92b-c446-4b15-9969-fa730010d1ea.png)



