### PR TITLE
(2180) Don't show unconfirmed organisations in select boxes and filters on the admin pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - Fix bug where industries weren't being shown in the Admin Organisations index page
+- Don't display unconfirmed organisations in selects or filters
 
 ## [release-006] - 2022-03-02
 

--- a/cypress/integration/admin/professions/index.spec.ts
+++ b/cypress/integration/admin/professions/index.spec.ts
@@ -115,8 +115,10 @@ describe('Listing professions', () => {
       );
     });
 
-    it('I can filter by organisation', () => {
+    it('I can filter by live, draft and archived organisation', () => {
       expandFilters();
+
+      cy.get('label').should('not.contain', 'Unconfirmed Organisation');
 
       cy.get('label')
         .contains('Law Society of England and Wales')

--- a/cypress/integration/admin/professions/new.spec.ts
+++ b/cypress/integration/admin/professions/new.spec.ts
@@ -48,6 +48,10 @@ describe('Adding a new profession', () => {
       cy.get('select[name="regulatoryBody"]').select(
         'Department for Education',
       );
+      cy.get('select[name="regulatoryBody"]').should(
+        'not.contain',
+        'Unconfirmed Organisation',
+      );
       cy.get('select[name="additionalRegulatoryBody"]').select(
         'General Medical Council',
       );

--- a/src/organisations/organisation-versions.service.spec.ts
+++ b/src/organisations/organisation-versions.service.spec.ts
@@ -243,6 +243,63 @@ describe('OrganisationVersionsService', () => {
     });
   });
 
+  describe('allLiveAndDraft', () => {
+    it('fetches all of the live and draft organisations', async () => {
+      const versions = organisationVersionFactory.buildList(5);
+      const queryBuilder = createMock<SelectQueryBuilder<OrganisationVersion>>({
+        leftJoinAndSelect: () => queryBuilder,
+        distinctOn: () => queryBuilder,
+        where: () => queryBuilder,
+        orderBy: () => queryBuilder,
+        getMany: async () => versions,
+      });
+
+      jest
+        .spyOn(repo, 'createQueryBuilder')
+        .mockImplementation(() => queryBuilder);
+
+      const result = await service.allLiveAndDraft();
+
+      const expectedOrganisations = versions.map((version) =>
+        Organisation.withVersion(version.organisation, version),
+      );
+
+      expect(result).toEqual(expectedOrganisations);
+
+      expect(queryBuilder).toHaveJoined([
+        'organisationVersion.organisation',
+        'organisationVersion.user',
+        'organisation.professions',
+      ]);
+
+      expect(queryBuilder.leftJoinAndSelect).toHaveBeenCalledWith(
+        'professions.versions',
+        'professionVersions',
+      );
+
+      expect(queryBuilder.leftJoinAndSelect).toHaveBeenCalledWith(
+        'professionVersions.industries',
+        'industries',
+      );
+
+      expect(queryBuilder.distinctOn).toHaveBeenCalledWith([
+        'organisation.name',
+      ]);
+
+      expect(queryBuilder.where).toHaveBeenCalledWith(
+        'organisationVersion.status IN(:...status)',
+        {
+          status: [
+            OrganisationVersionStatus.Live,
+            OrganisationVersionStatus.Draft,
+          ],
+        },
+      );
+
+      expect(queryBuilder.orderBy).toHaveBeenCalledWith('organisation.name');
+    });
+  });
+
   describe('allWithLatestVersion', () => {
     it('gets all organisations and their latest draft or live version with draft or live Professions', async () => {
       const versions = organisationVersionFactory.buildList(5);

--- a/src/organisations/organisation-versions.service.ts
+++ b/src/organisations/organisation-versions.service.ts
@@ -82,6 +82,23 @@ export class OrganisationVersionsService {
     );
   }
 
+  async allLiveAndDraft(): Promise<Organisation[]> {
+    const versions = await this.versionsWithJoins()
+      .distinctOn(['organisation.name'])
+      .where('organisationVersion.status IN(:...status)', {
+        status: [
+          OrganisationVersionStatus.Live,
+          OrganisationVersionStatus.Draft,
+        ],
+      })
+      .orderBy('organisation.name')
+      .getMany();
+
+    return versions.map((version) =>
+      Organisation.withVersion(version.organisation, version),
+    );
+  }
+
   async allWithLatestVersion(): Promise<Organisation[]> {
     const versions = await this.versionsWithJoins()
       .distinctOn(['organisationVersion.organisation', 'professions.id'])

--- a/src/professions/admin/professions.controller.spec.ts
+++ b/src/professions/admin/professions.controller.spec.ts
@@ -6,7 +6,6 @@ import { createMockI18nService } from '../../testutils/create-mock-i18n-service'
 import { IndustriesService } from '../../industries/industries.service';
 import { Nation } from '../../nations/nation';
 import { Organisation } from '../../organisations/organisation.entity';
-import { OrganisationsService } from '../../organisations/organisations.service';
 import { FilterInput } from '../../common/interfaces/filter-input.interface';
 import { Profession } from '../profession.entity';
 import { ProfessionsService } from '../professions.service';
@@ -21,6 +20,7 @@ import userFactory from '../../testutils/factories/user';
 import { RequestWithAppSession } from '../../common/interfaces/request-with-app-session.interface';
 import { getActingUser } from '../../users/helpers/get-acting-user.helper';
 import { createDefaultMockRequest } from '../../testutils/factories/create-default-mock-request';
+import { OrganisationVersionsService } from '../../organisations/organisation-versions.service';
 
 jest.mock('../../users/helpers/get-acting-user.helper');
 
@@ -82,14 +82,14 @@ describe('ProfessionsController', () => {
   let professionsService: DeepMocked<ProfessionsService>;
   let professionVersionsService: DeepMocked<ProfessionVersionsService>;
   let industriesService: DeepMocked<IndustriesService>;
-  let organisationsService: DeepMocked<OrganisationsService>;
+  let organisationVersionsService: DeepMocked<OrganisationVersionsService>;
 
   beforeEach(async () => {
     request = createDefaultMockRequest();
 
     professionsService = createMock<ProfessionsService>();
     professionVersionsService = createMock<ProfessionVersionsService>();
-    organisationsService = createMock<OrganisationsService>();
+    organisationVersionsService = createMock<OrganisationVersionsService>();
     industriesService = createMock<IndustriesService>();
     i18nService = createMockI18nService();
 
@@ -99,9 +99,9 @@ describe('ProfessionsController', () => {
       profession3,
     ]);
 
-    organisationsService.all.mockImplementation(async () => {
-      return organisations;
-    });
+    organisationVersionsService.allWithLatestVersion.mockResolvedValue(
+      organisations,
+    );
 
     industriesService.all.mockImplementation(async () => {
       return industries;
@@ -118,8 +118,8 @@ describe('ProfessionsController', () => {
           useValue: professionVersionsService,
         },
         {
-          provide: OrganisationsService,
-          useValue: organisationsService,
+          provide: OrganisationVersionsService,
+          useValue: organisationVersionsService,
         },
         {
           provide: IndustriesService,

--- a/src/professions/admin/professions.controller.ts
+++ b/src/professions/admin/professions.controller.ts
@@ -21,7 +21,6 @@ import {
 } from './professions.presenter';
 import { AuthenticationGuard } from '../../common/authentication.guard';
 import { FilterDto } from './dto/filter.dto';
-import { OrganisationsService } from '../../organisations/organisations.service';
 import { Profession } from '../profession.entity';
 import { BackLink } from '../../common/decorators/back-link.decorator';
 import { createFilterInput } from '../../helpers/create-filter-input.helper';
@@ -31,6 +30,7 @@ import { RequestWithAppSession } from '../../common/interfaces/request-with-app-
 import { UserPermission } from '../../users/user-permission';
 import { Permissions } from '../../common/permissions.decorator';
 import { getActingUser } from '../../users/helpers/get-acting-user.helper';
+import { OrganisationVersionsService } from '../../organisations/organisation-versions.service';
 
 @UseGuards(AuthenticationGuard)
 @Controller('admin/professions')
@@ -38,7 +38,7 @@ export class ProfessionsController {
   constructor(
     private readonly professionsService: ProfessionsService,
     private readonly professionVersionsService: ProfessionVersionsService,
-    private readonly organisationsService: OrganisationsService,
+    private readonly organisationVersionsService: OrganisationVersionsService,
     private readonly industriesService: IndustriesService,
     private readonly i18Service: I18nService,
   ) {}
@@ -88,7 +88,8 @@ export class ProfessionsController {
     request: RequestWithAppSession,
   ): Promise<IndexTemplate> {
     const allNations = Nation.all();
-    const allOrganisations = await this.organisationsService.all();
+    const allOrganisations =
+      await this.organisationVersionsService.allWithLatestVersion();
     const allIndustries = await this.industriesService.all();
 
     const allProfessions =

--- a/src/professions/admin/top-level-information.controller.spec.ts
+++ b/src/professions/admin/top-level-information.controller.spec.ts
@@ -11,17 +11,20 @@ import { when } from 'jest-when';
 import { I18nService } from 'nestjs-i18n';
 import { createMockI18nService } from '../../testutils/create-mock-i18n-service';
 import { translationOf } from '../../testutils/translation-of';
+import { OrganisationVersionsService } from '../../organisations/organisation-versions.service';
 
 describe('TopLevelInformationController', () => {
   let controller: TopLevelInformationController;
   let professionsService: DeepMocked<ProfessionsService>;
   let organisationsService: DeepMocked<OrganisationsService>;
+  let organisationVersionsService: DeepMocked<OrganisationVersionsService>;
   let response: DeepMocked<Response>;
   let i18nService: I18nService;
 
   beforeEach(async () => {
     professionsService = createMock<ProfessionsService>();
     organisationsService = createMock<OrganisationsService>();
+    organisationVersionsService = createMock<OrganisationVersionsService>();
     i18nService = createMockI18nService();
 
     const module: TestingModule = await Test.createTestingModule({
@@ -29,6 +32,10 @@ describe('TopLevelInformationController', () => {
       providers: [
         { provide: ProfessionsService, useValue: professionsService },
         { provide: OrganisationsService, useValue: organisationsService },
+        {
+          provide: OrganisationVersionsService,
+          useValue: organisationVersionsService,
+        },
         { provide: I18nService, useValue: i18nService },
       ],
     }).compile();
@@ -50,7 +57,9 @@ describe('TopLevelInformationController', () => {
         professionsService.findWithVersions.mockResolvedValue(blankProfession);
 
         const organisations = organisationFactory.buildList(2);
-        organisationsService.all.mockResolvedValue(organisations);
+        organisationVersionsService.allLiveAndDraft.mockResolvedValue(
+          organisations,
+        );
 
         const regulatedAuthoritiesSelectPresenter =
           new RegulatedAuthoritiesSelectPresenter(organisations, null);
@@ -95,8 +104,9 @@ describe('TopLevelInformationController', () => {
           additionalOrganisation,
           organisationFactory.build(),
         ];
-        organisationsService.all.mockResolvedValue(organisations);
-
+        organisationVersionsService.allLiveAndDraft.mockResolvedValue(
+          organisations,
+        );
         const regulatedAuthoritiesSelectPresenterWithSelectedOrganisation =
           new RegulatedAuthoritiesSelectPresenter(organisations, organisation);
 

--- a/src/professions/admin/top-level-information.controller.ts
+++ b/src/professions/admin/top-level-information.controller.ts
@@ -25,6 +25,7 @@ import { OrganisationsService } from '../../organisations/organisations.service'
 import { RegulatedAuthoritiesSelectPresenter } from './regulated-authorities-select-presenter';
 import { Organisation } from '../../organisations/organisation.entity';
 import { I18nService } from 'nestjs-i18n';
+import { OrganisationVersionsService } from '../../organisations/organisation-versions.service';
 
 @UseGuards(AuthenticationGuard)
 @Controller('admin/professions')
@@ -32,6 +33,7 @@ export class TopLevelInformationController {
   constructor(
     private readonly professionsService: ProfessionsService,
     private readonly organisationsService: OrganisationsService,
+    private readonly organisationVersionsService: OrganisationVersionsService,
     private readonly i18nService: I18nService,
   ) {}
 
@@ -141,7 +143,8 @@ export class TopLevelInformationController {
     change: boolean,
     errors: object | undefined = undefined,
   ): Promise<void> {
-    const regulatedAuthorities = await this.organisationsService.all();
+    const regulatedAuthorities =
+      await this.organisationVersionsService.allLiveAndDraft();
 
     const regulatedAuthoritiesSelectArgs =
       new RegulatedAuthoritiesSelectPresenter(

--- a/src/professions/professions.module.ts
+++ b/src/professions/professions.module.ts
@@ -22,6 +22,8 @@ import { RegistrationController } from './admin/registration.controller';
 import { ScopeController } from './admin/scope.controller';
 import { ProfessionPublicationController } from './admin/profession-publication.controller';
 import { ProfessionArchiveController } from './admin/profession-archive.controller';
+import { OrganisationVersionsService } from '../organisations/organisation-versions.service';
+import { OrganisationVersion } from '../organisations/organisation-version.entity';
 
 @Module({
   imports: [
@@ -29,11 +31,13 @@ import { ProfessionArchiveController } from './admin/profession-archive.controll
     TypeOrmModule.forFeature([ProfessionVersion]),
     TypeOrmModule.forFeature([Industry]),
     TypeOrmModule.forFeature([Organisation]),
+    TypeOrmModule.forFeature([OrganisationVersion]),
   ],
   providers: [
     ProfessionsService,
     IndustriesService,
     OrganisationsService,
+    OrganisationVersionsService,
     ProfessionVersionsService,
   ],
   controllers: [


### PR DESCRIPTION
# Changes in this PR

- Remove unconfirmed and archived organisations from the Top Level Details page when adding or editing a Profession.
- Remove unconfirmed organisations from the list of filters when filtering professions by their Organisation.
