### PR TITLE
(2171) Support professions with missing entries

### DIFF
--- a/cypress/integration/admin/organisations/index.spec.ts
+++ b/cypress/integration/admin/organisations/index.spec.ts
@@ -42,11 +42,13 @@ describe('Listing organisations', () => {
                 );
 
                 professionsForOrganisation.forEach((profession: any) => {
-                  profession.versions[0].industries.forEach((industry: any) => {
-                    cy.translate(industry).then((industry) => {
-                      cy.wrap($row).should('contain', industry);
-                    });
-                  });
+                  (profession.versions[0].industries || []).forEach(
+                    (industry: any) => {
+                      cy.translate(industry).then((industry) => {
+                        cy.wrap($row).should('contain', industry);
+                      });
+                    },
+                  );
                 });
               });
           });

--- a/cypress/integration/admin/professions/edit.spec.ts
+++ b/cypress/integration/admin/professions/edit.spec.ts
@@ -508,6 +508,54 @@ describe('Editing an existing profession', () => {
         );
       });
     });
+
+    context('When the Profession has minimal data', () => {
+      it('I can add missing data', () => {
+        cy.visitAndCheckAccessibility('/admin/professions');
+
+        cy.get('table')
+          .contains('tr', 'Draft Profession')
+          .within(() => {
+            cy.contains('View details').click();
+          });
+
+        cy.checkAccessibility();
+
+        cy.translate('professions.admin.button.edit.draft').then(
+          (buttonText) => {
+            cy.contains(buttonText).click();
+          },
+        );
+
+        cy.checkAccessibility();
+
+        cy.clickSummaryListRowAction(
+          'professions.form.label.legislation.nationalLegislation',
+          'Change',
+        );
+        cy.checkAccessibility();
+        cy.translate('professions.form.captions.edit').then((editCaption) => {
+          cy.get('body').contains(editCaption);
+        });
+        cy.get('textarea[name="nationalLegislation"]').type(
+          'National legislation',
+        );
+        cy.get('input[name="link"]').type('http://www.example.com/legislation');
+        cy.translate('app.continue').then((buttonText) => {
+          cy.get('button').contains(buttonText).click();
+        });
+        cy.checkIndexedSummaryListRowValue(
+          'professions.form.label.legislation.nationalLegislation',
+          'National legislation',
+          1,
+        );
+        cy.checkIndexedSummaryListRowValue(
+          'professions.form.label.legislation.link',
+          'http://www.example.com/legislation',
+          1,
+        );
+      });
+    });
   });
 
   context('when I am logged in as a registrar', () => {
@@ -515,7 +563,7 @@ describe('Editing an existing profession', () => {
       cy.loginAuth0('registrar');
     });
 
-    it('I edit the top-level information of a profession', () => {
+    it('I can edit the top-level information of a profession', () => {
       cy.visitAndCheckAccessibility('/admin/professions');
 
       cy.get('table')

--- a/seeds/development/professions.json
+++ b/seeds/development/professions.json
@@ -97,5 +97,16 @@
         "keywords": "Adviser, heating,Connector, coupling,Consultant, heating,Contractor, plumbing,Converter,Craftsman, distribution,Craftsman, governor,Craftsman, transmission,Craftsman,Engineer, biomass,Engineer, domestic,Engineer, field,Engineer, Gas, British,Engineer, gas, domestic,Engineer, gas, emergency,Engineer, gas, technical,Engineer, gas,Engineer, gas and heating,Engineer, gas and water,Engineer, heat and domestic,Engineer, heating, central,Engineer, heating, gas,Engineer, heating,Engineer, heating and lighting,Engineer, heating and plumbing,Engineer, heating and ventilating,Engineer, installation, gas,Engineer, installation,Engineer, mains,Engineer, maintenance,Engineer, plumber and gas,Engineer, plumbing,Engineer, plumbing and heating,Engineer, pump, heat,Engineer, safe, gas,Engineer, sanitary,Engineer, service, gas,Engineer, service,Engineer, service,Engineer, service,Engineer, technical, gas,Engineer, technical,Engineer, thermal,Engineer, thermal and acoustic,Engineer, ventilating,Engineer, ventilation,Engineer, ventilation,Engineer, water, hot,Erector, mains, gas,Fitter, bathroom,Fitter, burner,Fitter, district,Fitter, engineer's, heating,Fitter, engineer's, sanitary,Fitter, fire, gas,Fitter, gas,Fitter, governor,Fitter, heating,Fitter, heating and ventilation,Fitter, kitchen and bathroom,Fitter, maintenance,Fitter, maintenance,Fitter, maintenance,Fitter, sanitary,Fitter, sprinkler,Fitter, steam,Fitter, steam and hot water,Fitter, stove,Fitter, ventilation,Fitter, water,Fitter,Fitter,Fitter,Fitter-welder,Fixer, appliances,Fixer, meter,Fixer, meter,Fixer, ventilator,Inserter, ferrule,Installer, bathroom,Installer, heating,Installer, meter,Installer, meter,Installer, pump, heat,Installer,Jointer, pipe, sprinkler,Linesman, gas,Man, maintenance,Man, service, sales,Man, service,Man, service,Mender,Pewterer,Plumber,Plumber and decorator,Plumber and gasfitter,Plumber-welder,Repairer, stove,Repairer,Technician, gas,Technician, network,Technician, network,Technician, plumbing,Technician, service,Worker, gas, maintenance"
       }
     ]
+  },
+  {
+    "name": "Draft Profession",
+    "slug": "draft-profession",
+    "organisation": "Council of Registered Gas Installers",
+    "additionalOrganisation": null,
+    "versions": [
+      {
+        "status": "draft"
+      }
+    ]
   }
 ]

--- a/seeds/staging/professions.json
+++ b/seeds/staging/professions.json
@@ -97,5 +97,16 @@
         "keywords": "Adviser, heating,Connector, coupling,Consultant, heating,Contractor, plumbing,Converter,Craftsman, distribution,Craftsman, governor,Craftsman, transmission,Craftsman,Engineer, biomass,Engineer, domestic,Engineer, field,Engineer, Gas, British,Engineer, gas, domestic,Engineer, gas, emergency,Engineer, gas, technical,Engineer, gas,Engineer, gas and heating,Engineer, gas and water,Engineer, heat and domestic,Engineer, heating, central,Engineer, heating, gas,Engineer, heating,Engineer, heating and lighting,Engineer, heating and plumbing,Engineer, heating and ventilating,Engineer, installation, gas,Engineer, installation,Engineer, mains,Engineer, maintenance,Engineer, plumber and gas,Engineer, plumbing,Engineer, plumbing and heating,Engineer, pump, heat,Engineer, safe, gas,Engineer, sanitary,Engineer, service, gas,Engineer, service,Engineer, service,Engineer, service,Engineer, technical, gas,Engineer, technical,Engineer, thermal,Engineer, thermal and acoustic,Engineer, ventilating,Engineer, ventilation,Engineer, ventilation,Engineer, water, hot,Erector, mains, gas,Fitter, bathroom,Fitter, burner,Fitter, district,Fitter, engineer's, heating,Fitter, engineer's, sanitary,Fitter, fire, gas,Fitter, gas,Fitter, governor,Fitter, heating,Fitter, heating and ventilation,Fitter, kitchen and bathroom,Fitter, maintenance,Fitter, maintenance,Fitter, maintenance,Fitter, sanitary,Fitter, sprinkler,Fitter, steam,Fitter, steam and hot water,Fitter, stove,Fitter, ventilation,Fitter, water,Fitter,Fitter,Fitter,Fitter-welder,Fixer, appliances,Fixer, meter,Fixer, meter,Fixer, ventilator,Inserter, ferrule,Installer, bathroom,Installer, heating,Installer, meter,Installer, meter,Installer, pump, heat,Installer,Jointer, pipe, sprinkler,Linesman, gas,Man, maintenance,Man, service, sales,Man, service,Man, service,Mender,Pewterer,Plumber,Plumber and decorator,Plumber and gasfitter,Plumber-welder,Repairer, stove,Repairer,Technician, gas,Technician, network,Technician, network,Technician, plumbing,Technician, service,Worker, gas, maintenance"
       }
     ]
+  },
+  {
+    "name": "Draft Profession",
+    "slug": "draft-profession",
+    "organisation": "Council of Registered Gas Installers",
+    "additionalOrganisation": null,
+    "versions": [
+      {
+        "status": "draft"
+      }
+    ]
   }
 ]

--- a/seeds/test/professions.json
+++ b/seeds/test/professions.json
@@ -118,5 +118,16 @@
         "keywords": "Associate, nursing"
       }
     ]
+  },
+  {
+    "name": "Draft Profession",
+    "slug": "draft-profession",
+    "organisation": "Council of Registered Gas Installers",
+    "additionalOrganisation": null,
+    "versions": [
+      {
+        "status": "draft"
+      }
+    ]
   }
 ]

--- a/src/organisations/organisation-versions.service.spec.ts
+++ b/src/organisations/organisation-versions.service.spec.ts
@@ -19,6 +19,7 @@ import { OrganisationVersionsService } from './organisation-versions.service';
 import organisationVersionFactory from '../testutils/factories/organisation-version';
 import organisationFactory from '../testutils/factories/organisation';
 import userFactory from '../testutils/factories/user';
+import { ProfessionVersionStatus } from '../professions/profession-version.entity';
 
 describe('OrganisationVersionsService', () => {
   let service: OrganisationVersionsService;
@@ -272,6 +273,7 @@ describe('OrganisationVersionsService', () => {
 
       expect(queryBuilder.distinctOn).toHaveBeenCalledWith([
         'organisationVersion.organisation',
+        'professions.id',
       ]);
 
       expect(queryBuilder.where).toHaveBeenCalledWith(
@@ -284,8 +286,15 @@ describe('OrganisationVersionsService', () => {
         },
       );
 
+      expect(queryBuilder.where).toHaveBeenCalledWith(
+        'professionVersions.status IN(:...status) OR professionVersions.status IS NULL',
+        {
+          status: [ProfessionVersionStatus.Live, ProfessionVersionStatus.Draft],
+        },
+      );
+
       expect(queryBuilder.orderBy).toHaveBeenCalledWith(
-        'organisationVersion.organisation, organisationVersion.created_at',
+        'organisationVersion.organisation, professions.id, professionVersions.created_at, organisationVersion.created_at',
         'DESC',
       );
     });

--- a/src/organisations/organisation-versions.service.ts
+++ b/src/organisations/organisation-versions.service.ts
@@ -7,6 +7,7 @@ import {
 } from './organisation-version.entity';
 import { Organisation } from './organisation.entity';
 import { User } from '../users/user.entity';
+import { ProfessionVersionStatus } from '../professions/profession-version.entity';
 
 @Injectable()
 export class OrganisationVersionsService {
@@ -81,15 +82,21 @@ export class OrganisationVersionsService {
 
   async allDraftOrLive(): Promise<Organisation[]> {
     const versions = await this.versionsWithJoins()
-      .distinctOn(['organisationVersion.organisation'])
+      .distinctOn(['organisationVersion.organisation', 'professions.id'])
       .where('organisationVersion.status IN(:...status)', {
         status: [
           OrganisationVersionStatus.Live,
           OrganisationVersionStatus.Draft,
         ],
       })
+      .where(
+        'professionVersions.status IN(:...status) OR professionVersions.status IS NULL',
+        {
+          status: [ProfessionVersionStatus.Live, ProfessionVersionStatus.Draft],
+        },
+      )
       .orderBy(
-        'organisationVersion.organisation, organisationVersion.created_at',
+        'organisationVersion.organisation, professions.id, professionVersions.created_at, organisationVersion.created_at',
         'DESC',
       )
       .getMany();

--- a/src/professions/admin/check-your-answers.controller.spec.ts
+++ b/src/professions/admin/check-your-answers.controller.spec.ts
@@ -142,7 +142,7 @@ describe('CheckYourAnswersController', () => {
       });
     });
 
-    describe('when the profession has only one legislation', () => {
+    describe('when the Profession has only one legislation', () => {
       it('the legislations array passed to the template is padded to length 2', async () => {
         const legislation = legislationFactory.build({
           url: 'www.gas-legislation.com',
@@ -167,6 +167,58 @@ describe('CheckYourAnswersController', () => {
         );
 
         expect(templateParams.legislations).toEqual([legislation, undefined]);
+      });
+    });
+
+    describe('when the Profession has just been created by a service owner user', () => {
+      it('renders a mostly blank check your answers page', async () => {
+        const profession = professionFactory
+          .justCreated('profession-id')
+          .build({
+            name: 'Gas Safe Engineer',
+            organisation: organisationFactory.build({
+              name: 'Council of Gas Registered Engineers',
+            }),
+          });
+
+        const version = professionVersionFactory
+          .justCreated('version-id')
+          .build({
+            industries: [],
+            legislations: [],
+          });
+
+        professionsService.findWithVersions.mockResolvedValue(profession);
+        professionVersionsService.findWithProfession.mockResolvedValue(version);
+
+        const templateParams = await controller.show(
+          'profession-id',
+          'version-id',
+          'false',
+        );
+
+        expect(templateParams.name).toEqual('Gas Safe Engineer');
+        expect(templateParams.nations).toEqual([]);
+        expect(templateParams.industries).toEqual([]);
+        expect(templateParams.organisation).toEqual(
+          'Council of Gas Registered Engineers',
+        );
+        expect(templateParams.mandatoryRegistration).toEqual(undefined);
+        expect(templateParams.registrationRequirements).toEqual(undefined);
+        expect(templateParams.registrationUrl).toEqual(undefined);
+        expect(templateParams.regulationSummary).toEqual(undefined);
+        expect(templateParams.reservedActivities).toEqual(undefined);
+        expect(templateParams.protectedTitles).toEqual(undefined);
+        expect(templateParams.regulationUrl).toEqual(undefined);
+        expect(templateParams.qualification).toEqual(
+          new QualificationPresenter(undefined, i18nService),
+        );
+        expect(templateParams.legislations).toEqual([undefined, undefined]);
+        expect(templateParams.confirmed).toEqual(false);
+
+        expect(professionsService.findWithVersions).toHaveBeenCalledWith(
+          'profession-id',
+        );
       });
     });
   });

--- a/src/professions/admin/check-your-answers.controller.ts
+++ b/src/professions/admin/check-your-answers.controller.ts
@@ -22,6 +22,7 @@ import { BackLink } from '../../common/decorators/back-link.decorator';
 import { ProfessionVersionsService } from '../profession-versions.service';
 import { isConfirmed } from '../../helpers/is-confirmed';
 import { isUK } from '../../helpers/nations.helper';
+
 @UseGuards(AuthenticationGuard)
 @Controller('admin/professions')
 export class CheckYourAnswersController {
@@ -63,7 +64,7 @@ export class CheckYourAnswersController {
     );
 
     const selectedNations: string[] = await Promise.all(
-      version.occupationLocations.map(async (nationCode) =>
+      (version.occupationLocations || []).map(async (nationCode) =>
         Nation.find(nationCode).translatedName(this.i18nService),
       ),
     );
@@ -96,7 +97,7 @@ export class CheckYourAnswersController {
       legislations,
       confirmed: isConfirmed(draftProfession),
       captionText: ViewUtils.captionText(isConfirmed(draftProfession)),
-      isUK: isUK(version.occupationLocations),
+      isUK: isUK(version.occupationLocations || []),
       edit: edit === 'true',
     };
   }

--- a/src/professions/admin/list-entry.presenter.ts
+++ b/src/professions/admin/list-entry.presenter.ts
@@ -67,7 +67,9 @@ export class ListEntryPresenter {
     );
 
     const nations = await stringifyNations(
-      this.profession.occupationLocations.map((code) => Nation.find(code)),
+      (this.profession.occupationLocations || []).map((code) =>
+        Nation.find(code),
+      ),
       this.i18nService,
     );
 

--- a/src/professions/admin/profession-versions.controller.ts
+++ b/src/professions/admin/profession-versions.controller.ts
@@ -68,7 +68,7 @@ export class ProfessionVersionsController {
     );
 
     const nations = await Promise.all(
-      profession.occupationLocations.map(async (code) =>
+      (profession.occupationLocations || []).map(async (code) =>
         Nation.find(code).translatedName(this.i18nService),
       ),
     );

--- a/src/professions/admin/qualifications.controller.spec.ts
+++ b/src/professions/admin/qualifications.controller.spec.ts
@@ -13,6 +13,7 @@ import { isUK } from '../../helpers/nations.helper';
 
 import professionVersionFactory from '../../testutils/factories/profession-version';
 import qualificationFactory from '../../testutils/factories/qualification';
+import organisationFactory from '../../testutils/factories/organisation';
 
 jest.mock('../../helpers/nations.helper');
 
@@ -46,47 +47,97 @@ describe(QualificationsController, () => {
   });
 
   describe('edit', () => {
-    it('should render form page', async () => {
-      const profession = professionFactory.build({
-        id: 'profession-id',
+    describe('when the Profession is complete', () => {
+      it('should render form page', async () => {
+        const profession = professionFactory.build({
+          id: 'profession-id',
+        });
+
+        const version = professionVersionFactory.build({
+          id: 'version-id',
+          profession: profession,
+          qualification: qualificationFactory.build(),
+        });
+
+        professionsService.findWithVersions.mockResolvedValue(profession);
+        professionVersionsService.findWithProfession.mockResolvedValue(version);
+        (isUK as jest.Mock).mockImplementation(() => false);
+
+        await controller.edit(response, 'profession-id', 'version-id', false);
+
+        expect(response.render).toHaveBeenCalledWith(
+          'admin/professions/qualifications',
+          expect.objectContaining({
+            level: profession.qualification.level,
+            routesToObtain: profession.qualification.routesToObtain,
+            mostCommonRouteToObtain:
+              profession.qualification.mostCommonRouteToObtain,
+            duration: profession.qualification.educationDuration,
+            moreInformationUrl: profession.qualification.url,
+            captionText: 'professions.form.captions.edit',
+            ukRecognition: profession.qualification.ukRecognition,
+            ukRecognitionUrl: profession.qualification.ukRecognitionUrl,
+            otherCountriesRecognition:
+              profession.qualification.otherCountriesRecognition,
+            otherCountriesRecognitionUrl:
+              profession.qualification.otherCountriesRecognitionUrl,
+            mandatoryProfessionalExperienceRadioButtonArgs:
+              await new YesNoRadioButtonArgsPresenter(
+                version.qualification.mandatoryProfessionalExperience,
+                i18nService,
+              ).radioButtonArgs(),
+            isUK: false,
+          }),
+        );
       });
+    });
 
-      const version = professionVersionFactory.build({
-        id: 'version-id',
-        profession: profession,
-        qualification: qualificationFactory.build(),
+    describe('when the Profession has just been created by a service owner user', () => {
+      it('returns a mostly empty table row', async () => {
+        const profession = professionFactory
+          .justCreated('profession-id')
+          .build({
+            name: 'Example Profession',
+            organisation: organisationFactory.build(),
+            slug: 'example-profession',
+          });
+
+        const version = professionVersionFactory
+          .justCreated('version-id')
+          .build({
+            profession: profession,
+          });
+
+        professionsService.findWithVersions.mockResolvedValue(profession);
+        professionVersionsService.findWithProfession.mockResolvedValue(version);
+        (isUK as jest.Mock).mockImplementation(() => false);
+
+        await controller.edit(response, 'profession-id', 'version-id', false);
+
+        expect(response.render).toHaveBeenCalledWith(
+          'admin/professions/qualifications',
+          expect.objectContaining({
+            level: undefined,
+            routesToObtain: undefined,
+            mostCommonRouteToObtain: undefined,
+            duration: undefined,
+            moreInformationUrl: undefined,
+            captionText: 'professions.form.captions.edit',
+            ukRecognition: undefined,
+            ukRecognitionUrl: undefined,
+            otherCountriesRecognition: undefined,
+            otherCountriesRecognitionUrl: undefined,
+            mandatoryProfessionalExperienceRadioButtonArgs:
+              await new YesNoRadioButtonArgsPresenter(
+                null,
+                i18nService,
+              ).radioButtonArgs(),
+            isUK: false,
+          }),
+        );
+
+        expect(isUK).toBeCalledWith([]);
       });
-
-      professionsService.findWithVersions.mockResolvedValue(profession);
-      professionVersionsService.findWithProfession.mockResolvedValue(version);
-      (isUK as jest.Mock).mockImplementation(() => false);
-
-      await controller.edit(response, 'profession-id', 'version-id', false);
-
-      expect(response.render).toHaveBeenCalledWith(
-        'admin/professions/qualifications',
-        expect.objectContaining({
-          level: profession.qualification.level,
-          routesToObtain: profession.qualification.routesToObtain,
-          mostCommonRouteToObtain:
-            profession.qualification.mostCommonRouteToObtain,
-          duration: profession.qualification.educationDuration,
-          moreInformationUrl: profession.qualification.url,
-          captionText: 'professions.form.captions.edit',
-          ukRecognition: profession.qualification.ukRecognition,
-          ukRecognitionUrl: profession.qualification.ukRecognitionUrl,
-          otherCountriesRecognition:
-            profession.qualification.otherCountriesRecognition,
-          otherCountriesRecognitionUrl:
-            profession.qualification.otherCountriesRecognitionUrl,
-          mandatoryProfessionalExperienceRadioButtonArgs:
-            await new YesNoRadioButtonArgsPresenter(
-              version.qualification.mandatoryProfessionalExperience,
-              i18nService,
-            ).radioButtonArgs(),
-          isUK: false,
-        }),
-      );
     });
   });
 

--- a/src/professions/admin/qualifications.controller.ts
+++ b/src/professions/admin/qualifications.controller.ts
@@ -170,7 +170,7 @@ export class QualificationsController {
       ukRecognitionUrl: qualification?.ukRecognitionUrl,
       otherCountriesRecognition: qualification?.otherCountriesRecognition,
       otherCountriesRecognitionUrl: qualification?.otherCountriesRecognitionUrl,
-      isUK: isUK(version.occupationLocations),
+      isUK: isUK(version.occupationLocations || []),
       change,
       errors,
     };

--- a/src/professions/presenters/profession.presenter.spec.ts
+++ b/src/professions/presenters/profession.presenter.spec.ts
@@ -101,21 +101,39 @@ describe('ProfessionPresenter', () => {
   });
 
   describe('occupationLocations', () => {
-    it('should pass the locations to stringifyNations', async () => {
-      const i18nService = createMockI18nService();
+    describe('when occupationLocations is defined', () => {
+      it('should pass the locations to stringifyNations', async () => {
+        const i18nService = createMockI18nService();
 
-      profession = professionFactory.build({
-        occupationLocations: ['GB-ENG', 'GB-SCT', 'GB-WLS', 'GB-NIR'],
+        profession = professionFactory.build({
+          occupationLocations: ['GB-ENG', 'GB-SCT', 'GB-WLS', 'GB-NIR'],
+        });
+
+        const presenter = new ProfessionPresenter(profession, i18nService);
+        const nations = profession.occupationLocations.map((code) =>
+          Nation.find(code),
+        );
+
+        await presenter.occupationLocations();
+
+        expect(stringifyNations).toHaveBeenCalledWith(nations, i18nService);
       });
+    });
 
-      const presenter = new ProfessionPresenter(profession, i18nService);
-      const nations = profession.occupationLocations.map((code) =>
-        Nation.find(code),
-      );
+    describe('when occupationLocations is undefined', () => {
+      it('should pass an empty array to stringifyNations', async () => {
+        const i18nService = createMockI18nService();
 
-      await presenter.occupationLocations();
+        profession = professionFactory.build({
+          occupationLocations: undefined,
+        });
 
-      expect(stringifyNations).toHaveBeenCalledWith(nations, i18nService);
+        const presenter = new ProfessionPresenter(profession, i18nService);
+
+        await presenter.occupationLocations();
+
+        expect(stringifyNations).toHaveBeenCalledWith([], i18nService);
+      });
     });
   });
 

--- a/src/professions/presenters/profession.presenter.ts
+++ b/src/professions/presenters/profession.presenter.ts
@@ -51,7 +51,9 @@ export class ProfessionPresenter {
 
   public async occupationLocations(): Promise<string> {
     return await stringifyNations(
-      this.profession.occupationLocations.map((code) => Nation.find(code)),
+      (this.profession.occupationLocations || []).map((code) =>
+        Nation.find(code),
+      ),
       this.i18nService,
     );
   }

--- a/src/professions/profession-versions.service.spec.ts
+++ b/src/professions/profession-versions.service.spec.ts
@@ -95,46 +95,82 @@ describe('ProfessionVersionsService', () => {
   });
 
   describe('create', () => {
-    it('creates a copy of an existing version and sets the user', async () => {
-      const legislation = legislationFactory.build();
-      const qualification = qualificationFactory.build();
-      const profession = professionFactory.build();
+    describe('when the Profession is complete', () => {
+      it('creates a copy of an existing version and sets the user', async () => {
+        const legislation = legislationFactory.build();
+        const qualification = qualificationFactory.build();
+        const profession = professionFactory.build();
 
-      const previousVersion = professionVersionFactory.build({
-        profession: profession,
-        legislations: [legislation],
-        qualification: qualification,
+        const previousVersion = professionVersionFactory.build({
+          profession: profession,
+          legislations: [legislation],
+          qualification: qualification,
+        });
+
+        const newQualification = {
+          ...previousVersion.qualification,
+          id: undefined,
+          created_at: undefined,
+          updated_at: undefined,
+        };
+
+        const newLegislation = {
+          ...legislation,
+          id: undefined,
+          created_at: undefined,
+          updated_at: undefined,
+        };
+        const user = userFactory.build();
+
+        const repoSpy = jest.spyOn(repo, 'save');
+
+        await service.create(previousVersion, user);
+
+        expect(repoSpy).toHaveBeenCalledWith({
+          ...previousVersion,
+          id: undefined,
+          status: undefined,
+          created_at: undefined,
+          updated_at: undefined,
+          qualification: newQualification,
+          legislations: [newLegislation],
+          profession: profession,
+          user: user,
+        });
       });
+    });
 
-      const newQualification = {
-        ...previousVersion.qualification,
-        id: undefined,
-        created_at: undefined,
-        updated_at: undefined,
-      };
+    describe('when the Profession has just been created by a service owner user', () => {
+      it('creates a copy of an existing version and sets the user', async () => {
+        const profession = professionFactory
+          .justCreated('profession-id')
+          .build();
 
-      const newLegislation = {
-        ...legislation,
-        id: undefined,
-        created_at: undefined,
-        updated_at: undefined,
-      };
-      const user = userFactory.build();
+        const previousVersion = professionVersionFactory
+          .justCreated('version-id')
+          .build({
+            legislations: [],
+            qualification: undefined,
+            profession: profession,
+          });
 
-      const repoSpy = jest.spyOn(repo, 'save');
+        const user = userFactory.build();
 
-      await service.create(previousVersion, user);
+        const repoSpy = jest.spyOn(repo, 'save');
 
-      expect(repoSpy).toHaveBeenCalledWith({
-        ...previousVersion,
-        id: undefined,
-        status: undefined,
-        created_at: undefined,
-        updated_at: undefined,
-        qualification: newQualification,
-        legislations: [newLegislation],
-        profession: profession,
-        user: user,
+        await service.create(previousVersion, user);
+
+        expect(repoSpy).toHaveBeenCalledWith({
+          ...previousVersion,
+          id: undefined,
+          status: undefined,
+          created_at: undefined,
+          updated_at: undefined,
+          qualification: undefined,
+          legislations: [],
+          profession: profession,
+          user: user,
+        });
       });
     });
   });

--- a/src/professions/profession-versions.service.ts
+++ b/src/professions/profession-versions.service.ts
@@ -40,12 +40,14 @@ export class ProfessionVersionsService {
     previousVersion: ProfessionVersion,
     user: User,
   ): Promise<ProfessionVersion> {
-    const newQualification = {
-      ...previousVersion.qualification,
-      id: undefined,
-      created_at: undefined,
-      updated_at: undefined,
-    } as Qualification;
+    const newQualification =
+      previousVersion.qualification &&
+      ({
+        ...previousVersion.qualification,
+        id: undefined,
+        created_at: undefined,
+        updated_at: undefined,
+      } as Qualification);
 
     const newLegislations = previousVersion.legislations.map((legislation) => {
       return {

--- a/src/professions/professions.seeder.ts
+++ b/src/professions/professions.seeder.ts
@@ -131,14 +131,17 @@ export class ProfessionsSeeder implements Seeder {
           },
         );
 
-        const industries = await this.industriesRepository.find({
-          where: { name: In(version.industries || []) },
-        });
+        const industries =
+          version.industries &&
+          (await this.industriesRepository.find({
+            where: { name: In(version.industries || []) },
+          }));
 
         let qualification: Qualification =
-          await this.qualificationsRepository.findOne({
+          version.qualification &&
+          (await this.qualificationsRepository.findOne({
             where: { level: version.qualification },
-          });
+          }));
 
         if (qualification) {
           // Currently the Qualification relation has a unique constraint
@@ -158,11 +161,12 @@ export class ProfessionsSeeder implements Seeder {
         }
 
         let legislations: Legislation[] =
-          await this.legislationsRepository.find({
+          version.legislations &&
+          (await this.legislationsRepository.find({
             where: { name: In(version.legislations) },
-          });
+          }));
 
-        if (legislations.length > 0) {
+        if (legislations && legislations.length > 0) {
           // Currently the Legislation relation has a unique constraint
           // on the legislationID, so we need to create a new Legislation
           // each time. We need to fix this, but in the interests of getting

--- a/src/qualifications/presenters/qualification.presenter.spec.ts
+++ b/src/qualifications/presenters/qualification.presenter.spec.ts
@@ -8,51 +8,13 @@ import { translationOf } from '../../testutils/translation-of';
 jest.mock('../../helpers/format-multiline-string.helper');
 
 describe(QualificationPresenter, () => {
-  describe('routesToObtain', () => {
-    it('returns the a multiline string of the text value', () => {
-      (formatMultilineString as jest.Mock).mockImplementation(multilineOf);
+  describe('when the Qualification is defined', () => {
+    describe('routesToObtain', () => {
+      it('returns the a multiline string of the text value', () => {
+        (formatMultilineString as jest.Mock).mockImplementation(multilineOf);
 
-      const qualification = qualificationFactory.build({
-        routesToObtain: 'other value',
-      });
-
-      const presenter = new QualificationPresenter(
-        qualification,
-        createMockI18nService(),
-      );
-
-      expect(presenter.routesToObtain).toEqual(multilineOf('other value'));
-
-      expect(formatMultilineString).toBeCalledWith('other value');
-    });
-  });
-
-  describe('mostCommonRouteToObtain', () => {
-    it('returns the a multiline string of the text value', () => {
-      (formatMultilineString as jest.Mock).mockImplementation(multilineOf);
-
-      const qualification = qualificationFactory.build({
-        mostCommonRouteToObtain: 'other value',
-      });
-
-      const presenter = new QualificationPresenter(
-        qualification,
-        createMockI18nService(),
-      );
-
-      expect(presenter.mostCommonRouteToObtain).toEqual(
-        multilineOf('other value'),
-      );
-
-      expect(formatMultilineString).toBeCalledWith('other value');
-    });
-  });
-
-  describe('mandatoryProfessionalExperience', () => {
-    describe('when true', () => {
-      it('returns the localisation id for "Yes"', () => {
         const qualification = qualificationFactory.build({
-          mandatoryProfessionalExperience: true,
+          routesToObtain: 'other value',
         });
 
         const presenter = new QualificationPresenter(
@@ -60,14 +22,18 @@ describe(QualificationPresenter, () => {
           createMockI18nService(),
         );
 
-        expect(presenter.mandatoryProfessionalExperience).toEqual('app.yes');
+        expect(presenter.routesToObtain).toEqual(multilineOf('other value'));
+
+        expect(formatMultilineString).toBeCalledWith('other value');
       });
     });
 
-    describe('when false', () => {
-      it('returns the localisation id for "No"', () => {
+    describe('mostCommonRouteToObtain', () => {
+      it('returns the a multiline string of the text value', () => {
+        (formatMultilineString as jest.Mock).mockImplementation(multilineOf);
+
         const qualification = qualificationFactory.build({
-          mandatoryProfessionalExperience: false,
+          mostCommonRouteToObtain: 'other value',
         });
 
         const presenter = new QualificationPresenter(
@@ -75,109 +41,162 @@ describe(QualificationPresenter, () => {
           createMockI18nService(),
         );
 
-        expect(presenter.mandatoryProfessionalExperience).toEqual('app.no');
+        expect(presenter.mostCommonRouteToObtain).toEqual(
+          multilineOf('other value'),
+        );
+
+        expect(formatMultilineString).toBeCalledWith('other value');
       });
     });
 
-    describe('when not set at all on a blank Qualification', () => {
-      it('returns an empty string', () => {
-        const qualification = qualificationFactory.build({
-          mandatoryProfessionalExperience: null,
+    describe('mandatoryProfessionalExperience', () => {
+      describe('when true', () => {
+        it('returns the localisation id for "Yes"', () => {
+          const qualification = qualificationFactory.build({
+            mandatoryProfessionalExperience: true,
+          });
+
+          const presenter = new QualificationPresenter(
+            qualification,
+            createMockI18nService(),
+          );
+
+          expect(presenter.mandatoryProfessionalExperience).toEqual('app.yes');
         });
-
-        const presenter = new QualificationPresenter(
-          qualification,
-          createMockI18nService(),
-        );
-
-        expect(presenter.mandatoryProfessionalExperience).toEqual('');
       });
-    });
-  });
 
-  describe('moreInformationUrl', () => {
-    describe('when a blank string is provided', () => {
-      it('returns null', () => {
-        const qualification = qualificationFactory.build({
-          url: '',
+      describe('when false', () => {
+        it('returns the localisation id for "No"', () => {
+          const qualification = qualificationFactory.build({
+            mandatoryProfessionalExperience: false,
+          });
+
+          const presenter = new QualificationPresenter(
+            qualification,
+            createMockI18nService(),
+          );
+
+          expect(presenter.mandatoryProfessionalExperience).toEqual('app.no');
         });
-
-        const presenter = new QualificationPresenter(
-          qualification,
-          createMockI18nService(),
-        );
-
-        expect(presenter.moreInformationUrl).toEqual(null);
       });
-    });
-    describe('when a URL is provided', () => {
-      it('returns a link', () => {
-        const qualification = qualificationFactory.build({
-          url: 'http://example.com',
+
+      describe('when not set at all on a blank Qualification', () => {
+        it('returns an empty string', () => {
+          const qualification = qualificationFactory.build({
+            mandatoryProfessionalExperience: null,
+          });
+
+          const presenter = new QualificationPresenter(
+            qualification,
+            createMockI18nService(),
+          );
+
+          expect(presenter.mandatoryProfessionalExperience).toEqual('');
         });
-
-        const presenter = new QualificationPresenter(
-          qualification,
-          createMockI18nService(),
-        );
-
-        expect(presenter.moreInformationUrl).toEqual(
-          '<a class="govuk-link" href="http://example.com">http://example.com</a>',
-        );
       });
     });
-  });
 
-  describe('ukRecognitionUrl', () => {
-    describe('when a blank string is provided', () => {
-      it('returns null', () => {
-        const qualification = qualificationFactory.build({
-          ukRecognitionUrl: '',
+    describe('moreInformationUrl', () => {
+      describe('when a blank string is provided', () => {
+        it('returns null', () => {
+          const qualification = qualificationFactory.build({
+            url: '',
+          });
+
+          const presenter = new QualificationPresenter(
+            qualification,
+            createMockI18nService(),
+          );
+
+          expect(presenter.moreInformationUrl).toEqual(null);
         });
-
-        const presenter = new QualificationPresenter(
-          qualification,
-          createMockI18nService(),
-        );
-
-        expect(presenter.ukRecognitionUrl).toEqual(null);
       });
-    });
-    describe('when a URL is provided', () => {
-      it('returns a link', () => {
-        const qualification = qualificationFactory.build({
-          ukRecognitionUrl: 'http://example.com',
+      describe('when a URL is provided', () => {
+        it('returns a link', () => {
+          const qualification = qualificationFactory.build({
+            url: 'http://example.com',
+          });
+
+          const presenter = new QualificationPresenter(
+            qualification,
+            createMockI18nService(),
+          );
+
+          expect(presenter.moreInformationUrl).toEqual(
+            '<a class="govuk-link" href="http://example.com">http://example.com</a>',
+          );
         });
-
-        const presenter = new QualificationPresenter(
-          qualification,
-          createMockI18nService(),
-        );
-
-        expect(presenter.ukRecognitionUrl).toEqual(
-          '<a class="govuk-link" href="http://example.com">http://example.com</a>',
-        );
       });
     });
-  });
 
-  describe('otherCountriesRecognitionUrl', () => {
-    describe('when a blank string is provided', () => {
-      it('returns null', () => {
-        const qualification = qualificationFactory.build({
-          otherCountriesRecognitionUrl: '',
+    describe('ukRecognitionUrl', () => {
+      describe('when a blank string is provided', () => {
+        it('returns null', () => {
+          const qualification = qualificationFactory.build({
+            ukRecognitionUrl: '',
+          });
+
+          const presenter = new QualificationPresenter(
+            qualification,
+            createMockI18nService(),
+          );
+
+          expect(presenter.ukRecognitionUrl).toEqual(null);
         });
+      });
+      describe('when a URL is provided', () => {
+        it('returns a link', () => {
+          const qualification = qualificationFactory.build({
+            ukRecognitionUrl: 'http://example.com',
+          });
 
-        const presenter = new QualificationPresenter(
-          qualification,
-          createMockI18nService(),
-        );
+          const presenter = new QualificationPresenter(
+            qualification,
+            createMockI18nService(),
+          );
 
-        expect(presenter.otherCountriesRecognitionUrl).toEqual(null);
+          expect(presenter.ukRecognitionUrl).toEqual(
+            '<a class="govuk-link" href="http://example.com">http://example.com</a>',
+          );
+        });
       });
     });
-    describe('when a URL is provided', () => {
-      it('returns a link', () => {
+
+    describe('otherCountriesRecognitionUrl', () => {
+      describe('when a blank string is provided', () => {
+        it('returns null', () => {
+          const qualification = qualificationFactory.build({
+            otherCountriesRecognitionUrl: '',
+          });
+
+          const presenter = new QualificationPresenter(
+            qualification,
+            createMockI18nService(),
+          );
+
+          expect(presenter.otherCountriesRecognitionUrl).toEqual(null);
+        });
+      });
+      describe('when a URL is provided', () => {
+        it('returns a link', () => {
+          const qualification = qualificationFactory.build({
+            otherCountriesRecognitionUrl: 'http://example.com',
+          });
+
+          const presenter = new QualificationPresenter(
+            qualification,
+            createMockI18nService(),
+          );
+
+          expect(presenter.otherCountriesRecognitionUrl).toEqual(
+            '<a class="govuk-link" href="http://example.com">http://example.com</a>',
+          );
+        });
+      });
+    });
+
+    describe('summaryList', () => {
+      it('returns a summary list of all Qualification fields', async () => {
         const qualification = qualificationFactory.build({
           otherCountriesRecognitionUrl: 'http://example.com',
         });
@@ -187,85 +206,91 @@ describe(QualificationPresenter, () => {
           createMockI18nService(),
         );
 
-        expect(presenter.otherCountriesRecognitionUrl).toEqual(
-          '<a class="govuk-link" href="http://example.com">http://example.com</a>',
-        );
+        expect(presenter.summaryList()).resolves.toEqual({
+          classes: 'govuk-summary-list--no-border',
+          rows: [
+            {
+              key: {
+                text: translationOf('professions.show.qualification.level'),
+              },
+              value: {
+                html: formatMultilineString(presenter.level),
+              },
+            },
+            {
+              key: {
+                text: translationOf(
+                  'professions.show.qualification.routesToObtain',
+                ),
+              },
+              value: {
+                html: presenter.routesToObtain,
+              },
+            },
+            {
+              key: {
+                text: translationOf(
+                  'professions.show.qualification.mostCommonRouteToObtain',
+                ),
+              },
+              value: {
+                html: presenter.mostCommonRouteToObtain,
+              },
+            },
+            {
+              key: {
+                text: translationOf('professions.show.qualification.duration'),
+              },
+              value: {
+                text: presenter.duration,
+              },
+            },
+            {
+              key: {
+                text: translationOf(
+                  'professions.show.qualification.mandatoryExperience',
+                ),
+              },
+              value: {
+                text: translationOf(presenter.mandatoryProfessionalExperience),
+              },
+            },
+            {
+              key: {
+                text: translationOf(
+                  'professions.show.qualification.moreInformationUrl',
+                ),
+              },
+              value: {
+                html: presenter.moreInformationUrl,
+              },
+            },
+          ],
+        });
       });
     });
   });
 
-  describe('summaryList', () => {
-    it('returns a summary list of all Qualification fields', async () => {
-      const qualification = qualificationFactory.build({
-        otherCountriesRecognitionUrl: 'http://example.com',
-      });
+  describe('when the Qualification is undefined', () => {
+    it('presents empty values', () => {
+      (formatMultilineString as jest.Mock).mockImplementation(multilineOf);
 
-      const presenter = new QualificationPresenter(
-        qualification,
-        createMockI18nService(),
+      expect(
+        new QualificationPresenter(undefined, createMockI18nService()),
+      ).toEqual(
+        expect.objectContaining({
+          duration: undefined,
+          level: undefined,
+          moreInformationUrl: null,
+          mostCommonRouteToObtain: multilineOf(undefined),
+          otherCountriesRecognition: undefined,
+          otherCountriesRecognitionUrl: null,
+          qualification: undefined,
+          routesToObtain: multilineOf(undefined),
+          ukRecognition: undefined,
+          ukRecognitionUrl: null,
+        }),
       );
-
-      expect(presenter.summaryList()).resolves.toEqual({
-        classes: 'govuk-summary-list--no-border',
-        rows: [
-          {
-            key: {
-              text: translationOf('professions.show.qualification.level'),
-            },
-            value: {
-              html: formatMultilineString(presenter.level),
-            },
-          },
-          {
-            key: {
-              text: translationOf(
-                'professions.show.qualification.routesToObtain',
-              ),
-            },
-            value: {
-              html: presenter.routesToObtain,
-            },
-          },
-          {
-            key: {
-              text: translationOf(
-                'professions.show.qualification.mostCommonRouteToObtain',
-              ),
-            },
-            value: {
-              html: presenter.mostCommonRouteToObtain,
-            },
-          },
-          {
-            key: {
-              text: translationOf('professions.show.qualification.duration'),
-            },
-            value: {
-              text: presenter.duration,
-            },
-          },
-          {
-            key: {
-              text: translationOf(
-                'professions.show.qualification.mandatoryExperience',
-              ),
-            },
-            value: {
-              text: translationOf(presenter.mandatoryProfessionalExperience),
-            },
-          },
-          {
-            key: {
-              text: translationOf(
-                'professions.show.qualification.moreInformationUrl',
-              ),
-            },
-            value: {
-              html: presenter.moreInformationUrl,
-            },
-          },
-        ],
-      });
     });
   });
 

--- a/src/qualifications/presenters/qualification.presenter.ts
+++ b/src/qualifications/presenters/qualification.presenter.ts
@@ -9,19 +9,24 @@ export default class QualificationPresenter {
     private readonly i18nService: I18nService,
   ) {}
 
-  readonly level = this.qualification.level;
+  readonly level = this.qualification && this.qualification.level;
 
   readonly routesToObtain = formatMultilineString(
-    this.qualification.routesToObtain,
+    this.qualification && this.qualification.routesToObtain,
   );
 
   readonly mostCommonRouteToObtain = formatMultilineString(
-    this.qualification.mostCommonRouteToObtain,
+    this.qualification && this.qualification.mostCommonRouteToObtain,
   );
 
-  readonly duration = this.qualification.educationDuration;
+  readonly duration =
+    this.qualification && this.qualification.educationDuration;
 
   get mandatoryProfessionalExperience(): string {
+    if (!this.qualification) {
+      return '';
+    }
+
     if (this.qualification.mandatoryProfessionalExperience === null) {
       return '';
     }
@@ -31,29 +36,32 @@ export default class QualificationPresenter {
       : 'app.no';
   }
 
-  readonly moreInformationUrl = this.qualification.url
-    ? `<a class="govuk-link" href="${escape(this.qualification.url)}">${escape(
-        this.qualification.url,
-      )}</a>`
-    : null;
+  readonly moreInformationUrl =
+    this.qualification && this.qualification.url
+      ? `<a class="govuk-link" href="${escape(
+          this.qualification.url,
+        )}">${escape(this.qualification.url)}</a>`
+      : null;
 
-  readonly ukRecognition = this.qualification.ukRecognition;
+  readonly ukRecognition =
+    this.qualification && this.qualification.ukRecognition;
 
-  readonly ukRecognitionUrl = this.qualification.ukRecognitionUrl
-    ? `<a class="govuk-link" href="${escape(
-        this.qualification.ukRecognitionUrl,
-      )}">${escape(this.qualification.ukRecognitionUrl)}</a>`
-    : null;
+  readonly ukRecognitionUrl =
+    this.qualification && this.qualification.ukRecognitionUrl
+      ? `<a class="govuk-link" href="${escape(
+          this.qualification.ukRecognitionUrl,
+        )}">${escape(this.qualification.ukRecognitionUrl)}</a>`
+      : null;
 
   readonly otherCountriesRecognition =
-    this.qualification.otherCountriesRecognition;
+    this.qualification && this.qualification.otherCountriesRecognition;
 
-  readonly otherCountriesRecognitionUrl = this.qualification
-    .otherCountriesRecognitionUrl
-    ? `<a class="govuk-link" href="${escape(
-        this.qualification.otherCountriesRecognitionUrl,
-      )}">${escape(this.qualification.otherCountriesRecognitionUrl)}</a>`
-    : null;
+  readonly otherCountriesRecognitionUrl =
+    this.qualification && this.qualification.otherCountriesRecognitionUrl
+      ? `<a class="govuk-link" href="${escape(
+          this.qualification.otherCountriesRecognitionUrl,
+        )}">${escape(this.qualification.otherCountriesRecognitionUrl)}</a>`
+      : null;
 
   async summaryList(): Promise<SummaryList> {
     return {

--- a/src/testutils/factories/profession-version.ts
+++ b/src/testutils/factories/profession-version.ts
@@ -25,6 +25,8 @@ class ProfessionVersionFactory extends Factory<ProfessionVersion> {
       qualification: undefined,
       legislations: undefined,
       reservedActivities: undefined,
+      protectedTitles: undefined,
+      regulationUrl: undefined,
       profession: undefined,
       user: undefined,
       keywords: undefined,
@@ -47,7 +49,6 @@ export default ProfessionVersionFactory.define(({ sequence }) => ({
   industries: [
     industryFactory.build({ name: 'Example industry', id: 'example-industry' }),
   ],
-  qualifications: [],
   qualification: qualificationFactory.build(),
   legislations: legislationFactory.buildList(1),
   regulationSummary: 'Example summary',

--- a/views/admin/professions/check-your-answers.njk
+++ b/views/admin/professions/check-your-answers.njk
@@ -144,7 +144,7 @@
                   text: ("professions.form.label.registration.mandatoryRegistration" | t)
                 },
                 value: {
-                  text: ("professions.mandatoryRegistration." + mandatoryRegistration) | t
+                  text: (("professions.mandatoryRegistration." + mandatoryRegistration) | t) if mandatoryRegistration else ''
                 },
                 actions: {
                   items: [


### PR DESCRIPTION
# Changes in this PR

This PR is mostly to ensure that pages do not throw an error if data is missing from a profession.

Some E2E testing is included, though this is limited, as there is currently no "natural" way to add a profession with minimal data

## Screenshots of UI changes

![localhost_3000_admin_professions_328a5d4c-6fa3-441d-a2fb-83d84d538298_versions_ed88f0cd-e81e-4e72-bc5c-a418f59e03da_check-your-answers_edit=true](https://user-images.githubusercontent.com/94137563/155323620-9e32febf-cfa0-4ac6-9ca5-51bd0758275f.png)

