### PR TITLE
(2187) Allow editors to publish from the add/edit journey

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- Allow users to publish professions and organisations when editing
+
 ### Changed
 
 - Display a second Regulatory Authority if specified for a profession

--- a/assets/stylesheets/application.scss
+++ b/assets/stylesheets/application.scss
@@ -145,6 +145,10 @@ $small-screen: 768px;
       }
     }
   }
+
+  &__buttons-container {
+    align-items: center;
+  }
 }
 
 @media print {

--- a/cypress/integration/admin/organisations/edit.spec.ts
+++ b/cypress/integration/admin/organisations/edit.spec.ts
@@ -156,9 +156,11 @@ describe('Editing organisations', () => {
       );
       cy.checkSummaryListRowValue('organisations.label.telephone', '1234');
 
-      cy.translate('organisations.admin.button.amend').then((buttonText) => {
-        cy.get('button').contains(buttonText).click();
-      });
+      cy.translate('organisations.admin.button.saveAsDraft').then(
+        (buttonText) => {
+          cy.get('button').contains(buttonText).click();
+        },
+      );
 
       cy.checkAccessibility();
 

--- a/cypress/integration/admin/organisations/new.spec.ts
+++ b/cypress/integration/admin/organisations/new.spec.ts
@@ -106,9 +106,11 @@ describe('Creating organisations', () => {
       );
       cy.checkSummaryListRowValue('organisations.label.telephone', '1234');
 
-      cy.translate('organisations.admin.button.amend').then((buttonText) => {
-        cy.get('button').contains(buttonText).click();
-      });
+      cy.translate('organisations.admin.button.saveAsDraft').then(
+        (buttonText) => {
+          cy.get('button').contains(buttonText).click();
+        },
+      );
 
       cy.translate('organisations.admin.create.confirmation.heading').then(
         (confirmationHeading) => {

--- a/cypress/integration/admin/organisations/publish.spec.ts
+++ b/cypress/integration/admin/organisations/publish.spec.ts
@@ -7,7 +7,7 @@ describe('Publishing organisations', () => {
       cy.visitAndCheckAccessibility('/admin');
     });
 
-    it('Allows me to publish a draft organisation', () => {
+    it('Allows me to publish a draft organisation from the organisation page', () => {
       cy.get('a').contains('Regulatory authorities').click();
       cy.checkAccessibility();
 
@@ -28,6 +28,127 @@ describe('Publishing organisations', () => {
       );
 
       cy.checkAccessibility();
+
+      cy.translate('organisations.admin.publish.caption').then(
+        (publishCaption) => {
+          cy.get('body').contains(publishCaption);
+        },
+      );
+
+      cy.translate('organisations.admin.publish.heading', {
+        organisationName: 'Department for Education',
+      }).then((heading) => {
+        cy.contains(heading);
+      });
+
+      // Testing back link goes where we expect
+      cy.translate('app.back').then((backLink) => {
+        cy.get('a').contains(backLink).click();
+      });
+      cy.checkAccessibility();
+      cy.get('h1').should('contain', 'Department for Education');
+
+      cy.translate('organisations.admin.button.publish').then(
+        (publishButton) => {
+          cy.get('[data-cy=publish-button]').contains(publishButton).click();
+        },
+      );
+
+      cy.checkAccessibility();
+      cy.translate('organisations.admin.button.publish').then(
+        (publishButton) => {
+          cy.get('[data-cy=publish-button]').contains(publishButton).click();
+        },
+      );
+
+      cy.checkAccessibility();
+
+      cy.translate('organisations.admin.publish.confirmation.heading').then(
+        (confirmation) => {
+          cy.get('html').should('contain', confirmation);
+        },
+      );
+
+      cy.translate('organisations.admin.button.edit.live').then(
+        (editButton) => {
+          cy.get('html').should('contain', editButton);
+        },
+      );
+
+      cy.get('[data-cy=changed-by-user]').should('contain', 'Editor');
+      cy.get('[data-cy=last-modified]').should(
+        'contain',
+        format(new Date(), 'd MMM yyyy'),
+      );
+
+      cy.visitAndCheckAccessibility('/admin/organisations');
+
+      cy.get('tr')
+        .contains('Department for Education')
+        .then(($header) => {
+          const $row = $header.parent();
+
+          cy.translate(`organisations.status.live`).then((status) => {
+            cy.wrap($row).should('contain', status);
+          });
+        });
+    });
+
+    it('Allows me to publish a draft organisation from the check your answers page', () => {
+      cy.get('a').contains('Regulatory authorities').click();
+      cy.checkAccessibility();
+
+      cy.contains('Department for Education')
+        .parent('tr')
+        .within(() => {
+          cy.get('a').contains('View details').click();
+        });
+
+      cy.translate('organisations.admin.button.edit.live').then(
+        (editButton) => {
+          cy.get('button').contains(editButton).click();
+          cy.checkAccessibility();
+        },
+      );
+
+      cy.get('input[name="email"]').invoke('val', '').type('foo@example.com');
+      cy.get('input[name="telephone"]').invoke('val', '').type('1234');
+
+      cy.translate('app.continue').then((buttonText) => {
+        cy.get('button').contains(buttonText).click();
+      });
+      cy.checkAccessibility();
+
+      cy.checkSummaryListRowValue(
+        'organisations.label.email',
+        'foo@example.com',
+      );
+      cy.checkSummaryListRowValue('organisations.label.telephone', '1234');
+
+      cy.translate('organisations.admin.button.publish').then(
+        (publishButton) => {
+          cy.get('a').contains(publishButton).click();
+        },
+      );
+
+      // Testing back link goes where we expect
+      cy.translate('app.back').then((backLink) => {
+        cy.get('a').contains(backLink).click();
+      });
+      cy.translate('organisations.admin.edit.heading', {
+        organisationName: 'Department for Education',
+      }).then((editHeading) => {
+        cy.get('body').should('contain', editHeading);
+      });
+      cy.checkAccessibility();
+      cy.translate('app.continue').then((buttonText) => {
+        cy.get('button').contains(buttonText).click();
+      });
+      cy.translate('organisations.admin.button.publish').then(
+        (publishButton) => {
+          cy.get('a').contains(publishButton).click();
+        },
+      );
 
       cy.translate('organisations.admin.publish.caption').then(
         (publishCaption) => {

--- a/cypress/integration/admin/professions/publish.spec.ts
+++ b/cypress/integration/admin/professions/publish.spec.ts
@@ -23,11 +23,9 @@ describe('Publishing professions', () => {
 
       cy.get('[data-cy=changed-by-user]').should('contain', '');
 
-      cy.translate('professions.form.button.publishNow').then(
-        (publishButton) => {
-          cy.get('a').contains(publishButton).click();
-        },
-      );
+      cy.translate('professions.form.button.publish').then((publishButton) => {
+        cy.get('a').contains(publishButton).click();
+      });
 
       cy.checkAccessibility();
 
@@ -38,7 +36,7 @@ describe('Publishing professions', () => {
 
       cy.get('h1').should('contain', 'Gas Safe Engineer');
 
-      cy.translate('professions.form.button.publishNow').then((buttonText) => {
+      cy.translate('professions.form.button.publish').then((buttonText) => {
         cy.get('[data-cy=publish-button]').contains(buttonText).click();
       });
 
@@ -54,7 +52,7 @@ describe('Publishing professions', () => {
         cy.contains(heading);
       });
 
-      cy.translate('professions.form.button.publishNow').then((buttonText) => {
+      cy.translate('professions.form.button.publish').then((buttonText) => {
         cy.get('button').contains(buttonText).click();
       });
 
@@ -130,7 +128,7 @@ describe('Publishing professions', () => {
         1,
       );
 
-      cy.translate('professions.form.button.publishNow').then((buttonText) => {
+      cy.translate('professions.form.button.publish').then((buttonText) => {
         cy.get('a').contains(buttonText).click();
       });
 
@@ -142,7 +140,7 @@ describe('Publishing professions', () => {
         cy.get('body').should('contain', heading);
       });
 
-      cy.translate('professions.form.button.publishNow').then((buttonText) => {
+      cy.translate('professions.form.button.publish').then((buttonText) => {
         cy.get('a').contains(buttonText).click();
       });
 
@@ -160,7 +158,7 @@ describe('Publishing professions', () => {
         cy.contains(heading);
       });
 
-      cy.translate('professions.form.button.publishNow').then((buttonText) => {
+      cy.translate('professions.form.button.publish').then((buttonText) => {
         cy.get('button').contains(buttonText).click();
       });
 

--- a/cypress/integration/admin/professions/publish.spec.ts
+++ b/cypress/integration/admin/professions/publish.spec.ts
@@ -7,7 +7,7 @@ describe('Publishing professions', () => {
       cy.visitAndCheckAccessibility('/admin');
     });
 
-    it('Allows me to publish a draft profession', () => {
+    it('Allows me to publish a draft profession from the profession page', () => {
       cy.get('a').contains('Regulated professions').click();
       cy.checkAccessibility();
 
@@ -30,6 +30,18 @@ describe('Publishing professions', () => {
       );
 
       cy.checkAccessibility();
+
+      // Testing back link goes where we expect
+      cy.translate('app.back').then((backLink) => {
+        cy.get('a').contains(backLink).click();
+      });
+
+      cy.get('h1').should('contain', 'Gas Safe Engineer');
+
+      cy.translate('professions.form.button.publishNow').then((buttonText) => {
+        cy.get('[data-cy=publish-button]').contains(buttonText).click();
+      });
+
       cy.translate('professions.form.captions.publish').then(
         (publishCaption) => {
           cy.get('body').contains(publishCaption);
@@ -62,6 +74,112 @@ describe('Publishing professions', () => {
       cy.get('[data-cy=last-modified]').should(
         'contain',
         format(new Date(), 'd MMM yyyy'),
+      );
+
+      cy.visitAndCheckAccessibility('/admin/professions');
+
+      cy.get('tr')
+        .contains('Gas Safe Engineer')
+        .then(($header) => {
+          const $row = $header.parent();
+
+          cy.translate('professions.admin.status.live').then((status) => {
+            cy.wrap($row).should('contain', status);
+          });
+        });
+    });
+
+    it('Allows me to publish a draft profession from the check your answers page', () => {
+      cy.get('a').contains('Regulated professions').click();
+      cy.checkAccessibility();
+
+      cy.contains('Orthodontic Therapist')
+        .parent('tr')
+        .within(() => {
+          cy.get('a').contains('View details').click();
+        });
+
+      cy.translate('professions.admin.status.draft').then((status) => {
+        cy.get('h2[data-status]').should('contain', status);
+      });
+
+      cy.get('[data-cy=changed-by-user]').should('contain', '');
+
+      cy.translate('professions.admin.button.edit.draft').then((buttonText) => {
+        cy.contains(buttonText).click();
+      });
+
+      cy.clickSummaryListRowAction(
+        'professions.form.label.legislation.nationalLegislation',
+        'Change',
+      );
+      cy.checkAccessibility();
+
+      cy.get('textarea[name="nationalLegislation"]').type(
+        'National legislation',
+      );
+
+      cy.translate('app.continue').then((buttonText) => {
+        cy.get('button').contains(buttonText).click();
+      });
+      cy.checkAccessibility();
+
+      cy.checkIndexedSummaryListRowValue(
+        'professions.form.label.legislation.nationalLegislation',
+        'National legislation',
+        1,
+      );
+
+      cy.translate('professions.form.button.publishNow').then((buttonText) => {
+        cy.get('a').contains(buttonText).click();
+      });
+
+      // Testing back link goes where we expect
+      cy.translate('app.back').then((backLink) => {
+        cy.get('a').contains(backLink).click();
+      });
+      cy.translate('professions.form.headings.checkAnswers').then((heading) => {
+        cy.get('body').should('contain', heading);
+      });
+
+      cy.translate('professions.form.button.publishNow').then((buttonText) => {
+        cy.get('a').contains(buttonText).click();
+      });
+
+      cy.checkAccessibility();
+
+      cy.translate('professions.form.captions.publish').then(
+        (publishCaption) => {
+          cy.get('body').contains(publishCaption);
+        },
+      );
+
+      cy.translate('professions.form.headings.publish', {
+        professionName: 'Orthodontic Therapist',
+      }).then((heading) => {
+        cy.contains(heading);
+      });
+
+      cy.translate('professions.form.button.publishNow').then((buttonText) => {
+        cy.get('button').contains(buttonText).click();
+      });
+
+      cy.checkAccessibility();
+
+      cy.translate('professions.admin.publish.confirmation.heading').then(
+        (confirmation) => {
+          cy.get('html').should('contain', confirmation);
+        },
+      );
+
+      cy.translate('professions.admin.button.edit.live').then((buttonText) => {
+        cy.get('html').should('contain', buttonText);
+      });
+
+      cy.get('[data-cy=changed-by-user]').should('contain', 'Editor');
+      cy.get('[data-cy=last-modified]').should(
+        'contain',
+        format(new Date(), 'dd-MM-yyyy'),
       );
 
       cy.visitAndCheckAccessibility('/admin/professions');

--- a/cypress/integration/admin/professions/publish.spec.ts
+++ b/cypress/integration/admin/professions/publish.spec.ts
@@ -177,7 +177,7 @@ describe('Publishing professions', () => {
       cy.get('[data-cy=changed-by-user]').should('contain', 'Editor');
       cy.get('[data-cy=last-modified]').should(
         'contain',
-        format(new Date(), 'dd-MM-yyyy'),
+        format(new Date(), 'd MMM yyyy'),
       );
 
       cy.visitAndCheckAccessibility('/admin/professions');

--- a/src/i18n/en/organisations.json
+++ b/src/i18n/en/organisations.json
@@ -111,7 +111,7 @@
       },
       "archive": "Archive this regulatory authority",
       "saveAsDraft": "Save as draft",
-      "publish": "Publish regulatory authority"
+      "publish": "Publish to register"
     }
   },
   "search": {

--- a/src/i18n/en/organisations.json
+++ b/src/i18n/en/organisations.json
@@ -110,7 +110,7 @@
         "live": "Edit this regulatory authority"
       },
       "archive": "Archive this regulatory authority",
-      "amend": "Amend regulatory authority",
+      "saveAsDraft": "Save as draft",
       "publish": "Publish regulatory authority"
     }
   },

--- a/src/i18n/en/professions.json
+++ b/src/i18n/en/professions.json
@@ -82,7 +82,7 @@
     "button": {
       "create": "Create profession",
       "edit": "Yes, continue",
-      "publishNow": "Publish now",
+      "publish": "Publish to register",
       "saveAsDraft": "Save as draft"
     },
     "select": {

--- a/src/organisations/admin/organisation-publication.controller.ts
+++ b/src/organisations/admin/organisation-publication.controller.ts
@@ -1,5 +1,5 @@
 import { Controller, Get, Param, Put, Render, Req, Res } from '@nestjs/common';
-import { Response } from 'express';
+import { Request, Response } from 'express';
 import { I18nService } from 'nestjs-i18n';
 import { BackLink } from '../../common/decorators/back-link.decorator';
 import { flashMessage } from '../../common/flash-message';
@@ -20,7 +20,11 @@ export class OrganisationPublicationController {
   @Get('/:organisationId/versions/:versionId/publish')
   @Permissions(UserPermission.PublishOrganisation)
   @Render('admin/organisations/publication/new')
-  @BackLink('/admin/organisations/:organisationId/versions/:versionId')
+  @BackLink((request: Request) =>
+    request.query.fromEdit === 'true'
+      ? '/admin/organisations/:organisationId/versions/:versionId/edit'
+      : '/admin/organisations/:organisationId/versions/:versionId',
+  )
   async new(
     @Param('organisationId') organisationId: string,
     @Param('versionId') versionId: string,

--- a/src/professions/admin/profession-publication.controller.ts
+++ b/src/professions/admin/profession-publication.controller.ts
@@ -1,5 +1,5 @@
 import { Controller, Get, Param, Put, Render, Req, Res } from '@nestjs/common';
-import { Response } from 'express';
+import { Request, Response } from 'express';
 import { I18nService } from 'nestjs-i18n';
 import { BackLink } from '../../common/decorators/back-link.decorator';
 import { flashMessage } from '../../common/flash-message';
@@ -20,7 +20,11 @@ export class ProfessionPublicationController {
   @Get('/:professionId/versions/:versionId/publish')
   @Permissions(UserPermission.PublishProfession)
   @Render('admin/professions/publication/new')
-  @BackLink('/admin/professions/:professionId/versions/:versionId')
+  @BackLink((request: Request) =>
+    request.query.fromEdit === 'true'
+      ? '/admin/professions/:professionId/versions/:versionId/check-your-answers'
+      : '/admin/professions/:professionId/versions/:versionId',
+  )
   async new(
     @Param('professionId') professionId: string,
     @Param('versionId') versionId: string,

--- a/views/admin/organisations/publication/new.njk
+++ b/views/admin/organisations/publication/new.njk
@@ -13,7 +13,10 @@
       <form action="/admin/organisations/{{ organisation.id }}/versions/{{ organisation.versionId }}/publish?_method=PUT" method="post">
         {{
           govukButton({
-            text: ("organisations.admin.button.publish" | t)
+            text: ("organisations.admin.button.publish" | t),
+            attributes: {
+              "data-cy": "publish-button"
+            }
           })
         }}
       </form>

--- a/views/admin/organisations/review.njk
+++ b/views/admin/organisations/review.njk
@@ -20,7 +20,11 @@
 
         {{
           govukButton({
-            text: "organisations.admin.button.amend" | t
+            text: "organisations.admin.button.saveAsDraft" | t,
+            id: "submit-button",
+            classes: "govuk-button--secondary",
+            type: "Submit",
+            preventDoubleClick: true
           })
         }}
       </form>

--- a/views/admin/organisations/review.njk
+++ b/views/admin/organisations/review.njk
@@ -15,19 +15,30 @@
   <div class="govuk-grid-column-two-thirds">
       {{ govukSummaryList(summaryList) }}
 
-      <form action="{{ currentUrl }}" method="post">
-        <input type="hidden" name="confirm" value="true" />
-
-        {{
-          govukButton({
-            text: "organisations.admin.button.saveAsDraft" | t,
-            id: "submit-button",
-            classes: "govuk-button--secondary",
-            type: "Submit",
-            preventDoubleClick: true
-          })
-        }}
-      </form>
+      <div class="govuk-button-group rpr-internal__buttons-container">
+        <form action="{{ currentUrl }}" method="post">
+          <input type="hidden" name="confirm" value="true" />
+          {{
+            govukButton({
+              text: "organisations.admin.button.saveAsDraft" | t,
+              id: "submit-button",
+              classes: "govuk-button--secondary",
+              type: "Submit",
+              preventDoubleClick: true
+            })
+          }}
+        </form>
+        {% if 'publishOrganisation' in permissions %}
+          {{
+            govukButton({
+              text: ("organisations.admin.button.publish" | t),
+              classes: "govuk-button",
+              id: "publish-button",
+              href: "/admin/organisations/" + id + "/versions/" + versionId + "/publish?fromEdit=true"
+            })
+          }}
+        {% endif %}
+      </div>
   </div>
 </div>
 {% endblock %}

--- a/views/admin/organisations/show.njk
+++ b/views/admin/organisations/show.njk
@@ -39,7 +39,9 @@
                   govukButton({
                     text: ("organisations.admin.button.publish" | t),
                     classes: "govuk-button",
-                    id: "publish-button",
+                    attributes: {
+                      "data-cy": "publish-button"
+                    },
                     href: "/admin/organisations/" + organisation.id + "/versions/" + organisation.versionId + "/publish"
                   })
                 }}

--- a/views/admin/professions/check-your-answers.njk
+++ b/views/admin/professions/check-your-answers.njk
@@ -437,17 +437,33 @@
     <div class="govuk-grid-column-one-third">
       {% if not edit and confirmed %}
         <aside class="app-related-items rpr-internal__details-page-sidebar" role="complementary">
-          <form method="post" action="confirmation">
-            {{
-              govukButton({
-                id: "submit-button",
-                classes: "govuk-button--secondary",
-                type: "Submit",
-                preventDoubleClick: true,
-                text: ("professions.form.button.saveAsDraft" | t)
-              })
-            }}
-          </form>
+          <ul class="govuk-list">
+            <li>
+              <form method="post" action="confirmation">
+                {{
+                  govukButton({
+                    id: "submit-button",
+                    classes: "govuk-button--secondary",
+                    type: "Submit",
+                    preventDoubleClick: true,
+                    text: ("professions.form.button.saveAsDraft" | t)
+                  })
+                }}
+              </form>
+            </li>
+            {% if 'publishProfession' in permissions %}
+              <li>
+                {{
+                  govukButton({
+                    text: ('professions.form.button.publishNow' | t),
+                    classes: "govuk-button",
+                    id: "publish-button",
+                    href: "/admin/professions/" + professionId + "/versions/" + versionId + "/publish?fromEdit=true"
+                  })
+                }}
+              </li>
+            {% endif %}
+          </ul>
         </aside>
       {% endif %}
     </div>

--- a/views/admin/professions/check-your-answers.njk
+++ b/views/admin/professions/check-your-answers.njk
@@ -455,7 +455,7 @@
               <li>
                 {{
                   govukButton({
-                    text: ('professions.form.button.publishNow' | t),
+                    text: ('professions.form.button.publish' | t),
                     classes: "govuk-button",
                     id: "publish-button",
                     href: "/admin/professions/" + professionId + "/versions/" + versionId + "/publish?fromEdit=true"

--- a/views/admin/professions/publication/new.njk
+++ b/views/admin/professions/publication/new.njk
@@ -14,7 +14,7 @@
         <form action="/admin/professions/{{ profession.id }}/versions/{{ profession.versionId }}/publish?_method=PUT" method="post">
           {{
             govukButton({
-              text: ('professions.form.button.publishNow' | t),
+              text: ('professions.form.button.publish' | t),
               classes: "govuk-button",
               id: "publish-button"
             })

--- a/views/admin/professions/show.njk
+++ b/views/admin/professions/show.njk
@@ -37,7 +37,7 @@
                     govukButton({
                       text: ('professions.form.button.publishNow' | t),
                       classes: "govuk-button",
-                      id: "publish-button",
+                      attributes: { "data-cy": "publish-button" },
                       href: "/admin/professions/" + profession.id + "/versions/" + profession.versionId + "/publish"
                     })
                   }}

--- a/views/admin/professions/show.njk
+++ b/views/admin/professions/show.njk
@@ -35,7 +35,7 @@
                 <li>
                   {{
                     govukButton({
-                      text: ('professions.form.button.publishNow' | t),
+                      text: ('professions.form.button.publish' | t),
                       classes: "govuk-button",
                       attributes: { "data-cy": "publish-button" },
                       href: "/admin/professions/" + profession.id + "/versions/" + profession.versionId + "/publish"


### PR DESCRIPTION
# Changes in this PR

- Adds "Publish to register" buttons to the "Check your answers" pages when adding or editing a profession or an organisation.
- Updates back links for the publish confirmation page and ensures they're going to the right place with tests.

## Screenshots of UI changes

### After

![image](https://user-images.githubusercontent.com/19826940/156754843-2c4e1165-e73c-4487-88fc-2932f3bab764.png)

<img width="998" alt="image" src="https://user-images.githubusercontent.com/19826940/156755030-a9d186e2-802e-4b9c-af13-f53da74ed878.png">


