### PR TITLE
(1766) Archive an organisation's professions

### DIFF
--- a/cypress/integration/admin/organisations/archive.spec.ts
+++ b/cypress/integration/admin/organisations/archive.spec.ts
@@ -139,6 +139,28 @@ describe('Archiving organisations', () => {
         'not.contain',
         'Council of Registered Gas Installers',
       );
+
+      cy.visit('/admin/professions');
+
+      cy.get('tr')
+        .contains('Gas Safe Engineer')
+        .then(($header) => {
+          const $row = $header.parent();
+
+          cy.translate('professions.admin.status.archived').then((status) => {
+            cy.wrap($row).should('contain', status);
+          });
+        });
+
+      cy.get('tr')
+        .contains('Draft Profession')
+        .then(($header) => {
+          const $row = $header.parent();
+
+          cy.translate('professions.admin.status.archived').then((status) => {
+            cy.wrap($row).should('contain', status);
+          });
+        });
     });
   });
 });

--- a/src/i18n/en/organisations.json
+++ b/src/i18n/en/organisations.json
@@ -68,6 +68,7 @@
     "archive": {
       "heading": "Are you sure you want to archive {organisationName}?",
       "caption": "Archiving an organisation",
+      "details": "This will also archive all of this regulator's professions.",
       "confirmation": {
         "heading": "Regulatory authority archived",
         "body": "The regulator <strong>{name}</strong> has been archived."

--- a/src/organisations/admin/organisation-archive.controller.spec.ts
+++ b/src/organisations/admin/organisation-archive.controller.spec.ts
@@ -108,6 +108,7 @@ describe('OrganisationArchiveController', () => {
 
       expect(organisationVersionsService.archive).toHaveBeenCalledWith(
         versionToArchive,
+        user,
       );
 
       expect(flashMock).toHaveBeenCalledWith(

--- a/src/organisations/admin/organisation-archive.controller.ts
+++ b/src/organisations/admin/organisation-archive.controller.ts
@@ -61,12 +61,14 @@ export class OrganisationArchiveController {
         versionId,
       );
 
+    const user = getActingUser(req);
+
     const versionToArchive = await this.organisationVersionsService.create(
       version,
-      getActingUser(req),
+      user,
     );
 
-    await this.organisationVersionsService.archive(versionToArchive);
+    await this.organisationVersionsService.archive(versionToArchive, user);
 
     const messageTitle = await this.i18nService.translate(
       'organisations.admin.archive.confirmation.heading',

--- a/src/organisations/organisation.entity.spec.ts
+++ b/src/organisations/organisation.entity.spec.ts
@@ -133,7 +133,7 @@ describe('Organisation', () => {
     it('should get the latest live version', () => {
       const organisationVersion = organisationVersionFactory.build({
         status: OrganisationVersionStatus.Live,
-        updated_at: new Date(2022, 1, 2),
+        updated_at: new Date(2022, 1, 3),
       });
       const organisation = organisationFactory.build({
         versions: [
@@ -144,7 +144,7 @@ describe('Organisation', () => {
           organisationVersion,
           organisationVersionFactory.build({
             status: OrganisationVersionStatus.Live,
-            updated_at: new Date(2022, 1, 3),
+            updated_at: new Date(2022, 1, 2),
           }),
         ],
       });

--- a/src/organisations/organisation.entity.spec.ts
+++ b/src/organisations/organisation.entity.spec.ts
@@ -154,4 +154,27 @@ describe('Organisation', () => {
       );
     });
   });
+
+  describe('withLatestVersion', () => {
+    it('should get the latest version', () => {
+      const organisationVersion = organisationVersionFactory.build({
+        updated_at: new Date(2022, 1, 3),
+      });
+      const organisation = organisationFactory.build({
+        versions: [
+          organisationVersionFactory.build({
+            updated_at: new Date(2022, 1, 1),
+          }),
+          organisationVersion,
+          organisationVersionFactory.build({
+            updated_at: new Date(2022, 1, 2),
+          }),
+        ],
+      });
+
+      expect(Organisation.withLatestVersion(organisation)).toEqual(
+        Organisation.withVersion(organisation, organisationVersion),
+      );
+    });
+  });
 });

--- a/src/organisations/organisation.entity.ts
+++ b/src/organisations/organisation.entity.ts
@@ -77,6 +77,12 @@ export class Organisation {
     return Organisation.withVersion(organisation, latestVersion);
   }
 
+  public static withLatestVersion(organisation: Organisation): Organisation {
+    const versions = Organisation.sortedVersions(organisation);
+
+    return Organisation.withVersion(organisation, versions[0]);
+  }
+
   private static sortedVersions(
     organisation: Organisation,
   ): OrganisationVersion[] {

--- a/src/organisations/organisation.entity.ts
+++ b/src/organisations/organisation.entity.ts
@@ -68,13 +68,22 @@ export class Organisation {
   public static withLatestLiveVersion(
     organisation: Organisation,
   ): Organisation {
-    const liveVersions = organisation.versions
-      .filter((v) => v.status == OrganisationVersionStatus.Live)
-      .sort((a, b) => a.updated_at.getTime() - b.updated_at.getTime());
+    const liveVersions = Organisation.sortedVersions(organisation).filter(
+      (v) => v.status == OrganisationVersionStatus.Live,
+    );
 
     const latestVersion = liveVersions[0];
 
     return Organisation.withVersion(organisation, latestVersion);
+  }
+
+  private static sortedVersions(
+    organisation: Organisation,
+  ): OrganisationVersion[] {
+    return organisation.versions.sort(
+      (a: OrganisationVersion, b: OrganisationVersion) =>
+        b.updated_at.getTime() - a.updated_at.getTime(),
+    );
   }
 
   public static withVersion(

--- a/src/organisations/organisations.module.ts
+++ b/src/organisations/organisations.module.ts
@@ -3,6 +3,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { IndustriesService } from '../industries/industries.service';
 import { Industry } from '../industries/industry.entity';
 import { Organisation } from './organisation.entity';
+import { ProfessionVersion } from '../professions/profession-version.entity';
 import { OrganisationVersion } from './organisation-version.entity';
 import { OrganisationsService } from './organisations.service';
 import { OrganisationVersionsService } from './organisation-versions.service';
@@ -13,12 +14,14 @@ import { SearchController } from './search/search.controller';
 import { OrganisationsController } from './organisations.controller';
 import { OrganisationPublicationController } from './admin/organisation-publication.controller';
 import { OrganisationArchiveController } from './admin/organisation-archive.controller';
+import { ProfessionVersionsService } from '../professions/profession-versions.service';
 
 @Module({
   providers: [
     OrganisationsService,
     IndustriesService,
     OrganisationVersionsService,
+    ProfessionVersionsService,
   ],
   controllers: [
     AdminOrganisationsController,
@@ -32,6 +35,7 @@ import { OrganisationArchiveController } from './admin/organisation-archive.cont
     TypeOrmModule.forFeature([Organisation]),
     TypeOrmModule.forFeature([OrganisationVersion]),
     TypeOrmModule.forFeature([Industry]),
+    TypeOrmModule.forFeature([ProfessionVersion]),
   ],
 })
 export class OrganisationsModule {}

--- a/src/professions/admin/profession-versions.controller.spec.ts
+++ b/src/professions/admin/profession-versions.controller.spec.ts
@@ -110,7 +110,7 @@ describe('ProfessionVersionsController', () => {
 
         (ProfessionPresenter as jest.Mock).mockReturnValue({});
 
-        (Organisation.withLatestLiveVersion as jest.Mock).mockImplementation(
+        (Organisation.withLatestVersion as jest.Mock).mockImplementation(
           () => profession.organisation,
         );
 
@@ -166,7 +166,7 @@ describe('ProfessionVersionsController', () => {
 
         (ProfessionPresenter as jest.Mock).mockReturnValue({});
 
-        (Organisation.withLatestLiveVersion as jest.Mock).mockImplementation(
+        (Organisation.withLatestVersion as jest.Mock).mockImplementation(
           () => profession.organisation,
         );
 
@@ -211,7 +211,7 @@ describe('ProfessionVersionsController', () => {
 
         (ProfessionPresenter as jest.Mock).mockReturnValue({});
 
-        (Organisation.withLatestLiveVersion as jest.Mock).mockImplementation(
+        (Organisation.withLatestVersion as jest.Mock).mockImplementation(
           () => profession.organisation,
         );
 

--- a/src/professions/admin/profession-versions.controller.ts
+++ b/src/professions/admin/profession-versions.controller.ts
@@ -61,7 +61,7 @@ export class ProfessionVersionsController {
     const profession = Profession.withVersion(version.profession, version);
     const presenter = new ProfessionPresenter(profession, this.i18nService);
 
-    const organisation = Organisation.withLatestLiveVersion(
+    const organisation = Organisation.withLatestVersion(
       profession.organisation,
     );
 

--- a/src/professions/profession-versions.service.ts
+++ b/src/professions/profession-versions.service.ts
@@ -183,6 +183,20 @@ export class ProfessionVersionsService {
     );
   }
 
+  async latestVersion(profession: Profession): Promise<ProfessionVersion> {
+    return await this.versionsWithJoins()
+      .distinctOn(['professionVersion.profession'])
+      .where('professionVersion.status IN(:...status)', {
+        status: [ProfessionVersionStatus.Live, ProfessionVersionStatus.Draft],
+      })
+      .where({ profession: profession })
+      .orderBy(
+        'professionVersion.profession, professionVersion.created_at',
+        'DESC',
+      )
+      .getOne();
+  }
+
   async findLiveBySlug(slug: string): Promise<Profession> {
     const version = await this.versionsWithJoins()
       .leftJoinAndSelect('organisation.versions', 'organisationVersions')

--- a/views/admin/organisations/archive/new.njk
+++ b/views/admin/organisations/archive/new.njk
@@ -8,8 +8,9 @@
   <h1 class="govuk-heading-l">{{ ('organisations.admin.archive.heading' | t({organisationName: organisation.name})) }}</h1>
 
   <div class="govuk-grid-row">
-
     <div class="govuk-grid-column-full">
+      <p class="govuk-body">{{ 'organisations.admin.archive.details' | t }}</p>
+
       <form action="/admin/organisations/{{ organisation.id }}/versions/{{ organisation.versionId }}/archive?_method=DELETE" method="post">
         {{
           govukButton({


### PR DESCRIPTION
When we archive an Organisation, we should also archive their professions, otherwise we'll get orphaned professions showing up on the public facing side of the site, as well as a bunch of other unexpected oddness.

# Screenshots

## Before

![image](https://user-images.githubusercontent.com/109774/156015237-3b05795b-1dab-4a91-9afc-6f2b41a9007a.png)

## After

![image](https://user-images.githubusercontent.com/109774/156015157-3b63f26e-57f4-44d1-99a1-107bd01443cc.png)
