### PR TITLE
Add basic auth

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,6 +48,8 @@ jobs:
       TF_VAR_notify_template_id: ${{ secrets.PROD_NOTIFY_TEMPLATE_ID }}
       TF_VAR_notify_api_key: ${{ secrets.PROD_NOTIFY_API_KEY }}
       TF_VAR_rollbar_token: ${{ secrets.PROD_ROLLBAR_TOKEN }}
+      TF_VAR_basic_auth_username: ${{ secrets.PROD_BASIC_AUTH_USERNAME }}
+      TF_VAR_basic_auth_password: ${{ secrets.PROD_BASIC_AUTH_PASSWORD }}
     steps:
       - uses: actions/checkout@v2
       - name: Deploy latest code to Production
@@ -71,6 +73,8 @@ jobs:
       TF_VAR_notify_template_id: ${{ secrets.STAGING_NOTIFY_TEMPLATE_ID }}
       TF_VAR_notify_api_key: ${{ secrets.STAGING_NOTIFY_API_KEY }}
       TF_VAR_rollbar_token: ${{ secrets.STAGING_ROLLBAR_TOKEN }}
+      TF_VAR_basic_auth_username: ${{ secrets.STAGING_BASIC_AUTH_USERNAME }}
+      TF_VAR_basic_auth_password: ${{ secrets.STAGING_BASIC_AUTH_PASSWORD }}
     steps:
       - uses: actions/checkout@v2
       - name: Deploy latest code to Staging

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "class-validator": "^0.13.2",
         "connect-flash": "^0.1.1",
         "date-fns": "^2.28.0",
+        "express-basic-auth": "^1.2.1",
         "express-openid-connect": "^2.7.0",
         "express-session": "^1.17.2",
         "file-loader": "^6.2.0",
@@ -5020,6 +5021,17 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/basic-auth": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
+      "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
+      "dependencies": {
+        "safe-buffer": "5.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/batch": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
@@ -8904,6 +8916,14 @@
       },
       "engines": {
         "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/express-basic-auth": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/express-basic-auth/-/express-basic-auth-1.2.1.tgz",
+      "integrity": "sha512-L6YQ1wQ/mNjVLAmK3AG1RK6VkokA1BIY6wmiH304Xtt/cLTps40EusZsU1Uop+v9lTDPxdtzbFmdXfFO3KEnwA==",
+      "dependencies": {
+        "basic-auth": "^2.0.1"
       }
     },
     "node_modules/express-openid-connect": {
@@ -22761,6 +22781,14 @@
       "resolved": "https://registry.npmjs.org/base64url/-/base64url-3.0.1.tgz",
       "integrity": "sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A=="
     },
+    "basic-auth": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
+      "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
+      "requires": {
+        "safe-buffer": "5.1.2"
+      }
+    },
     "batch": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
@@ -25785,6 +25813,14 @@
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
           "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
         }
+      }
+    },
+    "express-basic-auth": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/express-basic-auth/-/express-basic-auth-1.2.1.tgz",
+      "integrity": "sha512-L6YQ1wQ/mNjVLAmK3AG1RK6VkokA1BIY6wmiH304Xtt/cLTps40EusZsU1Uop+v9lTDPxdtzbFmdXfFO3KEnwA==",
+      "requires": {
+        "basic-auth": "^2.0.1"
       }
     },
     "express-openid-connect": {

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "class-validator": "^0.13.2",
     "connect-flash": "^0.1.1",
     "date-fns": "^2.28.0",
+    "express-basic-auth": "^1.2.1",
     "express-openid-connect": "^2.7.0",
     "express-session": "^1.17.2",
     "file-loader": "^6.2.0",

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,6 +7,7 @@ import path from 'path';
 import session from 'express-session';
 import methodOverride from 'method-override';
 import connectFlash from 'connect-flash';
+import basicAuth from 'express-basic-auth';
 
 import { AppModule } from './app.module';
 import { AuthenticationMidleware } from './middleware/authentication.middleware';
@@ -62,6 +63,23 @@ async function bootstrap() {
 
   // Add global variables to the application to be used in the templates
   app.use(globalLocals);
+
+  // Add basic auth to the application if the environment variables are set
+  if (
+    process.env['BASIC_AUTH_USERNAME'] &&
+    process.env['BASIC_AUTH_PASSWORD']
+  ) {
+    app.use(
+      basicAuth({
+        users: {
+          [process.env['BASIC_AUTH_USERNAME']]:
+            process.env['BASIC_AUTH_PASSWORD'],
+        },
+        challenge: true,
+        realm: process.env['HOST_URL'],
+      }),
+    );
+  }
 
   await app.listen(process.env.PORT || 3000);
 }

--- a/terraform/app.tf
+++ b/terraform/app.tf
@@ -27,6 +27,8 @@ resource "cloudfoundry_app" "beis-rpr-app" {
     "NOTIFY_API_KEY"      = var.notify_api_key
     "ENVIRONMENT"         = var.environment
     "ROLLBAR_TOKEN"       = var.rollbar_token
+    "BASIC_AUTH_USERNAME" = var.basic_auth_username
+    "BASIC_AUTH_PASSWORD" = var.basic_auth_password
   }
   # routes need to be declared with the app for blue green deployments to work
   routes {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -67,3 +67,14 @@ variable "rollbar_token" {
   type = string
   description = "The access token to use when sending Rollbar errors"
 }
+
+variable "basic_auth_username" {
+  type = string
+  description = "The username we use for basic authentication if we want to hide the site from the public"
+}
+
+variable "basic_auth_password" {
+  type = string
+  description = "The password we use for basic authentication if we want to hide the site from the public"
+}
+


### PR DESCRIPTION
This adds basic auth to apps that have the `BASIC_AUTH_USERNAME` and `BASIC_AUTH_PASSWORD` environment vars set - protecting sites that aren't live from prying eyes and preventing potentially incorrect information from leaking out. 

The usernames and passwords are saved as actions secrets and accessible in 1Password. This should not be merged until we've communicated the username/passwords to the client.