### PR TITLE
(2216) Mark optional organisation fields and add errors for missing fields

### DIFF
--- a/cypress/integration/admin/organisations/edit.spec.ts
+++ b/cypress/integration/admin/organisations/edit.spec.ts
@@ -72,6 +72,9 @@ describe('Editing organisations', () => {
     it('Shows errors when I input data incorrectly', () => {
       cy.get('input[name="url"]').invoke('val', '').type('this is not a url');
 
+      cy.get('textarea[name="address"]').clear();
+      cy.get('input[name="telephone"]').clear();
+
       cy.get('input[name="email"]')
         .invoke('val', '')
         .type('this is not an email');
@@ -81,7 +84,13 @@ describe('Editing organisations', () => {
       });
       cy.checkAccessibility();
 
-      cy.translate('organisations.admin.form.errors.email.invalid').then(
+      cy.translate('organisations.admin.form.errors.address.empty').then(
+        (error) => {
+          cy.get('body').should('contain', error);
+        },
+      );
+
+      cy.translate('organisations.admin.form.errors.phone.empty').then(
         (error) => {
           cy.get('body').should('contain', error);
         },

--- a/src/i18n/en/organisations.json
+++ b/src/i18n/en/organisations.json
@@ -86,7 +86,7 @@
     "form": {
       "label": {
         "name": "Name of the regulatory authority",
-        "alternateName": "Alternate name",
+        "alternateName": "Alternate name (optional)",
         "url": "Website",
         "address": "Address",
         "email": "Email",

--- a/src/i18n/en/organisations.json
+++ b/src/i18n/en/organisations.json
@@ -96,6 +96,12 @@
         "name": {
           "empty": "Enter the name of the regulatory authority"
         },
+        "address": {
+          "empty": "Enter the address for the regulatory authority"
+        },
+        "phone": {
+          "empty": "Enter the phone number for the regulatory authority"
+        },
         "email": {
           "invalid": "Please enter a valid email address"
         },

--- a/src/organisations/admin/dto/organisation.dto.ts
+++ b/src/organisations/admin/dto/organisation.dto.ts
@@ -13,6 +13,10 @@ export class OrganisationDto {
   name: string;
 
   alternateName: string;
+
+  @IsNotEmpty({
+    message: 'organisations.admin.form.errors.address.empty',
+  })
   address: string;
 
   @IsEmail(
@@ -31,8 +35,11 @@ export class OrganisationDto {
   @Transform(({ value }) => preprocessUrl(value))
   url: string;
 
+  @IsNotEmpty({
+    message: 'organisations.admin.form.errors.phone.empty',
+  })
   telephone: string;
-  fax: string;
+  fax?: string;
 
   confirm?: boolean;
 }

--- a/views/admin/organisations/edit.njk
+++ b/views/admin/organisations/edit.njk
@@ -61,18 +61,6 @@
         }}
 
         {{
-          govukTextarea({
-            label: {
-              text: ("organisations.admin.form.label.address" | t),
-              classes: "govuk-label--m"
-            },
-            id: "address",
-            name: "address",
-            value: address
-          })
-        }}
-
-        {{
           govukInput({
             label: {
               text: ("organisations.admin.form.label.email" | t),
@@ -93,6 +81,18 @@
             id: "telephone",
             name: "telephone",
             value: telephone
+          })
+        }}
+
+        {{
+          govukTextarea({
+            label: {
+              text: ("organisations.admin.form.label.address" | t),
+              classes: "govuk-label--m"
+            },
+            id: "address",
+            name: "address",
+            value: address
           })
         }}
 


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR

- Marks alternate name as optional
- Adds error messages when phone number and address aren't entered
- Moves address field below the rest of the fields in line with latest designs

## Screenshots of UI changes

### Before

![image](https://user-images.githubusercontent.com/19826940/157255499-c2e8acbe-78f8-4e86-9711-e51cd7a444fb.png)


### After

![image](https://user-images.githubusercontent.com/19826940/157254835-3f352518-88c9-47a2-bd9b-78f99ad3216e.png)

![image](https://user-images.githubusercontent.com/19826940/157254970-d50cf1e5-cbcd-41dd-ad97-9d3576603bd9.png)
