### PR TITLE
(2160) Fix bug where industries weren't showing on an organisation in the admin table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- Fix bug where industries weren't being shown in the Admin Organisations index page
+
 ## [release-006] - 2022-03-02
 
 ### Added

--- a/src/organisations/presenters/organisation-summary.presenter.ts
+++ b/src/organisations/presenters/organisation-summary.presenter.ts
@@ -28,14 +28,9 @@ export class OrganisationSummaryPresenter {
         (profession) => new ProfessionPresenter(profession, this.i18nService),
       );
 
-    const presenter = new OrganisationPresenter(
-      this.organisation,
-      this.i18nService,
-    );
-
     return {
       organisation: this.organisation,
-      presenter,
+      presenter: organisationPresenter,
       summaryList: await organisationPresenter.summaryList({
         removeBlank: true,
       }),

--- a/src/organisations/presenters/organisation.presenter.spec.ts
+++ b/src/organisations/presenters/organisation.presenter.spec.ts
@@ -1,7 +1,4 @@
 import { OrganisationPresenter } from './organisation.presenter';
-import { Organisation } from '../organisation.entity';
-import { Industry } from '../../industries/industry.entity';
-import { Profession } from '../../professions/profession.entity';
 import { createMockI18nService } from '../../testutils/create-mock-i18n-service';
 
 import organisationFactory from '../../testutils/factories/organisation';
@@ -28,34 +25,27 @@ jest.mock('../../helpers/format-link.helper');
 jest.mock('../../helpers/format-email.helper');
 
 describe('OrganisationPresenter', () => {
-  let organisation: Organisation;
-  let industries: Industry[];
-  let professions: Profession[];
-
   describe('tableRow', () => {
     describe('when all relations are present', () => {
       describe('when the professions share one industry', () => {
-        beforeEach(() => {
-          industries = [industryFactory.build({ name: 'Industry 1' })];
+        const industries = [industryFactory.build({ name: 'Industry 1' })];
 
-          professions = [
-            professionFactory.buildList(4, { industries: [industries[0]] }),
-          ].flat();
+        const professions = [
+          professionFactory.buildList(4, { industries: [industries[0]] }),
+        ].flat();
 
-          organisation = organisationFactory.build({
-            professions: professions,
-            lastModified: new Date('01-01-2022'),
-            changedByUser: userFactory.build({ name: 'beis-rpr' }),
-          });
+        const organisation = organisationFactory.build({
+          professions: professions,
+          lastModified: new Date('01-01-2022'),
+          changedByUser: userFactory.build({ name: 'beis-rpr' }),
         });
 
         it('returns the table row data', async () => {
-          const i18nService = createMockI18nService();
           (escape as jest.Mock).mockImplementation(escapeOf);
 
           const presenter = new OrganisationPresenter(
             organisation,
-            i18nService,
+            createMockI18nService(),
           );
           const tableRow = await presenter.tableRow();
 
@@ -91,34 +81,30 @@ describe('OrganisationPresenter', () => {
       });
 
       describe('when the professions share multiple industries', () => {
-        beforeEach(() => {
-          industries = [
+        it('returns the table row data', async () => {
+          const industries = [
             industryFactory.build({ name: 'industry.1' }),
             industryFactory.build({ name: 'industry.2' }),
             industryFactory.build({ name: 'industry.3' }),
           ];
 
-          professions = [
+          const professions = [
             professionFactory.buildList(4, { industries: [industries[0]] }),
             professionFactory.buildList(2, {
               industries: [industries[1], industries[2]],
             }),
           ].flat();
 
-          organisation = organisationFactory.build({
+          const organisation = organisationFactory.build({
             professions: professions,
             lastModified: new Date('01-01-2022'),
             changedByUser: userFactory.build({ name: 'beis-rpr' }),
           });
-        });
-
-        it('returns the table row data', async () => {
-          const i18nService = createMockI18nService();
           (escape as jest.Mock).mockImplementation(escapeOf);
 
           const presenter = new OrganisationPresenter(
             organisation,
-            i18nService,
+            createMockI18nService(),
           );
           const tableRow = await presenter.tableRow();
 
@@ -148,15 +134,14 @@ describe('OrganisationPresenter', () => {
     });
 
     describe('when the professions relation is not loaded', () => {
-      beforeEach(() => {
-        organisation = organisationFactory.build({
+      it('should raise an error', async () => {
+        const organisation = organisationFactory.build({
           professions: undefined,
         });
-      });
-
-      it('should raise an error', async () => {
-        const i18nService = createMockI18nService();
-        const presenter = new OrganisationPresenter(organisation, i18nService);
+        const presenter = new OrganisationPresenter(
+          organisation,
+          createMockI18nService(),
+        );
 
         expect(async () => {
           await presenter.tableRow();
@@ -167,15 +152,15 @@ describe('OrganisationPresenter', () => {
     });
 
     describe('when the industries relation is not loaded', () => {
-      beforeEach(() => {
-        organisation = organisationFactory.build({
+      it('should raise an error', async () => {
+        const organisation = organisationFactory.build({
           professions: [professionFactory.build({ industries: undefined })],
         });
-      });
 
-      it('should raise an error', async () => {
-        const i18nService = createMockI18nService();
-        const presenter = new OrganisationPresenter(organisation, i18nService);
+        const presenter = new OrganisationPresenter(
+          organisation,
+          createMockI18nService(),
+        );
 
         expect(async () => {
           await presenter.tableRow();
@@ -192,7 +177,7 @@ describe('OrganisationPresenter', () => {
         const i18nService = createMockI18nService();
         (escape as jest.Mock).mockImplementation(escapeOf);
 
-        organisation = organisationFactory.withVersion().build();
+        const organisation = organisationFactory.withVersion().build();
 
         const presenter = new OrganisationPresenter(organisation, i18nService);
 
@@ -250,7 +235,7 @@ describe('OrganisationPresenter', () => {
           const i18nService = createMockI18nService();
           (escape as jest.Mock).mockImplementation(escapeOf);
 
-          organisation = organisationFactory
+          const organisation = organisationFactory
             .withVersion()
             .build({ alternateName: '' });
 
@@ -276,7 +261,7 @@ describe('OrganisationPresenter', () => {
           const i18nService = createMockI18nService();
           (escape as jest.Mock).mockImplementation(escapeOf);
 
-          organisation = organisationFactory
+          const organisation = organisationFactory
             .withVersion()
             .build({ alternateName: '' });
 
@@ -305,7 +290,7 @@ describe('OrganisationPresenter', () => {
         const i18nService = createMockI18nService();
         (escape as jest.Mock).mockImplementation(escapeOf);
 
-        organisation = organisationFactory
+        const organisation = organisationFactory
           .withVersion()
           .build({ name: 'My Organisation' });
 
@@ -332,7 +317,7 @@ describe('OrganisationPresenter', () => {
 
         const version = organisationVersionFactory.build();
 
-        organisation = organisationFactory
+        const organisation = organisationFactory
           .withVersion(version)
           .build({ name: 'My Organisation' });
 
@@ -361,6 +346,8 @@ describe('OrganisationPresenter', () => {
         const i18nService = createMockI18nService();
         (escape as jest.Mock).mockImplementation(escapeOf);
 
+        const organisation = organisationFactory.build();
+
         const presenter = new OrganisationPresenter(organisation, i18nService);
         const list = await presenter.summaryList({ classes: 'foo' });
 
@@ -374,7 +361,7 @@ describe('OrganisationPresenter', () => {
       const i18nService = createMockI18nService();
       (formatMultilineString as jest.Mock).mockImplementation(multilineOf);
 
-      organisation = organisationFactory.build({
+      const organisation = organisationFactory.build({
         address: '123 Fake Street, London, SW1A 1AA',
       });
 
@@ -445,7 +432,7 @@ describe('OrganisationPresenter', () => {
       const i18nService = createMockI18nService();
       (formatEmail as jest.Mock).mockImplementation(emailOf);
 
-      organisation = organisationFactory.build({
+      const organisation = organisationFactory.build({
         email: 'foo@example.com',
       });
 
@@ -462,7 +449,7 @@ describe('OrganisationPresenter', () => {
       const i18nService = createMockI18nService();
       (formatLink as jest.Mock).mockImplementation(linkOf);
 
-      organisation = organisationFactory.build({
+      const organisation = organisationFactory.build({
         url: 'http://www.example.com',
       });
 

--- a/src/organisations/presenters/organisation.presenter.ts
+++ b/src/organisations/presenters/organisation.presenter.ts
@@ -7,6 +7,7 @@ import { formatMultilineString } from '../../helpers/format-multiline-string.hel
 import { formatDate } from '../../common/utils';
 import { formatLink } from '../../helpers/format-link.helper';
 import { formatEmail } from '../../helpers/format-email.helper';
+import { Profession } from '../../professions/profession.entity';
 
 interface OrganisationSummaryListOptions {
   classes?: string;
@@ -180,24 +181,12 @@ export class OrganisationPresenter {
   }
 
   private async industries(): Promise<string> {
-    const professions = this.organisation.professions;
-
-    if (professions === undefined) {
-      throw new Error(
-        'You must eagerly load professions to show industries. Try calling a "WithProfessions" method on the `OrganisationsService` class',
-      );
-    }
+    const professions = this.organisation.professions.map((profession) =>
+      Profession.withLatestLiveOrDraftVersion(profession),
+    );
 
     const industries = professions
-      .map((profession) => {
-        if (profession.industries === undefined) {
-          throw new Error(
-            'You must eagerly load industries to show industries. Try calling a "WithProfessions" method on the `OrganisationsService` class',
-          );
-        }
-
-        return profession.industries;
-      })
+      .map((profession) => profession.industries)
       .flat();
 
     const industryNames = await Promise.all(


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR

- Fixes bug where industries weren't showing on an organisation in the admin table, as they weren't being accessed from a ProfessionVersion.
- Refactors OrganisationPresenter test to be more in-line with our current style of writing tests.

## Screenshots of UI changes

![image](https://user-images.githubusercontent.com/19826940/156379112-234cdbe7-f6b9-4140-b648-1e5ca7b11743.png)

Now multiple industries are displayed against an organisation. For any Orgs without a Profession, the industries field will still be blank.
