### PR TITLE
Remove top level profession fields from seeds

### DIFF
--- a/seeds/development/professions.json
+++ b/seeds/development/professions.json
@@ -2,17 +2,8 @@
   {
     "name": "Registered Trademark Attorney",
     "slug": "registered-trademark-attorney",
-    "alternateName": "Patent Agent / Trademark agent",
-    "description": "Registration protection and exploitation of trade marks",
-    "occupationLocations": ["GB-ENG", "GB-SCT", "GB-WLS", "GB-NIR"],
-    "regulationType": "Reserves of activities",
-    "industries": ["industries.law"],
-    "qualification": "DSE - Diploma (post-secondary education), including Annex II (ex 92/51, Annex C,D) , Art. 11 c",
-    "reservedActivities": "England and Wales: the exercise of a right of audience; the conduct of litigation; reserved instrument activities; probate activities; the administration of oaths (see section 12 Legal Services Act 2007).",
-    "legislation": "The Trade Marks Act 1994",
     "organisation": "Law Society of England and Wales",
     "additionalOrganisation": null,
-    "mandatoryRegistration": "voluntary",
     "versions": [
       {
         "alternateName": "Patent Agent / Trademark agent",
@@ -35,17 +26,8 @@
   {
     "name": "Secondary School Teacher in State maintained schools (England)",
     "slug": "secondary-school-teacher-in-state-maintained-schools-england",
-    "alternateName": "Secondary school teacher",
-    "description": "Teaching work (known as specified work), as an activity, is regulated by law through the Education (Specified Work) (England) Regulations 2012/762. Regulation 5 lists the activities which are classed as specified work for the purposes of teaching in a school maintained by a local authority - which includes a maintained nursery - and a special school not so maintained:\n planning and preparing lessons and courses for pupils;\ndelivering lessons to pupils;\nassessing the development, progress and attainment of pupils; and\n reporting on the development, progress and attainment of pupils.",
-    "occupationLocations": ["GB-ENG"],
-    "regulationType": "N/A",
-    "industries": ["industries.education"],
-    "qualification": "PS3 - Diploma of post-secondary level (3-4 years) , Art. 11 d",
-    "reservedActivities": "No information submitted",
-    "legislation": "The Education (School Teachers' Qualifications) (England) Regulations 2003/1662 (as amended)",
     "organisation": "Department for Education",
     "additionalOrganisation": null,
-    "mandatoryRegistration": "mandatory",
     "versions": [
       {
         "alternateName": "Secondary school teacher",
@@ -69,17 +51,8 @@
   {
     "name": "Gas Safe Engineer",
     "slug": "gas-safe-engineer",
-    "alternateName": "Registered Gas Engineer",
-    "description": "Gas Safe Register is the official list of gas engineers in the UK, Isle of Man and Guernsey. Gas installers work on gas appliances and installations.",
-    "occupationLocations": ["GB-ENG", "GB-WLS", "GB-NIR"],
-    "regulationType": "N/A",
-    "industries": ["industries.constructionAndEngineering"],
-    "qualification": "ATT - Attestation of competence , Art. 11 a",
-    "reservedActivities": "Gas Safe Register is the official list of gas engineers in the UK, Isle of Man and Guernsey. To work on gas appliances and installations you must be on the gas safe register. The register exists to protect the public from unsafe gas work (EN)",
-    "legislation": "Gas Safety (Installation and Use) Regulations 1998",
     "organisation": "Council of Registered Gas Installers",
     "additionalOrganisation": null,
-    "mandatoryRegistration": "voluntary",
     "versions": [
       {
         "alternateName": "Registered Gas Engineer",

--- a/seeds/staging/professions.json
+++ b/seeds/staging/professions.json
@@ -2,17 +2,8 @@
   {
     "name": "Registered Trademark Attorney",
     "slug": "registered-trademark-attorney",
-    "alternateName": "Patent Agent / Trademark agent",
-    "description": "Registration protection and exploitation of trade marks",
-    "occupationLocations": ["GB-ENG", "GB-SCT", "GB-WLS", "GB-NIR"],
-    "regulationType": "Reserves of activities",
-    "industries": ["industries.law"],
-    "qualification": "DSE - Diploma (post-secondary education), including Annex II (ex 92/51, Annex C,D) , Art. 11 c",
-    "reservedActivities": "England and Wales: the exercise of a right of audience; the conduct of litigation; reserved instrument activities; probate activities; the administration of oaths (see section 12 Legal Services Act 2007).",
-    "legislation": "The Trade Marks Act 1994",
     "organisation": "Law Society of England and Wales",
     "additionalOrganisation": null,
-    "mandatoryRegistration": "voluntary",
     "versions": [
       {
         "alternateName": "Patent Agent / Trademark agent",
@@ -35,17 +26,8 @@
   {
     "name": "Secondary School Teacher in State maintained schools (England)",
     "slug": "secondary-school-teacher-in-state-maintained-schools-england",
-    "alternateName": "Secondary school teacher",
-    "description": "Teaching work (known as specified work), as an activity, is regulated by law through the Education (Specified Work) (England) Regulations 2012/762. Regulation 5 lists the activities which are classed as specified work for the purposes of teaching in a school maintained by a local authority - which includes a maintained nursery - and a special school not so maintained:\n planning and preparing lessons and courses for pupils;\ndelivering lessons to pupils;\nassessing the development, progress and attainment of pupils; and\n reporting on the development, progress and attainment of pupils.",
-    "occupationLocations": ["GB-ENG"],
-    "regulationType": "N/A",
-    "industries": ["industries.education"],
-    "qualification": "PS3 - Diploma of post-secondary level (3-4 years) , Art. 11 d",
-    "reservedActivities": "No information submitted",
-    "legislation": "The Education (School Teachers' Qualifications) (England) Regulations 2003/1662 (as amended)",
     "organisation": "Department for Education",
     "additionalOrganisation": null,
-    "mandatoryRegistration": "mandatory",
     "versions": [
       {
         "alternateName": "Secondary school teacher",
@@ -69,17 +51,8 @@
   {
     "name": "Gas Safe Engineer",
     "slug": "gas-safe-engineer",
-    "alternateName": "Registered Gas Engineer",
-    "description": "Gas Safe Register is the official list of gas engineers in the UK, Isle of Man and Guernsey. Gas installers work on gas appliances and installations.",
-    "occupationLocations": ["GB-ENG", "GB-WLS", "GB-NIR"],
-    "regulationType": "N/A",
-    "industries": ["industries.constructionAndEngineering"],
-    "qualification": "ATT - Attestation of competence , Art. 11 a",
-    "reservedActivities": "Gas Safe Register is the official list of gas engineers in the UK, Isle of Man and Guernsey. To work on gas appliances and installations you must be on the gas safe register. The register exists to protect the public from unsafe gas work (EN)",
-    "legislation": "Gas Safety (Installation and Use) Regulations 1998",
     "organisation": "Council of Registered Gas Installers",
     "additionalOrganisation": null,
-    "mandatoryRegistration": "voluntary",
     "versions": [
       {
         "alternateName": "Registered Gas Engineer",

--- a/seeds/test/professions.json
+++ b/seeds/test/professions.json
@@ -2,17 +2,8 @@
   {
     "name": "Registered Trademark Attorney",
     "slug": "registered-trademark-attorney",
-    "alternateName": "Patent Agent / Trademark agent",
-    "description": "Registration protection and exploitation of trade marks",
-    "occupationLocations": ["GB-ENG", "GB-SCT", "GB-WLS", "GB-NIR"],
-    "regulationType": "Reserves of activities",
-    "industries": ["industries.law"],
-    "qualification": "DSE - Diploma (post-secondary education), including Annex II (ex 92/51, Annex C,D) , Art. 11 c",
-    "reservedActivities": "England and Wales: the exercise of a right of audience; the conduct of litigation; reserved instrument activities; probate activities; the administration of oaths (see section 12 Legal Services Act 2007).",
-    "legislation": "The Trade Marks Act 1994",
     "organisation": "Law Society of England and Wales",
     "additionalOrganisation": null,
-    "mandatoryRegistration": "voluntary",
     "versions": [
       {
         "alternateName": "Patent Agent / Trademark agent",
@@ -35,17 +26,8 @@
   {
     "name": "Secondary School Teacher in State maintained schools (England)",
     "slug": "secondary-school-teacher-in-state-maintained-schools-england",
-    "alternateName": "Secondary school teacher",
-    "description": "Teaching work (known as specified work), as an activity, is regulated by law through the Education (Specified Work) (England) Regulations 2012/762. Regulation 5 lists the activities which are classed as specified work for the purposes of teaching in a school maintained by a local authority - which includes a maintained nursery - and a special school not so maintained:\n planning and preparing lessons and courses for pupils;\ndelivering lessons to pupils;\nassessing the development, progress and attainment of pupils; and\n reporting on the development, progress and attainment of pupils.",
-    "occupationLocations": ["GB-ENG"],
-    "regulationType": "N/A",
-    "industries": ["industries.education"],
-    "qualification": "PS3 - Diploma of post-secondary level (3-4 years) , Art. 11 d",
-    "reservedActivities": "No information submitted",
-    "legislation": "The Education (School Teachers' Qualifications) (England) Regulations 2003/1662 (as amended)",
     "organisation": "Department for Education",
     "additionalOrganisation": null,
-    "mandatoryRegistration": "mandatory",
     "versions": [
       {
         "alternateName": "Secondary school teacher",
@@ -69,17 +51,8 @@
   {
     "name": "Gas Safe Engineer",
     "slug": "gas-safe-engineer",
-    "alternateName": "Registered Gas Engineer",
-    "description": "Gas Safe Register is the official list of gas engineers in the UK, Isle of Man and Guernsey. Gas installers work on gas appliances and installations.",
-    "occupationLocations": ["GB-ENG", "GB-WLS", "GB-NIR"],
-    "regulationType": "N/A",
-    "industries": ["industries.constructionAndEngineering"],
-    "qualification": "ATT - Attestation of competence , Art. 11 a",
-    "reservedActivities": "Gas Safe Register is the official list of gas engineers in the UK, Isle of Man and Guernsey. To work on gas appliances and installations you must be on the gas safe register. The register exists to protect the public from unsafe gas work (EN)",
-    "legislation": "Gas Safety (Installation and Use) Regulations 1998",
     "organisation": "Council of Registered Gas Installers",
     "additionalOrganisation": null,
-    "mandatoryRegistration": "voluntary",
     "versions": [
       {
         "alternateName": "Registered Gas Engineer",

--- a/src/professions/professions.seeder.ts
+++ b/src/professions/professions.seeder.ts
@@ -18,23 +18,9 @@ import {
 
 type SeedProfession = {
   name: string;
-  alternateName: string;
   slug: string;
-  description: string;
-  occupationLocations: string[];
-  regulationType: string;
-  industries: string[];
-  qualification: string;
-  reservedActivities: string;
-  protectedTitles: string;
-  regulationUrl: string;
-  legislation: string;
   organisation: string;
   additionalOrganisation: string;
-  socCode: number;
-  keywords: string;
-  mandatoryRegistration: MandatoryRegistration;
-  confirmed: boolean;
   versions: SeedVersion[];
 };
 
@@ -98,7 +84,6 @@ export class ProfessionsSeeder implements Seeder {
 
         const newProfession = {
           name: seedProfession.name,
-          alternateName: seedProfession.alternateName,
           slug: seedProfession.slug,
           organisation: organisation,
           additionalOrganisation: additionalOrganisation,


### PR DESCRIPTION
# Changes in this PR

Remove fields we're now setting on the version from top level profession seeds.

These are no longer be used anywhere as they're now on
the "version" entities.

I've also removed `alternateName` from the top level seeding here, as
even though we're not actually setting it anywhere, it seems like the
sort of thing we'll want to version, so if/when we do add it, we'll put
it on the ProfessionVersion.