### PR TITLE
(2213) Don't show unconfirmed orgs or professions in admin table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Remove placeholder nav subsection on public-facing homepage
 - Improve URL validation and presentation
 - Improve email address validation
+- Fixed Regulatory Authorities showing in internal listing before being saved as draft or published
 
 ## [release-005] - 2022-02-24
 

--- a/cypress/integration/admin/organisations/index.spec.ts
+++ b/cypress/integration/admin/organisations/index.spec.ts
@@ -22,40 +22,44 @@ describe('Listing organisations', () => {
             const latestVersion =
               organisation.versions[organisation.versions.length - 1];
 
-            cy.get('tr')
-              .contains(organisation.name)
-              .then(($header) => {
-                const $row = $header.parent();
+            if (latestVersion.status === 'unconfirmed') {
+              cy.get('tr').should('not.contain', organisation.name);
+            } else {
+              cy.get('tr')
+                .contains(organisation.name)
+                .then(($header) => {
+                  const $row = $header.parent();
 
-                cy.wrap($row).should('contain', organisation.name);
-                cy.wrap($row).should('contain', latestVersion.alternateName);
-                cy.get('[data-cy=changed-by-user]').should('contain', '');
-                cy.wrap($row).should(
-                  'contain',
-                  format(new Date(), 'dd-MM-yyyy'),
-                );
-
-                cy.translate(
-                  `organisations.status.${latestVersion.status}`,
-                ).then((status) => {
-                  cy.wrap($row).should('contain', status);
-                });
-
-                const professionsForOrganisation = professions.filter(
-                  (profession: any) =>
-                    profession.organisation == organisation.name,
-                );
-
-                professionsForOrganisation.forEach((profession: any) => {
-                  (profession.versions[0].industries || []).forEach(
-                    (industry: any) => {
-                      cy.translate(industry).then((industry) => {
-                        cy.wrap($row).should('contain', industry);
-                      });
-                    },
+                  cy.wrap($row).should('contain', organisation.name);
+                  cy.wrap($row).should('contain', latestVersion.alternateName);
+                  cy.get('[data-cy=changed-by-user]').should('contain', '');
+                  cy.wrap($row).should(
+                    'contain',
+                    format(new Date(), 'dd-MM-yyyy'),
                   );
+
+                  cy.translate(
+                    `organisations.status.${latestVersion.status}`,
+                  ).then((status) => {
+                    cy.wrap($row).should('contain', status);
+                  });
+
+                  const professionsForOrganisation = professions.filter(
+                    (profession: any) =>
+                      profession.organisation == organisation.name,
+                  );
+
+                  professionsForOrganisation.forEach((profession: any) => {
+                    (profession.versions[0].industries || []).forEach(
+                      (industry: any) => {
+                        cy.translate(industry).then((industry) => {
+                          cy.wrap($row).should('contain', industry);
+                        });
+                      },
+                    );
+                  });
                 });
-              });
+            }
           });
         });
       });

--- a/seeds/development/organisations.json
+++ b/seeds/development/organisations.json
@@ -72,5 +72,14 @@
         "status": "live"
       }
     ]
+  },
+  {
+    "name": "Unconfirmed Organisation",
+    "slug": "",
+    "versions": [
+      {
+        "status": "unconfirmed"
+      }
+    ]
   }
 ]

--- a/seeds/test/organisations.json
+++ b/seeds/test/organisations.json
@@ -74,5 +74,14 @@
         "status": "live"
       }
     ]
+  },
+  {
+    "name": "Unconfirmed Organisation",
+    "slug": "",
+    "versions": [
+      {
+        "status": "unconfirmed"
+      }
+    ]
   }
 ]

--- a/src/organisations/organisation-versions.service.spec.ts
+++ b/src/organisations/organisation-versions.service.spec.ts
@@ -288,20 +288,17 @@ describe('OrganisationVersionsService', () => {
       ]);
 
       expect(queryBuilder.where).toHaveBeenCalledWith(
-        'organisationVersion.status IN(:...status)',
+        '(organisationVersion.status IN(:...organisationStatus)) AND (professionVersions.status IN(:...professionStatus) OR professionVersions.status IS NULL)',
         {
-          status: [
+          organisationStatus: [
             OrganisationVersionStatus.Live,
             OrganisationVersionStatus.Draft,
             OrganisationVersionStatus.Archived,
           ],
-        },
-      );
-
-      expect(queryBuilder.where).toHaveBeenCalledWith(
-        'professionVersions.status IN(:...status) OR professionVersions.status IS NULL',
-        {
-          status: [ProfessionVersionStatus.Live, ProfessionVersionStatus.Draft],
+          professionStatus: [
+            ProfessionVersionStatus.Live,
+            ProfessionVersionStatus.Draft,
+          ],
         },
       );
 

--- a/src/organisations/organisation-versions.service.ts
+++ b/src/organisations/organisation-versions.service.ts
@@ -85,17 +85,18 @@ export class OrganisationVersionsService {
   async allWithLatestVersion(): Promise<Organisation[]> {
     const versions = await this.versionsWithJoins()
       .distinctOn(['organisationVersion.organisation', 'professions.id'])
-      .where('organisationVersion.status IN(:...status)', {
-        status: [
-          OrganisationVersionStatus.Live,
-          OrganisationVersionStatus.Draft,
-          OrganisationVersionStatus.Archived,
-        ],
-      })
       .where(
-        'professionVersions.status IN(:...status) OR professionVersions.status IS NULL',
+        '(organisationVersion.status IN(:...organisationStatus)) AND (professionVersions.status IN(:...professionStatus) OR professionVersions.status IS NULL)',
         {
-          status: [ProfessionVersionStatus.Live, ProfessionVersionStatus.Draft],
+          organisationStatus: [
+            OrganisationVersionStatus.Live,
+            OrganisationVersionStatus.Draft,
+            OrganisationVersionStatus.Archived,
+          ],
+          professionStatus: [
+            ProfessionVersionStatus.Live,
+            ProfessionVersionStatus.Draft,
+          ],
         },
       )
       .orderBy(


### PR DESCRIPTION
# Changes in this PR

This fixes a broken TypeORM query that meant any organisation without any professions would show in the internal listing, regardless of status

## Screenshots of UI changes

### Before
![localhost_3000_admin_organisations (3)](https://user-images.githubusercontent.com/94137563/156221664-48b3e1ca-3fbf-4b76-9fa7-96b9507f6b9a.png)

### After
![localhost_3000_admin_organisations (2)](https://user-images.githubusercontent.com/94137563/156221650-cd8716cd-e40c-4d0b-8f3d-1c33792d76ee.png)

