### PR TITLE
(2073) Handle user entered URLs not containing protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - Remove placeholder nav subsection on public-facing homepage
+- Improve URL validation and presentation
 
 ## [release-005] - 2022-02-24
 

--- a/src/config/nunjucks.config.ts
+++ b/src/config/nunjucks.config.ts
@@ -6,6 +6,7 @@ import * as nunjucks from 'nunjucks';
 
 import { AssetsHelper } from '../helpers/assets.helper';
 import { formatMultilineString } from '../helpers/format-multiline-string.helper';
+import { formatLink } from '../helpers/format-link.helper';
 import { I18nHelper } from '../helpers/i18n.helper';
 
 export const nunjucksConfig = async (
@@ -76,6 +77,10 @@ export const nunjucksConfig = async (
     return new nunjucks.runtime.SafeString(
       formatMultilineString(text, classes),
     );
+  });
+
+  env.addFilter('link', (text) => {
+    return new nunjucks.runtime.SafeString(formatLink(text));
   });
 
   return env;

--- a/src/helpers/format-link.helper.spec.ts
+++ b/src/helpers/format-link.helper.spec.ts
@@ -1,0 +1,53 @@
+import { isURL } from 'class-validator';
+import { escapeOf } from '../testutils/escape-of';
+import { escape } from './escape.helper';
+import { formatLink } from './format-link.helper';
+import { preprocessUrl } from './preprocess-url.helper';
+
+jest.mock('./escape.helper');
+jest.mock('./preprocess-url.helper');
+jest.mock('class-validator');
+
+describe('formatLink', () => {
+  describe('when given a URL', () => {
+    it('returns the URL wrapped in link tags', () => {
+      (preprocessUrl as jest.Mock).mockImplementation(preprocessUrlOf);
+      (escape as jest.Mock).mockImplementation(escapeOf);
+      (isURL as jest.Mock).mockReturnValue(true);
+
+      const result = formatLink('http://www.example.com');
+
+      const presentedUrl = escapeOf(preprocessUrlOf('http://www.example.com'));
+
+      expect(result).toEqual(
+        `<a href="${presentedUrl}" class="govuk-link">${presentedUrl}</a>`,
+      );
+    });
+  });
+
+  describe('when given a non-URL', () => {
+    it('returns the escaped input string', () => {
+      (preprocessUrl as jest.Mock).mockImplementation(preprocessUrlOf);
+      (escape as jest.Mock).mockImplementation(escapeOf);
+      (isURL as jest.Mock).mockReturnValue(false);
+
+      const result = formatLink('not a url');
+
+      expect(result).toEqual(escapeOf('not a url'));
+    });
+  });
+
+  describe('when given `null`', () => {
+    it('returns an empty string', () => {
+      expect(formatLink(null)).toEqual('');
+    });
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+});
+
+export function preprocessUrlOf(text: string): string {
+  return `Preprocessed URL of '${text}'`;
+}

--- a/src/helpers/format-link.helper.ts
+++ b/src/helpers/format-link.helper.ts
@@ -1,0 +1,19 @@
+import { isURL } from 'class-validator';
+import { escape } from './escape.helper';
+import { preprocessUrl, urlOptions } from './preprocess-url.helper';
+
+export function formatLink(url: string): string {
+  if (!url) {
+    return '';
+  }
+
+  const preprocessedUrl = preprocessUrl(url);
+
+  if (!isURL(preprocessedUrl, urlOptions)) {
+    return escape(url);
+  }
+
+  const escapedUrl = escape(preprocessedUrl);
+
+  return `<a href="${escapedUrl}" class="govuk-link">${escapedUrl}</a>`;
+}

--- a/src/helpers/format-multiline-string.helper.spec.ts
+++ b/src/helpers/format-multiline-string.helper.spec.ts
@@ -1,6 +1,7 @@
 import { escapeOf } from '../testutils/escape-of';
 import { escape } from './escape.helper';
 import { formatMultilineString } from './format-multiline-string.helper';
+
 jest.mock('./escape.helper');
 
 describe('formatMultilineString', () => {

--- a/src/helpers/parse-boolean.helper.spec.ts
+++ b/src/helpers/parse-boolean.helper.spec.ts
@@ -1,0 +1,31 @@
+import { parseBoolean } from './parse-boolean.helper';
+
+describe('parseBoolean', () => {
+  it('parses `true` as `true`', () => {
+    expect(parseBoolean(true)).toEqual(true);
+  });
+
+  it("parses `'true'` as `true`", () => {
+    expect(parseBoolean('true')).toEqual(true);
+  });
+
+  it('parses `false` as `false`', () => {
+    expect(parseBoolean(false)).toEqual(false);
+  });
+
+  it("parses `'false'` as `false`", () => {
+    expect(parseBoolean('false')).toEqual(false);
+  });
+
+  it('parses `undefined` as `false`', () => {
+    expect(parseBoolean(undefined)).toEqual(false);
+  });
+
+  it('parses an arbitrary string as `false`', () => {
+    expect(parseBoolean('not a boolean')).toEqual(false);
+  });
+
+  it('parses an empty string as `false`', () => {
+    expect(parseBoolean('not a boolean')).toEqual(false);
+  });
+});

--- a/src/helpers/parse-boolean.helper.ts
+++ b/src/helpers/parse-boolean.helper.ts
@@ -1,0 +1,3 @@
+export function parseBoolean(value: string | boolean): boolean {
+  return value === 'true' || value === true;
+}

--- a/src/helpers/preprocess-url.helper.spec.ts
+++ b/src/helpers/preprocess-url.helper.spec.ts
@@ -1,0 +1,49 @@
+import { preprocessUrl } from './preprocess-url.helper';
+
+describe('preprocessUrl', () => {
+  describe('when the input string is not a URL', () => {
+    it('returns the input string', () => {
+      expect(preprocessUrl('  definitely not a URL')).toEqual(
+        '  definitely not a URL',
+      );
+    });
+  });
+
+  describe('when the input string has an unexpected protocol', () => {
+    it('returns the input string', () => {
+      expect(preprocessUrl('  ftp://example.com')).toEqual(
+        '  ftp://example.com',
+      );
+    });
+  });
+
+  describe('when the input string is missing a protocol', () => {
+    it('returns the input string with a default protocol prepended', () => {
+      expect(preprocessUrl('www.example.com')).toEqual(
+        'http://www.example.com',
+      );
+    });
+  });
+
+  describe('when the input string has an expected protocol', () => {
+    it('returns the input string', () => {
+      expect(preprocessUrl('http://www.example.com')).toEqual(
+        'http://www.example.com',
+      );
+      expect(preprocessUrl('https://www.example.com')).toEqual(
+        'https://www.example.com',
+      );
+    });
+  });
+
+  describe('when the input string is a URL surrounded with whitespace', () => {
+    it('returns the URL with the whitespace removed', () => {
+      expect(preprocessUrl(' https://www.example.com \n')).toEqual(
+        'https://www.example.com',
+      );
+      expect(preprocessUrl(' www.example.com \n')).toEqual(
+        'http://www.example.com',
+      );
+    });
+  });
+});

--- a/src/helpers/preprocess-url.helper.ts
+++ b/src/helpers/preprocess-url.helper.ts
@@ -1,0 +1,28 @@
+import { isURL } from 'class-validator';
+
+export const urlOptions = {
+  require_protocol: true,
+  protocols: ['http', 'https'],
+};
+
+export function preprocessUrl(url: string): string {
+  if (!url) {
+    return url;
+  }
+
+  const trimmedUrl = url.trim();
+
+  if (isURL(trimmedUrl, urlOptions)) {
+    return trimmedUrl;
+  }
+
+  if (isURL(trimmedUrl, { ...urlOptions, require_protocol: false })) {
+    const candidateUrl = `http://${trimmedUrl}`;
+
+    if (isURL(candidateUrl, urlOptions)) {
+      return candidateUrl;
+    }
+  }
+
+  return url;
+}

--- a/src/helpers/validator.ts
+++ b/src/helpers/validator.ts
@@ -1,19 +1,22 @@
 import { validate, ValidationError } from 'class-validator';
 import { plainToClass } from 'class-transformer';
 
-export class Validator {
-  obj: object;
+export class Validator<T extends object> {
+  obj: T;
   dtoType: any;
   errors: ValidationError[];
 
-  public static async validate(dtoType: any, obj: object) {
-    const object: object = plainToClass(dtoType, obj);
+  public static async validate<T extends object>(
+    dtoType: { new (): T },
+    obj: object,
+  ) {
+    const object: T = plainToClass(dtoType, obj);
     const errors = await validate(object);
 
-    return new Validator(dtoType, obj, errors);
+    return new Validator<T>(dtoType, object, errors);
   }
 
-  constructor(dtoType: any, obj: object, errors: ValidationError[]) {
+  constructor(dtoType: any, obj: T, errors: ValidationError[]) {
     this.obj = obj;
     this.dtoType = dtoType;
     this.errors = errors;

--- a/src/i18n/en/organisations.json
+++ b/src/i18n/en/organisations.json
@@ -95,7 +95,7 @@
       },
       "errors": {
         "name": {
-          "empty": "Enter the name of the regulated profession"
+          "empty": "Enter the name of the regulatory authority"
         },
         "email": {
           "invalid": "Please enter a valid email address"

--- a/src/i18n/en/professions.json
+++ b/src/i18n/en/professions.json
@@ -146,6 +146,9 @@
       "reservedActivities": {
         "empty": "Enter reserved activities"
       },
+      "regulationUrl": {
+        "invalid": "Please enter a valid website address"
+      },
       "registrationUrl": {
         "invalid": "Please enter a valid website address"
       },

--- a/src/organisations/admin/dto/organisation.dto.ts
+++ b/src/organisations/admin/dto/organisation.dto.ts
@@ -1,4 +1,9 @@
+import { Transform } from 'class-transformer';
 import { IsEmail, IsNotEmpty, IsUrl, ValidateIf } from 'class-validator';
+import {
+  preprocessUrl,
+  urlOptions,
+} from '../../../helpers/preprocess-url.helper';
 
 export class OrganisationDto {
   @IsNotEmpty({
@@ -18,20 +23,16 @@ export class OrganisationDto {
   @ValidateIf((e) => e.email)
   email: string;
 
-  @IsUrl(
-    {},
-    {
-      message: 'organisations.admin.form.errors.url.invalid',
-    },
-  )
+  @IsUrl(urlOptions, {
+    message: 'organisations.admin.form.errors.url.invalid',
+  })
+  @Transform(({ value }) => preprocessUrl(value))
   url: string;
 
-  @IsUrl(
-    {},
-    {
-      message: 'organisations.admin.form.errors.contactUrl.invalid',
-    },
-  )
+  @IsUrl(urlOptions, {
+    message: 'organisations.admin.form.errors.contactUrl.invalid',
+  })
+  @Transform(({ value }) => preprocessUrl(value))
   @ValidateIf((e) => e.contactUrl)
   contactUrl: string;
 

--- a/src/organisations/presenters/organisation.presenter.spec.ts
+++ b/src/organisations/presenters/organisation.presenter.spec.ts
@@ -16,10 +16,13 @@ import { multilineOf } from '../../testutils/multiline-of';
 import userFactory from '../../testutils/factories/user';
 import { formatDate } from '../../common/utils';
 import { translationOf } from '../../testutils/translation-of';
+import { formatLink } from '../../helpers/format-link.helper';
+import { linkOf } from '../../testutils/link-of';
 
 jest.mock('../../helpers/escape.helper');
 jest.mock('../../helpers/format-multiline-string.helper');
 jest.mock('../../common/utils');
+jest.mock('../../helpers/format-link.helper');
 
 describe('OrganisationPresenter', () => {
   let organisation: Organisation;
@@ -458,7 +461,7 @@ describe('OrganisationPresenter', () => {
   describe('contactUrl', () => {
     it('makes the url into a link', () => {
       const i18nService = createMockI18nService();
-      (escape as jest.Mock).mockImplementation(escapeOf);
+      (formatLink as jest.Mock).mockImplementation(linkOf);
 
       organisation = organisationFactory.build({
         contactUrl: 'http://www.example.com',
@@ -466,13 +469,9 @@ describe('OrganisationPresenter', () => {
 
       const presenter = new OrganisationPresenter(organisation, i18nService);
 
-      expect(presenter.contactUrl()).toEqual(
-        `<a href="${escapeOf(
-          'http://www.example.com',
-        )}" class="govuk-link">${escapeOf('http://www.example.com')}</a>`,
-      );
+      expect(presenter.contactUrl()).toEqual(linkOf('http://www.example.com'));
 
-      expect(escape).toBeCalledWith('http://www.example.com');
+      expect(formatLink).toBeCalledWith('http://www.example.com');
     });
   });
 

--- a/src/organisations/presenters/organisation.presenter.ts
+++ b/src/organisations/presenters/organisation.presenter.ts
@@ -5,6 +5,7 @@ import { SummaryList } from '../../common/interfaces/summary-list';
 import { escape } from '../../helpers/escape.helper';
 import { formatMultilineString } from '../../helpers/format-multiline-string.helper';
 import { formatDate } from '../../common/utils';
+import { formatLink } from '../../helpers/format-link.helper';
 
 interface OrganisationSummaryListOptions {
   classes?: string;
@@ -178,9 +179,7 @@ export class OrganisationPresenter {
   }
 
   public contactUrl(): string {
-    return `<a href="${escape(
-      this.organisation.contactUrl,
-    )}" class="govuk-link">${escape(this.organisation.contactUrl)}</a>`;
+    return formatLink(this.organisation.contactUrl);
   }
 
   private async industries(): Promise<string> {

--- a/src/professions/admin/dto/legislation.dto.ts
+++ b/src/professions/admin/dto/legislation.dto.ts
@@ -1,4 +1,9 @@
+import { Transform } from 'class-transformer';
 import { IsNotEmpty, IsUrl, ValidateIf } from 'class-validator';
+import {
+  preprocessUrl,
+  urlOptions,
+} from '../../../helpers/preprocess-url.helper';
 
 export default class LegislationDto {
   @IsNotEmpty({
@@ -6,12 +11,10 @@ export default class LegislationDto {
   })
   nationalLegislation: string;
 
-  @IsUrl(
-    {},
-    {
-      message: 'professions.form.errors.legislation.link.invalid',
-    },
-  )
+  @IsUrl(urlOptions, {
+    message: 'professions.form.errors.legislation.link.invalid',
+  })
+  @Transform(({ value }) => preprocessUrl(value))
   link: string;
 
   @IsNotEmpty({
@@ -21,12 +24,10 @@ export default class LegislationDto {
   @ValidateIf((e) => e.secondLink || e.secondNationalLegislation)
   secondNationalLegislation?: string;
 
-  @IsUrl(
-    {},
-    {
-      message: 'professions.form.errors.legislation.secondLink.invalid',
-    },
-  )
+  @IsUrl(urlOptions, {
+    message: 'professions.form.errors.legislation.secondLink.invalid',
+  })
+  @Transform(({ value }) => preprocessUrl(value))
   @ValidateIf((e) => e.secondLink || e.secondNationalLegislation)
   secondLink?: string;
 

--- a/src/professions/admin/dto/legislation.dto.ts
+++ b/src/professions/admin/dto/legislation.dto.ts
@@ -1,5 +1,6 @@
 import { Transform } from 'class-transformer';
 import { IsNotEmpty, IsUrl, ValidateIf } from 'class-validator';
+import { parseBoolean } from '../../../helpers/parse-boolean.helper';
 import {
   preprocessUrl,
   urlOptions,
@@ -31,5 +32,6 @@ export default class LegislationDto {
   @ValidateIf((e) => e.secondLink || e.secondNationalLegislation)
   secondLink?: string;
 
-  change: string;
+  @Transform(({ value }) => parseBoolean(value))
+  change: boolean;
 }

--- a/src/professions/admin/dto/qualifications.dto.ts
+++ b/src/professions/admin/dto/qualifications.dto.ts
@@ -1,4 +1,9 @@
+import { Transform } from 'class-transformer';
 import { IsNotEmpty, ValidateIf, IsUrl } from 'class-validator';
+import {
+  preprocessUrl,
+  urlOptions,
+} from '../../../helpers/preprocess-url.helper';
 
 export class QualificationsDto {
   @IsNotEmpty({ message: 'professions.form.errors.qualification.level.empty' })
@@ -26,36 +31,29 @@ export class QualificationsDto {
   })
   mandatoryProfessionalExperience: string;
 
-  @IsUrl(
-    {},
-    {
-      message:
-        'professions.form.errors.qualification.moreInformationUrl.invalid',
-    },
-  )
+  @IsUrl(urlOptions, {
+    message: 'professions.form.errors.qualification.moreInformationUrl.invalid',
+  })
+  @Transform(({ value }) => preprocessUrl(value))
   @ValidateIf((e) => e.moreInformationUrl)
   moreInformationUrl: string;
 
   ukRecognition: string;
 
-  @IsUrl(
-    {},
-    {
-      message: 'professions.form.errors.qualification.ukRecognitionUrl.invalid',
-    },
-  )
+  @IsUrl(urlOptions, {
+    message: 'professions.form.errors.qualification.ukRecognitionUrl.invalid',
+  })
+  @Transform(({ value }) => preprocessUrl(value))
   @ValidateIf((e) => e.ukRecognitionUrl)
   ukRecognitionUrl: string;
 
   otherCountriesRecognition: string;
 
-  @IsUrl(
-    {},
-    {
-      message:
-        'professions.form.errors.qualification.otherCountriesRecognitionUrl.invalid',
-    },
-  )
+  @IsUrl(urlOptions, {
+    message:
+      'professions.form.errors.qualification.otherCountriesRecognitionUrl.invalid',
+  })
+  @Transform(({ value }) => preprocessUrl(value))
   @ValidateIf((e) => e.otherCountriesRecognitionUrl)
   otherCountriesRecognitionUrl: string;
 

--- a/src/professions/admin/dto/qualifications.dto.ts
+++ b/src/professions/admin/dto/qualifications.dto.ts
@@ -1,5 +1,6 @@
 import { Transform } from 'class-transformer';
 import { IsNotEmpty, ValidateIf, IsUrl } from 'class-validator';
+import { parseBoolean } from '../../../helpers/parse-boolean.helper';
 import {
   preprocessUrl,
   urlOptions,
@@ -57,5 +58,6 @@ export class QualificationsDto {
   @ValidateIf((e) => e.otherCountriesRecognitionUrl)
   otherCountriesRecognitionUrl: string;
 
+  @Transform(({ value }) => parseBoolean(value))
   change: boolean;
 }

--- a/src/professions/admin/dto/registration.dto.ts
+++ b/src/professions/admin/dto/registration.dto.ts
@@ -17,4 +17,6 @@ export class RegistrationDto {
   )
   @ValidateIf((e) => e.registrationUrl)
   registrationUrl: string;
+
+  change: string;
 }

--- a/src/professions/admin/dto/registration.dto.ts
+++ b/src/professions/admin/dto/registration.dto.ts
@@ -1,4 +1,9 @@
+import { Transform } from 'class-transformer';
 import { IsNotEmpty, IsUrl, ValidateIf } from 'class-validator';
+import {
+  preprocessUrl,
+  urlOptions,
+} from '../../../helpers/preprocess-url.helper';
 import { MandatoryRegistration } from '../../profession.entity';
 
 export class RegistrationDto {
@@ -9,12 +14,10 @@ export class RegistrationDto {
 
   registrationRequirements: string;
 
-  @IsUrl(
-    {},
-    {
-      message: 'professions.form.errors.registrationUrl.invalid',
-    },
-  )
+  @IsUrl(urlOptions, {
+    message: 'professions.form.errors.registrationUrl.invalid',
+  })
+  @Transform(({ value }) => preprocessUrl(value))
   @ValidateIf((e) => e.registrationUrl)
   registrationUrl: string;
 

--- a/src/professions/admin/dto/registration.dto.ts
+++ b/src/professions/admin/dto/registration.dto.ts
@@ -1,5 +1,6 @@
 import { Transform } from 'class-transformer';
 import { IsNotEmpty, IsUrl, ValidateIf } from 'class-validator';
+import { parseBoolean } from '../../../helpers/parse-boolean.helper';
 import {
   preprocessUrl,
   urlOptions,
@@ -21,5 +22,6 @@ export class RegistrationDto {
   @ValidateIf((e) => e.registrationUrl)
   registrationUrl: string;
 
-  change: string;
+  @Transform(({ value }) => parseBoolean(value))
+  change: boolean;
 }

--- a/src/professions/admin/dto/regulated-activities.dto.ts
+++ b/src/professions/admin/dto/regulated-activities.dto.ts
@@ -10,5 +10,5 @@ export class RegulatedActivitiesDto {
   protectedTitles: string;
   regulationUrl: string;
 
-  change: boolean;
+  change: string;
 }

--- a/src/professions/admin/dto/regulated-activities.dto.ts
+++ b/src/professions/admin/dto/regulated-activities.dto.ts
@@ -1,4 +1,9 @@
-import { IsNotEmpty } from 'class-validator';
+import { Transform } from 'class-transformer';
+import { IsNotEmpty, IsUrl, ValidateIf } from 'class-validator';
+import {
+  preprocessUrl,
+  urlOptions,
+} from '../../../helpers/preprocess-url.helper';
 
 export class RegulatedActivitiesDto {
   @IsNotEmpty({ message: 'professions.form.errors.regulationSummary.empty' })
@@ -8,6 +13,12 @@ export class RegulatedActivitiesDto {
   reservedActivities: string;
 
   protectedTitles: string;
+
+  @IsUrl(urlOptions, {
+    message: 'professions.form.errors.regulationUrl.invalid',
+  })
+  @Transform(({ value }) => preprocessUrl(value))
+  @ValidateIf((e) => e.regulationUrl)
   regulationUrl: string;
 
   change: string;

--- a/src/professions/admin/dto/regulated-activities.dto.ts
+++ b/src/professions/admin/dto/regulated-activities.dto.ts
@@ -1,5 +1,6 @@
 import { Transform } from 'class-transformer';
 import { IsNotEmpty, IsUrl, ValidateIf } from 'class-validator';
+import { parseBoolean } from '../../../helpers/parse-boolean.helper';
 import {
   preprocessUrl,
   urlOptions,
@@ -21,5 +22,6 @@ export class RegulatedActivitiesDto {
   @ValidateIf((e) => e.regulationUrl)
   regulationUrl: string;
 
-  change: string;
+  @Transform(({ value }) => parseBoolean(value))
+  change: boolean;
 }

--- a/src/professions/admin/dto/scope.dto.ts
+++ b/src/professions/admin/dto/scope.dto.ts
@@ -1,4 +1,6 @@
+import { Transform } from 'class-transformer';
 import { IsNotEmpty, ValidateIf, IsIn } from 'class-validator';
+import { parseBoolean } from '../../../helpers/parse-boolean.helper';
 
 export class ScopeDto {
   @IsIn(['1', '0'], { message: 'professions.form.errors.nations.empty' })
@@ -11,5 +13,6 @@ export class ScopeDto {
   @IsNotEmpty({ message: 'professions.form.errors.industries.empty' })
   industries: string[];
 
-  change: string;
+  @Transform(({ value }) => parseBoolean(value))
+  change: boolean;
 }

--- a/src/professions/admin/dto/top-level-details.dto.ts
+++ b/src/professions/admin/dto/top-level-details.dto.ts
@@ -1,4 +1,6 @@
+import { Transform } from 'class-transformer';
 import { IsNotEmpty } from 'class-validator';
+import { parseBoolean } from '../../../helpers/parse-boolean.helper';
 
 export class TopLevelDetailsDto {
   @IsNotEmpty({ message: 'professions.form.errors.name.empty' })
@@ -11,5 +13,6 @@ export class TopLevelDetailsDto {
 
   additionalRegulatoryBody: string;
 
-  change: string;
+  @Transform(({ value }) => parseBoolean(value))
+  change: boolean;
 }

--- a/src/professions/admin/legislation.controller.spec.ts
+++ b/src/professions/admin/legislation.controller.spec.ts
@@ -114,7 +114,7 @@ describe(LegislationController, () => {
         const dto: LegislationDto = {
           link: 'www.legal-legislation.com',
           nationalLegislation: 'Legal Services Act 2008',
-          change: 'false',
+          change: false,
         };
 
         professionsService.findWithVersions.mockResolvedValue(profession);
@@ -153,7 +153,7 @@ describe(LegislationController, () => {
           nationalLegislation: 'Legal Services Act 2008',
           secondLink: 'http://www.another-legal-legislation.com',
           secondNationalLegislation: 'Another Legal Services Act 2008',
-          change: 'false',
+          change: false,
         };
 
         professionsService.findWithVersions.mockResolvedValue(profession);
@@ -196,7 +196,7 @@ describe(LegislationController, () => {
           nationalLegislation: 'Legal Services Act 2008',
           secondLink: 'www.another-legal-legislation.com   ',
           secondNationalLegislation: 'Another Legal Services Act 2008',
-          change: 'false',
+          change: false,
         };
 
         professionsService.findWithVersions.mockResolvedValue(profession);
@@ -237,7 +237,7 @@ describe(LegislationController, () => {
         const dto: LegislationDto = {
           link: undefined,
           nationalLegislation: undefined,
-          change: 'false',
+          change: false,
         };
 
         professionsService.findWithVersions.mockResolvedValue(profession);

--- a/src/professions/admin/legislation.controller.spec.ts
+++ b/src/professions/admin/legislation.controller.spec.ts
@@ -40,7 +40,7 @@ describe(LegislationController, () => {
       it('renders the Legislation page, passing in any values on the Profession that have already been set', async () => {
         const legislation = legislationFactory.build({
           name: 'Legal Services Act 2007',
-          url: 'www.example.com',
+          url: 'http://www.example.com',
         });
         const profession = professionFactory.build({
           id: 'profession-id',
@@ -69,12 +69,12 @@ describe(LegislationController, () => {
       it('renders the Legislation page, passing in any values on the Profession that have already been set', async () => {
         const legislation1 = legislationFactory.build({
           name: 'Legal Services Act 2007',
-          url: 'www.example.com',
+          url: 'http://www.example.com',
         });
 
         const legislation2 = legislationFactory.build({
           name: 'Another Legal Services Act 2007',
-          url: 'www.another-example.com',
+          url: 'http://www.another-example.com',
         });
 
         const profession = professionFactory.build({
@@ -126,7 +126,7 @@ describe(LegislationController, () => {
           expect.objectContaining({
             legislations: [
               expect.objectContaining({
-                url: 'www.legal-legislation.com',
+                url: 'http://www.legal-legislation.com',
                 name: 'Legal Services Act 2008',
               }),
             ],
@@ -149,9 +149,9 @@ describe(LegislationController, () => {
         });
 
         const dto: LegislationDto = {
-          link: 'www.legal-legislation.com',
+          link: 'http://www.legal-legislation.com',
           nationalLegislation: 'Legal Services Act 2008',
-          secondLink: 'www.another-legal-legislation.com',
+          secondLink: 'http://www.another-legal-legislation.com',
           secondNationalLegislation: 'Another Legal Services Act 2008',
           change: 'false',
         };
@@ -165,11 +165,54 @@ describe(LegislationController, () => {
           expect.objectContaining({
             legislations: [
               expect.objectContaining({
-                url: 'www.legal-legislation.com',
+                url: 'http://www.legal-legislation.com',
                 name: 'Legal Services Act 2008',
               }),
               expect.objectContaining({
-                url: 'www.another-legal-legislation.com',
+                url: 'http://www.another-legal-legislation.com',
+                name: 'Another Legal Services Act 2008',
+              }),
+            ],
+            profession: profession,
+          }),
+        );
+
+        expect(response.redirect).toHaveBeenCalledWith(
+          '/admin/professions/profession-id/versions/version-id/check-your-answers',
+        );
+      });
+    });
+
+    describe('when provided URLs are mis-formatted', () => {
+      it('correctly formats the URLs before saving', async () => {
+        const profession = professionFactory.build({ id: 'profession-id' });
+        const version = professionVersionFactory.build({
+          id: 'version-id',
+          profession: profession,
+        });
+
+        const dto: LegislationDto = {
+          link: 'www.legal-legislation.com',
+          nationalLegislation: 'Legal Services Act 2008',
+          secondLink: 'www.another-legal-legislation.com   ',
+          secondNationalLegislation: 'Another Legal Services Act 2008',
+          change: 'false',
+        };
+
+        professionsService.findWithVersions.mockResolvedValue(profession);
+        professionVersionsService.findWithProfession.mockResolvedValue(version);
+
+        await controller.update(response, 'profession-id', 'version-id', dto);
+
+        expect(professionVersionsService.save).toHaveBeenCalledWith(
+          expect.objectContaining({
+            legislations: [
+              expect.objectContaining({
+                url: 'http://www.legal-legislation.com',
+                name: 'Legal Services Act 2008',
+              }),
+              expect.objectContaining({
+                url: 'http://www.another-legal-legislation.com',
                 name: 'Another Legal Services Act 2008',
               }),
             ],

--- a/src/professions/admin/legislation.controller.ts
+++ b/src/professions/admin/legislation.controller.ts
@@ -41,7 +41,6 @@ export class LegislationController {
   async edit(
     @Res() res: Response,
     @Param('professionId') professionId: string,
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     @Param('versionId') versionId: string,
     @Query('change') change: string,
   ): Promise<void> {

--- a/src/professions/admin/legislation.controller.ts
+++ b/src/professions/admin/legislation.controller.ts
@@ -110,7 +110,7 @@ export class LegislationController {
         updatedLegislation,
         updatedSecondLegislation,
         isConfirmed(profession),
-        submittedValues.change === 'true',
+        submittedValues.change,
         errors,
       );
     }

--- a/src/professions/admin/legislation.controller.ts
+++ b/src/professions/admin/legislation.controller.ts
@@ -76,6 +76,7 @@ export class LegislationController {
     @Body() legislationDto,
   ): Promise<void> {
     const validator = await Validator.validate(LegislationDto, legislationDto);
+    const submittedValues = validator.obj;
 
     const profession = await this.professionsService.findWithVersions(
       professionId,
@@ -84,8 +85,6 @@ export class LegislationController {
     const version = await this.professionVersionsService.findWithProfession(
       versionId,
     );
-
-    const submittedValues: LegislationDto = legislationDto;
 
     const updatedLegislation: Legislation = {
       ...version.legislations[0],

--- a/src/professions/admin/qualifications.controller.spec.ts
+++ b/src/professions/admin/qualifications.controller.spec.ts
@@ -156,7 +156,7 @@ describe(QualificationsController, () => {
             routesToObtain: 'General secondary education',
             mostCommonRouteToObtain: 'General secondary education',
             duration: '3.0 Years',
-            moreInformationUrl: 'www.example.com/more-info',
+            moreInformationUrl: 'http://www.example.com/more-info',
             mandatoryProfessionalExperience: '1',
             ukRecognition: 'ukRecognition',
             ukRecognitionUrl: 'http://example.com/uk',
@@ -179,7 +179,7 @@ describe(QualificationsController, () => {
                 mostCommonRouteToObtain: 'General secondary education',
                 educationDuration: '3.0 Years',
                 level: 'Qualification level',
-                url: 'www.example.com/more-info',
+                url: 'http://www.example.com/more-info',
                 mandatoryProfessionalExperience: true,
                 ukRecognition: 'ukRecognition',
                 ukRecognitionUrl: 'http://example.com/uk',
@@ -210,7 +210,7 @@ describe(QualificationsController, () => {
             routesToObtain: 'General secondary education',
             mostCommonRouteToObtain: 'General secondary education',
             duration: '3.0 Years',
-            moreInformationUrl: 'www.example.com/more-info',
+            moreInformationUrl: 'http://www.example.com/more-info',
             mandatoryProfessionalExperience: '1',
             ukRecognition: 'ukRecognition',
             ukRecognitionUrl: 'http://example.com/uk',
@@ -233,7 +233,7 @@ describe(QualificationsController, () => {
                 mostCommonRouteToObtain: 'General secondary education',
                 educationDuration: '3.0 Years',
                 level: 'Qualification level',
-                url: 'www.example.com/more-info',
+                url: 'http://www.example.com/more-info',
                 mandatoryProfessionalExperience: true,
                 ukRecognition: 'ukRecognition',
                 ukRecognitionUrl: 'http://example.com/uk',
@@ -247,6 +247,58 @@ describe(QualificationsController, () => {
             '/admin/professions/profession-id/versions/version-id/check-your-answers',
           );
         });
+      });
+    });
+
+    describe('when provided URLs are mis-formatted', () => {
+      it('correctly formats the URLs before saving', async () => {
+        const profession = professionFactory.build({ id: 'profession-id' });
+
+        const version = professionVersionFactory.build({
+          id: 'version-id',
+          profession: profession,
+          qualification: qualificationFactory.build(),
+        });
+
+        const dto: QualificationsDto = {
+          level: 'Qualification level',
+          routesToObtain: 'General secondary education',
+          mostCommonRouteToObtain: 'General secondary education',
+          duration: '3.0 Years',
+          moreInformationUrl: 'www.example.com/more-info ',
+          mandatoryProfessionalExperience: '1',
+          ukRecognition: 'ukRecognition',
+          ukRecognitionUrl: 'example.com/uk',
+          otherCountriesRecognition: 'otherCountriesRecognition',
+          otherCountriesRecognitionUrl: '\nhttp://example.com/other',
+          change: true,
+        };
+
+        professionsService.findWithVersions.mockResolvedValue(profession);
+        professionVersionsService.findWithProfession.mockResolvedValue(version);
+
+        await controller.update(response, 'profession-id', 'version-id', dto);
+
+        expect(professionVersionsService.save).toHaveBeenCalledWith(
+          expect.objectContaining({
+            qualification: expect.objectContaining({
+              routesToObtain: 'General secondary education',
+              mostCommonRouteToObtain: 'General secondary education',
+              educationDuration: '3.0 Years',
+              level: 'Qualification level',
+              url: 'http://www.example.com/more-info',
+              mandatoryProfessionalExperience: true,
+              ukRecognition: 'ukRecognition',
+              ukRecognitionUrl: 'http://example.com/uk',
+              otherCountriesRecognition: 'otherCountriesRecognition',
+              otherCountriesRecognitionUrl: 'http://example.com/other',
+            }),
+          }),
+        );
+
+        expect(response.redirect).toHaveBeenCalledWith(
+          '/admin/professions/profession-id/versions/version-id/check-your-answers',
+        );
       });
     });
 

--- a/src/professions/admin/qualifications.controller.ts
+++ b/src/professions/admin/qualifications.controller.ts
@@ -83,6 +83,7 @@ export class QualificationsController {
       QualificationsDto,
       qualificationsDto,
     );
+    const submittedValues = validator.obj;
 
     const profession = await this.professionsService.findWithVersions(
       professionId,
@@ -91,8 +92,6 @@ export class QualificationsController {
     const version = await this.professionVersionsService.findWithProfession(
       versionId,
     );
-
-    const submittedValues: QualificationsDto = qualificationsDto;
 
     const mandatoryProfessionalExperience =
       submittedValues.mandatoryProfessionalExperience === undefined

--- a/src/professions/admin/registration.controller.spec.ts
+++ b/src/professions/admin/registration.controller.spec.ts
@@ -62,7 +62,7 @@ describe(RegistrationController, () => {
         const mandatoryRegistrationRadioButtonsPresenter =
           new MandatoryRegistrationRadioButtonsPresenter(null, i18nService);
 
-        await controller.edit(response, 'profession-id', 'version-id', false);
+        await controller.edit(response, 'profession-id', 'version-id', 'false');
 
         expect(response.render).toHaveBeenCalledWith(
           'admin/professions/registration',
@@ -95,7 +95,7 @@ describe(RegistrationController, () => {
             i18nService,
           );
 
-        await controller.edit(response, 'profession-id', 'version-id', false);
+        await controller.edit(response, 'profession-id', 'version-id', 'false');
 
         expect(response.render).toHaveBeenCalledWith(
           'admin/professions/registration',
@@ -205,7 +205,7 @@ describe(RegistrationController, () => {
           const registrationDtoWithChangeParam = {
             mandatoryRegistration: MandatoryRegistration.Voluntary,
             registrationUrl: '',
-            change: true,
+            change: 'true',
           };
 
           await controller.update(
@@ -240,7 +240,7 @@ describe(RegistrationController, () => {
           const registrationDtoWithFalseChangeParam = {
             mandatoryRegistration: MandatoryRegistration.Voluntary,
             registrationUrl: '',
-            change: false,
+            change: 'false',
           };
 
           await controller.update(

--- a/src/professions/admin/registration.controller.spec.ts
+++ b/src/professions/admin/registration.controller.spec.ts
@@ -247,7 +247,7 @@ describe(RegistrationController, () => {
           const registrationDtoWithChangeParam = {
             mandatoryRegistration: MandatoryRegistration.Voluntary,
             registrationUrl: '',
-            change: 'true',
+            change: true,
           };
 
           await controller.update(
@@ -282,7 +282,7 @@ describe(RegistrationController, () => {
           const registrationDtoWithFalseChangeParam = {
             mandatoryRegistration: MandatoryRegistration.Voluntary,
             registrationUrl: '',
-            change: 'false',
+            change: false,
           };
 
           await controller.update(

--- a/src/professions/admin/registration.controller.spec.ts
+++ b/src/professions/admin/registration.controller.spec.ts
@@ -153,6 +153,48 @@ describe(RegistrationController, () => {
       });
     });
 
+    describe('when provided URL is mis-formatted', () => {
+      it('correctly formats the URL before saving', async () => {
+        const profession = professionFactory.build({
+          id: 'profession-id',
+        });
+        const version = professionVersionFactory.build({
+          id: 'version-id',
+          profession: profession,
+          mandatoryRegistration: MandatoryRegistration.Mandatory,
+        });
+
+        professionsService.findWithVersions.mockResolvedValue(profession);
+        professionVersionsService.findWithProfession.mockResolvedValue(version);
+
+        const registrationDto = {
+          mandatoryRegistration: MandatoryRegistration.Voluntary,
+          registrationRequirements: 'Something',
+          registrationUrl: 'example.com',
+        };
+
+        await controller.update(
+          response,
+          'profession-id',
+          'version-id',
+          registrationDto,
+        );
+
+        expect(professionVersionsService.save).toHaveBeenCalledWith(
+          expect.objectContaining({
+            mandatoryRegistration: MandatoryRegistration.Voluntary,
+            registrationRequirements: 'Something',
+            registrationUrl: 'http://example.com',
+            profession: profession,
+          }),
+        );
+
+        expect(response.redirect).toHaveBeenCalledWith(
+          '/admin/professions/profession-id/versions/version-id/regulated-activities/edit',
+        );
+      });
+    });
+
     describe('when required parameters are not entered', () => {
       it('does not update the profession, and re-renders the regulatory body form page with errors', async () => {
         const registrationDtoWithoutMandatoryRegistration = {

--- a/src/professions/admin/registration.controller.ts
+++ b/src/professions/admin/registration.controller.ts
@@ -108,7 +108,7 @@ export class RegistrationController {
         res,
         submittedValues,
         isConfirmed(profession),
-        submittedValues.change === 'true',
+        submittedValues.change,
         errors,
       );
     }
@@ -124,7 +124,7 @@ export class RegistrationController {
 
     await this.professionVersionsService.save(updatedVersion);
 
-    if (submittedValues.change === 'true') {
+    if (submittedValues.change) {
       return res.redirect(
         `/admin/professions/${version.profession.id}/versions/${versionId}/check-your-answers`,
       );

--- a/src/professions/admin/registration.controller.ts
+++ b/src/professions/admin/registration.controller.ts
@@ -55,7 +55,7 @@ export class RegistrationController {
     @Res() res: Response,
     @Param('professionId') professionId: string,
     @Param('versionId') versionId: string,
-    @Query('change') change: boolean,
+    @Query('change') change: string,
   ): Promise<void> {
     const profession = await this.professionsService.findWithVersions(
       professionId,
@@ -65,7 +65,12 @@ export class RegistrationController {
       versionId,
     );
 
-    return this.renderForm(res, version, isConfirmed(profession), change);
+    return this.renderForm(
+      res,
+      version,
+      isConfirmed(profession),
+      change === 'true',
+    );
   }
 
   @Post('/:professionId/versions/:versionId/registration')
@@ -103,7 +108,7 @@ export class RegistrationController {
         res,
         submittedValues,
         isConfirmed(profession),
-        registrationDto.change,
+        submittedValues.change === 'true',
         errors,
       );
     }
@@ -119,7 +124,7 @@ export class RegistrationController {
 
     await this.professionVersionsService.save(updatedVersion);
 
-    if (registrationDto.change) {
+    if (submittedValues.change === 'true') {
       return res.redirect(
         `/admin/professions/${version.profession.id}/versions/${versionId}/check-your-answers`,
       );

--- a/src/professions/admin/registration.controller.ts
+++ b/src/professions/admin/registration.controller.ts
@@ -90,12 +90,12 @@ export class RegistrationController {
       RegistrationDto,
       registrationDto,
     );
+    const submittedValues = validator.obj;
 
     const version = await this.professionVersionsService.findWithProfession(
       versionId,
     );
 
-    const submittedValues: RegistrationDto = registrationDto;
     const selectedMandatoryRegistration = submittedValues.mandatoryRegistration;
 
     const profession = await this.professionsService.findWithVersions(
@@ -116,8 +116,8 @@ export class RegistrationController {
     const updatedVersion: ProfessionVersion = {
       ...version,
       ...{
-        registrationRequirements: registrationDto.registrationRequirements,
-        registrationUrl: registrationDto.registrationUrl,
+        registrationRequirements: submittedValues.registrationRequirements,
+        registrationUrl: submittedValues.registrationUrl,
         mandatoryRegistration: selectedMandatoryRegistration,
       },
     };

--- a/src/professions/admin/regulated-activities.controller.spec.ts
+++ b/src/professions/admin/regulated-activities.controller.spec.ts
@@ -88,7 +88,7 @@ describe(RegulatedActivitiesController, () => {
             reservedActivities: 'Example reserved activities',
             protectedTitles: 'Example protected titles',
             regulationUrl: 'https://example.com/regulation',
-            change: 'false',
+            change: false,
           };
 
           await controller.update(
@@ -136,7 +136,7 @@ describe(RegulatedActivitiesController, () => {
             reservedActivities: 'Example reserved activities',
             protectedTitles: 'Example protected titles',
             regulationUrl: ' example.com/regulation',
-            change: 'false',
+            change: false,
           };
 
           await controller.update(
@@ -184,7 +184,7 @@ describe(RegulatedActivitiesController, () => {
             reservedActivities: 'Example reserved activities',
             protectedTitles: 'Example protected titles',
             regulationUrl: 'https://example.com/regulation',
-            change: 'true',
+            change: true,
           };
 
           await controller.update(
@@ -232,7 +232,7 @@ describe(RegulatedActivitiesController, () => {
           reservedActivities: undefined,
           protectedTitles: undefined,
           regulationUrl: undefined,
-          change: 'false',
+          change: false,
         };
 
         await controller.update(

--- a/src/professions/admin/regulated-activities.controller.spec.ts
+++ b/src/professions/admin/regulated-activities.controller.spec.ts
@@ -114,6 +114,54 @@ describe(RegulatedActivitiesController, () => {
         });
       });
 
+      describe('when the provided URL is mis-formatted', () => {
+        it('correctly formats the URL before saving', async () => {
+          const profession = professionFactory.build({ id: 'profession-id' });
+          const version = professionVersionFactory.build({
+            id: 'version-id',
+            profession: profession,
+            description: 'Example regulation summary',
+            reservedActivities: 'Example reserved activities',
+            protectedTitles: 'Example protected titles',
+            regulationUrl: 'http://example.com/regulation',
+          });
+
+          professionsService.findWithVersions.mockResolvedValue(profession);
+          professionVersionsService.findWithProfession.mockResolvedValue(
+            version,
+          );
+
+          const regulatedActivitiesDto: RegulatedActivitiesDto = {
+            regulationSummary: 'Example regulation summary',
+            reservedActivities: 'Example reserved activities',
+            protectedTitles: 'Example protected titles',
+            regulationUrl: ' example.com/regulation',
+            change: 'false',
+          };
+
+          await controller.update(
+            response,
+            'profession-id',
+            'version-id',
+            regulatedActivitiesDto,
+          );
+
+          expect(professionVersionsService.save).toHaveBeenCalledWith(
+            expect.objectContaining({
+              id: 'version-id',
+              description: 'Example regulation summary',
+              reservedActivities: 'Example reserved activities',
+              protectedTitles: 'Example protected titles',
+              regulationUrl: 'http://example.com/regulation',
+            }),
+          );
+
+          expect(response.redirect).toHaveBeenCalledWith(
+            '/admin/professions/profession-id/versions/version-id/qualifications/edit',
+          );
+        });
+      });
+
       describe('when the "Change" query param is true', () => {
         it('updates the Profession and redirects to the Check your answers page', async () => {
           const profession = professionFactory.build({ id: 'profession-id' });

--- a/src/professions/admin/regulated-activities.controller.spec.ts
+++ b/src/professions/admin/regulated-activities.controller.spec.ts
@@ -52,7 +52,7 @@ describe(RegulatedActivitiesController, () => {
       professionsService.findWithVersions.mockResolvedValue(profession);
       professionVersionsService.findWithProfession.mockResolvedValue(version);
 
-      await controller.edit(response, 'profession-id', 'version-id', false);
+      await controller.edit(response, 'profession-id', 'version-id', 'false');
 
       expect(response.render).toHaveBeenCalledWith(
         'admin/professions/regulated-activities',
@@ -88,7 +88,7 @@ describe(RegulatedActivitiesController, () => {
             reservedActivities: 'Example reserved activities',
             protectedTitles: 'Example protected titles',
             regulationUrl: 'https://example.com/regulation',
-            change: false,
+            change: 'false',
           };
 
           await controller.update(
@@ -136,7 +136,7 @@ describe(RegulatedActivitiesController, () => {
             reservedActivities: 'Example reserved activities',
             protectedTitles: 'Example protected titles',
             regulationUrl: 'https://example.com/regulation',
-            change: true,
+            change: 'true',
           };
 
           await controller.update(
@@ -184,7 +184,7 @@ describe(RegulatedActivitiesController, () => {
           reservedActivities: undefined,
           protectedTitles: undefined,
           regulationUrl: undefined,
-          change: false,
+          change: 'false',
         };
 
         await controller.update(

--- a/src/professions/admin/regulated-activities.controller.ts
+++ b/src/professions/admin/regulated-activities.controller.ts
@@ -80,6 +80,7 @@ export class RegulatedActivitiesController {
       RegulatedActivitiesDto,
       regulatedActivitiesDto,
     );
+    const submittedValues = validator.obj;
 
     const profession = await this.professionsService.findWithVersions(
       professionId,
@@ -88,8 +89,6 @@ export class RegulatedActivitiesController {
     const version = await this.professionVersionsService.findWithProfession(
       versionId,
     );
-
-    const submittedValues: RegulatedActivitiesDto = regulatedActivitiesDto;
 
     if (!validator.valid()) {
       const errors = new ValidationFailedError(validator.errors).fullMessages();

--- a/src/professions/admin/regulated-activities.controller.ts
+++ b/src/professions/admin/regulated-activities.controller.ts
@@ -42,7 +42,7 @@ export class RegulatedActivitiesController {
     @Res() res: Response,
     @Param('professionId') professionId: string,
     @Param('versionId') versionId: string,
-    @Query('change') change: boolean,
+    @Query('change') change: string,
   ): Promise<void> {
     const profession = await this.professionsService.findWithVersions(
       professionId,
@@ -59,7 +59,7 @@ export class RegulatedActivitiesController {
       version.protectedTitles,
       version.regulationUrl,
       isConfirmed(profession),
-      change,
+      change === 'true',
     );
   }
 
@@ -101,7 +101,7 @@ export class RegulatedActivitiesController {
         submittedValues.protectedTitles,
         submittedValues.regulationUrl,
         isConfirmed(profession),
-        submittedValues.change,
+        submittedValues.change === 'true',
         errors,
       );
     }
@@ -118,7 +118,7 @@ export class RegulatedActivitiesController {
 
     await this.professionVersionsService.save(updatedVersion);
 
-    if (submittedValues.change) {
+    if (submittedValues.change === 'true') {
       return res.redirect(
         `/admin/professions/${professionId}/versions/${versionId}/check-your-answers`,
       );

--- a/src/professions/admin/regulated-activities.controller.ts
+++ b/src/professions/admin/regulated-activities.controller.ts
@@ -100,7 +100,7 @@ export class RegulatedActivitiesController {
         submittedValues.protectedTitles,
         submittedValues.regulationUrl,
         isConfirmed(profession),
-        submittedValues.change === 'true',
+        submittedValues.change,
         errors,
       );
     }
@@ -117,7 +117,7 @@ export class RegulatedActivitiesController {
 
     await this.professionVersionsService.save(updatedVersion);
 
-    if (submittedValues.change === 'true') {
+    if (submittedValues.change) {
       return res.redirect(
         `/admin/professions/${professionId}/versions/${versionId}/check-your-answers`,
       );

--- a/src/professions/admin/scope.controller.spec.ts
+++ b/src/professions/admin/scope.controller.spec.ts
@@ -373,7 +373,7 @@ describe('ScopeController', () => {
             coversUK: '0',
             nations: ['GB-ENG'],
             industries: ['construction-uuid'],
-            change: 'true',
+            change: true,
           };
 
           industriesService.findByIds.mockResolvedValue([industry]);

--- a/src/professions/admin/scope.controller.ts
+++ b/src/professions/admin/scope.controller.ts
@@ -116,7 +116,7 @@ export class ScopeController {
         submittedIndustries,
         submittedValues.nations || [],
         isConfirmed(profession),
-        submittedValues.change === 'true',
+        submittedValues.change,
         errors,
       );
     }
@@ -135,7 +135,7 @@ export class ScopeController {
 
     await this.professionVersionsService.save(updatedVersion);
 
-    if (submittedValues.change === 'true') {
+    if (submittedValues.change) {
       return res.redirect(
         `/admin/professions/${professionId}/versions/${versionId}/check-your-answers`,
       );

--- a/src/professions/admin/scope.controller.ts
+++ b/src/professions/admin/scope.controller.ts
@@ -92,8 +92,8 @@ export class ScopeController {
     @Param('versionId') versionId: string,
   ): Promise<void> {
     const validator = await Validator.validate(ScopeDto, scopeDto);
+    const submittedValues = validator.obj;
 
-    const submittedValues: ScopeDto = scopeDto;
     const coversUK = Boolean(Number(submittedValues.coversUK));
 
     const profession = await this.professionsService.findWithVersions(

--- a/src/professions/admin/top-level-information.controller.spec.ts
+++ b/src/professions/admin/top-level-information.controller.spec.ts
@@ -210,7 +210,7 @@ describe('TopLevelInformationController', () => {
           const topLevelDetailsDtoWithChangeParam = {
             name: 'A new profession',
             regulatoryBody: 'example-org-id',
-            change: 'true',
+            change: true,
           };
 
           const organisation = organisationFactory.build();

--- a/src/professions/admin/top-level-information.controller.ts
+++ b/src/professions/admin/top-level-information.controller.ts
@@ -104,7 +104,7 @@ export class TopLevelInformationController {
         selectedOrganisation,
         selectedAdditionalOrganisation,
         isConfirmed(profession),
-        submittedValues.change === 'true',
+        submittedValues.change,
         errors,
       );
     }
@@ -120,7 +120,7 @@ export class TopLevelInformationController {
 
     await this.professionsService.save(updatedProfession);
 
-    if (submittedValues.change === 'true') {
+    if (submittedValues.change) {
       return res.redirect(
         `/admin/professions/${professionId}/versions/${versionId}/check-your-answers`,
       );

--- a/src/professions/admin/top-level-information.controller.ts
+++ b/src/professions/admin/top-level-information.controller.ts
@@ -79,8 +79,7 @@ export class TopLevelInformationController {
       TopLevelDetailsDto,
       topLevelDetailsDto,
     );
-
-    const submittedValues: TopLevelDetailsDto = topLevelDetailsDto;
+    const submittedValues = validator.obj;
 
     const selectedOrganisation = submittedValues.regulatoryBody
       ? await this.organisationsService.find(submittedValues.regulatoryBody)

--- a/src/qualifications/presenters/qualification.presenter.spec.ts
+++ b/src/qualifications/presenters/qualification.presenter.spec.ts
@@ -4,8 +4,11 @@ import { formatMultilineString } from '../../helpers/format-multiline-string.hel
 import { multilineOf } from '../../testutils/multiline-of';
 import { createMockI18nService } from '../../testutils/create-mock-i18n-service';
 import { translationOf } from '../../testutils/translation-of';
+import { formatLink } from '../../helpers/format-link.helper';
+import { linkOf } from '../../testutils/link-of';
 
 jest.mock('../../helpers/format-multiline-string.helper');
+jest.mock('../../helpers/format-link.helper');
 
 describe(QualificationPresenter, () => {
   describe('when the Qualification is defined', () => {
@@ -97,101 +100,59 @@ describe(QualificationPresenter, () => {
     });
 
     describe('moreInformationUrl', () => {
-      describe('when a blank string is provided', () => {
-        it('returns null', () => {
-          const qualification = qualificationFactory.build({
-            url: '',
-          });
+      it('returns a link', () => {
+        (formatLink as jest.Mock).mockImplementation(linkOf);
 
-          const presenter = new QualificationPresenter(
-            qualification,
-            createMockI18nService(),
-          );
-
-          expect(presenter.moreInformationUrl).toEqual(null);
+        const qualification = qualificationFactory.build({
+          url: 'http://example.com',
         });
-      });
-      describe('when a URL is provided', () => {
-        it('returns a link', () => {
-          const qualification = qualificationFactory.build({
-            url: 'http://example.com',
-          });
 
-          const presenter = new QualificationPresenter(
-            qualification,
-            createMockI18nService(),
-          );
+        const presenter = new QualificationPresenter(
+          qualification,
+          createMockI18nService(),
+        );
 
-          expect(presenter.moreInformationUrl).toEqual(
-            '<a class="govuk-link" href="http://example.com">http://example.com</a>',
-          );
-        });
+        expect(presenter.moreInformationUrl).toEqual(
+          linkOf('http://example.com'),
+        );
       });
     });
 
     describe('ukRecognitionUrl', () => {
-      describe('when a blank string is provided', () => {
-        it('returns null', () => {
-          const qualification = qualificationFactory.build({
-            ukRecognitionUrl: '',
-          });
+      it('returns a link', () => {
+        (formatLink as jest.Mock).mockImplementation(linkOf);
 
-          const presenter = new QualificationPresenter(
-            qualification,
-            createMockI18nService(),
-          );
-
-          expect(presenter.ukRecognitionUrl).toEqual(null);
+        const qualification = qualificationFactory.build({
+          ukRecognitionUrl: 'http://example.com',
         });
-      });
-      describe('when a URL is provided', () => {
-        it('returns a link', () => {
-          const qualification = qualificationFactory.build({
-            ukRecognitionUrl: 'http://example.com',
-          });
 
-          const presenter = new QualificationPresenter(
-            qualification,
-            createMockI18nService(),
-          );
+        const presenter = new QualificationPresenter(
+          qualification,
+          createMockI18nService(),
+        );
 
-          expect(presenter.ukRecognitionUrl).toEqual(
-            '<a class="govuk-link" href="http://example.com">http://example.com</a>',
-          );
-        });
+        expect(presenter.ukRecognitionUrl).toEqual(
+          linkOf('http://example.com'),
+        );
       });
     });
 
     describe('otherCountriesRecognitionUrl', () => {
-      describe('when a blank string is provided', () => {
-        it('returns null', () => {
-          const qualification = qualificationFactory.build({
-            otherCountriesRecognitionUrl: '',
-          });
+      it('returns a link', () => {
+        (formatLink as jest.Mock).mockImplementation(linkOf);
 
-          const presenter = new QualificationPresenter(
-            qualification,
-            createMockI18nService(),
-          );
-
-          expect(presenter.otherCountriesRecognitionUrl).toEqual(null);
+        const qualification = qualificationFactory.build({
+          otherCountriesRecognitionUrl: 'http://example.com',
         });
-      });
-      describe('when a URL is provided', () => {
-        it('returns a link', () => {
-          const qualification = qualificationFactory.build({
-            otherCountriesRecognitionUrl: 'http://example.com',
-          });
 
-          const presenter = new QualificationPresenter(
-            qualification,
-            createMockI18nService(),
-          );
+        const presenter = new QualificationPresenter(
+          qualification,
+          createMockI18nService(),
+        );
 
-          expect(presenter.otherCountriesRecognitionUrl).toEqual(
-            '<a class="govuk-link" href="http://example.com">http://example.com</a>',
-          );
-        });
+        expect(presenter.otherCountriesRecognitionUrl).toEqual(
+          linkOf('http://example.com'),
+        );
       });
     });
 
@@ -274,6 +235,7 @@ describe(QualificationPresenter, () => {
   describe('when the Qualification is undefined', () => {
     it('presents empty values', () => {
       (formatMultilineString as jest.Mock).mockImplementation(multilineOf);
+      (formatLink as jest.Mock).mockImplementation(linkOf);
 
       expect(
         new QualificationPresenter(undefined, createMockI18nService()),
@@ -281,14 +243,14 @@ describe(QualificationPresenter, () => {
         expect.objectContaining({
           duration: undefined,
           level: undefined,
-          moreInformationUrl: null,
+          moreInformationUrl: linkOf(undefined),
           mostCommonRouteToObtain: multilineOf(undefined),
           otherCountriesRecognition: undefined,
-          otherCountriesRecognitionUrl: null,
+          otherCountriesRecognitionUrl: linkOf(undefined),
           qualification: undefined,
           routesToObtain: multilineOf(undefined),
           ukRecognition: undefined,
-          ukRecognitionUrl: null,
+          ukRecognitionUrl: linkOf(undefined),
         }),
       );
     });

--- a/src/qualifications/presenters/qualification.presenter.ts
+++ b/src/qualifications/presenters/qualification.presenter.ts
@@ -1,8 +1,8 @@
 import { formatMultilineString } from '../../helpers/format-multiline-string.helper';
 import { Qualification } from '../qualification.entity';
-import { escape } from '../../helpers/escape.helper';
 import { I18nService } from 'nestjs-i18n';
 import { SummaryList } from '../../common/interfaces/summary-list';
+import { formatLink } from '../../helpers/format-link.helper';
 export default class QualificationPresenter {
   constructor(
     private readonly qualification: Qualification,
@@ -36,32 +36,23 @@ export default class QualificationPresenter {
       : 'app.no';
   }
 
-  readonly moreInformationUrl =
-    this.qualification && this.qualification.url
-      ? `<a class="govuk-link" href="${escape(
-          this.qualification.url,
-        )}">${escape(this.qualification.url)}</a>`
-      : null;
+  readonly moreInformationUrl = formatLink(
+    this.qualification && this.qualification.url,
+  );
 
   readonly ukRecognition =
     this.qualification && this.qualification.ukRecognition;
 
-  readonly ukRecognitionUrl =
-    this.qualification && this.qualification.ukRecognitionUrl
-      ? `<a class="govuk-link" href="${escape(
-          this.qualification.ukRecognitionUrl,
-        )}">${escape(this.qualification.ukRecognitionUrl)}</a>`
-      : null;
+  readonly ukRecognitionUrl = formatLink(
+    this.qualification && this.qualification.ukRecognitionUrl,
+  );
 
   readonly otherCountriesRecognition =
     this.qualification && this.qualification.otherCountriesRecognition;
 
-  readonly otherCountriesRecognitionUrl =
-    this.qualification && this.qualification.otherCountriesRecognitionUrl
-      ? `<a class="govuk-link" href="${escape(
-          this.qualification.otherCountriesRecognitionUrl,
-        )}">${escape(this.qualification.otherCountriesRecognitionUrl)}</a>`
-      : null;
+  readonly otherCountriesRecognitionUrl = formatLink(
+    this.qualification && this.qualification.otherCountriesRecognitionUrl,
+  );
 
   async summaryList(): Promise<SummaryList> {
     return {

--- a/src/testutils/link-of.ts
+++ b/src/testutils/link-of.ts
@@ -1,0 +1,3 @@
+export function linkOf(text: string): string {
+  return `Link of '${text}'`;
+}

--- a/src/users/organisation/dto/organisation.dto.ts
+++ b/src/users/organisation/dto/organisation.dto.ts
@@ -1,4 +1,6 @@
+import { Transform } from 'class-transformer';
 import { IsNotEmpty, ValidateIf } from 'class-validator';
+import { parseBoolean } from '../../../helpers/parse-boolean.helper';
 
 export class OrganisationDto {
   @IsNotEmpty({
@@ -12,5 +14,6 @@ export class OrganisationDto {
   @ValidateIf((e) => e.serviceOwner === '0')
   organisation: string;
 
-  change: string;
+  @Transform(({ value }) => parseBoolean(value))
+  change: boolean;
 }

--- a/src/users/organisation/organisation.controller.spec.ts
+++ b/src/users/organisation/organisation.controller.spec.ts
@@ -207,7 +207,7 @@ describe('OrganisationController', () => {
         const organisationDto: OrganisationDto = {
           serviceOwner: '0',
           organisation: organisation.id,
-          change: 'false',
+          change: false,
         };
 
         usersService.find.mockResolvedValue(user);
@@ -272,7 +272,7 @@ describe('OrganisationController', () => {
         const organisationDto: OrganisationDto = {
           serviceOwner: '0',
           organisation: undefined,
-          change: 'false',
+          change: false,
         };
 
         usersService.find.mockResolvedValue(user);
@@ -332,7 +332,7 @@ describe('OrganisationController', () => {
         const organisationDto: OrganisationDto = {
           serviceOwner: '1',
           organisation: undefined,
-          change: 'false',
+          change: false,
         };
 
         usersService.find.mockResolvedValue(user);

--- a/src/users/organisation/organisation.controller.ts
+++ b/src/users/organisation/organisation.controller.ts
@@ -108,7 +108,7 @@ export class OrganisationController {
         res,
         organisation,
         serviceOwner,
-        submittedValues.change === 'true',
+        submittedValues.change,
         getActionTypeFromUser(user),
         errors,
       );
@@ -122,7 +122,7 @@ export class OrganisationController {
 
     await this.usersService.save(updatedUser);
 
-    if (submittedValues.change === 'true') {
+    if (submittedValues.change) {
       return res.redirect(`/admin/users/${id}/confirm`);
     }
 

--- a/src/users/organisation/organisation.controller.ts
+++ b/src/users/organisation/organisation.controller.ts
@@ -87,10 +87,9 @@ export class OrganisationController {
       OrganisationDto,
       organisationDto,
     );
+    const submittedValues = validator.obj;
 
     const user = await this.usersService.find(id);
-
-    const submittedValues: OrganisationDto = organisationDto;
 
     const serviceOwner =
       submittedValues.serviceOwner === undefined
@@ -123,7 +122,7 @@ export class OrganisationController {
 
     await this.usersService.save(updatedUser);
 
-    if (organisationDto.change === 'true') {
+    if (submittedValues.change === 'true') {
       return res.redirect(`/admin/users/${id}/confirm`);
     }
 

--- a/src/users/personal-details/dto/personal-details.dto.ts
+++ b/src/users/personal-details/dto/personal-details.dto.ts
@@ -1,4 +1,6 @@
+import { Transform } from 'class-transformer';
 import { IsEmail, IsNotEmpty } from 'class-validator';
+import { parseBoolean } from '../../../helpers/parse-boolean.helper';
 
 export class PersonalDetailsDto {
   @IsNotEmpty()
@@ -8,5 +10,6 @@ export class PersonalDetailsDto {
   @IsEmail()
   email: string;
 
-  change: string;
+  @Transform(({ value }) => parseBoolean(value))
+  change: boolean;
 }

--- a/src/users/personal-details/personal-details.controller.ts
+++ b/src/users/personal-details/personal-details.controller.ts
@@ -69,8 +69,7 @@ export class PersonalDetailsController {
       PersonalDetailsDto,
       personalDetailsDto,
     );
-
-    const submittedValues: PersonalDetailsDto = personalDetailsDto;
+    const submittedValues = validator.obj;
 
     const user = await this.usersService.find(id);
     const action = getActionTypeFromUser(user);

--- a/src/users/personal-details/personal-details.controller.ts
+++ b/src/users/personal-details/personal-details.controller.ts
@@ -102,7 +102,7 @@ export class PersonalDetailsController {
 
     await this.usersService.save(updatedUser);
 
-    if (submittedValues.change === 'true') {
+    if (submittedValues.change) {
       res.redirect(`/admin/users/${id}/confirm`);
     } else {
       res.redirect(`/admin/users/${id}/role/edit`);
@@ -128,7 +128,7 @@ function getBackLink(
   request: RequestWithAppSession,
   values: Record<string, any>,
 ): string {
-  const change = values.change === 'true';
+  const change = values.change;
   const serviceOwner = getActingUser(request).serviceOwner;
 
   if (change) {

--- a/src/users/role/dto/role.dto.ts
+++ b/src/users/role/dto/role.dto.ts
@@ -1,4 +1,6 @@
+import { Transform } from 'class-transformer';
 import { IsEnum, IsNotEmpty } from 'class-validator';
+import { parseBoolean } from '../../../helpers/parse-boolean.helper';
 import { Role } from '../../role';
 
 export class RoleDto {
@@ -8,5 +10,6 @@ export class RoleDto {
   @IsEnum(Role)
   role: Role;
 
-  change: string;
+  @Transform(({ value }) => parseBoolean(value))
+  change: boolean;
 }

--- a/src/users/role/role.controller.ts
+++ b/src/users/role/role.controller.ts
@@ -75,8 +75,7 @@ export class RoleController {
     const user = await this.usersService.find(id);
 
     const validator = await Validator.validate(RoleDto, permissionsDto);
-
-    const submittedValues: RoleDto = permissionsDto;
+    const submittedValues = validator.obj;
 
     const role = submittedValues.role;
 

--- a/src/users/role/role.controller.ts
+++ b/src/users/role/role.controller.ts
@@ -85,7 +85,7 @@ export class RoleController {
         res,
         user.serviceOwner,
         role,
-        submittedValues.change === 'true',
+        submittedValues.change,
         getActionTypeFromUser(user),
         errors,
       );

--- a/views/admin/professions/check-your-answers.njk
+++ b/views/admin/professions/check-your-answers.njk
@@ -178,7 +178,7 @@
                   text: ("professions.form.label.registration.registrationUrl" | t)
                 },
                 value: {
-                  html: ("<a class=\"govuk-link\" href=\"" + (registrationUrl | escape) + "\">" + (registrationUrl | escape) + "</a>") if registrationUrl else ""
+                  html: registrationUrl | link
                 },
                 actions: {
                   items: [
@@ -255,7 +255,7 @@
                   text: ("professions.form.label.regulatedActivities.regulationUrl" | t)
                 },
                 value: {
-                  html: ("<a class=\"govuk-link\" href=\"" + (regulationUrl | escape) + "\">" + (regulationUrl | escape) + "</a>") if regulationUrl else ""
+                  html: regulationUrl | link
                 },
                 actions: {
                   items: [
@@ -482,7 +482,7 @@
                     html: ("professions.form.label.legislation.link" | t) + "<span class=\"govuk-visually-hidden\"> " + loop.index + "</span>"
                   },
                   value: {
-                    html: ("<a class='govuk-link' href='" + (legislation.url | escape) + "'>" + (legislation.url | escape) + "</a>") if legislation else ""
+                    html: legislation.url | link
                   },
                   actions: {
                     items: [

--- a/views/professions/_profession-details.njk
+++ b/views/professions/_profession-details.njk
@@ -77,7 +77,7 @@
         text: ("professions.show.bodies.url" | t)
       },
       value: {
-        html: ["<a class=\"govuk-link\" href=\"", (organisation.url | escape), "\">", (organisation.url | escape),  "</a>" ] | join
+        html: organisation.url | link
       }
     },
     {
@@ -123,7 +123,7 @@
             text: ("professions.show.regulatedActivities.regulationUrl" | t)
           },
           value: {
-            html: ["<a class=\"govuk-link\" href=\"", (profession.regulationUrl | escape), "\">", (profession.regulationUrl | escape),  "</a>" ] | join
+            html: profession.regulationUrl | link
           }
         }
       ]
@@ -165,7 +165,7 @@
           html: ( "professions.show.legislation.legislationLink" | t) + "<span class=\"govuk-visually-hidden\"> " + loop.index + "</span>"
         },
         value: {
-          html: ["<a class=\"govuk-link\" href=\"", (legislation.url | escape), "\">", (legislation.url | escape),  "</a>" ] | join
+          html: legislation.url | link
         }
       }
     ]


### PR DESCRIPTION
We now silently add a default protocol if this is missing from the URL, and for any existing data in our database that is missing a URL protocol, we add the URL at presentation time.