### PR TITLE
(2117) Add back missing found text

### DIFF
--- a/cypress/integration/admin/organisations/index.spec.ts
+++ b/cypress/integration/admin/organisations/index.spec.ts
@@ -11,6 +11,11 @@ describe('Listing organisations', () => {
     });
 
     it('Lists all the organisations', () => {
+      cy.translate('organisations.search.foundPlural', { count: 4 }).then(
+        (foundText) => {
+          cy.get('body').should('contain', foundText);
+        },
+      );
       cy.readFile('./seeds/test/professions.json').then((professions) => {
         cy.readFile('./seeds/test/organisations.json').then((organisations) => {
           organisations.forEach((organisation) => {

--- a/cypress/integration/admin/professions/index.spec.ts
+++ b/cypress/integration/admin/professions/index.spec.ts
@@ -6,6 +6,11 @@ describe('Listing professions', () => {
     });
 
     it('I can view an unfiltered list of draft and live Professions', () => {
+      cy.translate('professions.search.foundPlural', { count: 5 }).then(
+        (foundText) => {
+          cy.get('body').should('contain', foundText);
+        },
+      );
       cy.get('tr')
         .contains('Registered Trademark Attorney')
         .then(($header) => {

--- a/cypress/integration/organisations/search/search.spec.ts
+++ b/cypress/integration/organisations/search/search.spec.ts
@@ -11,6 +11,11 @@ describe('Searching an organisation', () => {
   });
 
   it('I can view an unfiltered list of organisations', () => {
+    cy.translate('organisations.search.foundPlural', { count: 4 }).then(
+      (foundText) => {
+        cy.get('body').should('contain.text', foundText);
+      },
+    );
     cy.get('body').should('contain', 'Department for Education');
     cy.get('body').should('contain', 'General Medical Council');
 

--- a/cypress/integration/professions/search/search.spec.ts
+++ b/cypress/integration/professions/search/search.spec.ts
@@ -11,6 +11,11 @@ describe('Searching a profession', () => {
   });
 
   it('I can view an unfiltered list of live professions', () => {
+    cy.translate('professions.search.foundPlural', { count: 2 }).then(
+      (foundText) => {
+        cy.get('body').should('contain.text', foundText);
+      },
+    );
     cy.get('body').should('contain', 'Registered Trademark Attorney');
     cy.get('body').should(
       'contain',

--- a/src/i18n/en/organisations.json
+++ b/src/i18n/en/organisations.json
@@ -8,8 +8,6 @@
       "keywords": "Keywords:",
       "industries": "Industries:"
     },
-    "foundSingular": "{count} regulatory authority found",
-    "foundPlural": "{count} regulatory authorities found",
     "filter": {
       "keywords": {
         "label": "Keyword",
@@ -126,8 +124,8 @@
       "nations": "Nations:",
       "industries": "Industries:"
     },
-    "foundSingular": "authority found.",
-    "foundPlural": "authorities found.",
+    "foundSingular": "{count} regulatory authority found",
+    "foundPlural": "{count} regulatory authorities found",
     "filter": {
       "keywords": {
         "label": "Authority that you are looking for",

--- a/src/i18n/en/professions.json
+++ b/src/i18n/en/professions.json
@@ -262,8 +262,6 @@
       "industries": "Industries:",
       "changedBy": "Changed by:"
     },
-    "foundSingular": "{count} profession found",
-    "foundPlural": "{count} professions found",
     "filter": {
       "keywords": {
         "label": "Keyword",
@@ -331,6 +329,8 @@
   },
   "search": {
     "heading": "Find a regulated profession",
+    "foundSingular": "{count} profession found",
+    "foundPlural": "{count} professions found",
     "labels": {
       "keywords": "Keywords:",
       "nations": "Nations:",

--- a/src/organisations/admin/presenters/organisations.presenter.spec.ts
+++ b/src/organisations/admin/presenters/organisations.presenter.spec.ts
@@ -206,7 +206,7 @@ describe('OrganisationsPresenter', () => {
           const result = await presenter.present();
 
           expect(result.organisationsTable.caption).toEqual(
-            `${translationOf('organisations.admin.foundSingular')}`,
+            `${translationOf('organisations.search.foundSingular')}`,
           );
         });
       });
@@ -242,7 +242,7 @@ describe('OrganisationsPresenter', () => {
           const result = await presenter.present();
 
           expect(result.organisationsTable.caption).toEqual(
-            `${translationOf('organisations.admin.foundPlural')}`,
+            `${translationOf('organisations.search.foundPlural')}`,
           );
         });
       });

--- a/src/organisations/admin/presenters/organisations.presenter.ts
+++ b/src/organisations/admin/presenters/organisations.presenter.ts
@@ -69,10 +69,10 @@ export class OrganisationsPresenter {
     const caption =
       numberOfResults === 1
         ? await this.i18nService.translate(
-            'organisations.admin.foundSingular',
+            'organisations.search.foundSingular',
             { args: { count: numberOfResults } },
           )
-        : await this.i18nService.translate('organisations.admin.foundPlural', {
+        : await this.i18nService.translate('organisations.search.foundPlural', {
             args: { count: numberOfResults },
           });
 

--- a/src/professions/admin/professions.presenter.spec.ts
+++ b/src/professions/admin/professions.presenter.spec.ts
@@ -95,7 +95,7 @@ describe('ProfessionsPresenter', () => {
         view: 'overview',
         organisation: 'UK Centre for Professional Qualifications',
         professionsTable: {
-          caption: `${translationOf('professions.admin.foundPlural')}`,
+          caption: `${translationOf('professions.search.foundPlural')}`,
           captionClasses: 'govuk-table__caption--m',
           firstCellIsHeader: true,
           head: await ListEntryPresenter.headings(i18nService, 'overview'),
@@ -144,7 +144,7 @@ describe('ProfessionsPresenter', () => {
         view: 'single-organisation',
         organisation: 'Example Organisation 1',
         professionsTable: {
-          caption: `${translationOf('professions.admin.foundPlural')}`,
+          caption: `${translationOf('professions.search.foundPlural')}`,
           captionClasses: 'govuk-table__caption--m',
           firstCellIsHeader: true,
           head: await ListEntryPresenter.headings(
@@ -215,7 +215,7 @@ describe('ProfessionsPresenter', () => {
           const result = await presenter.present('overview');
 
           expect(result.professionsTable.caption).toEqual(
-            `${translationOf('professions.admin.foundSingular')}`,
+            `${translationOf('professions.search.foundSingular')}`,
           );
         });
       });
@@ -248,7 +248,7 @@ describe('ProfessionsPresenter', () => {
           const result = await presenter.present('overview');
 
           expect(result.professionsTable.caption).toEqual(
-            `${translationOf('professions.admin.foundPlural')}`,
+            `${translationOf('professions.search.foundPlural')}`,
           );
         });
       });

--- a/src/professions/admin/professions.presenter.ts
+++ b/src/professions/admin/professions.presenter.ts
@@ -82,10 +82,10 @@ export class ProfessionsPresenter {
 
     const caption =
       numberOfResults === 1
-        ? await this.i18nService.translate('professions.admin.foundSingular', {
+        ? await this.i18nService.translate('professions.search.foundSingular', {
             args: { count: numberOfResults },
           })
-        : await this.i18nService.translate('professions.admin.foundPlural', {
+        : await this.i18nService.translate('professions.search.foundPlural', {
             args: { count: numberOfResults },
           });
 

--- a/views/organisations/search/index.njk
+++ b/views/organisations/search/index.njk
@@ -18,7 +18,11 @@
       {% include "../../shared/_filter-criteria.njk" %}
 
       <p class="govuk-body-m">
-        <span class="govuk-!-font-size-36 govuk-!-font-weight-bold">{{ organisations.length }}</span> {{ ("organisations.search.foundSingular" | t) if (organisations.length === 1) else ("organisations.search.foundPlural" | t) }}
+        {% if (organisations.length === 1) %}
+          {{ ("organisations.search.foundSingular" | t({ count: "<span class='govuk-!-font-size-36 govuk-!-font-weight-bold'>" + organisations.length + "</span>" }) | safe) }}
+        {% else %}
+          {{ ("organisations.search.foundPlural" | t({ count: "<span class='govuk-!-font-size-36 govuk-!-font-weight-bold'>" + organisations.length + "</span>" }) | safe) }}
+        {% endif %}
       </p>
 
       <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">

--- a/views/professions/search/index.njk
+++ b/views/professions/search/index.njk
@@ -19,7 +19,11 @@
       {% include "../../shared/_filter-criteria.njk" %}
 
       <p class="govuk-body-m">
-        <span class="govuk-!-font-size-36 govuk-!-font-weight-bold">{{ professions.length }}</span> {{ ("professions.search.foundSingular" | t) if (professions.length === 1) else ("professions.search.foundPlural" | t) }}
+        {% if (professions.length === 1) %}
+          {{ ("professions.search.foundSingular" | t({ count: "<span class='govuk-!-font-size-36 govuk-!-font-weight-bold'>" + professions.length + "</span>" }) | safe) }}
+        {% else %}
+          {{ ("professions.search.foundPlural" | t({ count: "<span class='govuk-!-font-size-36 govuk-!-font-weight-bold'>" + professions.length + "</span>" }) | safe) }}
+        {% endif %}
       </p>
 
       <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR

- Fixes localisation id being displayed on professions search results when we moved it in the translation file to be nested under a different key.
- Refactors organisations to be treated the same way, using a single localisation id rather than duplicated ones.
- Adds e2e tests to ensure this doesn't happen again.

## Screenshots of UI changes

### Before

![image](https://user-images.githubusercontent.com/19826940/155980620-27b6b3a6-7bd9-47be-b24b-bfc464779585.png)

### After

![image](https://user-images.githubusercontent.com/19826940/155980663-a33dcdb6-178c-4ff6-9e93-c2e4d65588ed.png)

