### PR TITLE
(2216) Audit optional fields and a couple of related fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Display a second Regulatory Authority if specified for a profession
 - Inpsect a second Regulatory Authority when searching, if specified for a profession
 - Change visible columns in internal Professions listing
+- Audit optional fields and ensure correct messaging is used
 
 ## [release-007] - 2022-03-04
 

--- a/cypress/integration/admin/professions/edit.spec.ts
+++ b/cypress/integration/admin/professions/edit.spec.ts
@@ -215,15 +215,13 @@ describe('Editing an existing profession', () => {
       cy.translate('app.continue').then((buttonText) => {
         cy.get('button').contains(buttonText).click();
       });
-      cy.checkIndexedSummaryListRowValue(
+      cy.checkSummaryListRowValue(
         'professions.form.label.legislation.nationalLegislation',
         'Updated legislation',
-        1,
       );
-      cy.checkIndexedSummaryListRowValue(
-        'professions.form.label.legislation.nationalLegislation',
+      cy.checkSummaryListRowValue(
+        'professions.form.label.legislation.optionalNationalLegislation',
         'Second legislation',
-        2,
       );
       cy.checkIndexedSummaryListRowValue(
         'professions.form.label.legislation.link',

--- a/cypress/integration/admin/professions/edit.spec.ts
+++ b/cypress/integration/admin/professions/edit.spec.ts
@@ -464,7 +464,7 @@ describe('Editing an existing profession', () => {
         cy.checkAccessibility();
 
         cy.checkSummaryListRowValue(
-          'professions.form.label.qualifications.moreInformationUrl',
+          'professions.show.qualification.moreInformationUrl',
           'http://example.com/more-info',
         );
       });

--- a/cypress/integration/admin/professions/index.spec.ts
+++ b/cypress/integration/admin/professions/index.spec.ts
@@ -5,41 +5,49 @@ describe('Listing professions', () => {
       cy.visitAndCheckAccessibility('/admin/professions');
     });
 
-    it('I can view an unfiltered list of draft and live Professions', () => {
-      cy.translate('professions.search.foundPlural', { count: 5 }).then(
-        (foundText) => {
+    it('I can view an unfiltered list of draft, live and archived Professions', () => {
+      cy.readFile('./seeds/test/professions.json').then((professions) => {
+        const professionsToShow = professions.filter((profession) =>
+          profession.versions.some((version) =>
+            ['live', 'draft', 'archived'].includes(version.status),
+          ),
+        );
+
+        cy.translate('professions.search.foundPlural', {
+          count: professionsToShow.length,
+        }).then((foundText) => {
           cy.get('body').should('contain', foundText);
-        },
-      );
+        });
 
-      cy.translate('professions.admin.tableHeading.changedBy').then(
-        (changedBy) => {
-          cy.get('tr').eq(0).should('not.contain', changedBy);
-        },
-      );
+        cy.translate('professions.admin.tableHeading.changedBy').then(
+          (changedBy) => {
+            cy.get('tr').eq(0).should('not.contain', changedBy);
+          },
+        );
 
-      cy.translate('professions.admin.status.live').then((liveText) => {
-        cy.translate('professions.admin.status.draft').then((draftText) => {
-          cy.get('tr')
-            .contains('Registered Trademark Attorney')
-            .then(($header) => {
-              const $row = $header.parent();
-              cy.wrap($row).contains(liveText);
-            });
-          cy.get('tr')
-            .contains(
-              'Secondary School Teacher in State maintained schools (England)',
-            )
-            .then(($header) => {
-              const $row = $header.parent();
-              cy.wrap($row).contains(liveText);
-            });
-          cy.get('tr')
-            .contains('Gas Safe Engineer')
-            .then(($header) => {
-              const $row = $header.parent();
-              cy.wrap($row).contains(draftText);
-            });
+        cy.translate('professions.admin.status.live').then((liveText) => {
+          cy.translate('professions.admin.status.draft').then((draftText) => {
+            cy.get('tr')
+              .contains('Registered Trademark Attorney')
+              .then(($header) => {
+                const $row = $header.parent();
+                cy.wrap($row).contains(liveText);
+              });
+            cy.get('tr')
+              .contains(
+                'Secondary School Teacher in State maintained schools (England)',
+              )
+              .then(($header) => {
+                const $row = $header.parent();
+                cy.wrap($row).contains(liveText);
+              });
+            cy.get('tr')
+              .contains('Gas Safe Engineer')
+              .then(($header) => {
+                const $row = $header.parent();
+                cy.wrap($row).contains(draftText);
+              });
+          });
         });
       });
     });
@@ -83,19 +91,6 @@ describe('Listing professions', () => {
       cy.translate('professions.admin.tableHeading.status').then((status) => {
         cy.get('tr').eq(0).should('contain', status);
       });
-    });
-
-    it('I can click a profession to be taken to its details page', () => {
-      cy.get('tr')
-        .contains(
-          'Secondary School Teacher in State maintained schools (England)',
-        )
-        .parent()
-        .within(() => {
-          cy.get('a').contains('View details').click();
-        });
-
-      cy.checkAccessibility();
     });
 
     it('I can filter by keyword', () => {

--- a/cypress/integration/admin/professions/show.spec.ts
+++ b/cypress/integration/admin/professions/show.spec.ts
@@ -1,0 +1,230 @@
+describe('Listing professions', () => {
+  context('When I am logged in as editor', () => {
+    beforeEach(() => {
+      cy.loginAuth0('editor');
+      cy.visitAndCheckAccessibility('/admin/professions');
+    });
+
+    it('I can click a profession to be taken to its details page', () => {
+      cy.get('tr')
+        .contains('Registered Trademark Attorney')
+        .parent()
+        .within(() => {
+          cy.get('a').contains('View details').click();
+        });
+
+      cy.checkAccessibility();
+
+      cy.get('body').should('contain', 'Registered Trademark Attorney');
+
+      cy.translate('professions.show.overview.heading').then((heading) => {
+        cy.get('body').should('contain', heading);
+      });
+
+      cy.translate('professions.show.bodies.heading').then((heading) => {
+        cy.get('body').should('contain', heading);
+      });
+
+      cy.get('h3').should('contain', 'Law Society of England and Wales');
+      cy.get('h3')
+        .contains('Law Society of England and Wales')
+        .parent()
+        .within(() => {
+          cy.checkSummaryListRowMultilineValue(
+            'professions.show.bodies.address',
+            ['456 Example Street', 'London', 'EC1 1AB'],
+          );
+          cy.checkSummaryListRowValue(
+            'professions.show.bodies.emailAddress',
+            'law@example.com',
+          );
+          cy.checkSummaryListRowValue(
+            'professions.show.bodies.url',
+            'www.lawsociety.org.uk',
+          );
+          cy.checkSummaryListRowValue(
+            'professions.show.bodies.phoneNumber',
+            '+44 0123 456789',
+          );
+        });
+
+      cy.get('h3').should('contain', 'Alternative Law Society');
+      cy.get('h3')
+        .contains('Alternative Law Society')
+        .parent()
+        .within(() => {
+          cy.checkSummaryListRowMultilineValue(
+            'professions.show.bodies.address',
+            ['123 Example Street', 'London', 'WC1 1AB'],
+          );
+          cy.checkSummaryListRowValue(
+            'professions.show.bodies.emailAddress',
+            'alt-law@example.com',
+          );
+          cy.checkSummaryListRowValue(
+            'professions.show.bodies.url',
+            'www.alt-lawsociety.org.uk',
+          );
+          cy.checkSummaryListRowValue(
+            'professions.show.bodies.phoneNumber',
+            '+44 0123 987654',
+          );
+        });
+
+      cy.translate('professions.show.regulatedActivities.heading').then(
+        (heading) => {
+          cy.get('body h2').should('contain', heading);
+
+          cy.get('body h2')
+            .contains(heading)
+            .parent()
+            .within(() => {
+              cy.translate(
+                'professions.show.regulatedActivities.regulationSummary',
+              ).then((summaryHeading) => {
+                cy.get('h3').should('contain', summaryHeading);
+
+                cy.get('h3')
+                  .contains(summaryHeading)
+                  .parent()
+                  .within(() => {
+                    cy.get('p').should(
+                      'contain',
+                      'Registration protection and exploitation of trade marks',
+                    );
+                  });
+              });
+
+              cy.translate(
+                'professions.show.regulatedActivities.protectedTitles',
+              ).then((protectedTitlesHeading) => {
+                cy.get('h3').should('contain', protectedTitlesHeading);
+
+                cy.get('h3')
+                  .contains(protectedTitlesHeading)
+                  .parent()
+                  .within(() => {
+                    cy.get('p').should('contain', 'Trade Mark Agent');
+                  });
+              });
+            });
+        },
+      );
+
+      cy.translate('professions.show.qualification.heading').then((heading) => {
+        cy.get('body').should('contain', heading);
+      });
+      cy.checkSummaryListRowValue(
+        'professions.show.qualification.routesToObtain',
+        'Have a degree in any subject that is equivalent to a UK degree or level 6 qualification, or other qualification and/or experience equivalent to this.',
+      );
+      cy.checkSummaryListRowValue(
+        'professions.show.qualification.moreInformationUrl',
+        'https://www.sra.org.uk/become-solicitor/qualified-lawyers/',
+      );
+
+      cy.translate('professions.show.legislation.heading').then((heading) => {
+        cy.get('body').should('contain', heading);
+      });
+      cy.checkSummaryListRowValue(
+        'professions.show.legislation.nationalLegislation',
+        'The Trade Marks Act 1994',
+      );
+
+      cy.translate('professions.show.overview.heading').then((heading) => {
+        cy.get('body').should('contain', heading);
+      });
+    });
+
+    it('I can view a profession with the bare minimum fields', () => {
+      cy.get('tr')
+        .contains('Profession with no optional fields')
+        .parent()
+        .within(() => {
+          cy.get('a').contains('View details').click();
+        });
+
+      cy.checkAccessibility();
+
+      cy.get('body').should('contain', 'Profession with no optional fields');
+
+      cy.translate('professions.show.overview.heading').then((heading) => {
+        cy.get('body').should('contain', heading);
+      });
+
+      cy.translate('professions.show.bodies.heading').then((heading) => {
+        cy.get('body').should('contain', heading);
+      });
+
+      cy.get('h3').should('contain', 'Department for Education');
+      cy.get('h3')
+        .contains('Department for Education')
+        .parent()
+        .within(() => {
+          cy.checkSummaryListRowMultilineValue(
+            'professions.show.bodies.address',
+            ['345 Example Street', 'London', 'EC1 1AB'],
+          );
+          cy.checkSummaryListRowValue(
+            'professions.show.bodies.emailAddress',
+            'old@example.com',
+          );
+          cy.checkSummaryListRowValue(
+            'professions.show.bodies.url',
+            'https://www.gov.uk/guidance/early-years-qualifications-finder#overseas-qualifications',
+          );
+          cy.checkSummaryListRowValue(
+            'professions.show.bodies.phoneNumber',
+            '+44 0123 456789',
+          );
+        });
+
+      cy.translate('professions.show.regulatedActivities.heading').then(
+        (heading) => {
+          cy.get('body h2').should('contain', heading);
+
+          cy.get('body h2')
+            .contains(heading)
+            .parent()
+            .within(() => {
+              cy.translate(
+                'professions.show.regulatedActivities.regulationSummary',
+              ).then((summaryHeading) => {
+                cy.get('h3').should('contain', summaryHeading);
+
+                cy.get('h3')
+                  .contains(summaryHeading)
+                  .parent()
+                  .within(() => {
+                    cy.get('p').should(
+                      'contain',
+                      'A description of the profession',
+                    );
+                  });
+              });
+            });
+        },
+      );
+
+      cy.translate('professions.show.qualification.heading').then((heading) => {
+        cy.get('body').should('contain', heading);
+      });
+      cy.checkSummaryListRowValue(
+        'professions.show.qualification.routesToObtain',
+        'General post-secondary education',
+      );
+
+      cy.translate('professions.show.legislation.heading').then((heading) => {
+        cy.get('body').should('contain', heading);
+      });
+      cy.checkSummaryListRowValue(
+        'professions.show.legislation.nationalLegislation',
+        "The Education (School Teachers' Qualifications) (England) Regulations 2003/1662 (as amended)",
+      );
+
+      cy.translate('professions.show.overview.heading').then((heading) => {
+        cy.get('body').should('contain', heading);
+      });
+    });
+  });
+});

--- a/cypress/integration/organisations/search/search.spec.ts
+++ b/cypress/integration/organisations/search/search.spec.ts
@@ -55,35 +55,50 @@ describe('Searching an organisation', () => {
   });
 
   it('I can filter by nation', () => {
-    cy.get('input[name="nations[]"][value="GB-SCT"]').check();
+    cy.readFile('./seeds/test/professions.json').then((professions) => {
+      const scottishProfessions = professions.filter((profession) =>
+        profession.versions.some(
+          (version) =>
+            version.status === 'live' &&
+            version.occupationLocations.includes('GB-SCT'),
+        ),
+      );
 
-    cy.get('button').click();
-    cy.checkAccessibility();
+      cy.get('input[name="nations[]"][value="GB-SCT"]').check();
 
-    cy.get('input[name="nations[]"][value="GB-SCT"]').should('be.checked');
+      cy.get('button').click();
+      cy.checkAccessibility();
 
-    cy.get('body').should('contain', 'Law Society of England and Wales');
-    checkResultLength(1);
+      cy.get('input[name="nations[]"][value="GB-SCT"]').should('be.checked');
+
+      cy.get('body').should('contain', 'Law Society of England and Wales');
+      checkResultLength(scottishProfessions.length);
+    });
   });
 
   it('I can filter by industry', () => {
-    cy.translate('industries.law').then((nameLabel) => {
-      cy.get('label').contains(nameLabel).parent().find('input').check();
+    cy.readFile('./seeds/test/organisations.json').then((organisations) => {
+      const lawOrganisations = organisations.filter(
+        (org) => org.name === 'Law Society of England and Wales',
+      );
+      cy.translate('industries.law').then((nameLabel) => {
+        cy.get('label').contains(nameLabel).parent().find('input').check();
+      });
+
+      cy.get('button').click();
+      cy.checkAccessibility();
+
+      cy.translate('industries.law').then((nameLabel) => {
+        cy.get('label')
+          .contains(nameLabel)
+          .parent()
+          .find('input')
+          .should('be.checked');
+      });
+
+      cy.get('body').should('contain', 'Law Society of England and Wales');
+      checkResultLength(lawOrganisations.length);
     });
-
-    cy.get('button').click();
-    cy.checkAccessibility();
-
-    cy.translate('industries.law').then((nameLabel) => {
-      cy.get('label')
-        .contains(nameLabel)
-        .parent()
-        .find('input')
-        .should('be.checked');
-    });
-
-    cy.get('body').should('contain', 'Law Society of England and Wales');
-    checkResultLength(1);
   });
 
   it('I can filter by keyword', () => {

--- a/cypress/integration/professions/search/search.spec.ts
+++ b/cypress/integration/professions/search/search.spec.ts
@@ -11,17 +11,25 @@ describe('Searching a profession', () => {
   });
 
   it('I can view an unfiltered list of live professions', () => {
-    cy.translate('professions.search.foundPlural', { count: 2 }).then(
-      (foundText) => {
+    cy.readFile('./seeds/test/professions.json').then((professions) => {
+      const professionsToShow = professions.filter((profession) =>
+        profession.versions.some((version) =>
+          ['live'].includes(version.status),
+        ),
+      );
+
+      cy.translate('professions.search.foundPlural', {
+        count: professionsToShow.length,
+      }).then((foundText) => {
         cy.get('body').should('contain.text', foundText);
-      },
-    );
-    cy.get('body').should('contain', 'Registered Trademark Attorney');
-    cy.get('body').should(
-      'contain',
-      'Secondary School Teacher in State maintained schools (England)',
-    );
-    cy.get('body').should('not.contain', 'Gas Safe Engineer');
+      });
+      cy.get('body').should('contain', 'Registered Trademark Attorney');
+      cy.get('body').should(
+        'contain',
+        'Secondary School Teacher in State maintained schools (England)',
+      );
+      cy.get('body').should('not.contain', 'Gas Safe Engineer');
+    });
   });
 
   it('Organisations are sorted alphabetically', () => {

--- a/cypress/integration/professions/show.spec.ts
+++ b/cypress/integration/professions/show.spec.ts
@@ -122,4 +122,88 @@ describe('Showing a profession', () => {
       cy.get('body').should('contain', heading);
     });
   });
+
+  it('I can view a profession with the bare minimum fields', () => {
+    cy.visitAndCheckAccessibility('/professions/no-optional-fields');
+
+    cy.get('body').should('contain', 'Profession with no optional fields');
+
+    cy.translate('professions.show.overview.heading').then((heading) => {
+      cy.get('body').should('contain', heading);
+    });
+
+    cy.translate('professions.show.bodies.heading').then((heading) => {
+      cy.get('body').should('contain', heading);
+    });
+
+    cy.get('h3').should('contain', 'Department for Education');
+    cy.get('h3')
+      .contains('Department for Education')
+      .parent()
+      .within(() => {
+        cy.checkSummaryListRowMultilineValue(
+          'professions.show.bodies.address',
+          ['123 Example Street', 'London', 'EC1 1AB'],
+        );
+        cy.checkSummaryListRowValue(
+          'professions.show.bodies.emailAddress',
+          'dfe@example.com',
+        );
+        cy.checkSummaryListRowValue(
+          'professions.show.bodies.url',
+          'https://www.gov.uk/guidance/early-years-qualifications-finder#overseas-qualifications',
+        );
+        cy.checkSummaryListRowValue(
+          'professions.show.bodies.phoneNumber',
+          '+44 0123 456789',
+        );
+      });
+
+    cy.translate('professions.show.regulatedActivities.heading').then(
+      (heading) => {
+        cy.get('body h2').should('contain', heading);
+
+        cy.get('body h2')
+          .contains(heading)
+          .parent()
+          .within(() => {
+            cy.translate(
+              'professions.show.regulatedActivities.regulationSummary',
+            ).then((summaryHeading) => {
+              cy.get('h3').should('contain', summaryHeading);
+
+              cy.get('h3')
+                .contains(summaryHeading)
+                .parent()
+                .within(() => {
+                  cy.get('p').should(
+                    'contain',
+                    'A description of the profession',
+                  );
+                });
+            });
+          });
+      },
+    );
+
+    cy.translate('professions.show.qualification.heading').then((heading) => {
+      cy.get('body').should('contain', heading);
+    });
+    cy.checkSummaryListRowValue(
+      'professions.show.qualification.routesToObtain',
+      'General post-secondary education',
+    );
+
+    cy.translate('professions.show.legislation.heading').then((heading) => {
+      cy.get('body').should('contain', heading);
+    });
+    cy.checkSummaryListRowValue(
+      'professions.show.legislation.nationalLegislation',
+      "The Education (School Teachers' Qualifications) (England) Regulations 2003/1662 (as amended)",
+    );
+
+    cy.translate('professions.show.overview.heading').then((heading) => {
+      cy.get('body').should('contain', heading);
+    });
+  });
 });

--- a/seeds/test/professions.json
+++ b/seeds/test/professions.json
@@ -93,6 +93,25 @@
     ]
   },
   {
+    "name": "Profession with no optional fields",
+    "slug": "no-optional-fields",
+    "organisation": "Department for Education",
+    "additionalOrganisation": null,
+    "versions": [
+      {
+        "occupationLocations": ["GB-ENG", "GB-SCT", "GB-WLS", "GB-NIR"],
+        "industries": ["industries.education"],
+        "description": "A description of the profession",
+        "reservedActivities": "Some reserved activities",
+        "legislations": [
+          "The Education (School Teachers' Qualifications) (England) Regulations 2003/1662 (as amended)"
+        ],
+        "qualification": "General post-secondary education",
+        "status": "live"
+      }
+    ]
+  },
+  {
     "name": "Draft Profession",
     "slug": "draft-profession",
     "organisation": "Council of Registered Gas Installers",

--- a/seeds/test/qualifications.json
+++ b/seeds/test/qualifications.json
@@ -12,7 +12,6 @@
     "url": "https://www.euskills.co.uk/about/our-industries/gas/"
   },
   {
-    "routesToObtain": "General post-secondary education",
-    "url": "http://www.example.com"
+    "routesToObtain": "General post-secondary education"
   }
 ]

--- a/src/i18n/en/professions.json
+++ b/src/i18n/en/professions.json
@@ -49,9 +49,9 @@
         "regulationSummaryHint": "Brief description of the profession and how it is regulated.",
         "reservedActivities": "Reserved activities",
         "reservedActivitiesHint": "Any activities that only qualified professionals can do.",
-        "protectedTitles": "Protected titles",
+        "protectedTitles": "Protected titles (optional)",
         "protectedTitlesHint": "Professional titles and letters that only qualified professionals can use.",
-        "regulationUrl": "More about regulated activities and titles",
+        "regulationUrl": "More about regulated activities and titles (optional)",
         "regulationUrlHint": "Website link to more information."
       },
       "qualifications": {

--- a/src/i18n/en/professions.json
+++ b/src/i18n/en/professions.json
@@ -39,9 +39,9 @@
         "industryHint": "The sectors this profession is part of. Select all that apply."
       },
       "registration": {
-        "registrationRequirements": "Registration requirements",
+        "registrationRequirements": "Registration requirements (optional)",
         "registrationRequirementsHint": "The body professionals should register with and other requirements for registration.",
-        "registrationUrl": "More about registration",
+        "registrationUrl": "More about registration (optional)",
         "registrationUrlHint": "Website link to more information."
       },
       "regulatedActivities": {

--- a/src/i18n/en/professions.json
+++ b/src/i18n/en/professions.json
@@ -70,8 +70,9 @@
       },
       "legislation": {
         "nationalLegislation": "Legislation title",
+        "optionalNationalLegislation": "Legislation title (optional)",
         "nationalLegislationHint": "Title of the relevant act or charter.",
-        "link": "Legislation link",
+        "link": "Legislation link (optional)",
         "linkHint": "Website link to the legislation.",
         "secondNationalLegislation": "Second legislation title (optional)",
         "secondNationalLegislationHint": "Title of the relevant act or charter.",

--- a/src/i18n/en/professions.json
+++ b/src/i18n/en/professions.json
@@ -57,15 +57,15 @@
       "qualifications": {
         "routesToObtain": "Routes to qualification",
         "routesToObtainHint": "The ways that a new professional can become qualified",
-        "moreInformationUrl": "More about qualification",
+        "moreInformationUrl": "More about qualification (optional)",
         "moreInformationUrlHint": "Website link to more information",
-        "ukRecognition": "Recognition of qualifications in the UK",
+        "ukRecognition": "Recognition of qualifications in the UK (optional)",
         "ukRecognitionHint": "Routes to recognition for existing professionals from other UK nations",
-        "ukRecognitionUrl": "More about recognition within the UK",
+        "ukRecognitionUrl": "More about recognition within the UK (optional)",
         "ukRecognitionUrlHint": "Website link to more information",
-        "otherCountriesRecognition": "Recognition of qualifications from other countries",
+        "otherCountriesRecognition": "Recognition of qualifications from other countries (optional)",
         "otherCountriesRecognitionHint": "Routes to recognition for existing professionals from outside the UK",
-        "otherCountriesRecognitionUrl": "More about recognition from other countries",
+        "otherCountriesRecognitionUrl": "More about recognition from other countries (optional)",
         "otherCountriesRecognitionUrlHint": "Website link to more information"
       },
       "legislation": {

--- a/src/professions/admin/dto/legislation.dto.ts
+++ b/src/professions/admin/dto/legislation.dto.ts
@@ -15,6 +15,7 @@ export default class LegislationDto {
   @IsUrl(urlOptions, {
     message: 'professions.form.errors.legislation.link.invalid',
   })
+  @ValidateIf((e) => e.link)
   @Transform(({ value }) => preprocessUrl(value))
   link: string;
 

--- a/src/professions/admin/legislation.controller.spec.ts
+++ b/src/professions/admin/legislation.controller.spec.ts
@@ -234,40 +234,77 @@ describe(LegislationController, () => {
       });
     });
 
-    describe('when required parameters are not entered', () => {
-      it('renders the edit page with errors and does not update the Profession', async () => {
-        const profession = professionFactory.build({ id: 'profession-id' });
-        const version = professionVersionFactory.build({
-          id: 'version-id',
-          profession: profession,
+    describe('when there is a validation error', () => {
+      describe('when required parameters are not entered', () => {
+        it('renders the edit page with errors and does not update the Profession', async () => {
+          const profession = professionFactory.build({ id: 'profession-id' });
+          const version = professionVersionFactory.build({
+            id: 'version-id',
+            profession: profession,
+          });
+
+          const dto: LegislationDto = {
+            link: undefined,
+            nationalLegislation: undefined,
+            change: false,
+          };
+
+          professionsService.findWithVersions.mockResolvedValue(profession);
+          professionVersionsService.findWithProfession.mockResolvedValue(
+            version,
+          );
+
+          await controller.update(response, 'profession-id', 'version-id', dto);
+
+          expect(professionVersionsService.save).not.toHaveBeenCalled();
+
+          expect(response.render).toHaveBeenCalledWith(
+            'admin/professions/legislation',
+            expect.objectContaining({
+              errors: {
+                nationalLegislation: {
+                  text: 'professions.form.errors.legislation.nationalLegislation.empty',
+                },
+              },
+            }),
+          );
         });
+      });
 
-        const dto: LegislationDto = {
-          link: undefined,
-          nationalLegislation: undefined,
-          change: false,
-        };
+      describe('when the link is invalid', () => {
+        it('renders the edit page with errors and does not update the Profession', async () => {
+          const profession = professionFactory.build({ id: 'profession-id' });
+          const version = professionVersionFactory.build({
+            id: 'version-id',
+            profession: profession,
+          });
 
-        professionsService.findWithVersions.mockResolvedValue(profession);
-        professionVersionsService.findWithProfession.mockResolvedValue(version);
+          const dto: LegislationDto = {
+            link: 'bad link',
+            nationalLegislation: 'national legislation value',
+            change: false,
+          };
 
-        await controller.update(response, 'profession-id', 'version-id', dto);
+          professionsService.findWithVersions.mockResolvedValue(profession);
+          professionVersionsService.findWithProfession.mockResolvedValue(
+            version,
+          );
 
-        expect(professionVersionsService.save).not.toHaveBeenCalled();
+          await controller.update(response, 'profession-id', 'version-id', dto);
 
-        expect(response.render).toHaveBeenCalledWith(
-          'admin/professions/legislation',
-          expect.objectContaining({
-            errors: {
-              link: {
-                text: 'professions.form.errors.legislation.link.invalid',
+          expect(professionVersionsService.save).not.toHaveBeenCalled();
+
+          expect(response.render).toHaveBeenCalledWith(
+            'admin/professions/legislation',
+            expect.objectContaining({
+              errors: {
+                link: {
+                  text: 'professions.form.errors.legislation.link.invalid',
+                },
               },
-              nationalLegislation: {
-                text: 'professions.form.errors.legislation.nationalLegislation.empty',
-              },
-            },
-          }),
-        );
+            }),
+          );
+        });
       });
     });
   });

--- a/views/admin/professions/check-your-answers.njk
+++ b/views/admin/professions/check-your-answers.njk
@@ -382,7 +382,7 @@
               rows: [
                 {
                   key: {
-                    html: ("professions.form.label.legislation.nationalLegislation" | t) + "<span class=\"govuk-visually-hidden\"> " + loop.index + "</span>"
+                    html: (("professions.form.label.legislation.nationalLegislation" | t) if loop.index === 1 else ("professions.form.label.legislation.optionalNationalLegislation" | t)) + "<span class=\"govuk-visually-hidden\"> " + loop.index + "</span>"
                   },
                   value: {
                     text: legislation.name | multiline

--- a/views/admin/professions/regulated-activities.njk
+++ b/views/admin/professions/regulated-activities.njk
@@ -15,7 +15,7 @@
     <div class="govuk-grid-column-two-thirds">
 
       <span class="govuk-caption-l">{{ captionText }}</span>
-      <h1 class="govuk-heading-l">{{ title }}</h1>
+      <h1 class="govuk-heading-l">{{ heading }}</h1>
 
       <form method="post" action="./">
         <input type="hidden" name="change" value="{{ change }}" />

--- a/views/admin/professions/scope.njk
+++ b/views/admin/professions/scope.njk
@@ -55,8 +55,9 @@
                 html: nationHtml
               }
             }
-          ]
-        })
+          ],
+          errorMessage: (errors.coversUK | tError) or (errors.nations | tError)
+         })
       }}
 
       {{


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR

- Fixes error not being displayed when not selecting a nation.
- Fixes incorrect `<title>` on page.
- Ensures all optional fields when adding a profession are actually optional and marks them as so.
- Only validate legislation link if previous step in form is filled in.
- Updates a couple of tests to make sure we can display professions with only mandatory fields filled in.

## Screenshots of UI changes

### After


![image](https://user-images.githubusercontent.com/19826940/157077608-77ddd7c7-62e9-4cb4-9c19-d953ccdf325b.png)

![image](https://user-images.githubusercontent.com/19826940/157077674-c2c0096f-a882-4845-8cea-abffad5d7100.png)

![image](https://user-images.githubusercontent.com/19826940/157077714-9361d760-68de-430c-856e-b5e28c6d2f31.png)

![image](https://user-images.githubusercontent.com/19826940/157077781-b6d41315-3e6a-45e0-b86d-0f7360ab4f74.png)

![image](https://user-images.githubusercontent.com/19826940/157077823-6e558736-1910-46a7-b772-1e6d3746f046.png)

![image](https://user-images.githubusercontent.com/19826940/157077885-b9806e31-7ab0-4dc1-ab81-4420c5d0bf03.png)
