### PR TITLE
(2156) Deactivate users

### DIFF
--- a/cypress/integration/admin/user/archive.spec.ts
+++ b/cypress/integration/admin/user/archive.spec.ts
@@ -21,7 +21,7 @@ function createUser(name: string, email: string): void {
   cy.get('button').click();
 }
 
-describe('Deleting a user', () => {
+describe('Archiving a user', () => {
   context('when I am logged in', () => {
     const name = 'Example Name';
     const email = 'organisation@example.com';
@@ -35,16 +35,29 @@ describe('Deleting a user', () => {
       cy.visitAndCheckAccessibility('/admin/users');
       cy.contains(`View ${name}`).click();
 
-      cy.translate('users.form.button.delete').then((deleteButton) => {
-        cy.contains(deleteButton).click();
+      cy.translate('users.form.button.archive').then((archiveButton) => {
+        cy.contains(archiveButton).click();
       });
 
       cy.checkAccessibility();
-      cy.translate('users.form.delete.successMessage').then(
-        (successMessage) => {
-          cy.get('body').should('contain', successMessage);
-        },
-      );
+      cy.translate('users.archive.caption').then((caption) => {
+        cy.get('body').contains(caption);
+      });
+
+      cy.translate('users.archive.heading', {
+        email: email,
+      }).then((heading) => {
+        cy.contains(heading);
+      });
+
+      cy.translate('users.form.button.archive').then((buttonText) => {
+        cy.get('button').contains(buttonText).click();
+      });
+
+      cy.checkAccessibility();
+      cy.translate('users.archive.confirmation.body').then((successMessage) => {
+        cy.get('body').should('contain', successMessage);
+      });
       cy.get('body').should('not.contain', email);
     });
   });

--- a/src/db/migrate/1646127089269-AddArchivedFlagToUsers.ts
+++ b/src/db/migrate/1646127089269-AddArchivedFlagToUsers.ts
@@ -1,0 +1,15 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddArchivedFlagToUsers1646127089269 implements MigrationInterface {
+  name = 'AddArchivedFlagToUsers1646127089269';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "users" ADD "archived" boolean NOT NULL DEFAULT false`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "users" DROP COLUMN "archived"`);
+  }
+}

--- a/src/i18n/en/users.json
+++ b/src/i18n/en/users.json
@@ -21,7 +21,7 @@
       "new": "Create user",
       "edit": "Update user",
       "create": "Create user",
-      "delete": "Delete user"
+      "archive": "Archive user"
     },
     "errors": {
       "email": {
@@ -44,10 +44,6 @@
       "organisation": "Organisation",
       "personalDetails": "Personal details",
       "role": "Role"
-    },
-    "delete": {
-      "confirmMessage": "Are you sure you want to delete this user?",
-      "successMessage": "User has been deleted successfully"
     },
     "checkAnswers": "Check your answers"
   },
@@ -86,5 +82,12 @@
     "editProfessionsAndOrganisations": "Edit information about regulators and professions",
     "editProfessionsAndOwnOrganisation": "Edit information about the regulator and its professions"
   },
-  "serviceOwnerOrganisation": "Regulatory Professions Register"
+  "serviceOwnerOrganisation": "Regulatory Professions Register",
+  "archive": {
+    "heading": "Are you sure you want to archive {email}?",
+    "caption": "Archiving a user",
+    "confirmation": {
+      "body": "User has been archived successfully"
+    }
+  }
 }

--- a/src/testutils/factories/user.ts
+++ b/src/testutils/factories/user.ts
@@ -13,6 +13,7 @@ export default Factory.define<User>(({ sequence }) => ({
   organisation: undefined,
   serviceOwner: false,
   confirmed: false,
+  archived: false,
   created_at: new Date(),
   updated_at: new Date(),
 }));

--- a/src/users/user.entity.ts
+++ b/src/users/user.entity.ts
@@ -55,6 +55,9 @@ export class User {
   @Column({ default: false })
   confirmed: boolean;
 
+  @Column({ default: false })
+  archived: boolean;
+
   @OneToMany(
     () => OrganisationVersion,
     (organisationVersion) => organisationVersion.user,

--- a/src/users/users-archive.controller.spec.ts
+++ b/src/users/users-archive.controller.spec.ts
@@ -1,0 +1,115 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { createMock, DeepMocked } from '@golevelup/ts-jest';
+import { Request } from 'express';
+import { I18nService } from 'nestjs-i18n';
+
+import { UsersService } from './users.service';
+import { Auth0Service } from './auth0.service';
+import { UsersArchiveController } from './users-archive.controller';
+
+import userFactory from '../testutils/factories/user';
+import { translationOf } from '../testutils/translation-of';
+import { createMockI18nService } from '../testutils/create-mock-i18n-service';
+import { flashMessage } from '../common/flash-message';
+
+import { createDefaultMockRequest } from '../testutils/factories/create-default-mock-request';
+
+jest.mock('../common/flash-message');
+
+describe('UsersArchiveController', () => {
+  let controller: UsersArchiveController;
+  let auth0Service: DeepMocked<Auth0Service>;
+  let usersService: DeepMocked<UsersService>;
+  let request: DeepMocked<Request>;
+
+  beforeEach(async () => {
+    const i18nService = createMockI18nService();
+
+    request = createDefaultMockRequest();
+
+    auth0Service = createMock<Auth0Service>();
+    usersService = createMock<UsersService>();
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [UsersArchiveController],
+      providers: [
+        {
+          provide: UsersService,
+          useValue: usersService,
+        },
+        {
+          provide: Auth0Service,
+          useValue: auth0Service,
+        },
+        {
+          provide: I18nService,
+          useValue: i18nService,
+        },
+      ],
+    }).compile();
+
+    controller = module.get<UsersArchiveController>(UsersArchiveController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  describe('new', () => {
+    it('should return a user', async () => {
+      const user = userFactory.build();
+
+      usersService.find.mockResolvedValue(user);
+
+      expect(await controller.new('some-uuid')).toEqual({
+        ...user,
+      });
+
+      expect(usersService.find).toHaveBeenCalledWith('some-uuid');
+    });
+  });
+
+  describe('delete', () => {
+    it('should add an archived flag to a user', async () => {
+      const flashMock = flashMessage as jest.Mock;
+
+      flashMock.mockImplementation(() => 'Stub Archive Message');
+
+      const user = userFactory.build();
+
+      auth0Service.deleteUser.mockReturnValue({
+        performNow: async () => {
+          return null;
+        },
+        performLater: async () => {
+          return null;
+        },
+      });
+      usersService.find.mockResolvedValue(user);
+
+      await controller.delete(request, 'some-uuid');
+
+      expect(flashMock).toHaveBeenCalledWith(
+        translationOf('users.archive.confirmation.body'),
+      );
+
+      expect(request.flash).toHaveBeenCalledWith(
+        'success',
+        'Stub Archive Message',
+      );
+
+      expect(auth0Service.deleteUser).toHaveBeenCalledWith(
+        user.externalIdentifier,
+      );
+
+      expect(usersService.save).toHaveBeenCalledWith({
+        ...user,
+        archived: true,
+      });
+    });
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+});

--- a/src/users/users-archive.controller.ts
+++ b/src/users/users-archive.controller.ts
@@ -1,0 +1,59 @@
+import {
+  Controller,
+  Get,
+  Param,
+  Render,
+  Req,
+  UseGuards,
+  Delete,
+  Redirect,
+} from '@nestjs/common';
+import { I18nService } from 'nestjs-i18n';
+
+import { AuthenticationGuard } from '../common/authentication.guard';
+import { Auth0Service } from './auth0.service';
+import { UserPermission } from './user-permission';
+import { UsersService } from './users.service';
+import { ShowTemplate } from './interfaces/show-template';
+import { Permissions } from '../common/permissions.decorator';
+import { flashMessage } from '../common/flash-message';
+
+@Controller()
+@UseGuards(AuthenticationGuard)
+export class UsersArchiveController {
+  constructor(
+    private readonly usersService: UsersService,
+    private readonly auth0Service: Auth0Service,
+    private readonly i18nService: I18nService,
+  ) {}
+
+  @Get('/admin/users/:id/archive')
+  @Permissions(UserPermission.DeleteUser)
+  @Render('admin/users/archive/new')
+  async new(@Param('id') id): Promise<ShowTemplate> {
+    const user = await this.usersService.find(id);
+
+    return {
+      ...user,
+    };
+  }
+
+  @Delete('/admin/users/:id')
+  @Permissions(UserPermission.DeleteUser)
+  @Redirect('/admin/users')
+  async delete(@Req() req, @Param('id') id): Promise<void> {
+    const messageTitle = await this.i18nService.translate(
+      'users.archive.confirmation.body',
+    );
+    const user = await this.usersService.find(id);
+    user.archived = true;
+
+    await this.auth0Service.deleteUser(user.externalIdentifier).performLater();
+
+    await this.usersService.save(user);
+
+    const successMessage = flashMessage(messageTitle);
+
+    req.flash('success', successMessage);
+  }
+}

--- a/src/users/users.controller.spec.ts
+++ b/src/users/users.controller.spec.ts
@@ -1,6 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { createMock, DeepMocked } from '@golevelup/ts-jest';
-import { Response, Request } from 'express';
+import { Response } from 'express';
 import { I18nService } from 'nestjs-i18n';
 
 import { UsersService } from './users.service';
@@ -10,10 +10,8 @@ import { UsersPresenter } from './presenters/users.presenter';
 import { UserMailer } from './user.mailer';
 
 import userFactory from '../testutils/factories/user';
-import { translationOf } from '../testutils/translation-of';
 import { createMockI18nService } from '../testutils/create-mock-i18n-service';
 import { TableRow } from '../common/interfaces/table-row';
-import { flashMessage } from '../common/flash-message';
 import { getActionTypeFromUser } from './helpers/get-action-type-from-user';
 
 import organisationFactory from '../testutils/factories/organisation';
@@ -33,12 +31,9 @@ describe('UsersController', () => {
   let auth0Service: DeepMocked<Auth0Service>;
   let usersService: DeepMocked<UsersService>;
   let userMailer: DeepMocked<UserMailer>;
-  let request: DeepMocked<Request>;
 
   beforeEach(async () => {
     const i18nService = createMockI18nService();
-
-    request = createDefaultMockRequest();
 
     auth0Service = createMock<Auth0Service>();
     userMailer = createMock<UserMailer>();
@@ -353,43 +348,6 @@ describe('UsersController', () => {
           action: 'edit',
         });
       });
-    });
-  });
-
-  describe('delete', () => {
-    it('should delete a user', async () => {
-      const flashMock = flashMessage as jest.Mock;
-
-      flashMock.mockImplementation(() => 'Stub Deletion Message');
-
-      const user = userFactory.build();
-
-      auth0Service.deleteUser.mockReturnValue({
-        performNow: async () => {
-          return null;
-        },
-        performLater: async () => {
-          return null;
-        },
-      });
-      usersService.find.mockResolvedValue(user);
-
-      await controller.delete(request, 'some-uuid');
-
-      expect(flashMock).toHaveBeenCalledWith(
-        translationOf('users.form.delete.successMessage'),
-      );
-
-      expect(request.flash).toHaveBeenCalledWith(
-        'success',
-        'Stub Deletion Message',
-      );
-
-      expect(auth0Service.deleteUser).toHaveBeenCalledWith(
-        user.externalIdentifier,
-      );
-
-      expect(usersService.delete).toHaveBeenCalledWith('some-uuid');
     });
   });
 

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -7,8 +7,6 @@ import {
   Res,
   Req,
   UseGuards,
-  Delete,
-  Redirect,
 } from '@nestjs/common';
 import { I18nService } from 'nestjs-i18n';
 
@@ -22,7 +20,6 @@ import { IndexTemplate } from './interfaces/index-template';
 import { ShowTemplate } from './interfaces/show-template';
 import { ConfirmTemplate } from './interfaces/confirm-template';
 import { Permissions } from '../common/permissions.decorator';
-import { flashMessage } from '../common/flash-message';
 import { getActionTypeFromUser } from './helpers/get-action-type-from-user';
 
 import { UserMailer } from './user.mailer';
@@ -142,23 +139,6 @@ export class UsersController {
       ...user,
       action,
     } as CompleteTemplate);
-  }
-
-  @Delete('/admin/users/:id')
-  @Permissions(UserPermission.DeleteUser)
-  @Redirect('/admin/users')
-  async delete(@Req() req, @Param('id') id): Promise<void> {
-    const messageTitle = await this.i18nService.translate(
-      'users.form.delete.successMessage',
-    );
-    const user = await this.usersService.find(id);
-    const successMessage = flashMessage(messageTitle);
-
-    req.flash('success', successMessage);
-
-    await this.auth0Service.deleteUser(user.externalIdentifier).performLater();
-
-    await this.usersService.delete(id);
   }
 
   async createUserInAuth0(user: User): Promise<void> {

--- a/src/users/users.module.ts
+++ b/src/users/users.module.ts
@@ -5,6 +5,7 @@ import { PersonalDetailsController } from './personal-details/personal-details.c
 import { RoleController } from './role/role.controller';
 
 import { UsersController } from './users.controller';
+import { UsersArchiveController } from './users-archive.controller';
 
 import { User } from './user.entity';
 import { UsersService } from './users.service';
@@ -35,6 +36,7 @@ import { Organisation } from '../organisations/organisation.entity';
   ],
   controllers: [
     UsersController,
+    UsersArchiveController,
     OrganisationController,
     PersonalDetailsController,
     RoleController,

--- a/src/users/users.service.spec.ts
+++ b/src/users/users.service.spec.ts
@@ -74,7 +74,9 @@ describe('UsersService', () => {
       const posts = await service.allConfirmed();
 
       expect(posts).toEqual(userArray);
-      expect(repoSpy).toHaveBeenCalledWith({ where: { confirmed: true } });
+      expect(repoSpy).toHaveBeenCalledWith({
+        where: { confirmed: true, archived: false },
+      });
     });
   });
 
@@ -87,7 +89,7 @@ describe('UsersService', () => {
 
       expect(posts).toEqual(userArray);
       expect(repoSpy).toHaveBeenCalledWith({
-        where: { confirmed: true, organisation },
+        where: { confirmed: true, archived: false, organisation },
       });
     });
   });

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -18,12 +18,14 @@ export class UsersService {
   }
 
   allConfirmed(): Promise<User[]> {
-    return this.repository.find({ where: { confirmed: true } });
+    return this.repository.find({
+      where: { confirmed: true, archived: false },
+    });
   }
 
   allConfirmedForOrganisation(organisation: Organisation): Promise<User[]> {
     return this.repository.find({
-      where: { confirmed: true, organisation },
+      where: { confirmed: true, archived: false, organisation },
     });
   }
 

--- a/views/admin/users/archive/new.njk
+++ b/views/admin/users/archive/new.njk
@@ -1,0 +1,23 @@
+{% extends "admin/base.njk" %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% set bodyClasses = "rpr-internal__page" %}
+
+{% block content %}
+  <span class="govuk-caption-l">{{ 'users.archive.caption' | t }}</span>
+  <h1 class="govuk-heading-l">{{ ('users.archive.heading' | t({email: email})) }}</h1>
+
+  <div class="govuk-grid-row">
+
+    <div class="govuk-grid-column-full">
+      <form action="/admin/users/{{ id }}?_method=DELETE" method="post">
+        {{
+          govukButton({
+            text: ("users.form.button.archive" | t)
+          })
+        }}
+      </form>
+    </div>
+
+  </div>
+{% endblock %}

--- a/views/admin/users/show.njk
+++ b/views/admin/users/show.njk
@@ -18,17 +18,13 @@
         <ul class="govuk-list">
           {% if 'deleteUser' in permissions %}
             <li>
-              <form action="{{ "/admin/users/" + id }}?_method=DELETE" method="post" data-confirm data-confirm-message="{{ ("users.form.delete.confirmMessage" | t) }}">
-                <input type="hidden" name="_method" value="DELETE" />
-                {{
-                  govukButton({
-                    id: "submit-button",
-                    type: "Submit",
-                    classes: "govuk-button--warning",
-                    text: ("users.form.button.delete" | t)
-                  })
-                }}
-              </form>
+              {{
+                govukButton({
+                  href: '/admin/users/' + id + '/archive',
+                  classes: "govuk-button--warning",
+                  text: ("users.form.button.archive" | t)
+                })
+              }}
             </li>
           {% endif %}
         </ul>


### PR DESCRIPTION
This changes the "delete" action on a user to an "archive" action. User testing identified that deleting users was impossible once a user had created a profession/organisation because of foreign key restrictions. It's probably not a good idea to delete users completely anyway for historical reasons.

# Screenshots

![image](https://user-images.githubusercontent.com/109774/156159183-38601dc7-2646-4028-a655-7627bd6cc902.png)
![image](https://user-images.githubusercontent.com/109774/156159200-736a2f2f-b8a5-45fb-9973-921d13e63d7b.png)
![image](https://user-images.githubusercontent.com/109774/156159230-1993d1f2-8b0f-424b-ad7a-fb7975257a08.png)
