### PR TITLE
Release 005

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+### Changed
+
+## [release-005] - 2022-02-24
+
+### Added
+
 - Add "more information url" to Qualification detail entry page
 - Display message in search results when no professions match filter criteria
 - Add a confirmation page before publishing an organisation or a profession
@@ -124,6 +130,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Make validation errors more human readable
 
 [unreleased]: https://github.com/UKGovernmentBEIS/regulated-professions-register/compare/release-003...HEAD
+[release-005]: https://github.com/UKGovernmentBEIS/regulated-professions-register/compare/release004...release-005
+[release-004]: https://github.com/UKGovernmentBEIS/regulated-professions-register/compare/release003...release-004
 [release-003]: https://github.com/UKGovernmentBEIS/regulated-professions-register/compare/release002...release-003
 [release-002]: https://github.com/UKGovernmentBEIS/regulated-professions-register/compare/release001...release-002
 [release-001]: https://github.com/UKGovernmentBEIS/regulated-professions-register/compare/release...release-001


### PR DESCRIPTION
### Added

- Add "more information url" to Qualification detail entry page
- Display message in search results when no professions match filter criteria
- Add a confirmation page before publishing an organisation or a profession

### Changed

- Replace routes to obtain Qualification & most common path to obtain radio buttons with textareas
- Remove Qualification Level from admin organisation list
- Remove deprecated fields from Qualification
- Move Sectors filter above the Nations filter
- Allow admin users to edit blank Qualifications when no values have been set from a data import
- Remove confirmation screens when creating new entities
- Update labels and hint text for admin profession screens

<!-- Do you need to update the changelog? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR

## Screenshots of UI changes

### Before

### After
