### PR TITLE
(2226) Escape names passed in to flash message

### DIFF
--- a/src/organisations/admin/organisation-archive.controller.spec.ts
+++ b/src/organisations/admin/organisation-archive.controller.spec.ts
@@ -3,6 +3,7 @@ import { TestingModule, Test } from '@nestjs/testing';
 import { Response } from 'express';
 import { I18nService } from 'nestjs-i18n';
 import { flashMessage } from '../../common/flash-message';
+import { escape } from '../../helpers/escape.helper';
 import { createMockI18nService } from '../../testutils/create-mock-i18n-service';
 import { createDefaultMockRequest } from '../../testutils/factories/create-default-mock-request';
 import organisationFactory from '../../testutils/factories/organisation';
@@ -16,6 +17,7 @@ import { OrganisationArchiveController } from './organisation-archive.controller
 
 jest.mock('../../common/flash-message');
 jest.mock('../../users/helpers/get-acting-user.helper');
+jest.mock('../../helpers/escape.helper');
 
 describe('OrganisationArchiveController', () => {
   let controller: OrganisationArchiveController;
@@ -115,6 +117,8 @@ describe('OrganisationArchiveController', () => {
         translationOf('organisations.admin.archive.confirmation.heading'),
         translationOf('organisations.admin.archive.confirmation.body'),
       );
+
+      expect(escape).toHaveBeenCalledWith(organisation.name);
 
       expect(req.flash).toHaveBeenCalledWith('success', 'STUB_FLASH_MESSAGE');
 

--- a/src/organisations/admin/organisation-archive.controller.ts
+++ b/src/organisations/admin/organisation-archive.controller.ts
@@ -13,6 +13,7 @@ import { BackLink } from '../../common/decorators/back-link.decorator';
 import { flashMessage } from '../../common/flash-message';
 import { RequestWithAppSession } from '../../common/interfaces/request-with-app-session.interface';
 import { Permissions } from '../../common/permissions.decorator';
+import { escape } from '../../helpers/escape.helper';
 import { getActingUser } from '../../users/helpers/get-acting-user.helper';
 import { UserPermission } from '../../users/user-permission';
 import { OrganisationVersionsService } from '../organisation-versions.service';
@@ -76,7 +77,7 @@ export class OrganisationArchiveController {
 
     const messageBody = await this.i18nService.translate(
       'organisations.admin.archive.confirmation.body',
-      { args: { name: version.organisation.name } },
+      { args: { name: escape(version.organisation.name) } },
     );
 
     req.flash('success', flashMessage(messageTitle, messageBody));

--- a/src/organisations/admin/organisation-publication.controller.spec.ts
+++ b/src/organisations/admin/organisation-publication.controller.spec.ts
@@ -3,6 +3,7 @@ import { TestingModule, Test } from '@nestjs/testing';
 import { Response } from 'express';
 import { I18nService } from 'nestjs-i18n';
 import { flashMessage } from '../../common/flash-message';
+import { escape } from '../../helpers/escape.helper';
 import { createMockI18nService } from '../../testutils/create-mock-i18n-service';
 import { createDefaultMockRequest } from '../../testutils/factories/create-default-mock-request';
 import organisationFactory from '../../testutils/factories/organisation';
@@ -16,6 +17,7 @@ import { OrganisationPublicationController } from './organisation-publication.co
 
 jest.mock('../../common/flash-message');
 jest.mock('../../users/helpers/get-acting-user.helper');
+jest.mock('../../helpers/escape.helper');
 
 describe('OrganisationPublicationController', () => {
   let controller: OrganisationPublicationController;
@@ -114,6 +116,8 @@ describe('OrganisationPublicationController', () => {
         translationOf('organisations.admin.publish.confirmation.heading'),
         translationOf('organisations.admin.publish.confirmation.body'),
       );
+
+      expect(escape).toHaveBeenCalledWith(organisation.name);
 
       expect(req.flash).toHaveBeenCalledWith('success', 'STUB_FLASH_MESSAGE');
 

--- a/src/organisations/admin/organisation-publication.controller.ts
+++ b/src/organisations/admin/organisation-publication.controller.ts
@@ -5,6 +5,7 @@ import { BackLink } from '../../common/decorators/back-link.decorator';
 import { flashMessage } from '../../common/flash-message';
 import { RequestWithAppSession } from '../../common/interfaces/request-with-app-session.interface';
 import { Permissions } from '../../common/permissions.decorator';
+import { escape } from '../../helpers/escape.helper';
 import { getActingUser } from '../../users/helpers/get-acting-user.helper';
 import { UserPermission } from '../../users/user-permission';
 import { OrganisationVersionsService } from '../organisation-versions.service';
@@ -70,7 +71,7 @@ export class OrganisationPublicationController {
 
     const messageBody = await this.i18nService.translate(
       'organisations.admin.publish.confirmation.body',
-      { args: { name: version.organisation.name } },
+      { args: { name: escape(version.organisation.name) } },
     );
 
     req.flash('success', flashMessage(messageTitle, messageBody));

--- a/src/organisations/admin/organisations.controller.spec.ts
+++ b/src/organisations/admin/organisations.controller.spec.ts
@@ -29,12 +29,14 @@ import { FilterInput } from '../../common/interfaces/filter-input.interface';
 import { flashMessage } from '../../common/flash-message';
 import { createDefaultMockRequest } from '../../testutils/factories/create-default-mock-request';
 import { getActingUser } from '../../users/helpers/get-acting-user.helper';
+import { escape } from '../../helpers/escape.helper';
 
 jest.mock('./presenters/organisations.presenter');
 jest.mock('../presenters/organisation.presenter');
 jest.mock('../helpers/organisations-filter.helper');
 jest.mock('../../common/flash-message');
 jest.mock('../../users/helpers/get-acting-user.helper');
+jest.mock('../../helpers/escape.helper');
 
 describe('OrganisationsController', () => {
   let controller: OrganisationsController;
@@ -516,6 +518,8 @@ describe('OrganisationsController', () => {
             'Translation of `organisations.admin.create.confirmation.body`',
           );
 
+          expect(escape).toHaveBeenCalledWith(organisation.name);
+
           expect(request.flash).toHaveBeenCalledWith(
             'info',
             'STUB_FLASH_MESSAGE',
@@ -540,6 +544,8 @@ describe('OrganisationsController', () => {
 
           organisationsService.find.mockResolvedValue(organisation);
           organisationVersionsService.find.mockResolvedValue(version);
+
+          (escape as jest.Mock).mockImplementation();
 
           flashMock = flashMessage as jest.Mock;
           flashMock.mockImplementation(() => 'STUB_FLASH_MESSAGE');
@@ -567,6 +573,8 @@ describe('OrganisationsController', () => {
             'Translation of `organisations.admin.edit.confirmation.heading`',
             'Translation of `organisations.admin.edit.confirmation.body`',
           );
+
+          expect(escape).toHaveBeenCalledWith(organisation.name);
 
           expect(request.flash).toHaveBeenCalledWith(
             'info',

--- a/src/organisations/admin/organisations.controller.ts
+++ b/src/organisations/admin/organisations.controller.ts
@@ -41,6 +41,7 @@ import { isConfirmed } from '../../helpers/is-confirmed';
 import { UserPermission } from '../../users/user-permission';
 import { Permissions } from '../../common/permissions.decorator';
 import { getActingUser } from '../../users/helpers/get-acting-user.helper';
+import { escape } from '../../helpers/escape.helper';
 
 @UseGuards(AuthenticationGuard)
 @Controller('/admin/organisations')
@@ -215,7 +216,7 @@ export class OrganisationsController {
 
     const messageBody = await this.i18nService.translate(
       `organisations.admin.${action}.confirmation.body`,
-      { args: { name: organisation.name } },
+      { args: { name: escape(organisation.name) } },
     );
 
     req.flash('info', flashMessage(messageTitle, messageBody));

--- a/src/professions/admin/confirmation.controller.spec.ts
+++ b/src/professions/admin/confirmation.controller.spec.ts
@@ -3,6 +3,7 @@ import { TestingModule, Test } from '@nestjs/testing';
 import { Request, Response } from 'express';
 import { I18nService } from 'nestjs-i18n';
 import { flashMessage } from '../../common/flash-message';
+import { escape } from '../../helpers/escape.helper';
 import { createMockI18nService } from '../../testutils/create-mock-i18n-service';
 import professionFactory from '../../testutils/factories/profession';
 import professionVersionFactory from '../../testutils/factories/profession-version';
@@ -12,6 +13,7 @@ import { ProfessionsService } from '../professions.service';
 import { ConfirmationController } from './confirmation.controller';
 
 jest.mock('../../common/flash-message');
+jest.mock('../../helpers/escape.helper');
 
 describe('ConfirmationController', () => {
   let controller: ConfirmationController;
@@ -44,6 +46,7 @@ describe('ConfirmationController', () => {
       it('"Confirms" the Profession and the Profession Version, then displays a confirmation flash message on the Profession version page', async () => {
         const res = createMock<Response>();
         const req = createMock<Request>();
+
         const flashMock = flashMessage as jest.Mock;
         flashMock.mockImplementation(() => 'STUB_FLASH_MESSAGE');
 
@@ -69,6 +72,8 @@ describe('ConfirmationController', () => {
           translationOf('professions.admin.create.confirmation.body'),
         );
 
+        expect(escape).toHaveBeenCalledWith(profession.name);
+
         expect(req.flash).toHaveBeenCalledWith('success', 'STUB_FLASH_MESSAGE');
 
         expect(res.redirect).toHaveBeenCalledWith(
@@ -81,6 +86,8 @@ describe('ConfirmationController', () => {
       it("redirects with the 'amended' query param, 'confirming' the version, but not updating the Profession", async () => {
         const res = createMock<Response>();
         const req = createMock<Request>();
+
+        (escape as jest.Mock).mockImplementation();
         const flashMock = flashMessage as jest.Mock;
         flashMock.mockImplementation(() => 'STUB_FLASH_MESSAGE');
 
@@ -111,6 +118,8 @@ describe('ConfirmationController', () => {
           translationOf('professions.admin.update.confirmation.heading'),
           translationOf('professions.admin.update.confirmation.body'),
         );
+
+        expect(escape).toHaveBeenCalledWith(existingProfession.name);
 
         expect(req.flash).toHaveBeenCalledWith('info', 'STUB_FLASH_MESSAGE');
       });

--- a/src/professions/admin/confirmation.controller.ts
+++ b/src/professions/admin/confirmation.controller.ts
@@ -7,6 +7,7 @@ import { UserPermission } from '../../users/user-permission';
 import { ProfessionVersionsService } from '../profession-versions.service';
 import { I18nService } from 'nestjs-i18n';
 import { flashMessage } from '../../common/flash-message';
+import { escape } from '../../helpers/escape.helper';
 @UseGuards(AuthenticationGuard)
 @Controller('admin/professions')
 export class ConfirmationController {
@@ -51,7 +52,7 @@ export class ConfirmationController {
 
     const messageBody = await this.i18nService.translate(
       `professions.admin.${action}.confirmation.body`,
-      { args: { name: profession.name } },
+      { args: { name: escape(profession.name) } },
     );
 
     req.flash(bannerType, flashMessage(messageTitle, messageBody));

--- a/src/professions/admin/profession-archive.controller.spec.ts
+++ b/src/professions/admin/profession-archive.controller.spec.ts
@@ -3,6 +3,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { Response } from 'express';
 import { I18nService } from 'nestjs-i18n';
 import { flashMessage } from '../../common/flash-message';
+import { escape } from '../../helpers/escape.helper';
 import { createMockI18nService } from '../../testutils/create-mock-i18n-service';
 import { createDefaultMockRequest } from '../../testutils/factories/create-default-mock-request';
 import professionFactory from '../../testutils/factories/profession';
@@ -16,6 +17,7 @@ import { ProfessionArchiveController } from './profession-archive.controller';
 
 jest.mock('../../common/flash-message');
 jest.mock('../../users/helpers/get-acting-user.helper');
+jest.mock('../../helpers/escape.helper');
 
 describe('ProfessionArchiveController', () => {
   let controller: ProfessionArchiveController;
@@ -114,6 +116,8 @@ describe('ProfessionArchiveController', () => {
         translationOf('professions.admin.archive.confirmation.heading'),
         translationOf('professions.admin.archive.confirmation.body'),
       );
+
+      expect(escape).toHaveBeenCalledWith(profession.name);
 
       expect(req.flash).toHaveBeenCalledWith('success', 'STUB_FLASH_MESSAGE');
 

--- a/src/professions/admin/profession-archive.controller.ts
+++ b/src/professions/admin/profession-archive.controller.ts
@@ -13,6 +13,7 @@ import { BackLink } from '../../common/decorators/back-link.decorator';
 import { flashMessage } from '../../common/flash-message';
 import { RequestWithAppSession } from '../../common/interfaces/request-with-app-session.interface';
 import { Permissions } from '../../common/permissions.decorator';
+import { escape } from '../../helpers/escape.helper';
 import { getActingUser } from '../../users/helpers/get-acting-user.helper';
 import { UserPermission } from '../../users/user-permission';
 import { ProfessionVersionsService } from '../profession-versions.service';
@@ -69,7 +70,7 @@ export class ProfessionArchiveController {
 
     const messageBody = await this.i18nService.translate(
       'professions.admin.archive.confirmation.body',
-      { args: { name: version.profession.name } },
+      { args: { name: escape(version.profession.name) } },
     );
 
     req.flash('success', flashMessage(messageTitle, messageBody));

--- a/src/professions/admin/profession-publication.controller.spec.ts
+++ b/src/professions/admin/profession-publication.controller.spec.ts
@@ -3,6 +3,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { Response } from 'express';
 import { I18nService } from 'nestjs-i18n';
 import { flashMessage } from '../../common/flash-message';
+import { escape } from '../../helpers/escape.helper';
 import { createMockI18nService } from '../../testutils/create-mock-i18n-service';
 import { createDefaultMockRequest } from '../../testutils/factories/create-default-mock-request';
 import professionFactory from '../../testutils/factories/profession';
@@ -16,6 +17,7 @@ import { ProfessionPublicationController } from './profession-publication.contro
 
 jest.mock('../../common/flash-message');
 jest.mock('../../users/helpers/get-acting-user.helper');
+jest.mock('../../helpers/escape.helper');
 
 describe('ProfessionPublicationController', () => {
   let controller: ProfessionPublicationController;
@@ -114,6 +116,8 @@ describe('ProfessionPublicationController', () => {
         translationOf('professions.admin.publish.confirmation.heading'),
         translationOf('professions.admin.publish.confirmation.body'),
       );
+
+      expect(escape).toHaveBeenCalledWith(profession.name);
 
       expect(req.flash).toHaveBeenCalledWith('success', 'STUB_FLASH_MESSAGE');
 

--- a/src/professions/admin/profession-publication.controller.ts
+++ b/src/professions/admin/profession-publication.controller.ts
@@ -5,6 +5,7 @@ import { BackLink } from '../../common/decorators/back-link.decorator';
 import { flashMessage } from '../../common/flash-message';
 import { RequestWithAppSession } from '../../common/interfaces/request-with-app-session.interface';
 import { Permissions } from '../../common/permissions.decorator';
+import { escape } from '../../helpers/escape.helper';
 import { getActingUser } from '../../users/helpers/get-acting-user.helper';
 import { UserPermission } from '../../users/user-permission';
 import { ProfessionVersionsService } from '../profession-versions.service';
@@ -65,7 +66,7 @@ export class ProfessionPublicationController {
 
     const messageBody = await this.i18nService.translate(
       'professions.admin.publish.confirmation.body',
-      { args: { name: version.profession.name } },
+      { args: { name: escape(version.profession.name) } },
     );
 
     req.flash('success', flashMessage(messageTitle, messageBody));


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR

Ensures all names passed into flash message are escaped to prevent possibility of XSS attacks via the confirmation message banner.

I initially tried to escape this in the banner itself, but because we use HTML in some of our translated strings, this was outputting `"<strong>"` on the page, rather than the strong tag.
