### PR TITLE
Redirect to canonical hostname

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -16,6 +16,7 @@ import { globalLocals } from './common/global-locals';
 
 import { ValidationFailedError } from './common/validation/validation-failed.error';
 import { GlobalExceptionFilter } from './common/global-exception.filter';
+import { redirectToCanonicalHostname } from './middleware/redirect-to-canonical-hostname';
 
 async function bootstrap() {
   const app = await NestFactory.create<NestExpressApplication>(AppModule);
@@ -79,6 +80,10 @@ async function bootstrap() {
         realm: process.env['HOST_URL'],
       }),
     );
+  }
+
+  if (process.env['CANONICAL_HOSTNAME']) {
+    app.use(redirectToCanonicalHostname);
   }
 
   await app.listen(process.env.PORT || 3000);

--- a/src/middleware/redirect-to-canonical-hostname.spec.ts
+++ b/src/middleware/redirect-to-canonical-hostname.spec.ts
@@ -1,0 +1,64 @@
+import { createMock, DeepMocked } from '@golevelup/ts-jest';
+import { Request, Response, NextFunction } from 'express';
+import { redirectToCanonicalHostname } from './redirect-to-canonical-hostname';
+
+describe('redirectToCanonicalHostname', () => {
+  let request: DeepMocked<Request>;
+  let response: DeepMocked<Response>;
+  let next: jest.Mock<NextFunction>;
+
+  const OLD_ENV = process.env;
+
+  beforeEach(async () => {
+    jest.resetModules();
+  });
+
+  afterAll(() => {
+    process.env = OLD_ENV;
+  });
+
+  describe('when the request does not have the the canonical hostname', () => {
+    it('should redirect to the path with the correct hostname', () => {
+      process.env = { ...OLD_ENV, CANONICAL_HOSTNAME: 'www.example.org' };
+
+      request = createMock<Request>({
+        header() {
+          return 'www.example.com';
+        },
+        protocol: 'http',
+        url: '/some/path',
+      });
+      response = createMock<Response>();
+      next = jest.fn();
+
+      redirectToCanonicalHostname(request, response, next);
+
+      expect(response.redirect).toHaveBeenCalledWith(
+        301,
+        'http://www.example.org/some/path',
+      );
+      expect(next).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when the request has the the canonical hostname', () => {
+    it('should not redirect', () => {
+      process.env = { ...OLD_ENV, CANONICAL_HOSTNAME: 'www.example.org' };
+
+      request = createMock<Request>({
+        header() {
+          return 'www.example.org';
+        },
+        protocol: 'http',
+        url: '/some/path',
+      });
+      response = createMock<Response>();
+      next = jest.fn();
+
+      redirectToCanonicalHostname(request, response, next);
+
+      expect(response.redirect).not.toHaveBeenCalled();
+      expect(next).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/middleware/redirect-to-canonical-hostname.ts
+++ b/src/middleware/redirect-to-canonical-hostname.ts
@@ -1,0 +1,20 @@
+import { Request, Response, NextFunction } from 'express';
+
+export function redirectToCanonicalHostname(
+  request: Request,
+  response: Response,
+  next: NextFunction,
+) {
+  var host = request.header('host');
+  if (host === process.env['CANONICAL_HOSTNAME']) {
+    next();
+  } else {
+    response.redirect(
+      301,
+      request.protocol +
+        '://' +
+        process.env['CANONICAL_HOSTNAME'] +
+        request.url,
+    );
+  }
+}

--- a/terraform/app.tf
+++ b/terraform/app.tf
@@ -23,6 +23,7 @@ resource "cloudfoundry_app" "beis-rpr-app" {
     "AUTH0_REDIRECT_URL"  = var.auth0_redirect_url
     "APP_SECRET"          = var.app_secret
     "HOST_URL"            = "https://${var.custom_hostname}.${var.custom_domain}/"
+    "CANONICAL_HOSTNAME"  = "${var.custom_hostname}.${var.custom_domain}"
     "NOTIFY_TEMPLATE_ID"  = var.notify_template_id
     "NOTIFY_API_KEY"      = var.notify_api_key
     "ENVIRONMENT"         = var.environment


### PR DESCRIPTION
Now we have a domain set up, this adds some middleware to ensure that all requests are redirected to the correct domain.