### PR TITLE
(2199) Second regulator added doesn't appear on page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- Display a second Regulatory Authority if specified for a profession
+
 ## [release-007] - 2022-03-04
 
 ### Changed

--- a/assets/stylesheets/application.scss
+++ b/assets/stylesheets/application.scss
@@ -16,6 +16,16 @@ $govuk-assets-path: '~govuk-frontend/govuk/assets/';
   &__section-title {
     text-transform: uppercase;
   }
+
+  &__sub-group {
+    padding: 1em 0 0 0;
+    margin: 0;
+  }
+
+  &__sub-group-title {
+    border-left: 0.5em solid govuk-colour('black');
+    padding-left: 0.5em;
+  }
 }
 
 .rpr-listing {

--- a/cypress/integration/admin/organisations/index.spec.ts
+++ b/cypress/integration/admin/organisations/index.spec.ts
@@ -11,13 +11,10 @@ describe('Listing organisations', () => {
     });
 
     it('Lists all the organisations', () => {
-      cy.translate('organisations.search.foundPlural', { count: 4 }).then(
-        (foundText) => {
-          cy.get('body').should('contain', foundText);
-        },
-      );
       cy.readFile('./seeds/test/professions.json').then((professions) => {
         cy.readFile('./seeds/test/organisations.json').then((organisations) => {
+          let confirmedCount = 0;
+
           organisations.forEach((organisation) => {
             const latestVersion =
               organisation.versions[organisation.versions.length - 1];
@@ -25,6 +22,8 @@ describe('Listing organisations', () => {
             if (latestVersion.status === 'unconfirmed') {
               cy.get('tr').should('not.contain', organisation.name);
             } else {
+              confirmedCount++;
+
               cy.get('tr')
                 .contains(organisation.name)
                 .then(($header) => {
@@ -60,6 +59,12 @@ describe('Listing organisations', () => {
                   });
                 });
             }
+          });
+
+          cy.translate('organisations.search.foundPlural', {
+            count: confirmedCount,
+          }).then((foundText) => {
+            cy.get('body').should('contain', foundText);
           });
         });
       });

--- a/cypress/integration/admin/professions/edit.spec.ts
+++ b/cypress/integration/admin/professions/edit.spec.ts
@@ -584,12 +584,19 @@ describe('Editing an existing profession', () => {
       cy.get('select[name="regulatoryBody"]').select(
         'Department for Education',
       );
+      cy.get('select[name="additionalRegulatoryBody"]').select(
+        'Council of Registered Gas Installers',
+      );
       cy.translate('app.continue').then((buttonText) => {
         cy.get('button').contains(buttonText).click();
       });
       cy.checkSummaryListRowValue(
         'professions.form.label.topLevelInformation.regulatedAuthority',
         'Department for Education',
+      );
+      cy.checkSummaryListRowValue(
+        'professions.form.label.topLevelInformation.additionalAuthority',
+        'Council of Registered Gas Installers',
       );
 
       cy.translate('professions.form.button.saveAsDraft').then((buttonText) => {
@@ -602,6 +609,9 @@ describe('Editing an existing profession', () => {
         'contain',
         format(new Date(), 'dd-MM-yyyy'),
       );
+
+      cy.get('h3').should('contain', 'Department for Education');
+      cy.get('h3').should('contain', 'Council of Registered Gas Installers');
 
       cy.translate('professions.admin.update.confirmation.heading').then(
         (flashHeading) => {

--- a/cypress/integration/organisations/search/search.spec.ts
+++ b/cypress/integration/organisations/search/search.spec.ts
@@ -11,15 +11,30 @@ describe('Searching an organisation', () => {
   });
 
   it('I can view an unfiltered list of organisations', () => {
-    cy.translate('organisations.search.foundPlural', { count: 4 }).then(
-      (foundText) => {
-        cy.get('body').should('contain.text', foundText);
-      },
-    );
-    cy.get('body').should('contain', 'Department for Education');
-    cy.get('body').should('contain', 'General Medical Council');
+    cy.readFile('./seeds/test/organisations.json').then((organisations) => {
+      let confirmedCount = 0;
 
-    checkResultLength(4);
+      organisations.forEach((organisation) => {
+        const latestVersion =
+          organisation.versions[organisation.versions.length - 1];
+
+        if (latestVersion.status === 'unconfirmed') {
+          cy.get('body').should('not.contain', organisation.name);
+        } else {
+          confirmedCount++;
+
+          cy.get('body').should('contain', organisation.name);
+        }
+      });
+
+      cy.translate('organisations.search.foundPlural', {
+        count: confirmedCount,
+      }).then((foundText) => {
+        cy.get('body').should('contain.text', foundText);
+      });
+
+      checkResultLength(confirmedCount);
+    });
   });
 
   it('Organisations are sorted alphabetically', () => {

--- a/cypress/integration/professions/show.spec.ts
+++ b/cypress/integration/professions/show.spec.ts
@@ -11,27 +11,29 @@ describe('Showing a profession', () => {
     cy.translate('professions.show.bodies.heading').then((heading) => {
       cy.get('body').should('contain', heading);
     });
-    cy.checkSummaryListRowValue(
-      'professions.show.bodies.regulatedAuthority',
-      'Law Society of England and Wales',
-    );
-    cy.checkSummaryListRowMultilineValue('professions.show.bodies.address', [
-      '456 Example Street',
-      'London',
-      'EC1 1AB',
-    ]);
-    cy.checkSummaryListRowValue(
-      'professions.show.bodies.emailAddress',
-      'law@example.com',
-    );
-    cy.checkSummaryListRowValue(
-      'professions.show.bodies.url',
-      'www.lawsociety.org.uk',
-    );
-    cy.checkSummaryListRowValue(
-      'professions.show.bodies.phoneNumber',
-      '+44 0123 456789',
-    );
+
+    cy.get('h3').should('contain', 'Law Society of England and Wales');
+    cy.get('h3')
+      .contains('Law Society of England and Wales')
+      .parent()
+      .within(() => {
+        cy.checkSummaryListRowMultilineValue(
+          'professions.show.bodies.address',
+          ['456 Example Street', 'London', 'EC1 1AB'],
+        );
+        cy.checkSummaryListRowValue(
+          'professions.show.bodies.emailAddress',
+          'law@example.com',
+        );
+        cy.checkSummaryListRowValue(
+          'professions.show.bodies.url',
+          'www.lawsociety.org.uk',
+        );
+        cy.checkSummaryListRowValue(
+          'professions.show.bodies.phoneNumber',
+          '+44 0123 456789',
+        );
+      });
 
     cy.translate('professions.show.regulatedActivities.heading').then(
       (heading) => {

--- a/cypress/integration/professions/show.spec.ts
+++ b/cypress/integration/professions/show.spec.ts
@@ -35,6 +35,29 @@ describe('Showing a profession', () => {
         );
       });
 
+    cy.get('h3').should('contain', 'Alternative Law Society');
+    cy.get('h3')
+      .contains('Alternative Law Society')
+      .parent()
+      .within(() => {
+        cy.checkSummaryListRowMultilineValue(
+          'professions.show.bodies.address',
+          ['123 Example Street', 'London', 'WC1 1AB'],
+        );
+        cy.checkSummaryListRowValue(
+          'professions.show.bodies.emailAddress',
+          'alt-law@example.com',
+        );
+        cy.checkSummaryListRowValue(
+          'professions.show.bodies.url',
+          'www.alt-lawsociety.org.uk',
+        );
+        cy.checkSummaryListRowValue(
+          'professions.show.bodies.phoneNumber',
+          '+44 0123 987654',
+        );
+      });
+
     cy.translate('professions.show.regulatedActivities.heading').then(
       (heading) => {
         cy.get('body h2').should('contain', heading);

--- a/seeds/development/organisations.json
+++ b/seeds/development/organisations.json
@@ -54,6 +54,21 @@
     ]
   },
   {
+    "name": "Alternative Law Society",
+    "slug": "alternative-law-society",
+    "versions": [
+      {
+        "alternateName": "",
+        "address": "123 Example Street\nLondon\nWC1 1AB",
+        "url": "www.alt-lawsociety.org.uk",
+        "email": "alt-law@example.com",
+        "telephone": "+44 0123 987654",
+        "fax": "+44 0123 087654",
+        "status": "live"
+      }
+    ]
+  },
+  {
     "name": "General Medical Council",
     "slug": "general-medical-council",
     "versions": [

--- a/seeds/development/professions.json
+++ b/seeds/development/professions.json
@@ -3,7 +3,7 @@
     "name": "Registered Trademark Attorney",
     "slug": "registered-trademark-attorney",
     "organisation": "Law Society of England and Wales",
-    "additionalOrganisation": null,
+    "additionalOrganisation": "Alternative Law Society",
     "versions": [
       {
         "alternateName": "Patent Agent / Trademark agent",

--- a/seeds/test/organisations.json
+++ b/seeds/test/organisations.json
@@ -56,6 +56,21 @@
     ]
   },
   {
+    "name": "Alternative Law Society",
+    "slug": "alternative-law-society",
+    "versions": [
+      {
+        "alternateName": "",
+        "address": "123 Example Street\nLondon\nWC1 1AB",
+        "url": "www.alt-lawsociety.org.uk",
+        "email": "alt-law@example.com",
+        "telephone": "+44 0123 987654",
+        "fax": "+44 0123 087654",
+        "status": "live"
+      }
+    ]
+  },
+  {
     "name": "General Medical Council",
     "slug": "general-medical-council",
     "versions": [

--- a/seeds/test/professions.json
+++ b/seeds/test/professions.json
@@ -3,7 +3,7 @@
     "name": "Registered Trademark Attorney",
     "slug": "registered-trademark-attorney",
     "organisation": "Law Society of England and Wales",
-    "additionalOrganisation": null,
+    "additionalOrganisation": "Alternative Law Society",
     "versions": [
       {
         "alternateName": "Patent Agent / Trademark agent",

--- a/src/professions/admin/profession-versions.controller.ts
+++ b/src/professions/admin/profession-versions.controller.ts
@@ -65,6 +65,14 @@ export class ProfessionVersionsController {
       profession.organisation,
     );
 
+    const additionalOrganisation =
+      profession.additionalOrganisation &&
+      Organisation.withLatestVersion(profession.additionalOrganisation);
+
+    const organisations = additionalOrganisation
+      ? [organisation, additionalOrganisation]
+      : [organisation];
+
     const nations = await Promise.all(
       (profession.occupationLocations || []).map(async (code) =>
         Nation.find(code).translatedName(this.i18nService),
@@ -89,7 +97,7 @@ export class ProfessionVersionsController {
         : null,
       nations,
       industries,
-      organisation,
+      organisations,
     };
   }
 

--- a/src/professions/interfaces/show-template.interface.ts
+++ b/src/professions/interfaces/show-template.interface.ts
@@ -9,5 +9,5 @@ export interface ShowTemplate {
   qualificationSummaryList: SummaryList;
   nations: string[];
   industries: string[];
-  organisation: Organisation;
+  organisations: Organisation[];
 }

--- a/src/professions/profession-versions.service.spec.ts
+++ b/src/professions/profession-versions.service.spec.ts
@@ -436,6 +436,7 @@ describe('ProfessionVersionsService', () => {
         'professionVersion.profession',
         'professionVersion.industries',
         'profession.organisation',
+        'profession.additionalOrganisation',
         'professionVersion.user',
         'professionVersion.qualification',
         'professionVersion.legislations',
@@ -480,6 +481,7 @@ describe('ProfessionVersionsService', () => {
       expect(queryBuilder).toHaveJoined([
         'professionVersion.profession',
         'profession.organisation',
+        'profession.additionalOrganisation',
         'professionVersion.industries',
         'professionVersion.user',
         'professionVersion.qualification',
@@ -533,6 +535,7 @@ describe('ProfessionVersionsService', () => {
       expect(queryBuilder).toHaveJoined([
         'professionVersion.profession',
         'profession.organisation',
+        'profession.additionalOrganisation',
         'professionVersion.industries',
         'professionVersion.user',
         'professionVersion.qualification',
@@ -582,6 +585,7 @@ describe('ProfessionVersionsService', () => {
         'professionVersion.profession',
         'professionVersion.industries',
         'profession.organisation',
+        'profession.additionalOrganisation',
         'professionVersion.user',
         'professionVersion.qualification',
         'professionVersion.legislations',
@@ -590,6 +594,11 @@ describe('ProfessionVersionsService', () => {
       expect(queryBuilder.leftJoinAndSelect).toHaveBeenCalledWith(
         'organisation.versions',
         'organisationVersions',
+      );
+
+      expect(queryBuilder.leftJoinAndSelect).toHaveBeenCalledWith(
+        'additionalOrganisation.versions',
+        'additionalOrganisationVersions',
       );
 
       expect(queryBuilder.where).toHaveBeenCalledWith(
@@ -626,6 +635,7 @@ describe('ProfessionVersionsService', () => {
         'professionVersion.profession',
         'professionVersion.industries',
         'profession.organisation',
+        'profession.additionalOrganisation',
         'professionVersion.user',
         'professionVersion.qualification',
         'professionVersion.legislations',
@@ -634,6 +644,11 @@ describe('ProfessionVersionsService', () => {
       expect(queryBuilder.leftJoinAndSelect).toHaveBeenCalledWith(
         'organisation.versions',
         'organisationVersions',
+      );
+
+      expect(queryBuilder.leftJoinAndSelect).toHaveBeenCalledWith(
+        'additionalOrganisation.versions',
+        'additionalOrganisationVersions',
       );
 
       expect(queryBuilder.where).toHaveBeenCalledWith({

--- a/src/professions/profession-versions.service.ts
+++ b/src/professions/profession-versions.service.ts
@@ -200,6 +200,10 @@ export class ProfessionVersionsService {
   async findLiveBySlug(slug: string): Promise<Profession> {
     const version = await this.versionsWithJoins()
       .leftJoinAndSelect('organisation.versions', 'organisationVersions')
+      .leftJoinAndSelect(
+        'additionalOrganisation.versions',
+        'additionalOrganisationVersions',
+      )
       .where('professionVersion.status = :status AND profession.slug = :slug', {
         status: ProfessionVersionStatus.Live,
         slug: slug,
@@ -215,6 +219,10 @@ export class ProfessionVersionsService {
   ): Promise<ProfessionVersion> {
     const version = await this.versionsWithJoins()
       .leftJoinAndSelect('organisation.versions', 'organisationVersions')
+      .leftJoinAndSelect(
+        'additionalOrganisation.versions',
+        'additionalOrganisationVersions',
+      )
       .where({ profession: { id: professionId }, id })
       .getOne();
 
@@ -226,6 +234,10 @@ export class ProfessionVersionsService {
       .createQueryBuilder('professionVersion')
       .leftJoinAndSelect('professionVersion.profession', 'profession')
       .leftJoinAndSelect('profession.organisation', 'organisation')
+      .leftJoinAndSelect(
+        'profession.additionalOrganisation',
+        'additionalOrganisation',
+      )
       .leftJoinAndSelect('professionVersion.industries', 'industries')
       .leftJoinAndSelect('professionVersion.qualification', 'qualification')
       .leftJoinAndSelect('professionVersion.user', 'user')

--- a/src/professions/professions.controller.ts
+++ b/src/professions/professions.controller.ts
@@ -38,6 +38,14 @@ export class ProfessionsController {
       profession.organisation,
     );
 
+    const additionalOrganisation =
+      profession.additionalOrganisation &&
+      Organisation.withLatestLiveVersion(profession.additionalOrganisation);
+
+    const organisations = additionalOrganisation
+      ? [organisation, additionalOrganisation]
+      : [organisation];
+
     const nations = await Promise.all(
       profession.occupationLocations.map(async (code) =>
         Nation.find(code).translatedName(this.i18nService),
@@ -61,7 +69,7 @@ export class ProfessionsController {
         : null,
       nations,
       industries,
-      organisation,
+      organisations,
     };
   }
 }

--- a/views/professions/_profession-details.njk
+++ b/views/professions/_profession-details.njk
@@ -45,51 +45,48 @@
 
 <h2 class="govuk-heading-m rpr-details__section-title">{{ "professions.show.bodies.heading" | t }}</h2>
 
-{{ govukSummaryList({
-  classes: 'govuk-summary-list--no-border',
-  rows: [
-    {
-      key: {
-        text: ("professions.show.bodies.regulatedAuthority" | t)
-      },
-      value: {
-        text: organisation.name
-      }
-    },
-    {
-      key: {
-        text: ("professions.show.bodies.address" | t)
-      },
-      value: {
-        html: organisation.address | multiline
-      }
-    },
-    {
-      key: {
-        text: ("professions.show.bodies.emailAddress" | t)
-      },
-      value: {
-        html: organisation.email | email
-      }
-    },
-    {
-      key: {
-        text: ("professions.show.bodies.url" | t)
-      },
-      value: {
-        html: organisation.url | link
-      }
-    },
-    {
-      key: {
-        text: ("professions.show.bodies.phoneNumber" | t)
-      },
-      value: {
-        text: organisation.telephone
-      }
-    }
-  ]
-}) }}
+{% for organisation in organisations %}
+  <div class="rpr-details__sub-group">
+    <h3 class="govuk-heading-m rpr-details__sub-group-title">{{ organisation.name | escape }}</h3>
+    {{ govukSummaryList({
+      classes: 'govuk-summary-list--no-border',
+      rows: [
+        {
+          key: {
+            text: ("professions.show.bodies.address" | t)
+          },
+          value: {
+            html: organisation.address | multiline
+          }
+        },
+        {
+          key: {
+            text: ("professions.show.bodies.emailAddress" | t)
+          },
+          value: {
+            html: organisation.email | email
+          }
+        },
+        {
+          key: {
+            text: ("professions.show.bodies.url" | t)
+          },
+          value: {
+            html: organisation.url | link
+          }
+        },
+        {
+          key: {
+            text: ("professions.show.bodies.phoneNumber" | t)
+          },
+          value: {
+            text: organisation.telephone
+          }
+        }
+      ]
+    }) }}
+  </div>
+{% endfor %}
 
 <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 


### PR DESCRIPTION
# Changes in this PR

This PR fixes that a second regulator was not being shown on the main pages for view professions.

This PR does not address that only one regular shows in external or internal search results, or the redesign of the top section of the profession view shown in this ticket

## Screenshots of UI changes

### Before
![localhost_3000_professions_registered-trademark-attorney (1)](https://user-images.githubusercontent.com/94137563/156394504-59ceecfb-9a44-45c9-b7e1-63d38385f7f9.png)

### After
![localhost_3000_professions_registered-trademark-attorney](https://user-images.githubusercontent.com/94137563/156394511-ed8a9dd2-7d8d-4b80-9e61-1852858463a0.png)

