### PR TITLE
(2226) Ensure we're sanitising html in flash message

### DIFF
--- a/src/common/flash-message.spec.ts
+++ b/src/common/flash-message.spec.ts
@@ -1,27 +1,41 @@
+import { escape } from '../helpers/escape.helper';
+import { escapeOf } from '../testutils/escape-of';
 import { flashMessage } from './flash-message';
+
+jest.mock('../helpers/escape.helper');
 
 describe('flashMessage', () => {
   describe('when a body and title are provided', () => {
     it('returns the html with a body and title', () => {
+      (escape as jest.Mock).mockImplementation(escapeOf);
       const response = flashMessage('Title', 'Body');
 
       expect(response).toMatch(
-        '<h3 class="govuk-notification-banner__heading">Title</h3>',
+        `<h3 class="govuk-notification-banner__heading">${escapeOf(
+          'Title',
+        )}</h3>`,
       );
 
-      expect(response).toMatch('<p class="govuk-body">Body</p>');
+      expect(response).toMatch(`<p class="govuk-body">${escapeOf('Body')}</p>`);
     });
   });
 
   describe('when the title is provided', () => {
     it('only returns the title', () => {
+      (escape as jest.Mock).mockImplementation(escapeOf);
       const response = flashMessage('Title');
 
       expect(response).toMatch(
-        '<h3 class="govuk-notification-banner__heading">Title</h3>',
+        `<h3 class="govuk-notification-banner__heading">${escapeOf(
+          'Title',
+        )}</h3>`,
       );
 
       expect(response).not.toMatch('<p class="govuk-body">');
     });
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
   });
 });

--- a/src/common/flash-message.ts
+++ b/src/common/flash-message.ts
@@ -1,8 +1,12 @@
+import { escape } from '../helpers/escape.helper';
+
 export function flashMessage(heading: string, body?: string): string {
-  let html = `<h3 class="govuk-notification-banner__heading">${heading}</h3>`;
+  let html = `<h3 class="govuk-notification-banner__heading">${escape(
+    heading,
+  )}</h3>`;
 
   if (body) {
-    html += `<p class="govuk-body">${body}</p>`;
+    html += `<p class="govuk-body">${escape(body)}</p>`;
   }
 
   return html;


### PR DESCRIPTION
# Changes in this PR

Escapes title and body of flash message to protect against low possibility of an XSS attack via that banner being rendered on a page.
