### PR TITLE
(2091) Archive organisations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- Allow organisations to be archived
+
 ### Changed
 
 ## [release-005] - 2022-02-24

--- a/cypress/integration/admin/organisations/archive.spec.ts
+++ b/cypress/integration/admin/organisations/archive.spec.ts
@@ -64,6 +64,18 @@ describe('Archiving organisations', () => {
         format(new Date(), 'dd-MM-yyyy'),
       );
 
+      cy.visitAndCheckAccessibility('/admin/organisations');
+
+      cy.get('tr')
+        .contains('Department for Education')
+        .then(($header) => {
+          const $row = $header.parent();
+
+          cy.translate(`organisations.status.archived`).then((status) => {
+            cy.wrap($row).should('contain', status);
+          });
+        });
+
     });
   });
 });

--- a/cypress/integration/admin/organisations/archive.spec.ts
+++ b/cypress/integration/admin/organisations/archive.spec.ts
@@ -80,5 +80,65 @@ describe('Archiving organisations', () => {
 
       cy.get('body').should('not.contain', 'Department for Education');
     });
+
+    it('Allows me to archive a live organisation', () => {
+      cy.get('a').contains('Regulatory authorities').click();
+
+      cy.contains('Council of Registered Gas Installers')
+        .parent('tr')
+        .within(() => {
+          cy.get('a').contains('View details').click();
+        });
+
+      cy.translate('organisations.status.live').then((status) => {
+        cy.get('h2[data-status]').should('contain', status);
+      });
+
+      cy.translate('organisations.admin.button.archive').then(
+        (archiveButton) => {
+          cy.get('a').contains(archiveButton).click();
+        },
+      );
+
+      cy.translate('organisations.admin.button.archive').then((buttonText) => {
+        cy.get('button').contains(buttonText).click();
+      });
+
+      cy.translate('organisations.admin.archive.confirmation.heading').then(
+        (confirmation) => {
+          cy.get('html').should('contain', confirmation);
+        },
+      );
+
+      cy.get('[data-cy=actions]').should('not.exist');
+
+      cy.translate('organisations.status.archived').then((status) => {
+        cy.get('h2[data-status]').should('contain', status);
+      });
+      cy.get('[data-cy=changed-by-user]').should('contain', 'Registrar');
+      cy.get('[data-cy=last-modified]').should(
+        'contain',
+        format(new Date(), 'dd-MM-yyyy'),
+      );
+
+      cy.visit('/admin/organisations');
+
+      cy.get('tr')
+        .contains('Council of Registered Gas Installers')
+        .then(($header) => {
+          const $row = $header.parent();
+
+          cy.translate(`organisations.status.archived`).then((status) => {
+            cy.wrap($row).should('contain', status);
+          });
+        });
+
+      cy.visit('/regulatory-authorities');
+
+      cy.get('body').should(
+        'not.contain',
+        'Council of Registered Gas Installers',
+      );
+    });
   });
 });

--- a/cypress/integration/admin/organisations/archive.spec.ts
+++ b/cypress/integration/admin/organisations/archive.spec.ts
@@ -76,6 +76,9 @@ describe('Archiving organisations', () => {
           });
         });
 
+      cy.visitAndCheckAccessibility('/regulatory-authorities');
+
+      cy.get('body').should('not.contain', 'Department for Education');
     });
   });
 });

--- a/cypress/integration/admin/organisations/archive.spec.ts
+++ b/cypress/integration/admin/organisations/archive.spec.ts
@@ -1,0 +1,55 @@
+describe('Archiving organisations', () => {
+  context('When I am logged in as a registrar', () => {
+    beforeEach(() => {
+      cy.loginAuth0('registrar');
+      cy.visitAndCheckAccessibility('/admin');
+    });
+
+    it('Allows me to archive a draft organisation', () => {
+      cy.get('a').contains('Regulatory authorities').click();
+      cy.checkAccessibility();
+
+      cy.contains('Department for Education')
+        .parent('tr')
+        .within(() => {
+          cy.get('a').contains('View details').click();
+        });
+
+      cy.translate('organisations.status.draft').then((status) => {
+        cy.get('h2[data-status]').should('contain', status);
+      });
+
+      cy.translate('organisations.admin.button.archive').then(
+        (archiveButton) => {
+          cy.get('a').contains(archiveButton).click();
+        },
+      );
+
+      cy.checkAccessibility();
+
+      cy.translate('organisations.admin.archive.caption').then(
+        (archiveCaption) => {
+          cy.get('body').contains(archiveCaption);
+        },
+      );
+
+      cy.translate('organisations.admin.archive.heading', {
+        organisationName: 'Department for Education',
+      }).then((heading) => {
+        cy.contains(heading);
+      });
+
+      cy.translate('organisations.admin.button.archive').then((buttonText) => {
+        cy.get('button').contains(buttonText).click();
+      });
+
+      cy.checkAccessibility();
+
+      cy.translate('organisations.admin.archive.confirmation.heading').then(
+        (confirmation) => {
+          cy.get('html').should('contain', confirmation);
+        },
+      );
+    });
+  });
+});

--- a/cypress/integration/admin/organisations/archive.spec.ts
+++ b/cypress/integration/admin/organisations/archive.spec.ts
@@ -1,3 +1,5 @@
+import { format } from 'date-fns';
+
 describe('Archiving organisations', () => {
   context('When I am logged in as a registrar', () => {
     beforeEach(() => {
@@ -50,6 +52,18 @@ describe('Archiving organisations', () => {
           cy.get('html').should('contain', confirmation);
         },
       );
+
+      cy.get('[data-cy=actions]').should('not.exist');
+
+      cy.translate('organisations.status.archived').then((status) => {
+        cy.get('h2[data-status]').should('contain', status);
+      });
+      cy.get('[data-cy=changed-by-user]').should('contain', 'Registrar');
+      cy.get('[data-cy=last-modified]').should(
+        'contain',
+        format(new Date(), 'dd-MM-yyyy'),
+      );
+
     });
   });
 });

--- a/src/i18n/en/organisations.json
+++ b/src/i18n/en/organisations.json
@@ -161,6 +161,7 @@
   },
   "status": {
     "live": "Live",
-    "draft": "Draft"
+    "draft": "Draft",
+    "archived": "Archived"
   }
 }

--- a/src/i18n/en/organisations.json
+++ b/src/i18n/en/organisations.json
@@ -69,6 +69,10 @@
     "archive": {
       "heading": "Are you sure you want to archive {organisationName}?",
       "caption": "Archiving an organisation",
+      "confirmation": {
+        "heading": "Regulatory authority archived",
+        "body": "The regulator <strong>{name}</strong> has been archived."
+      }
     },
     "tableHeading": {
       "name": "Name",
@@ -109,7 +113,7 @@
         "draft": "Edit this draft",
         "live": "Edit this regulatory authority"
       },
-      "delete": "Delete this regulatory authority",
+      "archive": "Archive this regulatory authority",
       "amend": "Amend regulatory authority",
       "publish": "Publish regulatory authority"
     }

--- a/src/i18n/en/organisations.json
+++ b/src/i18n/en/organisations.json
@@ -66,6 +66,10 @@
         "backToDashboard": "Back to the dashboard"
       }
     },
+    "archive": {
+      "heading": "Are you sure you want to archive {organisationName}?",
+      "caption": "Archiving an organisation",
+    },
     "tableHeading": {
       "name": "Name",
       "alternateName": "Alternate name",

--- a/src/organisations/admin/organisation-archive.controller.spec.ts
+++ b/src/organisations/admin/organisation-archive.controller.spec.ts
@@ -1,0 +1,71 @@
+import { DeepMocked, createMock } from '@golevelup/ts-jest';
+import { TestingModule, Test } from '@nestjs/testing';
+import { Response } from 'express';
+import { I18nService } from 'nestjs-i18n';
+import { flashMessage } from '../../common/flash-message';
+import { createMockI18nService } from '../../testutils/create-mock-i18n-service';
+import { createDefaultMockRequest } from '../../testutils/factories/create-default-mock-request';
+import organisationFactory from '../../testutils/factories/organisation';
+import organisationVersionFactory from '../../testutils/factories/organisation-version';
+import userFactory from '../../testutils/factories/user';
+import { translationOf } from '../../testutils/translation-of';
+import { getActingUser } from '../../users/helpers/get-acting-user.helper';
+import { OrganisationVersionsService } from '../organisation-versions.service';
+import { Organisation } from '../organisation.entity';
+import { OrganisationArchiveController } from './organisation-archive.controller';
+
+jest.mock('../../common/flash-message');
+jest.mock('../../users/helpers/get-acting-user.helper');
+
+describe('OrganisationArchiveController', () => {
+  let controller: OrganisationArchiveController;
+
+  let organisationVersionsService: DeepMocked<OrganisationVersionsService>;
+  let i18nService: DeepMocked<I18nService>;
+
+  beforeEach(async () => {
+    organisationVersionsService = createMock<OrganisationVersionsService>();
+    i18nService = createMockI18nService();
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [OrganisationArchiveController],
+      providers: [
+        {
+          provide: OrganisationVersionsService,
+          useValue: organisationVersionsService,
+        },
+        {
+          provide: I18nService,
+          useValue: i18nService,
+        },
+      ],
+    }).compile();
+
+    controller = module.get<OrganisationArchiveController>(
+      OrganisationArchiveController,
+    );
+  });
+
+  describe('new', () => {
+    it('fetches the Organisation to render on the page', async () => {
+      const organisation = organisationFactory.build();
+      const version = organisationVersionFactory.build({
+        organisation,
+      });
+
+      organisationVersionsService.findByIdWithOrganisation.mockResolvedValue(
+        version,
+      );
+
+      const result = await controller.new(organisation.id, version.id);
+
+      expect(
+        organisationVersionsService.findByIdWithOrganisation,
+      ).toHaveBeenCalledWith(organisation.id, version.id);
+      expect(result).toEqual({
+        organisation: Organisation.withVersion(organisation, version),
+      });
+    });
+  });
+
+});

--- a/src/organisations/admin/organisation-archive.controller.ts
+++ b/src/organisations/admin/organisation-archive.controller.ts
@@ -1,0 +1,50 @@
+import {
+  Controller,
+  Get,
+  Param,
+  Delete,
+  Render,
+  Req,
+  Res,
+} from '@nestjs/common';
+import { Response } from 'express';
+import { I18nService } from 'nestjs-i18n';
+import { BackLink } from '../../common/decorators/back-link.decorator';
+import { flashMessage } from '../../common/flash-message';
+import { RequestWithAppSession } from '../../common/interfaces/request-with-app-session.interface';
+import { Permissions } from '../../common/permissions.decorator';
+import { getActingUser } from '../../users/helpers/get-acting-user.helper';
+import { UserPermission } from '../../users/user-permission';
+import { OrganisationVersionsService } from '../organisation-versions.service';
+import { Organisation } from '../organisation.entity';
+
+@Controller('/admin/organisations')
+export class OrganisationArchiveController {
+  constructor(
+    private organisationVersionsService: OrganisationVersionsService,
+    private i18nService: I18nService,
+  ) {}
+
+  @Get('/:organisationId/versions/:versionId/archive')
+  @Permissions(UserPermission.DeleteOrganisation)
+  @Render('admin/organisations/archive/new')
+  @BackLink('/admin/organisations/:organisationId/versions/:versionId')
+  async new(
+    @Param('organisationId') organisationId: string,
+    @Param('versionId') versionId: string,
+  ) {
+    const version =
+      await this.organisationVersionsService.findByIdWithOrganisation(
+        organisationId,
+        versionId,
+      );
+
+    const organisation = Organisation.withVersion(
+      version.organisation,
+      version,
+    );
+
+    return { organisation };
+  }
+
+}

--- a/src/organisations/admin/organisations.controller.spec.ts
+++ b/src/organisations/admin/organisations.controller.spec.ts
@@ -117,7 +117,9 @@ describe('OrganisationsController', () => {
 
           expect(await controller.index(request)).toEqual(templateParams);
 
-          expect(organisationVersionsService.allDraftOrLive).toHaveBeenCalled();
+          expect(
+            organisationVersionsService.allWithLatestVersion,
+          ).toHaveBeenCalled();
 
           expect(OrganisationsFilterHelper).toBeCalledWith(organisations);
           expect(OrganisationsFilterHelper.prototype.filter).toBeCalledWith({
@@ -179,7 +181,9 @@ describe('OrganisationsController', () => {
             } as FilterDto),
           ).toEqual(templateParams);
 
-          expect(organisationVersionsService.allDraftOrLive).toHaveBeenCalled();
+          expect(
+            organisationVersionsService.allWithLatestVersion,
+          ).toHaveBeenCalled();
 
           expect(OrganisationsFilterHelper).toBeCalledWith(organisations);
           expect(OrganisationsFilterHelper.prototype.filter).toBeCalledWith({
@@ -242,7 +246,9 @@ describe('OrganisationsController', () => {
 
         expect(await controller.index(request)).toEqual(templateParams);
 
-        expect(organisationVersionsService.allDraftOrLive).toHaveBeenCalled();
+        expect(
+          organisationVersionsService.allWithLatestVersion,
+        ).toHaveBeenCalled();
 
         expect(OrganisationsFilterHelper).toBeCalledWith(organisations);
         expect(OrganisationsFilterHelper.prototype.filter).toBeCalledWith({

--- a/src/organisations/admin/organisations.controller.ts
+++ b/src/organisations/admin/organisations.controller.ts
@@ -70,7 +70,7 @@ export class OrganisationsController {
     const showAllOrgs = actingUser.serviceOwner;
 
     const allOrganisations =
-      await this.organisationVersionsService.allDraftOrLive();
+      await this.organisationVersionsService.allWithLatestVersion();
     const allIndustries = await this.industriesService.all();
 
     const filter = query || new FilterDto();

--- a/src/organisations/organisation-versions.service.spec.ts
+++ b/src/organisations/organisation-versions.service.spec.ts
@@ -231,7 +231,7 @@ describe('OrganisationVersionsService', () => {
     });
   });
 
-  describe('allDraftOrLive', () => {
+  describe('allWithLatestVersion', () => {
     it('gets all organisations and their latest draft or live version with draft or live Professions', async () => {
       const versions = organisationVersionFactory.buildList(5);
       const queryBuilder = createMock<SelectQueryBuilder<OrganisationVersion>>({
@@ -246,7 +246,7 @@ describe('OrganisationVersionsService', () => {
         .spyOn(repo, 'createQueryBuilder')
         .mockImplementation(() => queryBuilder);
 
-      const result = await service.allDraftOrLive();
+      const result = await service.allWithLatestVersion();
 
       const expectedOrganisations = versions.map((version) =>
         Organisation.withVersion(version.organisation, version, true),
@@ -280,6 +280,7 @@ describe('OrganisationVersionsService', () => {
           status: [
             OrganisationVersionStatus.Live,
             OrganisationVersionStatus.Draft,
+            OrganisationVersionStatus.Archived,
           ],
         },
       );

--- a/src/organisations/organisation-versions.service.ts
+++ b/src/organisations/organisation-versions.service.ts
@@ -79,13 +79,14 @@ export class OrganisationVersionsService {
     );
   }
 
-  async allDraftOrLive(): Promise<Organisation[]> {
+  async allWithLatestVersion(): Promise<Organisation[]> {
     const versions = await this.versionsWithJoins()
       .distinctOn(['organisationVersion.organisation'])
       .where('organisationVersion.status IN(:...status)', {
         status: [
           OrganisationVersionStatus.Live,
           OrganisationVersionStatus.Draft,
+          OrganisationVersionStatus.Archived,
         ],
       })
       .orderBy(

--- a/src/organisations/organisations.module.ts
+++ b/src/organisations/organisations.module.ts
@@ -12,6 +12,7 @@ import { OrganisationVersionsController as AdminOrganisationVersionsController }
 import { SearchController } from './search/search.controller';
 import { OrganisationsController } from './organisations.controller';
 import { OrganisationPublicationController } from './admin/organisation-publication.controller';
+import { OrganisationArchiveController } from './admin/organisation-archive.controller';
 
 @Module({
   providers: [
@@ -25,6 +26,7 @@ import { OrganisationPublicationController } from './admin/organisation-publicat
     SearchController,
     OrganisationsController,
     OrganisationPublicationController,
+    OrganisationArchiveController,
   ],
   imports: [
     TypeOrmModule.forFeature([Organisation]),

--- a/views/admin/organisations/archive/new.njk
+++ b/views/admin/organisations/archive/new.njk
@@ -1,0 +1,24 @@
+{% extends "admin/base.njk" %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% set bodyClasses = "rpr-internal__page" %}
+
+{% block content %}
+  <span class="govuk-caption-l">{{ 'organisations.admin.archive.caption' | t }}</span>
+  <h1 class="govuk-heading-l">{{ ('organisations.admin.archive.heading' | t({organisationName: organisation.name})) }}</h1>
+
+  <div class="govuk-grid-row">
+
+    <div class="govuk-grid-column-full">
+      <form action="/admin/organisations/{{ organisation.id }}/versions/{{ organisation.versionId }}/archive?_method=DELETE" method="post">
+        {{
+          govukButton({
+            text: ("organisations.admin.button.archive" | t)
+          })
+        }}
+      </form>
+    </div>
+
+  </div>
+
+{% endblock %}

--- a/views/admin/organisations/show.njk
+++ b/views/admin/organisations/show.njk
@@ -58,8 +58,8 @@
             <li>
               {{
                 govukButton({
-                  text: ("organisations.admin.button.delete" | t),
-                  href: "#",
+                  text: ("organisations.admin.button.archive" | t),
+                  href: "/admin/organisations/" + organisation.id + "/versions/" + organisation.versionId + "/archive",
                   classes: "govuk-button--warning"
                 })
               }}

--- a/views/admin/organisations/show.njk
+++ b/views/admin/organisations/show.njk
@@ -28,45 +28,49 @@
           <span class="govuk-body" data-cy="changed-by-user">{{ presenter.changedBy }}</span>
         </h2>
 
-        <nav role="navigation" aria-labelledby="subsection-title">
-          <ul class="govuk-list">
-            {% if organisation.status === 'draft' and 'publishOrganisation' in permissions %}
-            <li>
-              {{
-                govukButton({
-                  text: ("organisations.admin.button.publish" | t),
-                  classes: "govuk-button",
-                  id: "publish-button",
-                  href: "/admin/organisations/" + organisation.id + "/versions/" + organisation.versionId + "/publish"
-                })
-              }}
-            </li>
-            {% endif %}
-            {% if 'editOrganisation' in permissions %}
-            <li>
-              <form method="post" action="/admin/organisations/{{ organisation.id }}/versions">
-                {{ govukButton({
-                  id: "submit-button",
-                  type: "Submit",
-                  classes: "govuk-button--secondary",
-                  text: (('organisations.admin.button.edit.' + organisation.status) | t)
-                }) }}
-              </form>
-            </li>
-            {% endif %}
-            {% if 'deleteOrganisation' in permissions %}
-            <li>
-              {{
-                govukButton({
-                  text: ("organisations.admin.button.archive" | t),
-                  href: "/admin/organisations/" + organisation.id + "/versions/" + organisation.versionId + "/archive",
-                  classes: "govuk-button--warning"
-                })
-              }}
-            </li>
-            {% endif %}
-          </ul>
-        </nav>
+        {% if organisation.status !== 'archived' %}
+
+          <nav role="navigation" aria-labelledby="subsection-title" data-cy="actions">
+            <ul class="govuk-list">
+              {% if organisation.status === 'draft' and 'publishOrganisation' in permissions %}
+              <li>
+                {{
+                  govukButton({
+                    text: ("organisations.admin.button.publish" | t),
+                    classes: "govuk-button",
+                    id: "publish-button",
+                    href: "/admin/organisations/" + organisation.id + "/versions/" + organisation.versionId + "/publish"
+                  })
+                }}
+              </li>
+              {% endif %}
+              {% if 'editOrganisation' in permissions %}
+              <li>
+                <form method="post" action="/admin/organisations/{{ organisation.id }}/versions">
+                  {{ govukButton({
+                    id: "submit-button",
+                    type: "Submit",
+                    classes: "govuk-button--secondary",
+                    text: (('organisations.admin.button.edit.' + organisation.status) | t)
+                  }) }}
+                </form>
+              </li>
+              {% endif %}
+              {% if 'deleteOrganisation' in permissions %}
+              <li>
+                {{
+                  govukButton({
+                    text: ("organisations.admin.button.archive" | t),
+                    href: "/admin/organisations/" + organisation.id + "/versions/" + organisation.versionId + "/archive",
+                    classes: "govuk-button--warning"
+                  })
+                }}
+              </li>
+              {% endif %}
+            </ul>
+          </nav>
+
+        {% endif %}
       </aside>
     </div>
   </div>


### PR DESCRIPTION
This adds a new controller to allow us to archive organisations. It acts in a very similar way to the publication endpoints, with a confirmation screen and an action that creates a new archived version. There was some additional work to allow us to filter by an organisation's type (and not show archived orgs by default), but given there's some work on the search coming soon, I think it's best to deprioritise this.

## Screenshots

![image](https://user-images.githubusercontent.com/109774/155732904-18718fc0-8850-4bbf-ac89-1d0f0df7cc29.png)

![image](https://user-images.githubusercontent.com/109774/155732927-0144edca-86e8-4dce-9c7d-d827a50dcd1e.png)

![image](https://user-images.githubusercontent.com/109774/155732957-b64960e3-7a7a-4839-8f67-5cfdf71d9f54.png)
