### PR TITLE
(2240) Fix publish on check your answers page

### DIFF
--- a/cypress/integration/admin/organisations/publish.spec.ts
+++ b/cypress/integration/admin/organisations/publish.spec.ts
@@ -7,7 +7,7 @@ describe('Publishing organisations', () => {
       cy.visitAndCheckAccessibility('/admin');
     });
 
-    it('Allows me to publish a draft organisation from the organisation page', () => {
+    it('Allows me to publish an existing draft organisation from the organisation page', () => {
       cy.get('a').contains('Regulatory authorities').click();
       cy.checkAccessibility();
 
@@ -94,7 +94,7 @@ describe('Publishing organisations', () => {
         });
     });
 
-    it('Allows me to publish a draft organisation from the check your answers page', () => {
+    it('Allows me to publish an existing draft organisation from the check your answers page', () => {
       cy.get('a').contains('Regulatory authorities').click();
       cy.checkAccessibility();
 
@@ -197,6 +197,120 @@ describe('Publishing organisations', () => {
             cy.wrap($row).should('contain', status);
           });
         });
+    });
+  });
+
+  context('when I am logged in as a registrar', () => {
+    describe('publishing a brand new profession', () => {
+      beforeEach(() => {
+        cy.loginAuth0('registrar');
+        cy.visitAndCheckAccessibility('/admin');
+      });
+      it('allows me to create and publish a brand new organisation from the check your answers page', () => {
+        cy.get('a').contains('Regulatory authorities').click();
+        cy.checkAccessibility();
+
+        cy.translate('organisations.admin.index.add.button').then(
+          (buttonText) => {
+            cy.get('button').contains(buttonText).click();
+          },
+        );
+
+        cy.translate('organisations.admin.create.heading').then((heading) => {
+          cy.get('html').should('contain', heading);
+        });
+
+        cy.get('input[name="name"]').invoke('val', 'New Organisation');
+
+        cy.get('input[name="alternateName"]').type('Alternate Name');
+
+        cy.get('input[name="url"]').type('http://example.com');
+
+        cy.get('textarea[name="address"]').type('123 Fake Street');
+
+        cy.get('input[name="email"]').type('foo@example.com');
+        cy.get('input[name="telephone"]').type('1234');
+
+        cy.translate('app.continue').then((buttonText) => {
+          cy.get('button').contains(buttonText).click();
+        });
+
+        cy.checkSummaryListRowValue(
+          'organisations.label.name',
+          'New Organisation',
+        );
+        cy.checkSummaryListRowValue(
+          'organisations.label.alternateName',
+          'Alternate Name',
+        );
+        cy.checkSummaryListRowValue(
+          'organisations.label.url',
+          'http://example.com',
+        );
+        cy.checkSummaryListRowValue(
+          'organisations.label.address',
+          '123 Fake Street',
+        );
+        cy.checkSummaryListRowValue(
+          'organisations.label.email',
+          'foo@example.com',
+        );
+        cy.checkSummaryListRowValue('organisations.label.telephone', '1234');
+
+        cy.translate('organisations.admin.button.publish').then(
+          (publishButton) => {
+            cy.get('a').contains(publishButton).click();
+          },
+        );
+
+        cy.translate('organisations.admin.publish.caption').then(
+          (publishCaption) => {
+            cy.get('body').contains(publishCaption);
+          },
+        );
+
+        cy.translate('organisations.admin.publish.heading', {
+          organisationName: 'New Organisation',
+        }).then((heading) => {
+          cy.contains(heading);
+        });
+
+        cy.translate('organisations.admin.button.publish').then(
+          (buttonText) => {
+            cy.get('button').contains(buttonText).click();
+          },
+        );
+
+        cy.checkAccessibility();
+
+        cy.translate('organisations.admin.publish.confirmation.heading').then(
+          (confirmation) => {
+            cy.get('html').should('contain', confirmation);
+          },
+        );
+
+        cy.translate('organisations.admin.publish.confirmation.body', {
+          name: 'New Organisation',
+        }).then((confirmationBody) => {
+          cy.get('html').should('contain.html', confirmationBody);
+        });
+
+        cy.get('body').should('contain', 'New Organisation');
+
+        cy.translate(`organisations.status.live`).then((status) => {
+          cy.get('h2[data-status]').should('contain', status);
+        });
+
+        cy.get('[data-cy=changed-by-user]').should('contain', 'Registrar');
+        cy.get('[data-cy=last-modified]').should(
+          'contain',
+          format(new Date(), 'd MMM yyyy'),
+        );
+
+        cy.visitAndCheckAccessibility('/regulatory-authorities/search');
+        cy.get('a').contains('New Organisation').click();
+        cy.get('h1').should('contain', 'New Organisation');
+      });
     });
   });
 });

--- a/cypress/integration/admin/professions/new.spec.ts
+++ b/cypress/integration/admin/professions/new.spec.ts
@@ -287,7 +287,7 @@ describe('Adding a new profession', () => {
         'www.example-legislation.com',
       );
 
-      cy.translate('professions.form.button.create').then((buttonText) => {
+      cy.translate('professions.form.button.saveAsDraft').then((buttonText) => {
         cy.get('button').contains(buttonText).click();
       });
 

--- a/cypress/integration/admin/professions/publish.spec.ts
+++ b/cypress/integration/admin/professions/publish.spec.ts
@@ -193,4 +193,201 @@ describe('Publishing professions', () => {
         });
     });
   });
+
+  context('When I am logged in as a registrar', () => {
+    beforeEach(() => {
+      cy.loginAuth0('registrar');
+      cy.visitAndCheckAccessibility('/admin');
+    });
+
+    it('I can create and publish a new profession from the Check your answers page', () => {
+      cy.visitAndCheckAccessibility('/admin/professions');
+
+      cy.translate('professions.admin.addButtonLabel').then((buttonText) => {
+        cy.get('button').contains(buttonText).click();
+      });
+
+      cy.checkAccessibility();
+      cy.translate('professions.form.headings.topLevelInformation').then(
+        (heading) => {
+          cy.get('body').should('contain', heading);
+        },
+      );
+      cy.translate('professions.form.captions.add').then((addCaption) => {
+        cy.get('body').contains(addCaption);
+      });
+      cy.get('input[name="name"]').type('Example Profession');
+      cy.get('select[name="regulatoryBody"]').select(
+        'Department for Education',
+      );
+      cy.get('select[name="regulatoryBody"]').should(
+        'not.contain',
+        'Unconfirmed Organisation',
+      );
+      cy.get('select[name="additionalRegulatoryBody"]').select(
+        'General Medical Council',
+      );
+      cy.translate('app.continue').then((buttonText) => {
+        cy.get('button').contains(buttonText).click();
+      });
+
+      // Conditional radio buttons add an additional `aria-expanded` field,
+      // so ignore that rule on this page
+      cy.checkAccessibility({ 'aria-allowed-attr': { enabled: false } });
+      cy.translate('professions.form.captions.addWithName', {
+        professionName: 'Example Profession',
+      }).then((addCaption) => {
+        cy.get('body').contains(addCaption);
+      });
+      cy.translate('professions.form.label.scope.certainNations').then(
+        (certainNations) => {
+          cy.get('label').contains(certainNations).click();
+          cy.get('[type="checkbox"]').check('GB-ENG');
+        },
+      );
+
+      cy.translate('industries.constructionAndEngineering').then(
+        (constructionAndEngineering) => {
+          cy.contains(constructionAndEngineering).click();
+        },
+      );
+      cy.translate('app.continue').then((buttonText) => {
+        cy.get('button').contains(buttonText).click();
+      });
+
+      cy.checkAccessibility();
+      cy.translate('professions.form.captions.addWithName', {
+        professionName: 'Example Profession',
+      }).then((addCaption) => {
+        cy.get('body').contains(addCaption);
+      });
+      cy.get('input[name="registrationRequirements"]').type('Requirements');
+
+      cy.get('input[name="registrationUrl"]')
+        .invoke('val', '')
+        .type('https://example.com/requirement');
+
+      cy.translate('app.continue').then((buttonText) => {
+        cy.get('button').contains(buttonText).click();
+      });
+
+      cy.checkAccessibility();
+
+      cy.translate('professions.form.headings.regulatedActivities').then(
+        (heading) => {
+          cy.get('body').should('contain', heading);
+        },
+      );
+      cy.translate('professions.form.captions.addWithName', {
+        professionName: 'Example Profession',
+      }).then((addCaption) => {
+        cy.get('body').contains(addCaption);
+      });
+      cy.get('textarea[name="regulationSummary"]').type(
+        'A summary of the regulation',
+      );
+      cy.get('textarea[name="reservedActivities"]').type('An example activity');
+      cy.get('textarea[name="protectedTitles"]').type(
+        'An example protected title',
+      );
+      cy.get('input[name="regulationUrl"]').type(
+        'https://example.com/regulation',
+      );
+
+      cy.translate('app.continue').then((buttonText) => {
+        cy.get('button').contains(buttonText).click();
+      });
+
+      cy.checkAccessibility();
+      cy.translate('professions.form.headings.qualifications').then(
+        (heading) => {
+          cy.get('body').should('contain', heading);
+        },
+      );
+      cy.translate('professions.form.captions.addWithName', {
+        professionName: 'Example Profession',
+      }).then((addCaption) => {
+        cy.get('body').contains(addCaption);
+      });
+      cy.get('textarea[name="routesToObtain"]').type(
+        'General secondary education',
+      );
+      cy.get('input[name="moreInformationUrl"]').type(
+        'http://example.com/more-info',
+      );
+
+      cy.get('input[name="ukRecognition"]').type('Recognition in the UK');
+      cy.get('input[name="ukRecognitionUrl"]').type('http://example.com/uk');
+      cy.get('input[name="otherCountriesRecognition"]').type(
+        'Recognition in other countries',
+      );
+      cy.get('input[name="otherCountriesRecognitionUrl"]').type(
+        'http://example.com/other',
+      );
+
+      cy.translate('app.continue').then((buttonText) => {
+        cy.get('button').contains(buttonText).click();
+      });
+
+      cy.checkAccessibility();
+      cy.translate('professions.form.headings.legislation').then((heading) => {
+        cy.get('body').should('contain', heading);
+      });
+      cy.translate('professions.form.captions.addWithName', {
+        professionName: 'Example Profession',
+      }).then((addCaption) => {
+        cy.get('body').contains(addCaption);
+      });
+      cy.get('textarea[name="nationalLegislation"]').type(
+        'National legislation description',
+      );
+      cy.get('input[name="link"]').type('www.example-legislation.com');
+
+      cy.translate('app.continue').then((buttonText) => {
+        cy.get('button').contains(buttonText).click();
+      });
+
+      cy.checkAccessibility();
+
+      cy.translate('professions.form.captions.addWithName', {
+        professionName: 'Example Profession',
+      }).then((addCaption) => {
+        cy.get('body').contains(addCaption);
+      });
+
+      cy.translate('professions.form.button.publish').then((buttonText) => {
+        cy.get('a').contains(buttonText).click();
+      });
+
+      cy.checkAccessibility();
+
+      cy.translate('professions.form.headings.publish', {
+        professionName: 'Example Profession',
+      }).then((heading) => {
+        cy.contains(heading);
+      });
+
+      cy.translate('professions.form.button.publish').then((buttonText) => {
+        cy.get('button').contains(buttonText).click();
+      });
+      cy.checkAccessibility();
+
+      cy.translate('professions.admin.publish.confirmation.heading').then(
+        (confirmation) => {
+          cy.get('html').should('contain', confirmation);
+        },
+      );
+
+      cy.get('[data-cy=changed-by-user]').should('contain', 'Registrar');
+      cy.get('[data-cy=last-modified]').should(
+        'contain',
+        format(new Date(), 'd MMM yyyy'),
+      );
+
+      cy.visitAndCheckAccessibility('/professions/search');
+      cy.get('a').contains('Example Profession').click();
+
+      cy.get('h1').should('contain', 'Example Profession');
+    });
+  });
 });

--- a/src/i18n/en/professions.json
+++ b/src/i18n/en/professions.json
@@ -81,7 +81,6 @@
       }
     },
     "button": {
-      "create": "Create profession",
       "edit": "Yes, continue",
       "publish": "Publish to register",
       "saveAsDraft": "Save as draft"

--- a/views/admin/professions/check-your-answers.njk
+++ b/views/admin/professions/check-your-answers.njk
@@ -420,18 +420,30 @@
         {% endfor %}
 
         {% if not edit and not confirmed %}
-          <form method="post" action="confirmation">
-            {{
-              govukButton({
-                id: "submit-button",
-                type: "Submit",
-                preventDoubleClick: true,
-                text: ("professions.form.button.create" | t)
-              })
-            }}
-          </form>
+          <div class="govuk-button-group rpr-internal__buttons-container">
+            <form method="post" action="confirmation">
+              {{
+                govukButton({
+                  id: "submit-button",
+                  classes: "govuk-button--secondary",
+                  type: "Submit",
+                  preventDoubleClick: true,
+                  text: ("professions.form.button.saveAsDraft" | t)
+                })
+              }}
+            </form>
+            {% if 'publishProfession' in permissions %}
+              {{
+                govukButton({
+                  text: ('professions.form.button.publish' | t),
+                  classes: "govuk-button",
+                  id: "publish-button",
+                  href: "/admin/professions/" + professionId + "/versions/" + versionId + "/publish?fromEdit=true"
+                })
+              }}
+            {% endif %}
+          </div>
         {% endif %}
-
     </div>
 
     <div class="govuk-grid-column-one-third">


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR

Fixes bug introduced when adding the "Publish to register" button to the Check your answers page. Publishing a newly-created entity (rather than editing an existing one) didn't set the slug. Now it does.

This also adds missing "Publish" button to the Check your answers page of creating a new Profession.

## Screenshots of UI changes

### Before

![image](https://user-images.githubusercontent.com/19826940/157288921-3bc9a7bd-7f57-440e-90c0-73e7f8d94a8c.png)

### After

![image](https://user-images.githubusercontent.com/19826940/157288760-9e5c1518-664e-4a6e-a018-81cafb6e5e3c.png)