### PR TITLE
(2199) Second regulator added doesn't appear on page (part 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - Display a second Regulatory Authority if specified for a profession
+- Inpsect a second Regulatory Authority when searching, if specified for a profession
 
 ## [release-007] - 2022-03-04
 

--- a/src/middleware/redirect-to-canonical-hostname.ts
+++ b/src/middleware/redirect-to-canonical-hostname.ts
@@ -5,7 +5,7 @@ export function redirectToCanonicalHostname(
   response: Response,
   next: NextFunction,
 ) {
-  var host = request.header('host');
+  const host = request.header('host');
   if (host === process.env['CANONICAL_HOSTNAME']) {
     next();
   } else {

--- a/src/professions/admin/list-entry.presenter.spec.ts
+++ b/src/professions/admin/list-entry.presenter.spec.ts
@@ -16,7 +16,7 @@ jest.mock('../presenters/profession.presenter');
 describe('ListEntryPresenter', () => {
   describe('tableRow', () => {
     describe('when the Profession is complete', () => {
-      it('returns a table row when called with `overview`', () => {
+      it('returns a table row when called with `overview`', async () => {
         const profession = professionFactory.build({
           name: 'Example Profession',
           id: 'profession-id',
@@ -67,10 +67,10 @@ describe('ListEntryPresenter', () => {
           },
         ];
 
-        expect(presenter.tableRow(`overview`)).resolves.toEqual(expected);
+        await expect(presenter.tableRow(`overview`)).resolves.toEqual(expected);
       });
 
-      it('returns a table row when called with `single-organisation`', () => {
+      it('returns a table row when called with `single-organisation`', async () => {
         const profession = professionFactory.build({
           name: 'Example Profession',
           id: 'profession-id',
@@ -115,14 +115,14 @@ describe('ListEntryPresenter', () => {
           },
         ];
 
-        expect(presenter.tableRow(`single-organisation`)).resolves.toEqual(
-          expected,
-        );
+        await expect(
+          presenter.tableRow(`single-organisation`),
+        ).resolves.toEqual(expected);
       });
     });
 
     describe('when the Profession has just been created by a service owner user', () => {
-      it('returns a mostly empty table row', () => {
+      it('returns a mostly empty table row', async () => {
         const profession = professionFactory
           .justCreated('profession-id')
           .build({
@@ -168,15 +168,15 @@ describe('ListEntryPresenter', () => {
           },
         ];
 
-        expect(presenter.tableRow(`single-organisation`)).resolves.toEqual(
-          expected,
-        );
+        await expect(
+          presenter.tableRow(`single-organisation`),
+        ).resolves.toEqual(expected);
       });
     });
   });
 
   describe('headers', () => {
-    it('returns a table row of headings when called with `overview`', () => {
+    it('returns a table row of headings when called with `overview`', async () => {
       const expected = [
         { text: translationOf('professions.admin.tableHeading.profession') },
         { text: translationOf('professions.admin.tableHeading.nations') },
@@ -188,12 +188,12 @@ describe('ListEntryPresenter', () => {
         { text: translationOf('professions.admin.tableHeading.actions') },
       ];
 
-      expect(
+      await expect(
         ListEntryPresenter.headings(createMockI18nService(), 'overview'),
       ).resolves.toEqual(expected);
     });
 
-    it('returns a table row of headings when called with `single-organisation`', () => {
+    it('returns a table row of headings when called with `single-organisation`', async () => {
       const expected = [
         { text: translationOf('professions.admin.tableHeading.profession') },
         { text: translationOf('professions.admin.tableHeading.nations') },
@@ -203,12 +203,16 @@ describe('ListEntryPresenter', () => {
         { text: translationOf('professions.admin.tableHeading.actions') },
       ];
 
-      expect(
+      await expect(
         ListEntryPresenter.headings(
           createMockI18nService(),
           'single-organisation',
         ),
       ).resolves.toEqual(expected);
     });
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
   });
 });

--- a/src/professions/admin/list-entry.presenter.spec.ts
+++ b/src/professions/admin/list-entry.presenter.spec.ts
@@ -10,6 +10,7 @@ import { ProfessionPresenter } from '../presenters/profession.presenter';
 import professionVersionFactory from '../../testutils/factories/profession-version';
 import { Profession } from '../profession.entity';
 import { ProfessionVersionStatus } from '../profession-version.entity';
+import * as getOrganisationsFromProfessionModule from '../helpers/get-organisations-from-profession.helper';
 
 jest.mock('../presenters/profession.presenter');
 
@@ -23,6 +24,9 @@ describe('ListEntryPresenter', () => {
           occupationLocations: ['GB-SCT', 'GB-NIR'],
           organisation: organisationFactory.build({
             name: 'Example Organisation',
+          }),
+          additionalOrganisation: organisationFactory.build({
+            name: 'Additional Example Organisation',
           }),
           industries: [
             industryFactory.build({ name: 'industries.law' }),
@@ -39,6 +43,11 @@ describe('ListEntryPresenter', () => {
           lastModified: '12-08-2003',
         });
 
+        const getOrganisationsFromProfessionSpy = jest.spyOn(
+          getOrganisationsFromProfessionModule,
+          'getOrganisationsFromProfession',
+        );
+
         const presenter = new ListEntryPresenter(
           profession,
           createMockI18nService(),
@@ -53,7 +62,7 @@ describe('ListEntryPresenter', () => {
           },
           { text: '12-08-2003' },
           { text: 'Administrator' },
-          { text: 'Example Organisation' },
+          { text: 'Example Organisation, Additional Example Organisation' },
           {
             text: `${translationOf('industries.law')}, ${translationOf(
               'industries.finance',
@@ -68,6 +77,7 @@ describe('ListEntryPresenter', () => {
         ];
 
         await expect(presenter.tableRow(`overview`)).resolves.toEqual(expected);
+        expect(getOrganisationsFromProfessionSpy).toBeCalledWith(profession);
       });
 
       it('returns a table row when called with `single-organisation`', async () => {
@@ -214,5 +224,6 @@ describe('ListEntryPresenter', () => {
 
   afterEach(() => {
     jest.resetAllMocks();
+    jest.restoreAllMocks();
   });
 });

--- a/src/professions/admin/list-entry.presenter.ts
+++ b/src/professions/admin/list-entry.presenter.ts
@@ -4,6 +4,7 @@ import { TableRow } from '../../common/interfaces/table-row';
 import { escape } from '../../helpers/escape.helper';
 import { stringifyNations } from '../../nations/helpers/stringifyNations';
 import { Nation } from '../../nations/nation';
+import { getOrganisationsFromProfession } from '../helpers/get-organisations-from-profession.helper';
 import { ProfessionPresenter } from '../presenters/profession.presenter';
 import { Profession } from '../profession.entity';
 import { ProfessionsPresenterView } from './professions.presenter';
@@ -90,15 +91,17 @@ export class ListEntryPresenter {
       { args: { name: escape(this.profession.name) } },
     )}</a>`;
 
+    const organisations = getOrganisationsFromProfession(this.profession)
+      .map((organisation) => organisation.name)
+      .join(', ');
+
     const entries: { [K in Field]: TableCell } = {
       profession: { text: this.profession.name },
       nations: { text: nations },
       lastModified: { text: presenter.lastModified },
       changedBy: { text: presenter.changedBy },
       organisation: {
-        text: this.profession.organisation
-          ? this.profession.organisation.name
-          : '',
+        text: organisations,
       },
       industry: { text: industries },
       status: {

--- a/src/professions/admin/profession-versions.controller.spec.ts
+++ b/src/professions/admin/profession-versions.controller.spec.ts
@@ -19,6 +19,7 @@ import { ProfessionPresenter } from '../presenters/profession.presenter';
 import { getActingUser } from '../../users/helpers/get-acting-user.helper';
 import { createDefaultMockRequest } from '../../testutils/factories/create-default-mock-request';
 import organisationFactory from '../../testutils/factories/organisation';
+import * as getOrganisationsFromProfessionModule from '../helpers/get-organisations-from-profession.helper';
 
 jest.mock('../../organisations/organisation.entity');
 jest.mock('../presenters/profession.presenter');
@@ -125,6 +126,11 @@ describe('ProfessionVersionsController', () => {
             (organisation) => organisation,
           );
 
+          const getOrganisationsFromProfessionSpy = jest.spyOn(
+            getOrganisationsFromProfessionModule,
+            'getOrganisationsFromProfession',
+          );
+
           const result = await controller.show('profession-id', 'version-id');
 
           expect(result).toEqual({
@@ -142,6 +148,9 @@ describe('ProfessionVersionsController', () => {
           expect(
             professionVersionsService.findByIdWithProfession,
           ).toHaveBeenCalledWith('profession-id', 'version-id');
+          expect(getOrganisationsFromProfessionSpy).toHaveBeenCalledWith(
+            professionWithVersion,
+          );
         });
       });
 
@@ -172,6 +181,11 @@ describe('ProfessionVersionsController', () => {
             (organisation) => organisation,
           );
 
+          const getOrganisationsFromProfessionSpy = jest.spyOn(
+            getOrganisationsFromProfessionModule,
+            'getOrganisationsFromProfession',
+          );
+
           const result = await controller.show('profession-id', 'version-id');
 
           expect(result).toEqual({
@@ -192,6 +206,9 @@ describe('ProfessionVersionsController', () => {
           expect(
             professionVersionsService.findByIdWithProfession,
           ).toHaveBeenCalledWith('profession-id', 'version-id');
+          expect(getOrganisationsFromProfessionSpy).toHaveBeenCalledWith(
+            professionWithVersion,
+          );
         });
       });
     });
@@ -287,5 +304,6 @@ describe('ProfessionVersionsController', () => {
 
   afterEach(() => {
     jest.resetAllMocks();
+    jest.restoreAllMocks();
   });
 });

--- a/src/professions/admin/profession-versions.controller.ts
+++ b/src/professions/admin/profession-versions.controller.ts
@@ -25,6 +25,7 @@ import { Profession } from '../profession.entity';
 import { ProfessionsService } from '../professions.service';
 import { ProfessionPresenter } from '../presenters/profession.presenter';
 import { getActingUser } from '../../users/helpers/get-acting-user.helper';
+import { getOrganisationsFromProfession } from '../helpers/get-organisations-from-profession.helper';
 
 @UseGuards(AuthenticationGuard)
 @Controller('/admin/professions')
@@ -61,17 +62,9 @@ export class ProfessionVersionsController {
     const profession = Profession.withVersion(version.profession, version);
     const presenter = new ProfessionPresenter(profession, this.i18nService);
 
-    const organisation = Organisation.withLatestVersion(
-      profession.organisation,
+    const organisations = getOrganisationsFromProfession(profession).map(
+      (organisation) => Organisation.withLatestVersion(organisation),
     );
-
-    const additionalOrganisation =
-      profession.additionalOrganisation &&
-      Organisation.withLatestVersion(profession.additionalOrganisation);
-
-    const organisations = additionalOrganisation
-      ? [organisation, additionalOrganisation]
-      : [organisation];
 
     const nations = await Promise.all(
       (profession.occupationLocations || []).map(async (code) =>

--- a/src/professions/helpers/get-organisations-from-profession.helper.spec.ts
+++ b/src/professions/helpers/get-organisations-from-profession.helper.spec.ts
@@ -1,0 +1,51 @@
+import organisationFactory from '../../testutils/factories/organisation';
+import professionFactory from '../../testutils/factories/profession';
+import { getOrganisationsFromProfession } from './get-organisations-from-profession.helper';
+
+describe('getOrganisationsFromProfession', () => {
+  describe('when the Prganisation has ony a main Organisation', () => {
+    it('returns a single-element array containing only that organisation', () => {
+      const organisation = organisationFactory.build();
+
+      const profession = professionFactory.build({
+        organisation,
+      });
+
+      expect(getOrganisationsFromProfession(profession)).toEqual([
+        organisation,
+      ]);
+    });
+  });
+
+  describe('when the Prganisation has a main Organisation and an additional Organisation', () => {
+    it('returns a two element array containing both organisations', () => {
+      const organisation = organisationFactory.build();
+      const additionalOrganisation = organisationFactory.build();
+
+      const profession = professionFactory.build({
+        organisation,
+        additionalOrganisation,
+      });
+
+      expect(getOrganisationsFromProfession(profession)).toEqual([
+        organisation,
+        additionalOrganisation,
+      ]);
+    });
+  });
+
+  describe('when the Prganisation has ony an additional Organisation', () => {
+    it('returns a single-element array containing only that organisation', () => {
+      const additionalOrganisation = organisationFactory.build();
+
+      const profession = professionFactory.build({
+        organisation: undefined,
+        additionalOrganisation,
+      });
+
+      expect(getOrganisationsFromProfession(profession)).toEqual([
+        additionalOrganisation,
+      ]);
+    });
+  });
+});

--- a/src/professions/helpers/get-organisations-from-profession.helper.ts
+++ b/src/professions/helpers/get-organisations-from-profession.helper.ts
@@ -1,0 +1,21 @@
+import { Organisation } from '../../organisations/organisation.entity';
+import { Profession } from '../profession.entity';
+
+export function getOrganisationsFromProfession(
+  profession: Profession,
+): Organisation[] {
+  const organisation = profession.organisation;
+  const additionalOrganisation = profession.additionalOrganisation;
+
+  const result: Organisation[] = [];
+
+  if (organisation) {
+    result.push(organisation);
+  }
+
+  if (additionalOrganisation) {
+    result.push(additionalOrganisation);
+  }
+
+  return result;
+}

--- a/src/professions/helpers/professions-filter.helper.spec.ts
+++ b/src/professions/helpers/professions-filter.helper.spec.ts
@@ -6,6 +6,7 @@ import { Profession } from '../profession.entity';
 import industryFactory from '../../testutils/factories/industry';
 import professionFactory from '../../testutils/factories/profession';
 import organisationFactory from '../../testutils/factories/organisation';
+import * as getOrganisationsFromProfessionModule from './get-organisations-from-profession.helper';
 
 describe('ProfessionsFilterHelper', () => {
   describe('filter', () => {
@@ -68,21 +69,36 @@ describe('ProfessionsFilterHelper', () => {
 
     it('can filter professions by organisation', () => {
       const exampleProfessions = [
-        createProfessionWithOrganisation('law-society'),
-        createProfessionWithOrganisation('department-for-education'),
-        createProfessionWithOrganisation('general-medical-council'),
+        createProfessionWithOrganisations('law-society'),
+        createProfessionWithOrganisations('department-for-education'),
+        createProfessionWithOrganisations('general-medical-council'),
+        createProfessionWithOrganisations(
+          'law-society',
+          'alternative-law-society',
+        ),
       ];
 
       const filterHelper = new ProfessionsFilterHelper(exampleProfessions);
+
+      const getOrganisationsFromProfessionSpy = jest.spyOn(
+        getOrganisationsFromProfessionModule,
+        'getOrganisationsFromProfession',
+      );
 
       const results = filterHelper.filter({
         organisations: [
           createOrganisationWithId('general-medical-council'),
           createOrganisationWithId('department-for-education'),
+          createOrganisationWithId('alternative-law-society'),
         ],
       });
 
-      expect(results).toEqual([exampleProfessions[1], exampleProfessions[2]]);
+      expect(results).toEqual([
+        exampleProfessions[1],
+        exampleProfessions[2],
+        exampleProfessions[3],
+      ]);
+      expect(getOrganisationsFromProfessionSpy).toBeCalledTimes(4);
     });
 
     it('can filter professions by industry', () => {
@@ -105,15 +121,25 @@ describe('ProfessionsFilterHelper', () => {
       expect(results).toEqual([exampleProfessions[0], exampleProfessions[3]]);
     });
   });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
 });
 
 function createProfessionWithNations(...nationCodes: string[]): Profession {
   return professionFactory.build({ occupationLocations: nationCodes });
 }
 
-function createProfessionWithOrganisation(organisationId: string): Profession {
+function createProfessionWithOrganisations(
+  organisationId: string,
+  additionalOrganisation: string = undefined,
+): Profession {
   return professionFactory.build({
     organisation: organisationFactory.build({ id: organisationId }),
+    additionalOrganisation:
+      additionalOrganisation &&
+      organisationFactory.build({ id: additionalOrganisation }),
   });
 }
 

--- a/src/professions/helpers/professions-filter.helper.ts
+++ b/src/professions/helpers/professions-filter.helper.ts
@@ -2,6 +2,7 @@ import { BaseFilterHelper } from '../../helpers/base-filter.helper';
 import { Industry } from '../../industries/industry.entity';
 import { Organisation } from '../../organisations/organisation.entity';
 import { Profession } from '../../professions/profession.entity';
+import { getOrganisationsFromProfession } from './get-organisations-from-profession.helper';
 
 export class ProfessionsFilterHelper extends BaseFilterHelper<Profession> {
   constructor(allProfessions: Profession[]) {
@@ -13,7 +14,7 @@ export class ProfessionsFilterHelper extends BaseFilterHelper<Profession> {
   }
 
   protected organisationsFromSubject(profession: Profession): Organisation[] {
-    return profession.organisation ? [profession.organisation] : [];
+    return getOrganisationsFromProfession(profession);
   }
 
   protected industriesFromSubject(profession: Profession): Industry[] {

--- a/src/professions/professions.controller.spec.ts
+++ b/src/professions/professions.controller.spec.ts
@@ -148,4 +148,8 @@ describe('ProfessionsController', () => {
       });
     });
   });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
 });

--- a/src/professions/professions.controller.spec.ts
+++ b/src/professions/professions.controller.spec.ts
@@ -13,6 +13,7 @@ import { ProfessionsController } from './professions.controller';
 
 import { Organisation } from '../organisations/organisation.entity';
 import organisationFactory from '../testutils/factories/organisation';
+import * as getOrganisationsFromProfessionModule from './helpers/get-organisations-from-profession.helper';
 
 jest.mock('../organisations/organisation.entity');
 
@@ -64,6 +65,11 @@ describe('ProfessionsController', () => {
           (organisation) => organisation,
         );
 
+        const getOrganisationsFromProfessionSpy = jest.spyOn(
+          getOrganisationsFromProfessionModule,
+          'getOrganisationsFromProfession',
+        );
+
         const result = await controller.show('example-slug');
 
         expect(result).toEqual({
@@ -80,6 +86,7 @@ describe('ProfessionsController', () => {
         expect(professionVersionsService.findLiveBySlug).toBeCalledWith(
           'example-slug',
         );
+        expect(getOrganisationsFromProfessionSpy).toBeCalledWith(profession);
       });
     });
 
@@ -98,6 +105,11 @@ describe('ProfessionsController', () => {
 
         (Organisation.withLatestLiveVersion as jest.Mock).mockImplementation(
           (organisation) => organisation,
+        );
+
+        const getOrganisationsFromProfessionSpy = jest.spyOn(
+          getOrganisationsFromProfessionModule,
+          'getOrganisationsFromProfession',
         );
 
         const result = await controller.show('example-slug');
@@ -119,6 +131,7 @@ describe('ProfessionsController', () => {
         expect(professionVersionsService.findLiveBySlug).toBeCalledWith(
           'example-slug',
         );
+        expect(getOrganisationsFromProfessionSpy).toBeCalledWith(profession);
       });
     });
 
@@ -151,5 +164,6 @@ describe('ProfessionsController', () => {
 
   afterEach(() => {
     jest.resetAllMocks();
+    jest.restoreAllMocks();
   });
 });

--- a/src/professions/professions.controller.ts
+++ b/src/professions/professions.controller.ts
@@ -12,6 +12,7 @@ import { ShowTemplate } from './interfaces/show-template.interface';
 import { BackLink } from '../common/decorators/back-link.decorator';
 import { Organisation } from '../organisations/organisation.entity';
 import { ProfessionVersionsService } from './profession-versions.service';
+import { getOrganisationsFromProfession } from './helpers/get-organisations-from-profession.helper';
 
 @Controller()
 export class ProfessionsController {
@@ -34,17 +35,9 @@ export class ProfessionsController {
       );
     }
 
-    const organisation = Organisation.withLatestLiveVersion(
-      profession.organisation,
+    const organisations = getOrganisationsFromProfession(profession).map(
+      (organisation) => Organisation.withLatestLiveVersion(organisation),
     );
-
-    const additionalOrganisation =
-      profession.additionalOrganisation &&
-      Organisation.withLatestLiveVersion(profession.additionalOrganisation);
-
-    const organisations = additionalOrganisation
-      ? [organisation, additionalOrganisation]
-      : [organisation];
 
     const nations = await Promise.all(
       profession.occupationLocations.map(async (code) =>

--- a/src/professions/search/interfaces/profession-search-result-template.interface.ts
+++ b/src/professions/search/interfaces/profession-search-result-template.interface.ts
@@ -1,7 +1,7 @@
 export interface ProfessionSearchResultTemplate {
   name: string;
   slug: string;
-  organisation: string;
+  organisations: string[];
   nations: string;
   industries: string[];
 }

--- a/src/professions/search/profession-search-result.presenter.spec.ts
+++ b/src/professions/search/profession-search-result.presenter.spec.ts
@@ -6,6 +6,7 @@ import organisationFactory from '../../testutils/factories/organisation';
 import professionFactory from '../../testutils/factories/profession';
 import { translationOf } from '../../testutils/translation-of';
 import { ProfessionSearchResultPresenter } from './profession-search-result.presenter';
+import * as getOrganisationsFromProfessionModule from '../helpers/get-organisations-from-profession.helper';
 
 describe('ProfessionSearchResultPresenter', () => {
   let i18nService: DeepMocked<I18nService>;
@@ -22,12 +23,20 @@ describe('ProfessionSearchResultPresenter', () => {
         organisation: organisationFactory.build({
           name: 'Example Organisation',
         }),
+        additionalOrganisation: organisationFactory.build({
+          name: 'Additional Example Organisation',
+        }),
         occupationLocations: ['GB-ENG', 'GB-WLS'],
         industries: [
           industryFactory.build({ id: 'industries.health', name: 'health' }),
           industryFactory.build({ id: 'industries.law', name: 'law' }),
         ],
       });
+
+      const getOrganisationsFromProfessionSpy = jest.spyOn(
+        getOrganisationsFromProfessionModule,
+        'getOrganisationsFromProfession',
+      );
 
       const result = await new ProfessionSearchResultPresenter(
         exampleProfession,
@@ -37,12 +46,23 @@ describe('ProfessionSearchResultPresenter', () => {
       expect(result).toEqual({
         name: 'Example Profession',
         slug: 'example-profession',
-        organisation: 'Example Organisation',
+        organisations: [
+          'Example Organisation',
+          'Additional Example Organisation',
+        ],
         nations: `${translationOf('nations.england')}, ${translationOf(
           'nations.wales',
         )}`,
         industries: [translationOf('health'), translationOf('law')],
       });
+
+      expect(getOrganisationsFromProfessionSpy).toBeCalledWith(
+        exampleProfession,
+      );
     });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
   });
 });

--- a/src/professions/search/profession-search-result.presenter.ts
+++ b/src/professions/search/profession-search-result.presenter.ts
@@ -1,6 +1,7 @@
 import { I18nService } from 'nestjs-i18n';
 import { stringifyNations } from '../../nations/helpers/stringifyNations';
 import { Nation } from '../../nations/nation';
+import { getOrganisationsFromProfession } from '../helpers/get-organisations-from-profession.helper';
 import { Profession } from '../profession.entity';
 import { ProfessionSearchResultTemplate } from './interfaces/profession-search-result-template.interface';
 
@@ -22,10 +23,12 @@ export class ProfessionSearchResultPresenter {
       ),
     );
 
+    const organisations = getOrganisationsFromProfession(this.profession);
+
     return {
       name: this.profession.name,
       slug: this.profession.slug,
-      organisation: this.profession.organisation.name,
+      organisations: organisations.map((organisation) => organisation.name),
       nations,
       industries,
     };

--- a/views/professions/search/index.njk
+++ b/views/professions/search/index.njk
@@ -39,6 +39,12 @@
             {% endfor %}
           {% endset %}
 
+          {% set organisationsHtml %}
+            {% for organisation in profession.organisations %}
+              <p class="govuk-body-m">{{ organisation }}</p>
+            {% endfor %}
+          {% endset %}
+
           <div>
             <h2>
               <a class="govuk-link govuk-heading-l rpr-listing__profession-title" href="/professions/{{ profession.slug }}">{{ profession.name }}<br>
@@ -53,7 +59,7 @@
                       text: ("professions.search.profession.regulators" | t)
                     },
                     value: {
-                      text: profession.organisation
+                      html: organisationsHtml
                     }
                   },
                   {


### PR DESCRIPTION
# Changes in this PR

We now display multiple Organisations for a Profession when displayed in internal and external search listings, completing 2199. We also now inspect the additional Organisation when searching Professions by Organisation

## Screenshots of UI changes

### Before
![localhost_3000_professions_search (2)](https://user-images.githubusercontent.com/94137563/156762260-48f9422e-62e0-4d17-8f58-0e9514d6dff4.png)
![localhost_3000_admin_professions (2)](https://user-images.githubusercontent.com/94137563/156762265-f0bafa7e-3c91-4d9f-8583-dfa51e3b28df.png)

### After
![localhost_3000_professions_search (1)](https://user-images.githubusercontent.com/94137563/156762239-dfd3cdc0-bf87-4b20-97b2-40402baa2624.png)
![localhost_3000_admin_professions (1)](https://user-images.githubusercontent.com/94137563/156762236-ae3939dd-44cb-4312-b574-8671271cbe9a.png)

