### PR TITLE
(2158) update label copy and hints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Move Sectors filter above the Nations filter
 - Allow admin users to edit blank Qualifications when no values have been set from a data import
 - Remove confirmation screens when creating new entities
+- Update labels and hint text for admin profession screens
 
 ## [release-004] - 2022-02-21
 

--- a/src/i18n/en/professions.json
+++ b/src/i18n/en/professions.json
@@ -30,7 +30,7 @@
       },
       "scope": {
         "nations": "Nations",
-        "nationsHint" : "The nations where you regulate this profession.",
+        "nationsHint": "The nations where you regulate this profession.",
         "certainNations": "Certain nations",
         "certainNationsHint": "Select all that apply.",
         "industry": "Sectors",
@@ -56,15 +56,25 @@
       },
       "qualifications": {
         "qualificationLevel": "Qualification level",
+        "qualificationLevelHint": "Equivalent qualification level against a recognised framework",
         "routesToObtain": "Routes to qualification",
+        "routesToObtainHint": "The ways that a new professional can become qualified",
         "mostCommonRouteToObtain": "Most common route",
+        "mostCommonRouteToObtainHint": "If there are many ways to qualify, the most common way",
         "duration": "How long to qualify",
+        "durationHint": "The number of months or years it takes to qualify. For example, 2 years.\nIf the length of time varies, provide the most typical or a range. For example, 6 to 12 months",
         "mandatoryProfessionalExperience": "Professional experience requirement",
+        "mandatoryProfessionalExperienceHint": "Is a period of professional practice require to become qualified?",
         "moreInformationUrl": "More about qualification",
+        "moreInformationUrlHint": "Website link to more information",
         "ukRecognition": "Recognition of qualifications in the UK",
+        "ukRecognitionHint": "Routes to recognition for existing professionals from other UK nations",
         "ukRecognitionUrl": "More about recognition within the UK",
+        "ukRecognitionUrlHint": "Website link to more information",
         "otherCountriesRecognition": "Recognition of qualifications from other countries",
-        "otherCountriesRecognitionUrl": "More about recognition from other countries"
+        "otherCountriesRecognitionHint": "Routes to recognition for existing professionals from outside the UK",
+        "otherCountriesRecognitionUrl": "More about recognition from other countries",
+        "otherCountriesRecognitionUrlHint": "Website link to more information"
       },
       "legislation": {
         "nationalLegislation": "Legislation title",
@@ -77,20 +87,6 @@
         "secondLinkHint": "Website link to the legislation."
       }
     },
-    "hint": {
-      "qualifications": {
-        "routesToObtain": "The ways that a new professional can become qualified",
-        "mostCommonRouteToObtain": "If there are many ways to qualify, the most common way",
-        "duration": "The number of months or years it takes to qualify. For example, 2 years.\nIf the length of time varies, provide the most typical or a range. For example, 6 to 12 months",
-        "mandatoryProfessionalExperience": "Is a period of professional practice require to become qualified?",
-        "qualificationLevel": "Equivalent qualification level against a recognised framework",
-        "moreInformationUrl": "Website link to more information",
-        "ukRecognition": "Routes to recognition for existing professionals from other UK nations",
-        "ukRecognitionUrl": "Website link to more information",
-        "otherCountriesRecognition": "Routes to recognition for existing professionals from outside the UK",
-        "otherCountriesRecognitionUrl": "Website link to more information"
-      }
-    },
     "details": {
       "regulatedActivities": {
         "summaryText": "What are reserved activities?",
@@ -98,7 +94,6 @@
       }
     },
     "radioButtons": {
-      "hint": "Select one option.",
       "mandatoryRegistration": {
         "mandatory": "Mandatory",
         "voluntary": "Voluntary"

--- a/src/i18n/en/professions.json
+++ b/src/i18n/en/professions.json
@@ -9,7 +9,7 @@
       "registration": "Registration",
       "confirmation": "New profession created",
       "amended": "Profession amended",
-      "regulatedActivities": "Regulations",
+      "regulatedActivities": "Regulation",
       "qualifications": "Qualifications",
       "legislation": "Legislation",
       "edit": "Are you sure you want to amend {professionName}?"
@@ -46,9 +46,13 @@
       },
       "regulatedActivities": {
         "regulationSummary": "Regulation summary",
+        "regulationSummaryHint": "Brief description of the profession and how it is regulated.",
         "reservedActivities": "Reserved activities",
+        "reservedActivitiesHint": "Any activities that only qualified professionals can do.",
         "protectedTitles": "Protected titles",
-        "regulationUrl": "More about regulated activities and titles"
+        "protectedTitlesHint": "Professional titles and letters that only qualified professionals can use.",
+        "regulationUrl": "More about regulated activities and titles",
+        "regulationUrlHint": "Website link to more information."
       },
       "qualifications": {
         "qualificationLevel": "Qualification level",

--- a/src/i18n/en/professions.json
+++ b/src/i18n/en/professions.json
@@ -2,7 +2,7 @@
   "form": {
     "headings": {
       "main": "Add a new profession",
-      "topLevelInformation": "Top level information",
+      "topLevelInformation": "Profession",
       "scope": "Scope",
       "checkAnswers": "Check your answers",
       "originalAnswers": "Your original answers",
@@ -21,9 +21,12 @@
     "editProfession": "Use this section of the site to add a new profession",
     "label": {
       "topLevelInformation": {
-        "name": "Name of regulated profession",
-        "regulatedAuthority": "Which body regulates this profession?",
-        "additionalAuthority": "Is there another regulator associated with this profession?"
+        "name": "Name",
+        "nameHint": "The official name for the profession.",
+        "regulatedAuthority": "Main regulator",
+        "regulatedAuthorityHint": "The main authority that regulates this profession.",
+        "additionalAuthority": "Additional regulator (optional)",
+        "additionalAuthorityHint": "Another authority or professional body involved in regulating this profession."
       },
       "scope": {
         "nations": "In which nation(s) is this profession regulated?",

--- a/src/i18n/en/professions.json
+++ b/src/i18n/en/professions.json
@@ -37,9 +37,12 @@
         "industryHint": "The sectors this profession is part of. Select all that apply."
       },
       "registration": {
-        "mandatoryRegistration": "Is registration mandatory with professional bodies?",
+        "mandatoryRegistration": "Registration with authority",
+        "mandatoryRegistrationHint": "Is registration with a regulator or professional body mandatory or voluntary.",
         "registrationRequirements": "Registration requirements",
-        "registrationUrl": "More about registration"
+        "registrationRequirementsHint": "The body professionals should register with and other requirements for registration.",
+        "registrationUrl": "More about registration",
+        "registrationUrlHint": "Website link to more information."
       },
       "regulatedActivities": {
         "regulationSummary": "Regulation summary",
@@ -70,9 +73,6 @@
       "regulatedActivities": {
         "regulationUrl": "Please enter a link"
       },
-      "registration": {
-        "registrationUrl": "Please enter a link"
-      },
       "qualifications": {
         "routesToObtain": "The ways that a new professional can become qualified",
         "mostCommonRouteToObtain": "If there are many ways to qualify, the most common way",
@@ -99,8 +99,7 @@
       "hint": "Select one option.",
       "mandatoryRegistration": {
         "mandatory": "Mandatory",
-        "voluntary": "Voluntary",
-        "unknown": "Unknown"
+        "voluntary": "Voluntary"
       }
     },
     "button": {

--- a/src/i18n/en/professions.json
+++ b/src/i18n/en/professions.json
@@ -3,7 +3,7 @@
     "headings": {
       "main": "Add a new profession",
       "topLevelInformation": "Profession",
-      "scope": "Scope",
+      "scope": "Nations and sectors",
       "checkAnswers": "Check your answers",
       "originalAnswers": "Your original answers",
       "registration": "Registration",
@@ -29,9 +29,12 @@
         "additionalAuthorityHint": "Another authority or professional body involved in regulating this profession."
       },
       "scope": {
-        "nations": "In which nation(s) is this profession regulated?",
-        "certainNations": "Certain Nations",
-        "industry": "Sectors"
+        "nations": "Nations",
+        "nationsHint" : "The nations where you regulate this profession.",
+        "certainNations": "Certain nations",
+        "certainNationsHint": "Select all that apply.",
+        "industry": "Sectors",
+        "industryHint": "The sectors this profession is part of. Select all that apply."
       },
       "registration": {
         "mandatoryRegistration": "Is registration mandatory with professional bodies?",
@@ -99,9 +102,6 @@
         "voluntary": "Voluntary",
         "unknown": "Unknown"
       }
-    },
-    "checkboxes": {
-      "hint": "Select all that apply."
     },
     "button": {
       "create": "Create profession",

--- a/src/i18n/en/professions.json
+++ b/src/i18n/en/professions.json
@@ -67,16 +67,17 @@
         "otherCountriesRecognitionUrl": "More about recognition from other countries"
       },
       "legislation": {
-        "nationalLegislation": "National legislation",
+        "nationalLegislation": "Legislation title",
+        "nationalLegislationHint": "Title of the relevant act or charter.",
         "link": "Legislation link",
-        "secondNationalLegislation": "Second national legislation (optional)",
-        "secondLink": "Second legislation link (optional)"
+        "linkHint": "Website link to the legislation.",
+        "secondNationalLegislation": "Second legislation title (optional)",
+        "secondNationalLegislationHint": "Title of the relevant act or charter.",
+        "secondLink": "Second legislation link (optional)",
+        "secondLinkHint": "Website link to the legislation."
       }
     },
     "hint": {
-      "regulatedActivities": {
-        "regulationUrl": "Please enter a link"
-      },
       "qualifications": {
         "routesToObtain": "The ways that a new professional can become qualified",
         "mostCommonRouteToObtain": "If there are many ways to qualify, the most common way",
@@ -88,9 +89,6 @@
         "ukRecognitionUrl": "Website link to more information",
         "otherCountriesRecognition": "Routes to recognition for existing professionals from outside the UK",
         "otherCountriesRecognitionUrl": "Website link to more information"
-      },
-      "legislation": {
-        "link": "Please enter a link"
       }
     },
     "details": {

--- a/src/professions/admin/mandatory-registration-radio-buttons-presenter.spec.ts
+++ b/src/professions/admin/mandatory-registration-radio-buttons-presenter.spec.ts
@@ -15,8 +15,6 @@ describe(MandatoryRegistrationRadioButtonsPresenter, () => {
           return 'Mandatory';
         case 'professions.form.radioButtons.mandatoryRegistration.voluntary':
           return 'Voluntary';
-        case 'professions.form.radioButtons.mandatoryRegistration.unknown':
-          return 'Unknown';
         default:
           return '';
       }
@@ -41,11 +39,6 @@ describe(MandatoryRegistrationRadioButtonsPresenter, () => {
           value: MandatoryRegistration.Voluntary,
           checked: false,
         },
-        {
-          text: 'Unknown',
-          value: MandatoryRegistration.Unknown,
-          checked: false,
-        },
       ]);
     });
 
@@ -64,11 +57,6 @@ describe(MandatoryRegistrationRadioButtonsPresenter, () => {
         {
           text: 'Voluntary',
           value: MandatoryRegistration.Voluntary,
-          checked: false,
-        },
-        {
-          text: 'Unknown',
-          value: MandatoryRegistration.Unknown,
           checked: false,
         },
       ]);

--- a/src/professions/admin/mandatory-registration-radio-buttons-presenter.ts
+++ b/src/professions/admin/mandatory-registration-radio-buttons-presenter.ts
@@ -24,13 +24,6 @@ export class MandatoryRegistrationRadioButtonsPresenter {
         ),
         checked: this.mandatoryRegistration === MandatoryRegistration.Voluntary,
       },
-      {
-        value: MandatoryRegistration.Unknown,
-        text: await this.i18nService.translate(
-          'professions.form.radioButtons.mandatoryRegistration.unknown',
-        ),
-        checked: this.mandatoryRegistration === MandatoryRegistration.Unknown,
-      },
     ];
   }
 }

--- a/src/professions/admin/scope.controller.spec.ts
+++ b/src/professions/admin/scope.controller.spec.ts
@@ -97,7 +97,9 @@ describe('ScopeController', () => {
               idPrefix: 'nations',
               name: 'nations[]',
               hint: {
-                text: translationOf('professions.form.checkboxes.hint'),
+                text: translationOf(
+                  'professions.form.label.scope.certainNationsHint',
+                ),
               },
               items: [
                 {
@@ -177,7 +179,9 @@ describe('ScopeController', () => {
               idPrefix: 'nations',
               name: 'nations[]',
               hint: {
-                text: translationOf('professions.form.checkboxes.hint'),
+                text: translationOf(
+                  'professions.form.label.scope.certainNationsHint',
+                ),
               },
               items: [
                 {

--- a/src/professions/admin/scope.controller.ts
+++ b/src/professions/admin/scope.controller.ts
@@ -172,7 +172,7 @@ export class ScopeController {
     const nationsCheckboxArgs = await nationsCheckboxPresenter.checkboxArgs(
       'nations',
       'nations[]',
-      'professions.form.checkboxes.hint',
+      'professions.form.label.scope.certainNationsHint',
     );
 
     const templateArgs: ScopeTemplate = {

--- a/views/admin/professions/legislation.njk
+++ b/views/admin/professions/legislation.njk
@@ -25,6 +25,9 @@
               classes: "govuk-label--m",
               isPageHeading: false
             },
+            hint: {
+              text: ("professions.form.label.legislation.nationalLegislationHint" | t)
+            },
             id: "nationalLegislation",
             name: "nationalLegislation",
             value: legislation.name,
@@ -40,7 +43,7 @@
               isPageHeading: false
             },
             hint: {
-              text: "professions.form.hint.legislation.link" | t
+              text: "professions.form.label.legislation.linkHint" | t
             },
             id: "link",
             name: "link",
@@ -55,6 +58,9 @@
               text: ("professions.form.label.legislation.secondNationalLegislation" | t),
               classes: "govuk-label--m",
               isPageHeading: false
+            },
+            hint: {
+              text: ("professions.form.label.legislation.secondNationalLegislationHint" | t)
             },
             id: "secondNationalLegislation",
             name: "secondNationalLegislation",
@@ -71,7 +77,7 @@
               isPageHeading: false
             },
             hint: {
-              text: "professions.form.hint.legislation.link" | t
+              text: "professions.form.label.legislation.secondLinkHint" | t
             },
             id: "secondLink",
             name: "secondLink",

--- a/views/admin/professions/qualifications.njk
+++ b/views/admin/professions/qualifications.njk
@@ -26,7 +26,7 @@
               isPageHeading: false
             },
             hint: {
-              text: ("professions.form.hint.qualifications.routesToObtain" | t)
+              text: ("professions.form.label.qualifications.routesToObtainHint" | t)
             },
             id: "routesToObtain",
             name: "routesToObtain",
@@ -44,7 +44,7 @@
               isPageHeading: false
             },
             hint: {
-              text: ("professions.form.hint.qualifications.mostCommonRouteToObtain" | t)
+              text: ("professions.form.label.qualifications.mostCommonRouteToObtainHint" | t)
             },
             id: "mostCommonRouteToObtain",
             name: "mostCommonRouteToObtain",
@@ -61,7 +61,7 @@
               classes: "govuk-label--m"
             },
             hint: {
-              text: ("professions.form.hint.qualifications.duration" | t | multiline)
+              text: ("professions.form.label.qualifications.durationHint" | t | multiline)
             },
             id: "duration",
             name: "duration",
@@ -82,7 +82,7 @@
               }
             },
             hint: {
-              text: ("professions.form.hint.qualifications.mandatoryProfessionalExperience" | t)
+              text: ("professions.form.label.qualifications.mandatoryProfessionalExperienceHint" | t)
             },
             items: mandatoryProfessionalExperienceRadioButtonArgs,
             errorMessage: errors.mandatoryProfessionalExperience | tError
@@ -97,7 +97,7 @@
               isPageHeading: false
             },
             hint: {
-              html: ("professions.form.hint.qualifications.qualificationLevel" | t)
+              html: ("professions.form.label.qualifications.qualificationLevelHint" | t)
             },
             id: "level",
             name: "level",
@@ -117,7 +117,7 @@
             name: "moreInformationUrl",
             value: moreInformationUrl,
             hint: {
-              text: ("professions.form.hint.qualifications.moreInformationUrl" | t)
+              text: ("professions.form.label.qualifications.moreInformationUrlHint" | t)
             },
             errorMessage: errors.moreInformationUrl | tError
           })
@@ -137,7 +137,7 @@
             name: "ukRecognition",
             value: ukRecognition,
             hint: {
-              text: ("professions.form.hint.qualifications.ukRecognition" | t)
+              text: ("professions.form.label.qualifications.ukRecognitionHint" | t)
             },
             errorMessage: errors.ukRecognition | tError
           })
@@ -153,7 +153,7 @@
             name: "ukRecognitionUrl",
             value: ukRecognitionUrl,
             hint: {
-              text: ("professions.form.hint.qualifications.ukRecognitionUrl" | t)
+              text: ("professions.form.label.qualifications.ukRecognitionUrlHint" | t)
             },
             errorMessage: errors.ukRecognitionUrl | tError
           })
@@ -173,7 +173,7 @@
             name: "otherCountriesRecognition",
             value: otherCountriesRecognition,
             hint: {
-              text: ("professions.form.hint.qualifications.otherCountriesRecognition" | t)
+              text: ("professions.form.label.qualifications.otherCountriesRecognitionHint" | t)
             },
             errorMessage: errors.otherCountriesRecognition | tError
           })
@@ -189,7 +189,7 @@
             name: "otherCountriesRecognitionUrl",
             value: otherCountriesRecognitionUrl,
             hint: {
-              text: ("professions.form.hint.qualifications.otherCountriesRecognitionUrl" | t)
+              text: ("professions.form.label.qualifications.otherCountriesRecognitionUrlHint" | t)
             },
             errorMessage: errors.otherCountriesRecognitionUrl | tError
           })

--- a/views/admin/professions/registration.njk
+++ b/views/admin/professions/registration.njk
@@ -30,7 +30,7 @@
               }
             },
             hint: {
-              text: ("professions.form.radioButtons.hint" | t)
+              text: ("professions.form.label.registration.mandatoryRegistrationHint" | t)
             },
             items: mandatoryRegistrationRadioButtonArgs,
             errorMessage: errors.mandatoryRegistration | tError
@@ -45,6 +45,9 @@
               text: ("professions.form.label.registration.registrationRequirements" | t),
               classes: "govuk-label--m",
               isPageHeading: false
+            },
+            hint: {
+              text: ("professions.form.label.registration.registrationRequirementsHint" | t)
             },
             value: registrationRequirements
           })
@@ -61,7 +64,7 @@
             },
             value: registrationUrl,
             hint: {
-              text: ("professions.form.hint.registration.registrationUrl" | t)
+              text: ("professions.form.label.registration.registrationUrlHint" | t)
             },
             errorMessage: errors.registrationUrl | tError
           })

--- a/views/admin/professions/regulated-activities.njk
+++ b/views/admin/professions/regulated-activities.njk
@@ -26,6 +26,9 @@
               classes: "govuk-label--m",
               isPageHeading: false
             },
+            hint: {
+              text: ("professions.form.label.regulatedActivities.regulationSummaryHint" | t)
+            },
             id: "regulationSummary",
             name: "regulationSummary",
             value: regulationSummary,
@@ -35,11 +38,15 @@
         }}
 
         <label class="govuk-label govuk-label--m" for="reservedActivities">{{ "professions.form.label.regulatedActivities.reservedActivities" | t }}</label>
+        <div class="govuk-hint">
+          {{ "professions.form.label.regulatedActivities.reservedActivitiesHint" | t }}
+        </div>
 
         {{
           govukDetails({
             summaryText: ("professions.form.details.regulatedActivities.summaryText" | t),
-            text: ("professions.form.details.regulatedActivities.text" | t)
+            text: ("professions.form.details.regulatedActivities.text" | t),
+            classes: "govuk-!-margin-bottom-2"
           })
         }}
 
@@ -60,6 +67,9 @@
               classes: "govuk-label--m",
               isPageHeading: false
             },
+            hint: {
+              text: ("professions.form.label.regulatedActivities.protectedTitlesHint" | t)
+            },
             id: "protectedTitles",
             name: "protectedTitles",
             value: protectedTitles,
@@ -76,7 +86,7 @@
               isPageHeading: false
             },
             hint: {
-              text: ("professions.form.hint.regulatedActivities.regulationUrl" | t)
+              text: ("professions.form.label.regulatedActivities.regulationUrlHint" | t)
             },
             id: "regulationUrl",
             name: "regulationUrl",

--- a/views/admin/professions/scope.njk
+++ b/views/admin/professions/scope.njk
@@ -38,7 +38,7 @@
             }
           },
           hint: {
-            text: ("professions.form.checkboxes.hint" | t)
+            text: ("professions.form.label.scope.nationsHint" | t)
           },
           items: [
             {
@@ -70,7 +70,7 @@
             }
           },
           hint: {
-            text: ("professions.form.checkboxes.hint" | t)
+            text: ("professions.form.label.scope.industryHint" | t)
           },
           items: industriesCheckboxItems,
           errorMessage: errors.industries | tError

--- a/views/admin/professions/top-level-information.njk
+++ b/views/admin/professions/top-level-information.njk
@@ -26,6 +26,9 @@
             classes: "govuk-label--m",
             isPageHeading: false
           },
+          hint: {
+            text: ("professions.form.label.topLevelInformation.nameHint" | t) 
+          },
           id: "name",
           name: "name",
           value: name,
@@ -40,6 +43,9 @@
             classes: "govuk-label--m",
             isPageHeading: false
           },
+          hint: {
+            text: ("professions.form.label.topLevelInformation.regulatedAuthorityHint" | t)
+          },
           id: "regulatoryBody",
           name: "regulatoryBody",
           items: regulatedAuthoritiesSelectArgs,
@@ -53,6 +59,9 @@
             text: ("professions.form.label.topLevelInformation.additionalAuthority" | t),
             classes: "govuk-label--m",
             isPageHeading: false
+          },
+          hint: {
+            text: ("professions.form.label.topLevelInformation.additionalAuthorityHint" | t)
           },
           id: "additionalRegulatoryBody",
           name: "additionalRegulatoryBody",


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR
- Updated content for the top level page
- Updated content for the scope page
- Updated content for the registration page
- Updated content for regulation
- Updated content for legislation
- Refactoring the i18n file for qualifications

One thing is that I have removed the radio button option `Unknown` from the Registration page and I hope I really have removed the necessary part only because I understand that `Unknown` could be still needed to handle the current set of data. Please let me know if there's any problem. 

## Screenshots of UI changes

### Before
<img width="1058" alt="Screenshot 2022-02-22 at 11 35 18" src="https://user-images.githubusercontent.com/6421298/155347508-195b0769-ce81-4cca-9fb0-52066216d03b.png">

### After
<img width="1027" alt="Screenshot 2022-02-22 at 16 23 49" src="https://user-images.githubusercontent.com/6421298/155347561-863162fa-1de9-4344-9f4a-be52167d3a8c.png">

### Before
<img width="1012" alt="Screenshot 2022-02-22 at 16 37 39" src="https://user-images.githubusercontent.com/6421298/155347665-01088b19-0eb1-40e5-a333-d7d013c8430c.png">

### After
<img width="1013" alt="Screenshot 2022-02-22 at 16 38 38" src="https://user-images.githubusercontent.com/6421298/155347716-20914dd1-0d42-479f-93bb-21fbfeaf745e.png">

### Before
<img width="994" alt="Screenshot 2022-02-22 at 18 22 07" src="https://user-images.githubusercontent.com/6421298/155347783-ac787af2-9e6c-4cad-90ba-5d1cfece3e27.png">

### After
<img width="1002" alt="Screenshot 2022-02-22 at 18 35 38" src="https://user-images.githubusercontent.com/6421298/155347826-2f35d660-8fd8-404a-a636-259077df1828.png">

### Before
![screencapture-beis-rpr-staging-london-cloudapps-digital-admin-professions-55ce8b5e-998e-401a-9a9a-80fe9df49a0b-versions-c1d0bd06-26bb-4ace-865a-adf9051ee906-regulated-activities-edit-2022-02-23-12_37_59](https://user-images.githubusercontent.com/6421298/155347925-72703c09-f771-40d2-86d2-7cf2fa10fd13.png)

### After
![screencapture-localhost-3000-admin-professions-a48aab7a-8fb1-498f-b2e4-d9d8975945ad-versions-f13903ea-8756-4219-84cc-b315a2b0175d-regulated-activities-edit-2022-02-23-12_37_50](https://user-images.githubusercontent.com/6421298/155347966-f0ae9b2e-b520-461d-88b8-cb6812de45a2.png)

### Before
![screencapture-beis-rpr-staging-london-cloudapps-digital-admin-professions-55ce8b5e-998e-401a-9a9a-80fe9df49a0b-versions-c1d0bd06-26bb-4ace-865a-adf9051ee906-check-your-answers-2022-02-23-14_41_14](https://user-images.githubusercontent.com/6421298/155348843-9bbc34bf-f4aa-4630-81c1-345e9edea000.png)


### After
![screencapture-localhost-3000-admin-professions-a48aab7a-8fb1-498f-b2e4-d9d8975945ad-versions-f13903ea-8756-4219-84cc-b315a2b0175d-check-your-answers-2022-02-23-14_41_24](https://user-images.githubusercontent.com/6421298/155348167-3eb85aed-5920-429f-9f90-dd33823fb6a3.png)



