### PR TITLE
Add the username and password to the health check

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -89,4 +89,5 @@ jobs:
       - name: Notifying the team of a successful deploy
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          HEALTH_CHECK_URL: https://${{ secrets.PROD_BASIC_AUTH_USERNAME }}:${{ secrets.PROD_BASIC_AUTH_PASSWORD }}@beis-rpr-prod.london.cloudapps.digital/health-check
         run: script/deploy-notification

--- a/script/deploy-notification
+++ b/script/deploy-notification
@@ -6,7 +6,7 @@ current_sha=$(git rev-parse HEAD)
 while :
 do
   printf "."
-  deployed_sha=$(curl -s https://beis-rpr-prod.london.cloudapps.digital/health-check | jq -r '.git_sha')
+  deployed_sha=$(curl -s "$HEALTH_CHECK_URL" | jq -r '.git_sha')
   if [ "$deployed_sha" = "$current_sha" ]; then
     break
   fi


### PR DESCRIPTION
At the moment the deploy notification times out because we’re not specifying the username/password