### PR TITLE
(2241) Replace UKCPQ with BEIS organisation name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Improve sidebar in the internal Organisation and Profession views
 - Hide empty fields in public Organisation and Profession views
 - Replace UKCPQ text with BEIS organisation name
+- Show user's name rather than username in welcome message
 
 ## [release-007] - 2022-03-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Move registration section further down the edit page to encourage more detail elsewhere
 - Improve sidebar in the internal Organisation and Profession views
 - Hide empty fields in public Organisation and Profession views
+- Replace UKCPQ text with BEIS organisation name
 
 ## [release-007] - 2022-03-04
 

--- a/cypress/integration/application.spec.ts
+++ b/cypress/integration/application.spec.ts
@@ -13,7 +13,7 @@ describe('/', () => {
       cy.visitAndCheckAccessibility('/admin');
     });
 
-    it('shows my username', () => {
+    it('shows my name', () => {
       cy.translate('app.welcome', { name: 'beis-rpr' }).then(
         (welcomeMessage) => {
           cy.get('body').should('contain', welcomeMessage);

--- a/src/app.controller.spec.ts
+++ b/src/app.controller.spec.ts
@@ -1,6 +1,4 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { Request } from 'express';
-import { RequestContext } from 'express-openid-connect';
 
 import { AppController } from './app.controller';
 
@@ -13,21 +11,6 @@ describe('AppController', () => {
     }).compile();
 
     appController = app.get<AppController>(AppController);
-  });
-
-  describe('admin', () => {
-    it('should return the name of the logged in user', () => {
-      const oidc: Partial<RequestContext> = {
-        user: {
-          nickname: 'Nickname',
-        },
-      };
-      const request = { oidc: oidc } as Request;
-
-      expect(appController.admin(request)).toEqual({
-        name: 'Nickname',
-      });
-    });
   });
 
   describe('healthCheck', () => {

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -1,6 +1,5 @@
-import { Controller, Get, Render, Req, UseGuards } from '@nestjs/common';
+import { Controller, Get, Render, UseGuards } from '@nestjs/common';
 import { AuthenticationGuard } from './common/authentication.guard';
-import { Request } from 'express';
 @Controller()
 export class AppController {
   @Get()
@@ -12,10 +11,8 @@ export class AppController {
   @Get('/admin')
   @UseGuards(AuthenticationGuard)
   @Render('admin/dashboard')
-  admin(@Req() req: Request): object {
-    return {
-      name: req.oidc.user.nickname,
-    };
+  admin() {
+    // do nothing.
   }
 
   @Get('/health-check')

--- a/src/i18n/en/app.json
+++ b/src/i18n/en/app.json
@@ -68,7 +68,7 @@
       "heading": "Admin"
     }
   },
-  "ukcpq": "UK Centre for Professional Qualifications",
+  "beis": "Department for Business, Energy & Industrial Strategy",
   "status": {
     "live": "Published",
     "draft": "Draft",

--- a/src/organisations/admin/interfaces/index-template.interface.ts
+++ b/src/organisations/admin/interfaces/index-template.interface.ts
@@ -2,6 +2,7 @@ import { CheckboxItems } from '../../../common/interfaces/checkbox-items.interfa
 import { Table } from '../../../common/interfaces/table';
 
 export interface IndexTemplate {
+  userOrganisation: string;
   organisationsTable: Table;
 
   filters: {

--- a/src/organisations/admin/organisations.controller.spec.ts
+++ b/src/organisations/admin/organisations.controller.spec.ts
@@ -30,6 +30,7 @@ import { flashMessage } from '../../common/flash-message';
 import { createDefaultMockRequest } from '../../testutils/factories/create-default-mock-request';
 import { getActingUser } from '../../users/helpers/get-acting-user.helper';
 import { escape } from '../../helpers/escape.helper';
+import { translationOf } from '../../testutils/translation-of';
 
 jest.mock('./presenters/organisations.presenter');
 jest.mock('../presenters/organisation.presenter');
@@ -90,6 +91,7 @@ describe('OrganisationsController', () => {
           );
 
           const templateParams: IndexTemplate = {
+            userOrganisation: translationOf('app.beis'),
             organisationsTable: {
               firstCellIsHeader: true,
               head: [{ text: 'Headers' }],
@@ -130,6 +132,7 @@ describe('OrganisationsController', () => {
           } as FilterInput);
 
           expect(OrganisationsPresenter).toHaveBeenCalledWith(
+            translationOf('app.beis'),
             industries,
             {
               keywords: '',
@@ -149,6 +152,7 @@ describe('OrganisationsController', () => {
           );
 
           const templateParams: IndexTemplate = {
+            userOrganisation: translationOf('app.beis'),
             organisationsTable: {
               firstCellIsHeader: true,
               head: [{ text: 'Headers' }],
@@ -194,6 +198,7 @@ describe('OrganisationsController', () => {
           } as FilterInput);
 
           expect(OrganisationsPresenter).toHaveBeenCalledWith(
+            translationOf('app.beis'),
             industries,
             {
               keywords: 'example keywords',
@@ -208,7 +213,11 @@ describe('OrganisationsController', () => {
 
     describe('when the user is not a service owner', () => {
       it("should return template params for the user's organisation", async () => {
+        const organisations = createOrganisations();
+        const userOrganisation = organisations[0];
+
         const templateParams: IndexTemplate = {
+          userOrganisation: userOrganisation.name,
           organisationsTable: {
             firstCellIsHeader: true,
             head: [{ text: 'Headers' }],
@@ -225,10 +234,7 @@ describe('OrganisationsController', () => {
           industriesCheckboxItems: [],
         };
 
-        const organisations = createOrganisations();
         const industries = industryFactory.buildList(5);
-
-        const userOrganisation = organisations[0];
 
         const request = createDefaultMockRequest();
         (getActingUser as jest.Mock).mockReturnValue(
@@ -260,6 +266,7 @@ describe('OrganisationsController', () => {
         } as FilterInput);
 
         expect(OrganisationsPresenter).toHaveBeenCalledWith(
+          userOrganisation.name,
           industries,
           {
             keywords: '',

--- a/src/organisations/admin/organisations.controller.ts
+++ b/src/organisations/admin/organisations.controller.ts
@@ -76,19 +76,22 @@ export class OrganisationsController {
 
     const filter = query || new FilterDto();
 
-    const userOrganisation = showAllOrgs ? null : actingUser.organisation;
-
     const filterInput = createFilterInput({ ...filter, allIndustries });
 
-    if (userOrganisation) {
-      filterInput.organisations = [userOrganisation];
+    if (!showAllOrgs) {
+      filterInput.organisations = [actingUser.organisation];
     }
 
     const filteredOrganisations = new OrganisationsFilterHelper(
       allOrganisations,
     ).filter(filterInput);
 
+    const userOrganisation = showAllOrgs
+      ? await this.i18nService.translate('app.beis')
+      : actingUser.organisation.name;
+
     const presenter = new OrganisationsPresenter(
+      userOrganisation,
       allIndustries,
       filterInput,
       filteredOrganisations,

--- a/src/organisations/admin/presenters/organisations.presenter.spec.ts
+++ b/src/organisations/admin/presenters/organisations.presenter.spec.ts
@@ -56,6 +56,7 @@ describe('OrganisationsPresenter', () => {
         const filterInput: FilterInput = {};
 
         const presenter = new OrganisationsPresenter(
+          'Organisation Name',
           industries,
           filterInput,
           organisations,
@@ -68,6 +69,8 @@ describe('OrganisationsPresenter', () => {
           organisations[4],
           i18nService,
         );
+
+        expect(result.userOrganisation).toEqual('Organisation Name');
 
         expect(result.organisationsTable.firstCellIsHeader).toEqual(true);
         expect(result.organisationsTable.head).toEqual([
@@ -116,6 +119,7 @@ describe('OrganisationsPresenter', () => {
         const filterInput: FilterInput = {};
 
         const presenter = new OrganisationsPresenter(
+          'Organisation name',
           industries,
           filterInput,
           organisations,
@@ -153,6 +157,7 @@ describe('OrganisationsPresenter', () => {
         };
 
         const presenter = new OrganisationsPresenter(
+          'Organisation name',
           industries,
           filterInput,
           organisations,
@@ -198,6 +203,7 @@ describe('OrganisationsPresenter', () => {
           const foundOrganisations = organisationFactory.buildList(1);
 
           const presenter = new OrganisationsPresenter(
+            'Organisation name',
             industries,
             filterInput,
             foundOrganisations,
@@ -234,6 +240,7 @@ describe('OrganisationsPresenter', () => {
           const foundOrganisations = organisationFactory.buildList(5);
 
           const presenter = new OrganisationsPresenter(
+            'Organisation name',
             industries,
             filterInput,
             foundOrganisations,

--- a/src/organisations/admin/presenters/organisations.presenter.ts
+++ b/src/organisations/admin/presenters/organisations.presenter.ts
@@ -28,6 +28,7 @@ const fields = [
 
 export class OrganisationsPresenter {
   constructor(
+    private readonly userOrganisation: string,
     private readonly allIndustries: Industry[],
     private readonly filterInput: FilterInput,
     private readonly filteredOrganisations: Organisation[],
@@ -42,6 +43,7 @@ export class OrganisationsPresenter {
     ).checkboxItems();
 
     return {
+      userOrganisation: this.userOrganisation,
       industriesCheckboxItems,
       organisationsTable: await this.table(),
       filters: {

--- a/src/professions/admin/professions.presenter.spec.ts
+++ b/src/professions/admin/professions.presenter.spec.ts
@@ -63,10 +63,7 @@ describe('ProfessionsPresenter', () => {
   let i18nService: DeepMocked<I18nService>;
 
   beforeEach(() => {
-    i18nService = createMockI18nService({
-      'app.ukcpq': 'UK Centre for Professional Qualifications',
-    });
-
+    i18nService = createMockI18nService();
     const filterInput: FilterInput = {
       keywords: 'Nuclear',
       nations: [Nation.find('GB-ENG')],
@@ -93,7 +90,7 @@ describe('ProfessionsPresenter', () => {
 
       const expected: IndexTemplate = {
         view: 'overview',
-        organisation: 'UK Centre for Professional Qualifications',
+        organisation: translationOf('app.beis'),
         professionsTable: {
           caption: `${translationOf('professions.search.foundPlural')}`,
           captionClasses: 'govuk-table__caption--m',

--- a/src/professions/admin/professions.presenter.ts
+++ b/src/professions/admin/professions.presenter.ts
@@ -27,7 +27,7 @@ export class ProfessionsPresenter {
   async present(view: ProfessionsPresenterView): Promise<IndexTemplate> {
     const organisation =
       view === 'overview'
-        ? await this.i18nService.translate('app.ukcpq')
+        ? await this.i18nService.translate('app.beis')
         : this.userOrganisaiton.name;
 
     const nationsCheckboxItems = await new NationsCheckboxPresenter(

--- a/views/admin/dashboard.njk
+++ b/views/admin/dashboard.njk
@@ -29,7 +29,7 @@
     </nav>
   </div>
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l">{{ "app.welcome" | t({name: name}) }}</h1>
+    <h1 class="govuk-heading-l">{{ "app.welcome" | t({name: user.name}) }}</h1>
   </div>
 </div>
 {% endblock %}

--- a/views/admin/organisations/index.njk
+++ b/views/admin/organisations/index.njk
@@ -7,6 +7,7 @@
 
 {% block content %}
   <h1 class="govuk-heading-xl">
+    <span class="govuk-caption-l">{{ userOrganisation }}</span>
     {{ title }}
   </h1>
 


### PR DESCRIPTION
# Changes in this PR

- Removes UKCPQ name for organisations when logged in
- Uses user's name rather than username on welcome screen
- Adds user's organisation (or BEIS) to regulated authority index

## Screenshots of UI changes

### Before

#### UKCPQ displaying for BEIS user

![image](https://user-images.githubusercontent.com/19826940/157457447-24a436d3-b0ca-419f-b2c4-b85e36829729.png)

#### Username shown on welcome page

![image](https://user-images.githubusercontent.com/19826940/157476274-d24cbebd-b4c5-4231-be2c-05c5ec67c0bb.png)

#### No org name on organisations index page

![image](https://user-images.githubusercontent.com/19826940/157476785-47a526b4-18c1-4a52-bc04-e7d22440b334.png)


### After

#### No more UKCPQ

![image](https://user-images.githubusercontent.com/19826940/157457709-f7caf915-ef08-49dd-bdf2-8f214a1d4d61.png)

#### User's name shown on welcome page

![image](https://user-images.githubusercontent.com/19826940/157476309-2c1abb28-fa4f-4eed-9fa8-e733e2b93b99.png)

#### Display Org user's org name on Organisations index

![image](https://user-images.githubusercontent.com/19826940/157476951-9141a80a-959f-456e-b487-01bf0001d8c1.png)

#### Display Org name for BEIS user on Organisations index

![image](https://user-images.githubusercontent.com/19826940/157476027-4f3e92c3-a7fb-41f3-93c6-588322d86b5c.png)
