### PR TITLE
(2034) Change HTML <title> attribute to match page title

### DIFF
--- a/src/i18n/en/app.json
+++ b/src/i18n/en/app.json
@@ -63,6 +63,9 @@
         "findAuthority": "Find a regulatory authority",
         "viewFigures": "View annual figures regarding applications"
       }
+    },
+    "admin": {
+      "heading": "Admin"
     }
   },
   "ukcpq": "UK Centre for Professional Qualifications"

--- a/views/admin/dashboard.njk
+++ b/views/admin/dashboard.njk
@@ -1,5 +1,7 @@
 {% extends "./base.njk" %}
 
+{% set title = ("app.pages.admin.heading" | t) %}
+
 {% block content %}
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-one-third">

--- a/views/admin/organisations/archive/new.njk
+++ b/views/admin/organisations/archive/new.njk
@@ -2,6 +2,11 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
 {% set bodyClasses = "rpr-internal__page" %}
+{% set title = ("organisations.admin.archive.heading" | t) %}
+
+{% block title %}
+  {{ "organisations.admin.archive.heading" | t }}
+{% endblock %}
 
 {% block content %}
   <span class="govuk-caption-l">{{ 'organisations.admin.archive.caption' | t }}</span>

--- a/views/admin/organisations/edit.njk
+++ b/views/admin/organisations/edit.njk
@@ -5,13 +5,15 @@
 
 {% set bodyClasses = "rpr-internal__page" %}
 
+{% if slug|length == 0 %}
+  {% set title = ("organisations.admin.create.heading" | t) %}
+{% else %}
+  {% set title = ("organisations.admin.edit.heading" | t({ organisationName: name })) %}
+{% endif %}
+
 {% block content %}
   <h1 class="govuk-heading-xl">
-    {% if slug|length == 0 %}
-      {{ "organisations.admin.create.heading" | t }}
-    {% else %}
-      {{ "organisations.admin.edit.heading" | t({ organisationName: name }) }}
-    {% endif %}
+    {{ title }}
   </h1>
 
   <div class="govuk-grid-row">

--- a/views/admin/organisations/index.njk
+++ b/views/admin/organisations/index.njk
@@ -3,10 +3,11 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
 {% set bodyClasses = "rpr-internal__listing rpr-internal__page" %}
+{% set title = ("organisations.admin.heading" | t) %}
 
 {% block content %}
   <h1 class="govuk-heading-xl">
-    {{ "organisations.admin.heading" | t }}
+    {{ title }}
   </h1>
 
   {% include "../../_messages.njk" %}

--- a/views/admin/organisations/publication/new.njk
+++ b/views/admin/organisations/publication/new.njk
@@ -3,8 +3,10 @@
 
 {% set bodyClasses = "rpr-internal__page" %}
 
+{% set title = ("organisations.admin.publish.caption" | t) %}
+
 {% block content %}
-  <span class="govuk-caption-l">{{ 'organisations.admin.publish.caption' | t }}</span>
+  <span class="govuk-caption-l">{{ title }}</span>
   <h1 class="govuk-heading-l">{{ ('organisations.admin.publish.heading' | t({organisationName: organisation.name})) }}</h1>
 
   <div class="govuk-grid-row">

--- a/views/admin/organisations/review.njk
+++ b/views/admin/organisations/review.njk
@@ -2,12 +2,16 @@
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
-
 {% set bodyClasses = "rpr-internal__page" %}
 
+{% set caption = ("organisations.admin.edit.heading" | t({ organisationName: name })) %}
+{% set heading = ("app.headings.checkAnswers" | t) %}
+
+{% set title =  caption + " | " + heading %}
+
 {% block content %}
-<span class="govuk-caption-l">{{ "organisations.admin.edit.heading" | t({ organisationName: name }) }}</span>
-<h1 class="govuk-heading-xl">{{ "app.headings.checkAnswers" | t }}</h1>
+<span class="govuk-caption-l">{{ caption }}</span>
+<h1 class="govuk-heading-xl">{{ heading }}</h1>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/views/admin/organisations/show.njk
+++ b/views/admin/organisations/show.njk
@@ -2,6 +2,7 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
 {% set bodyClasses = "rpr-internal__page rpr-details__page" %}
+{% set title = organisation.name %}
 
 {% block content %}
   {% include "../../_messages.njk" %}

--- a/views/admin/professions/archive/new.njk
+++ b/views/admin/professions/archive/new.njk
@@ -3,12 +3,13 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
 {% set bodyClasses = "rpr-internal__page" %}
+{% set title = ("professions.admin.archive.caption" | t) %}
 
 {% block content %}
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <span class="govuk-caption-l">{{ 'professions.admin.archive.caption' | t }}</span>
+      <span class="govuk-caption-l">{{ title }}</span>
       <h1 class="govuk-heading-l">{{ ('professions.admin.archive.heading' | t({professionName: profession.name})) }}</h1>
 
       <form action="/admin/professions/{{ profession.id }}/versions/{{ profession.versionId }}/archive?_method=DELETE" method="post">

--- a/views/admin/professions/check-your-answers.njk
+++ b/views/admin/professions/check-your-answers.njk
@@ -4,16 +4,23 @@
 
 {% set bodyClasses = "rpr-internal__page" %}
 
+{% set heading = ("app.headings.checkAnswers" | t) %}
+
+{% if edit %}
+  {% set heading =("professions.form.headings.originalAnswers" | t) %}
+{% else %}
+  {% set heading =("professions.form.headings.checkAnswers" | t) %}
+{% endif %}
+
+{% set title =  captionText + " | " + heading %}
+
 {% block content %}
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <span class="govuk-caption-l">{{ captionText }}</span>
-      {% if edit %}
-        <h1 class="govuk-heading-l">{{ ("professions.form.headings.originalAnswers" | t) }}</h1>
-      {% else %}
-        <h1 class="govuk-heading-l">{{ ("professions.form.headings.checkAnswers" | t) }}</h1>
-      {% endif %}
+      <h1 class="govuk-heading-l">{{ heading }}</h1>
+
 
         <h2 class="govuk-heading-m">{{ ("professions.form.headings.topLevelInformation" | t) }}</h2>
 

--- a/views/admin/professions/index.njk
+++ b/views/admin/professions/index.njk
@@ -7,11 +7,12 @@
 {% from "govuk/components/table/macro.njk" import govukTable %}
 
 {% set bodyClasses = "rpr-internal__listing rpr-internal__page" %}
+{% set title = ("professions.admin.heading" | t) %}
 
 {% block content %}
   <h1 class="govuk-heading-xl">
     <span class="govuk-caption-l">{{ organisation }}</span>
-    {{ "professions.admin.heading" | t }}
+    {{ title }}
   </h1>
 
   <div class="govuk-grid-row">

--- a/views/admin/professions/legislation.njk
+++ b/views/admin/professions/legislation.njk
@@ -5,6 +5,7 @@
 {% from "govuk/components/input/macro.njk" import govukInput %}
 
 {% set bodyClasses = "rpr-internal__page" %}
+{% set title = ("professions.form.headings.legislation" | t) %}
 
 {% block content %}
   {% include "../../shared/_errors.njk" %}

--- a/views/admin/professions/publication/new.njk
+++ b/views/admin/professions/publication/new.njk
@@ -3,12 +3,13 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
 {% set bodyClasses = "rpr-internal__page" %}
+{% set title = ("professions.form.captions.publish" | t) %}
 
 {% block content %}
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <span class="govuk-caption-l">{{ 'professions.form.captions.publish' | t }}</span>
+      <span class="govuk-caption-l">{{ title }}</span>
       <h1 class="govuk-heading-l">{{ ('professions.form.headings.publish' | t({professionName: profession.name})) }}</h1>
 
         <form action="/admin/professions/{{ profession.id }}/versions/{{ profession.versionId }}/publish?_method=PUT" method="post">

--- a/views/admin/professions/qualifications.njk
+++ b/views/admin/professions/qualifications.njk
@@ -6,6 +6,8 @@
 {% from "govuk/components/input/macro.njk" import govukInput %}
 
 {% set bodyClasses = "rpr-internal__page" %}
+{% set heading = ("professions.form.headings.qualifications" | t) %}
+{% set title = captionText + " | " + heading %}
 
 {% block content %}
   {% include "../../shared/_errors.njk" %}
@@ -14,7 +16,7 @@
     <div class="govuk-grid-column-two-thirds">
 
       <span class="govuk-caption-l">{{ captionText }}</span>
-      <h1 class="govuk-heading-l">{{ ("professions.form.headings.qualifications" | t) }}</h1>
+      <h1 class="govuk-heading-l">{{ heading }}</h1>
 
       <form method="post" action="./">
         <input type="hidden" name="change" value="{{ change }}" />

--- a/views/admin/professions/registration.njk
+++ b/views/admin/professions/registration.njk
@@ -5,6 +5,8 @@
 {% from "govuk/components/input/macro.njk" import govukInput %}
 
 {% set bodyClasses = "rpr-internal__page" %}
+{% set heading = ("professions.form.headings.registration" | t) %}
+{% set title =  captionText + " | " + heading %}
 
 {% block content %}
   {% include "../../shared/_errors.njk" %}
@@ -13,7 +15,7 @@
     <div class="govuk-grid-column-two-thirds">
 
       <span class="govuk-caption-l">{{ captionText }}</span>
-      <h1 class="govuk-heading-l">{{ ("professions.form.headings.registration" | t) }}</h1>
+      <h1 class="govuk-heading-l">{{ heading }}</h1>
 
       <form method="post" action="./">
         <input type="hidden" name="change" value="{{ change }}" />

--- a/views/admin/professions/regulated-activities.njk
+++ b/views/admin/professions/regulated-activities.njk
@@ -6,6 +6,8 @@
 {% from "govuk/components/input/macro.njk" import govukInput %}
 
 {% set bodyClasses = "rpr-internal__page" %}
+{% set heading = ("professions.form.headings.regulatedActivities" | t) %}
+{% set title =  captionText + " | " + heading %}
 
 {% block content %}
   {% include "../../shared/_errors.njk" %}
@@ -14,7 +16,7 @@
     <div class="govuk-grid-column-two-thirds">
 
       <span class="govuk-caption-l">{{ captionText }}</span>
-      <h1 class="govuk-heading-l">{{ ("professions.form.headings.regulatedActivities" | t) }}</h1>
+      <h1 class="govuk-heading-l">{{ title }}</h1>
 
       <form method="post" action="./">
         <input type="hidden" name="change" value="{{ change }}" />

--- a/views/admin/professions/scope.njk
+++ b/views/admin/professions/scope.njk
@@ -6,6 +6,8 @@
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 
 {% set bodyClasses = "rpr-internal__page" %}
+{% set heading = ("professions.form.headings.scope" | t) %}
+{% set title =  captionText + " | " + heading %}
 
 {% block content %}
 
@@ -15,7 +17,7 @@
   <div class="govuk-grid-column-two-thirds">
 
     <span class="govuk-caption-l">{{ captionText }}</span>
-    <h1 class="govuk-heading-l">{{ ("professions.form.headings.scope" | t) }}</h1>
+    <h1 class="govuk-heading-l">{{ heading }}</h1>
 
     <form method="post" action="./">
       <input type="hidden" name="change" value="{{ change }}" />

--- a/views/admin/professions/show.njk
+++ b/views/admin/professions/show.njk
@@ -3,6 +3,7 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
 {% set bodyClasses = "rpr-internal__page rpr-details__page" %}
+{% set title = profession.name %}
 
 {% block content %}
   {% include "../../_messages.njk" %}

--- a/views/admin/professions/top-level-information.njk
+++ b/views/admin/professions/top-level-information.njk
@@ -5,6 +5,8 @@
 {% from "govuk/components/select/macro.njk" import govukSelect %}
 
 {% set bodyClasses = "rpr-internal__page" %}
+{% set heading = ("professions.form.headings.topLevelInformation" | t) %}
+{% set title =  captionText + " | " + heading %}
 
 {% block content %}
 
@@ -14,7 +16,7 @@
   <div class="govuk-grid-column-two-thirds">
 
     <span class="govuk-caption-l">{{ captionText }}</span>
-    <h1 class="govuk-heading-l">{{ ("professions.form.headings.topLevelInformation" | t) }}</h1>
+    <h1 class="govuk-heading-l">{{ heading }}</h1>
 
     <form method="post" action="./">
       <input type="hidden" name="change" value="{{ change }}" />
@@ -27,7 +29,7 @@
             isPageHeading: false
           },
           hint: {
-            text: ("professions.form.label.topLevelInformation.nameHint" | t) 
+            text: ("professions.form.label.topLevelInformation.nameHint" | t)
           },
           id: "name",
           name: "name",

--- a/views/admin/users/archive/new.njk
+++ b/views/admin/users/archive/new.njk
@@ -2,9 +2,10 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
 {% set bodyClasses = "rpr-internal__page" %}
+{% set title = ("users.archive.caption" | t) %}
 
 {% block content %}
-  <span class="govuk-caption-l">{{ 'users.archive.caption' | t }}</span>
+  <span class="govuk-caption-l">{{ title }}</span>
   <h1 class="govuk-heading-l">{{ ('users.archive.heading' | t({email: email})) }}</h1>
 
   <div class="govuk-grid-row">

--- a/views/admin/users/complete.njk
+++ b/views/admin/users/complete.njk
@@ -1,13 +1,14 @@
 {% extends "admin/base.njk" %}
 
 {% from "govuk/components/panel/macro.njk" import govukPanel %}
+{% set title = (("users.headings." + action + ".done") | t) %}
 
 {% block content %}
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     {{ govukPanel({
-      titleText: (("users.headings." + action + ".done") | t),
+      titleText: title,
       html: ("users.body." + action + ".panel") | t({email: (email | escape)})
     }) }}
 

--- a/views/admin/users/confirm.njk
+++ b/views/admin/users/confirm.njk
@@ -5,6 +5,16 @@
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 
+{% if name %}
+  {% set caption = ("users.form.headings." + action) | t({ name: "- " + name}) %}
+{% else %}
+  {% set caption = (("users.form.headings." + action) | t) %}
+{% endif %}
+
+{% set heading = ("users.form.headings.checkAnswers" | t) %}
+{% set title =  caption + " | " + heading %}
+
+
 {% block content %}
 
 <div class="govuk-grid-row">
@@ -22,12 +32,8 @@
 
     {% endif %}
 
-    {% if name %}
-      <span class="govuk-caption-xl">{{ ("users.form.headings." + action) | t({ name: "- " + name}) }}</span>
-    {% else %}
-      <span class="govuk-caption-xl">{{ ("users.form.headings." + action) | t }}</span>
-    {% endif %}
-    <h1 class="govuk-heading-xl">{{ "users.form.headings.checkAnswers" | t }}</h1>
+    <span class="govuk-caption-xl">{{ caption }}</span>
+    <h1 class="govuk-heading-xl">{{ heading }}</h1>
 
     <h2 class="govuk-heading-m">{{ "users.form.headings.personalDetails" | t }}</h2>
 

--- a/views/admin/users/index.njk
+++ b/views/admin/users/index.njk
@@ -3,6 +3,8 @@
 {% from "govuk/components/table/macro.njk" import govukTable %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
+{% set title = ("users.headings.index" | t) %}
+
 {% block content %}
 
   {% include "../../_messages.njk" %}

--- a/views/admin/users/new.njk
+++ b/views/admin/users/new.njk
@@ -3,6 +3,8 @@
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
+{% set title = ("users.headings.addNew" | t) %}
+
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/views/admin/users/organisation/edit.njk
+++ b/views/admin/users/organisation/edit.njk
@@ -4,19 +4,25 @@
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/select/macro.njk" import govukSelect %}
 
+{% set title = (("users.form.headings." + action) | t ) %}
+
+{% if name %}
+  {% set caption = ("users.form.headings." + action) | t({ name: "- " + name}) %}
+{% else %}
+  {% set caption = (("users.form.headings." + action) | t) %}
+{% endif %}
+
+{% set heading = ("users.form.headings.organisation" | t) %}
+{% set title =  caption + " | " + heading %}
+
 {% block content %}
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     {% include "../../../shared/_errors.njk" %}
 
-    {% if name %}
-      <span class="govuk-caption-xl">{{ ("users.form.headings." + action) | t({ name: "- " + name}) }}</span>
-    {% else %}
-      <span class="govuk-caption-xl">{{ ("users.form.headings." + action) | t }}</span>
-    {% endif %}
-
-    <h1 class="govuk-heading-xl">{{ "users.form.headings.organisation" | t }}</h1>
+    <span class="govuk-caption-xl">{{ caption }}</span>
+    <h1 class="govuk-heading-xl">{{ heading }}</h1>
 
     <form method="post" action="./">
 

--- a/views/admin/users/personal-details/edit.njk
+++ b/views/admin/users/personal-details/edit.njk
@@ -2,6 +2,16 @@
 
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
+{% set title = ("users.form.headings.personalDetails" | t) %}
+
+{% if name %}
+  {% set caption = ("users.form.headings." + action) | t({ name: "- " + name}) %}
+{% else %}
+  {% set caption = (("users.form.headings." + action) | t) %}
+{% endif %}
+
+{% set heading = ("users.form.headings.personalDetails" | t) %}
+{% set title =  caption + " | " + heading %}
 
 {% block content %}
 
@@ -9,13 +19,8 @@
   <div class="govuk-grid-column-two-thirds">
     {% include "../../../shared/_errors.njk" %}
 
-    {% if name %}
-      <span class="govuk-caption-xl">{{ ("users.form.headings." + action) | t({ name: "- " + name}) }}</span>
-    {% else %}
-      <span class="govuk-caption-xl">{{ ("users.form.headings." + action) | t }}</span>
-    {% endif %}
-
-    <h1 class="govuk-heading-xl">{{ "users.form.headings.personalDetails" | t }}</h1>
+    <span class="govuk-caption-xl">{{ caption }}</span>
+    <h1 class="govuk-heading-xl">{{ heading }}</h1>
 
     <form method="post" action="./">
 

--- a/views/admin/users/role/edit.njk
+++ b/views/admin/users/role/edit.njk
@@ -4,19 +4,23 @@
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 
+{% if name %}
+  {% set caption = ("users.form.headings." + action) | t({ name: "- " + name}) %}
+{% else %}
+  {% set caption = (("users.form.headings." + action) | t) %}
+{% endif %}
+
+{% set heading = ("users.form.headings.role" | t) %}
+{% set title =  caption + " | " + heading %}
+
 {% block content %}
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     {% include "../../../shared/_errors.njk" %}
 
-    {% if name %}
-      <span class="govuk-caption-xl">{{ ("users.form.headings." + action) | t({ name: "- " + name}) }}</span>
-    {% else %}
-      <span class="govuk-caption-xl">{{ ("users.form.headings." + action) | t }}</span>
-    {% endif %}
-
-    <h1 class="govuk-heading-xl">{{ "users.form.headings.role" | t }}</h1>
+    <span class="govuk-caption-xl">{{ caption }}</span>
+    <h1 class="govuk-heading-xl">{{ heading }}</h1>
 
     <form method="post" action="./">
 

--- a/views/admin/users/show.njk
+++ b/views/admin/users/show.njk
@@ -3,6 +3,8 @@
 {% from "govuk/components/table/macro.njk" import govukTable %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
+{% set title = ("users.headings.show" | t) %}
+
 {% block content %}
 
 <div class="govuk-grid-row">

--- a/views/base.njk
+++ b/views/base.njk
@@ -2,6 +2,13 @@
 {% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 
+{% block pageTitle %}
+  {{ "app.name" | t }}
+  {% if title %}
+    | {{ title }}
+  {% endif %}
+{% endblock %}
+
 {% block header %}
   {{
     govukHeader({

--- a/views/errors/forbidden.njk
+++ b/views/errors/forbidden.njk
@@ -1,7 +1,9 @@
 {% extends "../base.njk" %}
 
+{% set title = ("errors.forbidden.heading" | t) %}
+
 {% block content %}
-<h1 class="govuk-heading-l">{{ "errors.forbidden.heading" | t }}</h1>
+<h1 class="govuk-heading-l">{{ title }}</h1>
 
 <p class="govuk-body">{{ "errors.forbidden.message" | t }}</p>
 

--- a/views/errors/generic-error.njk
+++ b/views/errors/generic-error.njk
@@ -1,7 +1,8 @@
 {% extends "../base.njk" %}
+{% set title = ("errors.generic.heading" | t) %}
 
 {% block content %}
-<h1 class="govuk-heading-l">{{ "errors.generic.heading" | t }}</h1>
+<h1 class="govuk-heading-l">{{ title }}</h1>
 
 <p class="govuk-body">{{ "errors.generic.message" | t }}</p>
 

--- a/views/errors/not-found.njk
+++ b/views/errors/not-found.njk
@@ -1,4 +1,5 @@
 {% extends "../base.njk" %}
+{% set title = ("errors.not-found.heading" | t) %}
 
 {% block content %}
 <h1 class="govuk-heading-l">{{ "errors.not-found.heading" | t }}</h1>

--- a/views/index.njk
+++ b/views/index.njk
@@ -1,12 +1,14 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% extends "base.njk" %}
 
+{% set title = ("app.pages.index.heading" | t) %}
+
 {% block content %}
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
       <h1 class="govuk-heading-xl">
-        {{ "app.pages.index.heading" | t }}
+        {{ title }}
       </h1>
 
       {% for _i, paragraph in ("app.pages.index.intro" | t) %}

--- a/views/organisations/search/index.njk
+++ b/views/organisations/search/index.njk
@@ -1,7 +1,9 @@
 {% extends "base.njk" %}
 
+{% set title = ("organisations.search.heading" | t) %}
+
 {% block content %}
-  <h1 class="govuk-heading-xl">{{ "organisations.search.heading" | t }}</h1>
+  <h1 class="govuk-heading-xl">{{ title }}</h1>
 
   <div class="govuk-grid-row">
 

--- a/views/organisations/shared/_organisation.njk
+++ b/views/organisations/shared/_organisation.njk
@@ -1,6 +1,6 @@
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 
-<h1 class="govuk-heading-xl">{{ organisation.name }}</h1>
+<h1 class="govuk-heading-xl">{{ title }}</h1>
 
 {{ govukSummaryList(summaryList) }}
 

--- a/views/organisations/show.njk
+++ b/views/organisations/show.njk
@@ -1,5 +1,6 @@
 {% extends "base.njk" %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
+{% set title = organisation.name %}
 
 {% set bodyClasses = "rpr-details__page" %}
 

--- a/views/professions/search/index.njk
+++ b/views/professions/search/index.njk
@@ -1,8 +1,9 @@
 {% extends "base.njk" %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{% set title = ("professions.search.heading" | t) %}
 
 {% block content %}
-<h1 class="govuk-heading-xl">{{ "professions.search.heading" | t }}</h1>
+<h1 class="govuk-heading-xl">{{ title }}</h1>
 
   <div class="govuk-grid-row">
 

--- a/views/professions/show.njk
+++ b/views/professions/show.njk
@@ -1,6 +1,7 @@
 {% extends "base.njk" %}
 
 {% set bodyClasses = "rpr-details__page" %}
+{% set title = profession.name %}
 
 {% block content %}
 


### PR DESCRIPTION
This updates the templates to make sure the page titles are set in the HTML. I've added a `pageTitle` block to show the app name. If there is a `title` variable present, then we append this with a `|` character and spaces before.

The admin editing pages have the caption (which gives the name of edit/create action and the entity) and the title (telling the user where they are in the journey) again, seperated by pipes.