### PR TITLE
(2117) Admin-facing accessibility fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Show a confirmation banner when publishing entities
 - Change order of data entry when creating a profession, so name and organisation(s) are inputted first
 - Only service administrators and registrars may edit the top-level information of a profession
+- Replace paragraph tags with captions in tables
+- Stop tables overflowing when zoomed in
 
 ## [release-003] - 2022-02-16
 

--- a/assets/stylesheets/application.scss
+++ b/assets/stylesheets/application.scss
@@ -78,6 +78,10 @@ $govuk-assets-path: '~govuk-frontend/govuk/assets/';
     }
   }
 
+  &__table-container {
+    overflow-x: scroll;
+  }
+
   &-listing {
     &__filter {
       background-color: govuk-colour('white');

--- a/src/common/interfaces/table.ts
+++ b/src/common/interfaces/table.ts
@@ -4,4 +4,6 @@ export interface Table {
   firstCellIsHeader?: boolean;
   head: TableRow;
   rows: TableRow[];
+  caption?: string;
+  captionClasses?: string;
 }

--- a/src/i18n/en/organisations.json
+++ b/src/i18n/en/organisations.json
@@ -8,8 +8,8 @@
       "keywords": "Keywords:",
       "industries": "Industries:"
     },
-    "foundSingular": "regulatory authorities found.",
-    "foundPlural": "regulatory authorities found.",
+    "foundSingular": "{count} regulatory authority found",
+    "foundPlural": "{count} regulatory authorities found",
     "filter": {
       "keywords": {
         "label": "Keyword",

--- a/src/i18n/en/organisations.json
+++ b/src/i18n/en/organisations.json
@@ -3,6 +3,7 @@
     "heading": "Regulatory authorities",
     "manageHeading": "Manage existing regulatory authorities",
     "showFilters": "Show filters",
+    "viewDetails": "View details <span class='govuk-visually-hidden'>about {name}</span>",
     "labels": {
       "keywords": "Keywords:",
       "industries": "Industries:"

--- a/src/i18n/en/professions.json
+++ b/src/i18n/en/professions.json
@@ -327,7 +327,7 @@
       "by": "Changed by",
       "on": "Last updated"
     },
-    "viewDetails": "View details"
+    "viewDetails": "View details <span class='govuk-visually-hidden'>about {name}</span>"
   },
   "search": {
     "heading": "Find a regulated profession",

--- a/src/i18n/en/professions.json
+++ b/src/i18n/en/professions.json
@@ -262,8 +262,8 @@
       "industries": "Industries:",
       "changedBy": "Changed by:"
     },
-    "foundSingular": "profession found.",
-    "foundPlural": "professions found.",
+    "foundSingular": "{count} profession found",
+    "foundPlural": "{count} professions found",
     "filter": {
       "keywords": {
         "label": "Keyword",
@@ -340,8 +340,6 @@
       "regulators": "Regulators",
       "industry": "Sectors"
     },
-    "foundSingular": "profession found.",
-    "foundPlural": "professions found.",
     "filter": {
       "keywords": {
         "label": "Profession that you are looking for",

--- a/src/organisations/admin/presenters/organisations.presenter.spec.ts
+++ b/src/organisations/admin/presenters/organisations.presenter.spec.ts
@@ -173,5 +173,79 @@ describe('OrganisationsPresenter', () => {
         });
       });
     });
+
+    describe('caption', () => {
+      describe('when only one organisation is found', () => {
+        it('uses the singular text for a caption', async () => {
+          mockTableRow.mockReturnValue([
+            {
+              text: 'Some text',
+            },
+          ]);
+
+          mockCheckboxItems.mockReturnValue([
+            {
+              text: 'Some text',
+              value: 'Some value',
+              checked: true,
+            },
+          ]);
+
+          const i18nService = createMockI18nService();
+          const industries = industryFactory.buildList(3);
+          const filterInput: FilterInput = {};
+
+          const foundOrganisations = organisationFactory.buildList(1);
+
+          const presenter = new OrganisationsPresenter(
+            industries,
+            filterInput,
+            foundOrganisations,
+            i18nService,
+          );
+          const result = await presenter.present();
+
+          expect(result.organisationsTable.caption).toEqual(
+            `${translationOf('organisations.admin.foundSingular')}`,
+          );
+        });
+      });
+
+      describe('when more than one profession is found', () => {
+        it('uses the plural text', async () => {
+          mockTableRow.mockReturnValue([
+            {
+              text: 'Some text',
+            },
+          ]);
+
+          mockCheckboxItems.mockReturnValue([
+            {
+              text: 'Some text',
+              value: 'Some value',
+              checked: true,
+            },
+          ]);
+
+          const i18nService = createMockI18nService();
+          const industries = industryFactory.buildList(3);
+          const filterInput: FilterInput = {};
+
+          const foundOrganisations = organisationFactory.buildList(5);
+
+          const presenter = new OrganisationsPresenter(
+            industries,
+            filterInput,
+            foundOrganisations,
+            i18nService,
+          );
+          const result = await presenter.present();
+
+          expect(result.organisationsTable.caption).toEqual(
+            `${translationOf('organisations.admin.foundPlural')}`,
+          );
+        });
+      });
+    });
   });
 });

--- a/src/organisations/admin/presenters/organisations.presenter.ts
+++ b/src/organisations/admin/presenters/organisations.presenter.ts
@@ -54,18 +54,34 @@ export class OrganisationsPresenter {
   }
 
   private async table(firstCellIsHeader = true): Promise<Table> {
+    const rows = await Promise.all(
+      this.filteredOrganisations.map(
+        async (organisation) =>
+          await new OrganisationPresenter(
+            organisation,
+            this.i18nService,
+          ).tableRow(),
+      ),
+    );
+
+    const numberOfResults = rows.length;
+
+    const caption =
+      numberOfResults === 1
+        ? await this.i18nService.translate(
+            'organisations.admin.foundSingular',
+            { args: { count: numberOfResults } },
+          )
+        : await this.i18nService.translate('organisations.admin.foundPlural', {
+            args: { count: numberOfResults },
+          });
+
     return {
+      caption,
+      captionClasses: 'govuk-table__caption--m',
       firstCellIsHeader: firstCellIsHeader,
       head: await this.headers(),
-      rows: await Promise.all(
-        this.filteredOrganisations.map(
-          async (organisation) =>
-            await new OrganisationPresenter(
-              organisation,
-              this.i18nService,
-            ).tableRow(),
-        ),
-      ),
+      rows: rows,
     };
   }
 

--- a/src/organisations/presenters/organisation.presenter.spec.ts
+++ b/src/organisations/presenters/organisation.presenter.spec.ts
@@ -15,6 +15,7 @@ import { formatMultilineString } from '../../helpers/format-multiline-string.hel
 import { multilineOf } from '../../testutils/multiline-of';
 import userFactory from '../../testutils/factories/user';
 import { formatDate } from '../../common/utils';
+import { translationOf } from '../../testutils/translation-of';
 
 jest.mock('../../helpers/escape.helper');
 jest.mock('../../helpers/format-multiline-string.helper');
@@ -71,12 +72,11 @@ describe('OrganisationPresenter', () => {
           });
           expect(tableRow[6]).toEqual({
             html: expect.stringContaining(
-              `<a class="govuk-link" href="/admin/organisations/${organisation.id}/versions/${organisation.versionId}">`,
-            ),
-          });
-          expect(tableRow[6]).toEqual({
-            html: expect.stringContaining(
-              `about ${escapeOf(organisation.name)}`,
+              `<a class="govuk-link" href="/admin/organisations/${
+                organisation.id
+              }/versions/${organisation.versionId}">${translationOf(
+                'organisations.admin.viewDetails',
+              )}`,
             ),
           });
 

--- a/src/organisations/presenters/organisation.presenter.ts
+++ b/src/organisations/presenters/organisation.presenter.ts
@@ -47,11 +47,12 @@ export class OrganisationPresenter {
       {
         html: `<a class="govuk-link" href="/admin/organisations/${
           this.organisation.id
-        }/versions/${this.organisation.versionId}">
-          View details
-          <span class="govuk-visually-hidden">
-            about ${escape(this.organisation.name)}
-          </span>
+        }/versions/${
+          this.organisation.versionId
+        }">${await this.i18nService.translate(
+          'organisations.admin.viewDetails',
+          { args: { name: escape(this.organisation.name) } },
+        )}
         </a>`,
       },
     ];

--- a/src/professions/admin/interfaces/index-template.interface.ts
+++ b/src/professions/admin/interfaces/index-template.interface.ts
@@ -1,5 +1,5 @@
 import { CheckboxItems } from 'src/common/interfaces/checkbox-items.interface';
-import { TableRow } from 'src/common/interfaces/table-row';
+import { Table } from '../../../common/interfaces/table';
 import { ProfessionsPresenterView } from '../professions.presenter';
 
 export interface IndexTemplate {
@@ -7,8 +7,7 @@ export interface IndexTemplate {
 
   organisation: string;
 
-  headings: TableRow;
-  professions: TableRow[];
+  professionsTable: Table;
 
   filters: {
     keywords: string;

--- a/src/professions/admin/list-entry.presenter.ts
+++ b/src/professions/admin/list-entry.presenter.ts
@@ -1,6 +1,7 @@
 import { I18nService } from 'nestjs-i18n';
 import { TableCell } from '../../common/interfaces/table-cell';
 import { TableRow } from '../../common/interfaces/table-row';
+import { escape } from '../../helpers/escape.helper';
 import { stringifyNations } from '../../nations/helpers/stringifyNations';
 import { Nation } from '../../nations/nation';
 import { ProfessionPresenter } from '../presenters/profession.presenter';
@@ -84,6 +85,7 @@ export class ListEntryPresenter {
       this.profession.id
     }/versions/${this.profession.versionId}">${await this.i18nService.translate(
       'professions.admin.viewDetails',
+      { args: { name: escape(this.profession.name) } },
     )}</a>`;
 
     const entries: { [K in Field]: TableCell } = {

--- a/src/professions/admin/professions.presenter.spec.ts
+++ b/src/professions/admin/professions.presenter.spec.ts
@@ -95,6 +95,8 @@ describe('ProfessionsPresenter', () => {
         view: 'overview',
         organisation: 'UK Centre for Professional Qualifications',
         professionsTable: {
+          caption: `${translationOf('professions.admin.foundPlural')}`,
+          captionClasses: 'govuk-table__caption--m',
           firstCellIsHeader: true,
           head: await ListEntryPresenter.headings(i18nService, 'overview'),
           rows: await Promise.all(
@@ -142,6 +144,8 @@ describe('ProfessionsPresenter', () => {
         view: 'single-organisation',
         organisation: 'Example Organisation 1',
         professionsTable: {
+          caption: `${translationOf('professions.admin.foundPlural')}`,
+          captionClasses: 'govuk-table__caption--m',
           firstCellIsHeader: true,
           head: await ListEntryPresenter.headings(
             i18nService,
@@ -180,6 +184,74 @@ describe('ProfessionsPresenter', () => {
       };
 
       expect(result).toEqual(expected);
+    });
+
+    describe('captions', () => {
+      describe('when only one profession is found', () => {
+        it('returns the singular professions found text', async () => {
+          const i18nService = createMockI18nService();
+          const industries = industryFactory.buildList(3);
+          const filterInput: FilterInput = {};
+
+          const organisation = organisationFactory.build({
+            id: 'example-organisation',
+            name: 'Example Organisation',
+          });
+
+          const organisations = [organisation, organisationFactory.build()];
+
+          const foundProfessions = professionFactory.buildList(1);
+
+          const presenter = new ProfessionsPresenter(
+            filterInput,
+            organisation,
+            Nation.all(),
+            organisations,
+            industries,
+            foundProfessions,
+            i18nService,
+          );
+
+          const result = await presenter.present('overview');
+
+          expect(result.professionsTable.caption).toEqual(
+            `${translationOf('professions.admin.foundSingular')}`,
+          );
+        });
+      });
+
+      describe('when more than one profession is found', () => {
+        it('returns the singular professions found text', async () => {
+          const i18nService = createMockI18nService();
+          const industries = industryFactory.buildList(3);
+          const filterInput: FilterInput = {};
+
+          const organisation = organisationFactory.build({
+            id: 'example-organisation',
+            name: 'Example Organisation',
+          });
+
+          const organisations = [organisation, organisationFactory.build()];
+
+          const foundProfessions = professionFactory.buildList(3);
+
+          const presenter = new ProfessionsPresenter(
+            filterInput,
+            organisation,
+            Nation.all(),
+            organisations,
+            industries,
+            foundProfessions,
+            i18nService,
+          );
+
+          const result = await presenter.present('overview');
+
+          expect(result.professionsTable.caption).toEqual(
+            `${translationOf('professions.admin.foundPlural')}`,
+          );
+        });
+      });
     });
   });
 });

--- a/src/professions/admin/professions.presenter.spec.ts
+++ b/src/professions/admin/professions.presenter.spec.ts
@@ -118,7 +118,7 @@ describe('ProfessionsPresenter', () => {
           [Nation.find('GB-ENG')],
           i18nService,
         ).checkboxItems(),
-        organisationsCheckboxItems: await new OrganisationsCheckboxPresenter(
+        organisationsCheckboxItems: new OrganisationsCheckboxPresenter(
           organisations,
           [organisation1],
         ).checkboxItems(),
@@ -167,7 +167,7 @@ describe('ProfessionsPresenter', () => {
           [Nation.find('GB-ENG')],
           i18nService,
         ).checkboxItems(),
-        organisationsCheckboxItems: await new OrganisationsCheckboxPresenter(
+        organisationsCheckboxItems: new OrganisationsCheckboxPresenter(
           organisations,
           [organisation1],
         ).checkboxItems(),

--- a/src/professions/admin/professions.presenter.spec.ts
+++ b/src/professions/admin/professions.presenter.spec.ts
@@ -12,6 +12,7 @@ import { ListEntryPresenter } from './list-entry.presenter';
 import industryFactory from '../../testutils/factories/industry';
 import organisationFactory from '../../testutils/factories/organisation';
 import professionFactory from '../../testutils/factories/profession';
+import { translationOf } from '../../testutils/translation-of';
 
 const transportIndustry = industryFactory.build({
   id: 'transport',
@@ -93,16 +94,17 @@ describe('ProfessionsPresenter', () => {
       const expected: IndexTemplate = {
         view: 'overview',
         organisation: 'UK Centre for Professional Qualifications',
-        headings: await ListEntryPresenter.headings(i18nService, 'overview'),
-
-        professions: await Promise.all(
-          [profession1, profession2, profession3].map((profession) =>
-            new ListEntryPresenter(profession, i18nService).tableRow(
-              'overview',
+        professionsTable: {
+          firstCellIsHeader: true,
+          head: await ListEntryPresenter.headings(i18nService, 'overview'),
+          rows: await Promise.all(
+            [profession1, profession2, profession3].map((profession) =>
+              new ListEntryPresenter(profession, i18nService).tableRow(
+                'overview',
+              ),
             ),
           ),
-        ),
-
+        },
         filters: {
           keywords: 'Nuclear',
           nations: ['nations.england'],
@@ -139,19 +141,20 @@ describe('ProfessionsPresenter', () => {
       const expected: IndexTemplate = {
         view: 'single-organisation',
         organisation: 'Example Organisation 1',
-        headings: await ListEntryPresenter.headings(
-          i18nService,
-          'single-organisation',
-        ),
-
-        professions: await Promise.all(
-          [profession1, profession2, profession3].map((profession) =>
-            new ListEntryPresenter(profession, i18nService).tableRow(
-              'single-organisation',
+        professionsTable: {
+          firstCellIsHeader: true,
+          head: await ListEntryPresenter.headings(
+            i18nService,
+            'single-organisation',
+          ),
+          rows: await Promise.all(
+            [profession1, profession2, profession3].map((profession) =>
+              new ListEntryPresenter(profession, i18nService).tableRow(
+                'single-organisation',
+              ),
             ),
           ),
-        ),
-
+        },
         filters: {
           keywords: 'Nuclear',
           nations: ['nations.england'],
@@ -159,7 +162,6 @@ describe('ProfessionsPresenter', () => {
           industries: ['industries.transport'],
           changedBy: [],
         },
-
         nationsCheckboxItems: await new NationsCheckboxPresenter(
           nations,
           [Nation.find('GB-ENG')],

--- a/src/professions/admin/professions.presenter.ts
+++ b/src/professions/admin/professions.presenter.ts
@@ -78,7 +78,20 @@ export class ProfessionsPresenter {
       ),
     );
 
+    const numberOfResults = rows.length;
+
+    const caption =
+      numberOfResults === 1
+        ? await this.i18nService.translate('professions.admin.foundSingular', {
+            args: { count: numberOfResults },
+          })
+        : await this.i18nService.translate('professions.admin.foundPlural', {
+            args: { count: numberOfResults },
+          });
+
     return {
+      caption,
+      captionClasses: 'govuk-table__caption--m',
       firstCellIsHeader: true,
       head: headings,
       rows: rows,

--- a/src/professions/admin/professions.presenter.ts
+++ b/src/professions/admin/professions.presenter.ts
@@ -36,7 +36,7 @@ export class ProfessionsPresenter {
       this.i18nService,
     ).checkboxItems();
 
-    const organisationsCheckboxItems = await new OrganisationsCheckboxPresenter(
+    const organisationsCheckboxItems = new OrganisationsCheckboxPresenter(
       this.allOrganisations,
       this.filterInput.organisations || [],
     ).checkboxItems();

--- a/src/professions/admin/professions.presenter.ts
+++ b/src/professions/admin/professions.presenter.ts
@@ -9,6 +9,7 @@ import { IndexTemplate } from './interfaces/index-template.interface';
 import { ListEntryPresenter } from './list-entry.presenter';
 import { Organisation } from '../../organisations/organisation.entity';
 import { OrganisationsCheckboxPresenter } from '../../organisations/organisations-checkbox-presenter';
+import { Table } from '../../common/interfaces/table';
 
 export type ProfessionsPresenterView = 'overview' | 'single-organisation';
 
@@ -29,8 +30,6 @@ export class ProfessionsPresenter {
         ? await this.i18nService.translate('app.ukcpq')
         : this.userOrganisaiton.name;
 
-    const headings = await ListEntryPresenter.headings(this.i18nService, view);
-
     const nationsCheckboxItems = await new NationsCheckboxPresenter(
       this.allNations,
       this.filterInput.nations || [],
@@ -48,17 +47,10 @@ export class ProfessionsPresenter {
       this.i18nService,
     ).checkboxItems();
 
-    const displayProfessions = await Promise.all(
-      this.filteredProfessions.map(async (profession) =>
-        new ListEntryPresenter(profession, this.i18nService).tableRow(view),
-      ),
-    );
-
     return {
       view,
       organisation,
-      headings,
-      professions: displayProfessions,
+      professionsTable: await this.table(view),
       nationsCheckboxItems,
       organisationsCheckboxItems,
       industriesCheckboxItems,
@@ -74,6 +66,22 @@ export class ProfessionsPresenter {
         ),
         changedBy: [],
       },
+    };
+  }
+
+  private async table(view: ProfessionsPresenterView): Promise<Table> {
+    const headings = await ListEntryPresenter.headings(this.i18nService, view);
+
+    const rows = await Promise.all(
+      this.filteredProfessions.map(async (profession) =>
+        new ListEntryPresenter(profession, this.i18nService).tableRow(view),
+      ),
+    );
+
+    return {
+      firstCellIsHeader: true,
+      head: headings,
+      rows: rows,
     };
   }
 }

--- a/views/admin/organisations/index.njk
+++ b/views/admin/organisations/index.njk
@@ -50,10 +50,6 @@
       {% set filterCriteriaTextPrefix = "organisations.admin" %}
       {% include "../../shared/_filter-criteria.njk" %}
 
-      <p class="govuk-body-m">
-        <span class="govuk-!-font-size-36 govuk-!-font-weight-bold">{{ organisationsTable.rows.length }}</span> {{ ("organisations.admin.foundSingular" | t) if (organisationsTable.rows.length === 1) else ("organisations.admin.foundPlural" | t) }}
-      </p>
-
       {{ govukTable(organisationsTable) }}
     </div>
 

--- a/views/admin/organisations/index.njk
+++ b/views/admin/organisations/index.njk
@@ -50,7 +50,9 @@
       {% set filterCriteriaTextPrefix = "organisations.admin" %}
       {% include "../../shared/_filter-criteria.njk" %}
 
-      {{ govukTable(organisationsTable) }}
+      <div class='rpr-internal__table-container'>
+        {{ govukTable(organisationsTable) }}
+      </div>
     </div>
 
   </div>

--- a/views/admin/professions/index.njk
+++ b/views/admin/professions/index.njk
@@ -53,7 +53,9 @@
       {% endif %}
       {% include "../../shared/_filter-criteria.njk" %}
 
-      {{ govukTable(professionsTable) }}
+      <div class='rpr-internal__table-container'>
+        {{ govukTable(professionsTable) }}
+      </div>
     </div>
 
   </div>

--- a/views/admin/professions/index.njk
+++ b/views/admin/professions/index.njk
@@ -53,10 +53,6 @@
       {% endif %}
       {% include "../../shared/_filter-criteria.njk" %}
 
-      <p class="govuk-body-m">
-        <span class="govuk-!-font-size-36 govuk-!-font-weight-bold">{{ professions.length }}</span> {{ ("professions.admin.foundSingular" | t) if (professions.length === 1) else ("professions.admin.foundPlural" | t) }}
-      </p>
-
       {{ govukTable(professionsTable) }}
     </div>
 

--- a/views/admin/professions/index.njk
+++ b/views/admin/professions/index.njk
@@ -57,11 +57,7 @@
         <span class="govuk-!-font-size-36 govuk-!-font-weight-bold">{{ professions.length }}</span> {{ ("professions.admin.foundSingular" | t) if (professions.length === 1) else ("professions.admin.foundPlural" | t) }}
       </p>
 
-      {{ govukTable({
-        firstCellIsHeader: true,
-        head: headings,
-        rows: professions
-      }) }}
+      {{ govukTable(professionsTable) }}
     </div>
 
   </div>

--- a/views/admin/users/index.njk
+++ b/views/admin/users/index.njk
@@ -31,24 +31,26 @@
 
       <h2 class="govuk-heading-l">{{ "users.headings.manageExisting" | t }}</h2>
 
-      {{
-        govukTable({
-          firstCellIsHeader: true,
-          head: [
-            {
-              text: "Name"
-            },
-            {
-              text: "Email"
-            },
-            {
-              text: "Actions"
-            }
+      <div class='rpr-internal__table-container'>
+        {{
+          govukTable({
+            firstCellIsHeader: true,
+            head: [
+              {
+                text: "Name"
+              },
+              {
+                text: "Email"
+              },
+              {
+                text: "Actions"
+              }
 
-          ],
-          rows: rows
-        })
-      }}
+            ],
+            rows: rows
+          })
+        }}
+      </div>
     </div>
   </div>
 

--- a/views/admin/users/index.njk
+++ b/views/admin/users/index.njk
@@ -29,11 +29,11 @@
         <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
       {% endif %}
 
-      <h2 class="govuk-heading-l">{{ "users.headings.manageExisting" | t }}</h2>
-
       <div class='rpr-internal__table-container'>
         {{
           govukTable({
+            caption: ("users.headings.manageExisting" | t),
+            captionClasses: "govuk-table__caption--l",
             firstCellIsHeader: true,
             head: [
               {


### PR DESCRIPTION
# Changes in this PR

- Add hidden text to "view details"
- Fix overflowing table by making it scrollable when zoomed in
- Replace paragraph / header tags with captions above a table
- Refactor ProfessionPresenter to be constent with OrganisationPresenter.

## Screenshots of UI changes

### Before (professions table zoomed in and overflowing)

![image](https://user-images.githubusercontent.com/19826940/155576046-381d187b-05ca-4ba7-8996-20394a755376.png)

### After (professions table zoomed in and scrollable)

![image](https://user-images.githubusercontent.com/19826940/155575990-362f13f4-0f85-4e7c-a8d8-7665a9cfb73c.png)

### After (caption replaces of `<p>` above tables on Organisations, Professions and Users pages)

![image](https://user-images.githubusercontent.com/19826940/155576154-cdbeca0d-21cb-49f5-bff0-6cd71b7f77ee.png)

![image](https://user-images.githubusercontent.com/19826940/155576705-0bff1239-43b6-46ca-9eee-3a215b5839c8.png)
