### PR TITLE
(2244) Hide the overseas qualification fields for initial onboarding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Hide empty fields in public Organisation and Profession views
 - Replace UKCPQ text with BEIS organisation name
 - Show user's name rather than username in welcome message
+- Display additional UK qualification data where the Profession itself is not a whole-UK Profession
+- Remove non-UK qualification data
 
 ## [release-007] - 2022-03-04
 

--- a/cypress/integration/admin/professions/edit.spec.ts
+++ b/cypress/integration/admin/professions/edit.spec.ts
@@ -286,9 +286,7 @@ describe('Editing an existing profession', () => {
 
       cy.translate('professions.form.label.qualifications.ukRecognition').then(
         (ukRecognition) => {
-          cy.contains('.govuk-summary-list__row', ukRecognition).should(
-            'be.visible',
-          );
+          cy.get('body').should('not.contain', ukRecognition);
         },
       );
 

--- a/cypress/integration/admin/professions/edit.spec.ts
+++ b/cypress/integration/admin/professions/edit.spec.ts
@@ -434,6 +434,9 @@ describe('Editing an existing profession', () => {
           'http://example.com/more-info',
         );
 
+        cy.get('input[name="ukRecognition"]').type('Recognition in UK');
+        cy.get('input[name="ukRecognitionUrl"]').type('http://example.com/uk');
+
         cy.get('input[name="otherCountriesRecognition"]').type(
           'Recognition in other countries',
         );
@@ -451,10 +454,17 @@ describe('Editing an existing profession', () => {
           'professions.form.label.qualifications.routesToObtain',
           'General secondary education',
         );
-
         cy.checkSummaryListRowValue(
           'professions.form.label.qualifications.moreInformationUrl',
           'http://example.com/more-info',
+        );
+        cy.checkSummaryListRowValue(
+          'professions.form.label.qualifications.ukRecognition',
+          'Recognition in UK',
+        );
+        cy.checkSummaryListRowValue(
+          'professions.form.label.qualifications.ukRecognitionUrl',
+          'http://example.com/uk',
         );
 
         cy.translate('professions.form.button.saveAsDraft').then(

--- a/cypress/integration/admin/professions/edit.spec.ts
+++ b/cypress/integration/admin/professions/edit.spec.ts
@@ -437,13 +437,6 @@ describe('Editing an existing profession', () => {
         cy.get('input[name="ukRecognition"]').type('Recognition in UK');
         cy.get('input[name="ukRecognitionUrl"]').type('http://example.com/uk');
 
-        cy.get('input[name="otherCountriesRecognition"]').type(
-          'Recognition in other countries',
-        );
-        cy.get('input[name="otherCountriesRecognitionUrl"]').type(
-          'http://example.com/other',
-        );
-
         cy.translate('app.continue').then((buttonText) => {
           cy.get('button').contains(buttonText).click();
         });

--- a/cypress/integration/admin/professions/new.spec.ts
+++ b/cypress/integration/admin/professions/new.spec.ts
@@ -157,12 +157,6 @@ describe('Adding a new profession', () => {
 
       cy.get('input[name="ukRecognition"]').type('Recognition in the UK');
       cy.get('input[name="ukRecognitionUrl"]').type('http://example.com/uk');
-      cy.get('input[name="otherCountriesRecognition"]').type(
-        'Recognition in other countries',
-      );
-      cy.get('input[name="otherCountriesRecognitionUrl"]').type(
-        'http://example.com/other',
-      );
 
       cy.translate('app.continue').then((buttonText) => {
         cy.get('button').contains(buttonText).click();
@@ -267,14 +261,6 @@ describe('Adding a new profession', () => {
       cy.checkSummaryListRowValue(
         'professions.form.label.qualifications.ukRecognitionUrl',
         'http://example.com/uk',
-      );
-      cy.checkSummaryListRowValue(
-        'professions.form.label.qualifications.otherCountriesRecognition',
-        'Recognition in other countries',
-      );
-      cy.checkSummaryListRowValue(
-        'professions.form.label.qualifications.otherCountriesRecognitionUrl',
-        'http://example.com/other',
       );
 
       cy.checkSummaryListRowValue(

--- a/cypress/integration/admin/professions/publish.spec.ts
+++ b/cypress/integration/admin/professions/publish.spec.ts
@@ -351,12 +351,6 @@ describe('Publishing professions', () => {
 
       cy.get('input[name="ukRecognition"]').type('Recognition in the UK');
       cy.get('input[name="ukRecognitionUrl"]').type('http://example.com/uk');
-      cy.get('input[name="otherCountriesRecognition"]').type(
-        'Recognition in other countries',
-      );
-      cy.get('input[name="otherCountriesRecognitionUrl"]').type(
-        'http://example.com/other',
-      );
 
       cy.translate('app.continue').then((buttonText) => {
         cy.get('button').contains(buttonText).click();

--- a/cypress/integration/admin/professions/show.spec.ts
+++ b/cypress/integration/admin/professions/show.spec.ts
@@ -222,6 +222,10 @@ describe('Listing professions', () => {
         'professions.show.qualification.routesToObtain',
         'General post-secondary education',
       );
+      cy.checkSummaryListRowValue(
+        'professions.show.qualification.moreInformationUrl',
+        '',
+      );
 
       cy.translate('professions.show.legislation.heading').then((heading) => {
         cy.get('body').should('contain', heading);

--- a/cypress/integration/professions/show.spec.ts
+++ b/cypress/integration/professions/show.spec.ts
@@ -209,6 +209,11 @@ describe('Showing a profession', () => {
       'professions.show.qualification.routesToObtain',
       'General post-secondary education',
     );
+    cy.translate('professions.show.qualification.moreInformationUrl').then(
+      (moreInformationUrl) => {
+        cy.get('body').should('not.contain', moreInformationUrl);
+      },
+    );
 
     cy.translate('professions.show.legislation.heading').then((heading) => {
       cy.get('body').should('contain', heading);

--- a/seeds/development/professions.json
+++ b/seeds/development/professions.json
@@ -80,7 +80,7 @@
       {
         "alternateName": "Orthodontic Auxiliary",
         "description": "Orthodontic therapists are registered dental professionals who carry out certain parts of orthodontic treatment under prescription from a dentist.",
-        "occupationLocations": ["GB-ENG", "GB-SCT", "GB-WLS", "GB-NIR"],
+        "occupationLocations": ["GB-ENG", "GB-SCT"],
         "regulationType": "licensing",
         "industries": ["industries.health"],
         "reservedActivities": "",

--- a/seeds/test/professions.json
+++ b/seeds/test/professions.json
@@ -80,7 +80,7 @@
       {
         "alternateName": "Orthodontic Auxiliary",
         "description": "Orthodontic therapists are registered dental professionals who carry out certain parts of orthodontic treatment under prescription from a dentist.",
-        "occupationLocations": ["GB-ENG", "GB-SCT", "GB-WLS", "GB-NIR"],
+        "occupationLocations": ["GB-ENG", "GB-SCT"],
         "regulationType": "licensing",
         "industries": ["industries.health"],
         "reservedActivities": "",

--- a/src/db/migrate/1646841929408-RemoveOtherCountriesFromQualifications.ts
+++ b/src/db/migrate/1646841929408-RemoveOtherCountriesFromQualifications.ts
@@ -1,0 +1,25 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class RemoveOtherCountriesFromQualifications1646841929408
+  implements MigrationInterface
+{
+  name = 'RemoveOtherCountriesFromQualifications1646841929408';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "qualifications" DROP COLUMN "otherCountriesRecognition"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "qualifications" DROP COLUMN "otherCountriesRecognitionUrl"`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "qualifications" ADD "otherCountriesRecognitionUrl" character varying`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "qualifications" ADD "otherCountriesRecognition" character varying`,
+    );
+  }
+}

--- a/src/i18n/en/professions.json
+++ b/src/i18n/en/professions.json
@@ -62,11 +62,7 @@
         "ukRecognition": "Recognition of qualifications in the UK (optional)",
         "ukRecognitionHint": "Routes to recognition for existing professionals from other UK nations",
         "ukRecognitionUrl": "More about recognition within the UK (optional)",
-        "ukRecognitionUrlHint": "Website link to more information",
-        "otherCountriesRecognition": "Recognition of qualifications from other countries (optional)",
-        "otherCountriesRecognitionHint": "Routes to recognition for existing professionals from outside the UK",
-        "otherCountriesRecognitionUrl": "More about recognition from other countries (optional)",
-        "otherCountriesRecognitionUrlHint": "Website link to more information"
+        "ukRecognitionUrlHint": "Website link to more information"
       },
       "legislation": {
         "nationalLegislation": "Legislation title",
@@ -136,9 +132,6 @@
           "invalid": "Please enter a valid website address"
         },
         "ukRecognitionUrl": {
-          "invalid": "Please enter a valid website address"
-        },
-        "otherCountriesRecognitionUrl": {
           "invalid": "Please enter a valid website address"
         }
       },

--- a/src/i18n/en/professions.json
+++ b/src/i18n/en/professions.json
@@ -183,7 +183,9 @@
     "qualification": {
       "heading": "Qualification information",
       "routesToObtain": "Routes to qualification",
-      "moreInformationUrl": "More about qualification"
+      "moreInformationUrl": "More about qualification",
+      "ukRecognition": "Recognition of qualifications in the UK",
+      "ukRecognitionUrl": "More about recognition within the UK"
     },
     "legislation": {
       "heading": "Legislation",

--- a/src/i18n/en/professions.json
+++ b/src/i18n/en/professions.json
@@ -59,8 +59,8 @@
         "routesToObtainHint": "The ways that a new professional can become qualified",
         "moreInformationUrl": "More about qualification (optional)",
         "moreInformationUrlHint": "Website link to more information",
-        "ukRecognition": "Recognition of qualifications in the UK (optional)",
-        "ukRecognitionHint": "Routes to recognition for existing professionals from other UK nations",
+        "ukRecognition": "Routes to recognition within the UK (optional)",
+        "ukRecognitionHint": "Routes for professionals who practise a corresponding profession that is regulated differently in other parts of the UK",
         "ukRecognitionUrl": "More about recognition within the UK (optional)",
         "ukRecognitionUrlHint": "Website link to more information"
       },
@@ -177,7 +177,7 @@
       "heading": "Qualification information",
       "routesToObtain": "Routes to qualification",
       "moreInformationUrl": "More about qualification",
-      "ukRecognition": "Recognition of qualifications in the UK",
+      "ukRecognition": "Routes to recognition within the UK",
       "ukRecognitionUrl": "More about recognition within the UK"
     },
     "legislation": {

--- a/src/professions/admin/dto/qualifications.dto.ts
+++ b/src/professions/admin/dto/qualifications.dto.ts
@@ -28,16 +28,6 @@ export class QualificationsDto {
   @ValidateIf((e) => e.ukRecognitionUrl)
   ukRecognitionUrl: string;
 
-  otherCountriesRecognition: string;
-
-  @IsUrl(urlOptions, {
-    message:
-      'professions.form.errors.qualification.otherCountriesRecognitionUrl.invalid',
-  })
-  @Transform(({ value }) => preprocessUrl(value))
-  @ValidateIf((e) => e.otherCountriesRecognitionUrl)
-  otherCountriesRecognitionUrl: string;
-
   @Transform(({ value }) => parseBoolean(value))
   change: boolean;
 }

--- a/src/professions/admin/interfaces/qualifications.template.ts
+++ b/src/professions/admin/interfaces/qualifications.template.ts
@@ -3,8 +3,6 @@ export interface QualificationsTemplate {
   moreInformationUrl: string;
   ukRecognition: string;
   ukRecognitionUrl: string;
-  otherCountriesRecognition: string;
-  otherCountriesRecognitionUrl: string;
   captionText: string;
   isUK: boolean;
   change: boolean;

--- a/src/professions/admin/profession-versions.controller.spec.ts
+++ b/src/professions/admin/profession-versions.controller.spec.ts
@@ -134,7 +134,7 @@ describe('ProfessionVersionsController', () => {
             qualificationSummaryList: await new QualificationPresenter(
               professionWithVersion.qualification,
               createMockI18nService(),
-            ).summaryList(true),
+            ).summaryList(true, true),
             nations: ['Translation of `nations.england`'],
             industries: ['Translation of `industries.example`'],
             organisations: [profession.organisation],
@@ -194,7 +194,7 @@ describe('ProfessionVersionsController', () => {
             qualificationSummaryList: await new QualificationPresenter(
               professionWithVersion.qualification,
               createMockI18nService(),
-            ).summaryList(true),
+            ).summaryList(true, true),
             nations: ['Translation of `nations.england`'],
             industries: ['Translation of `industries.example`'],
             organisations: [
@@ -252,7 +252,7 @@ describe('ProfessionVersionsController', () => {
           qualificationSummaryList: await new QualificationPresenter(
             professionWithVersion.qualification,
             createMockI18nService(),
-          ).summaryList(true),
+          ).summaryList(true, true),
           nations: [translationOf('nations.england')],
           industries: [translationOf('industries.example')],
           organisations: [profession.organisation],
@@ -300,9 +300,9 @@ describe('ProfessionVersionsController', () => {
           presenter: {},
           hasLiveVersion: true,
           qualificationSummaryList: await new QualificationPresenter(
-            null,
+            undefined,
             createMockI18nService(),
-          ).summaryList(true),
+          ).summaryList(true, true),
           nations: [],
           industries: [],
           organisations: [profession.organisation],

--- a/src/professions/admin/profession-versions.controller.ts
+++ b/src/professions/admin/profession-versions.controller.ts
@@ -25,6 +25,7 @@ import { ProfessionPresenter } from '../presenters/profession.presenter';
 import { getActingUser } from '../../users/helpers/get-acting-user.helper';
 import { getOrganisationsFromProfession } from '../helpers/get-organisations-from-profession.helper';
 import { ShowTemplate } from './interfaces/show-template.interface';
+import { isUK } from '../../helpers/nations.helper';
 
 @UseGuards(AuthenticationGuard)
 @Controller('/admin/professions')
@@ -89,7 +90,12 @@ export class ProfessionVersionsController {
       profession,
       presenter,
       hasLiveVersion,
-      qualificationSummaryList: await qualification.summaryList(true),
+      qualificationSummaryList: await qualification.summaryList(
+        true,
+        profession.occupationLocations
+          ? !isUK(profession.occupationLocations)
+          : true,
+      ),
       nations,
       industries,
       organisations,

--- a/src/professions/admin/qualifications.controller.spec.ts
+++ b/src/professions/admin/qualifications.controller.spec.ts
@@ -73,10 +73,6 @@ describe(QualificationsController, () => {
             captionText: translationOf('professions.form.captions.edit'),
             ukRecognition: profession.qualification.ukRecognition,
             ukRecognitionUrl: profession.qualification.ukRecognitionUrl,
-            otherCountriesRecognition:
-              profession.qualification.otherCountriesRecognition,
-            otherCountriesRecognitionUrl:
-              profession.qualification.otherCountriesRecognitionUrl,
             isUK: false,
           }),
         );
@@ -113,8 +109,6 @@ describe(QualificationsController, () => {
             captionText: translationOf('professions.form.captions.edit'),
             ukRecognition: undefined,
             ukRecognitionUrl: undefined,
-            otherCountriesRecognition: undefined,
-            otherCountriesRecognitionUrl: undefined,
             isUK: false,
           }),
         );
@@ -139,8 +133,6 @@ describe(QualificationsController, () => {
             moreInformationUrl: 'http://www.example.com/more-info',
             ukRecognition: 'ukRecognition',
             ukRecognitionUrl: 'http://example.com/uk',
-            otherCountriesRecognition: 'otherCountriesRecognition',
-            otherCountriesRecognitionUrl: 'http://example.com/other',
             change: false,
           };
 
@@ -158,8 +150,6 @@ describe(QualificationsController, () => {
                 url: 'http://www.example.com/more-info',
                 ukRecognition: 'ukRecognition',
                 ukRecognitionUrl: 'http://example.com/uk',
-                otherCountriesRecognition: 'otherCountriesRecognition',
-                otherCountriesRecognitionUrl: 'http://example.com/other',
               }),
             }),
           );
@@ -185,8 +175,6 @@ describe(QualificationsController, () => {
             moreInformationUrl: 'http://www.example.com/more-info',
             ukRecognition: 'ukRecognition',
             ukRecognitionUrl: 'http://example.com/uk',
-            otherCountriesRecognition: 'otherCountriesRecognition',
-            otherCountriesRecognitionUrl: 'http://example.com/other',
             change: true,
           };
 
@@ -204,8 +192,6 @@ describe(QualificationsController, () => {
                 url: 'http://www.example.com/more-info',
                 ukRecognition: 'ukRecognition',
                 ukRecognitionUrl: 'http://example.com/uk',
-                otherCountriesRecognition: 'otherCountriesRecognition',
-                otherCountriesRecognitionUrl: 'http://example.com/other',
               }),
             }),
           );
@@ -232,8 +218,6 @@ describe(QualificationsController, () => {
           moreInformationUrl: 'www.example.com/more-info ',
           ukRecognition: 'ukRecognition',
           ukRecognitionUrl: 'example.com/uk',
-          otherCountriesRecognition: 'otherCountriesRecognition',
-          otherCountriesRecognitionUrl: '\nhttp://example.com/other',
           change: true,
         };
 
@@ -249,8 +233,6 @@ describe(QualificationsController, () => {
               url: 'http://www.example.com/more-info',
               ukRecognition: 'ukRecognition',
               ukRecognitionUrl: 'http://example.com/uk',
-              otherCountriesRecognition: 'otherCountriesRecognition',
-              otherCountriesRecognitionUrl: 'http://example.com/other',
             }),
           }),
         );
@@ -277,8 +259,6 @@ describe(QualificationsController, () => {
           change: false,
           ukRecognition: '',
           ukRecognitionUrl: 'not a url',
-          otherCountriesRecognition: '',
-          otherCountriesRecognitionUrl: 'not a url',
         };
 
         professionsService.findWithVersions.mockResolvedValue(profession);
@@ -300,9 +280,6 @@ describe(QualificationsController, () => {
               },
               ukRecognitionUrl: {
                 text: 'professions.form.errors.qualification.ukRecognitionUrl.invalid',
-              },
-              otherCountriesRecognitionUrl: {
-                text: 'professions.form.errors.qualification.otherCountriesRecognitionUrl.invalid',
               },
             },
           }),

--- a/src/professions/admin/qualifications.controller.ts
+++ b/src/professions/admin/qualifications.controller.ts
@@ -99,9 +99,6 @@ export class QualificationsController {
         url: submittedValues.moreInformationUrl,
         ukRecognition: submittedValues.ukRecognition,
         ukRecognitionUrl: submittedValues.ukRecognitionUrl,
-        otherCountriesRecognition: submittedValues.otherCountriesRecognition,
-        otherCountriesRecognitionUrl:
-          submittedValues.otherCountriesRecognitionUrl,
       },
     };
 
@@ -147,8 +144,6 @@ export class QualificationsController {
       captionText: await ViewUtils.captionText(this.i18nService, profession),
       ukRecognition: qualification?.ukRecognition,
       ukRecognitionUrl: qualification?.ukRecognitionUrl,
-      otherCountriesRecognition: qualification?.otherCountriesRecognition,
-      otherCountriesRecognitionUrl: qualification?.otherCountriesRecognitionUrl,
       isUK: version.occupationLocations
         ? isUK(version.occupationLocations)
         : false,

--- a/src/professions/professions.controller.spec.ts
+++ b/src/professions/professions.controller.spec.ts
@@ -77,7 +77,7 @@ describe('ProfessionsController', () => {
           qualificationSummaryList: await new QualificationPresenter(
             profession.qualification,
             createMockI18nService(),
-          ).summaryList(false),
+          ).summaryList(false, true),
           nations: [translationOf('nations.england')],
           industries: [translationOf('industries.example')],
           organisations: [profession.organisation],
@@ -119,7 +119,7 @@ describe('ProfessionsController', () => {
           qualificationSummaryList: await new QualificationPresenter(
             profession.qualification,
             createMockI18nService(),
-          ).summaryList(false),
+          ).summaryList(false, true),
           nations: [translationOf('nations.england')],
           industries: [translationOf('industries.example')],
           organisations: [

--- a/src/professions/professions.controller.ts
+++ b/src/professions/professions.controller.ts
@@ -13,6 +13,7 @@ import { BackLink } from '../common/decorators/back-link.decorator';
 import { Organisation } from '../organisations/organisation.entity';
 import { ProfessionVersionsService } from './profession-versions.service';
 import { getOrganisationsFromProfession } from './helpers/get-organisations-from-profession.helper';
+import { isUK } from '../helpers/nations.helper';
 
 @Controller()
 export class ProfessionsController {
@@ -58,7 +59,12 @@ export class ProfessionsController {
     return {
       profession,
       qualificationSummaryList: qualification
-        ? await qualification.summaryList(false)
+        ? await qualification.summaryList(
+            false,
+            profession.occupationLocations
+              ? !isUK(profession.occupationLocations)
+              : true,
+          )
         : null,
       nations,
       industries,

--- a/src/qualifications/presenters/qualification.presenter.spec.ts
+++ b/src/qualifications/presenters/qualification.presenter.spec.ts
@@ -90,40 +90,113 @@ describe(QualificationPresenter, () => {
 
     describe('summaryList', () => {
       describe('when a Qualification has all fields', () => {
-        it('returns a summary list of all Qualification fields', async () => {
-          const qualification = qualificationFactory.build({
-            otherCountriesRecognitionUrl: 'http://example.com',
+        describe('when the Qualifications are from a UK profession', () => {
+          it('returns a summary list of all relevant Qualification fields', async () => {
+            (formatMultilineString as jest.Mock).mockImplementation(
+              multilineOf,
+            );
+            (formatLink as jest.Mock).mockImplementation((link) =>
+              link ? linkOf(link) : '',
+            );
+
+            const qualification = qualificationFactory.build();
+
+            const presenter = new QualificationPresenter(
+              qualification,
+              createMockI18nService(),
+            );
+
+            await expect(presenter.summaryList(true, false)).resolves.toEqual({
+              classes: 'govuk-summary-list--no-border',
+              rows: [
+                {
+                  key: {
+                    text: translationOf(
+                      'professions.show.qualification.routesToObtain',
+                    ),
+                  },
+                  value: {
+                    html: presenter.routesToObtain,
+                  },
+                },
+                {
+                  key: {
+                    text: translationOf(
+                      'professions.show.qualification.moreInformationUrl',
+                    ),
+                  },
+                  value: {
+                    html: presenter.moreInformationUrl,
+                  },
+                },
+              ],
+            });
           });
+        });
+        describe('when the Qualifications are from a non-UK profession', () => {
+          it('returns a summary list of all relevant Qualification fields', async () => {
+            (formatMultilineString as jest.Mock).mockImplementation(
+              multilineOf,
+            );
+            (formatLink as jest.Mock).mockImplementation((link) =>
+              link ? linkOf(link) : '',
+            );
 
-          const presenter = new QualificationPresenter(
-            qualification,
-            createMockI18nService(),
-          );
+            const qualification = qualificationFactory.build({
+              ukRecognition: 'UK recognition',
+              ukRecognitionUrl: 'http://example.com/uk',
+            });
 
-          await expect(presenter.summaryList(true)).resolves.toEqual({
-            classes: 'govuk-summary-list--no-border',
-            rows: [
-              {
-                key: {
-                  text: translationOf(
-                    'professions.show.qualification.routesToObtain',
-                  ),
+            const presenter = new QualificationPresenter(
+              qualification,
+              createMockI18nService(),
+            );
+
+            await expect(presenter.summaryList(true, true)).resolves.toEqual({
+              classes: 'govuk-summary-list--no-border',
+              rows: [
+                {
+                  key: {
+                    text: translationOf(
+                      'professions.show.qualification.routesToObtain',
+                    ),
+                  },
+                  value: {
+                    html: presenter.routesToObtain,
+                  },
                 },
-                value: {
-                  html: presenter.routesToObtain,
+                {
+                  key: {
+                    text: translationOf(
+                      'professions.show.qualification.moreInformationUrl',
+                    ),
+                  },
+                  value: {
+                    html: presenter.moreInformationUrl,
+                  },
                 },
-              },
-              {
-                key: {
-                  text: translationOf(
-                    'professions.show.qualification.moreInformationUrl',
-                  ),
+                {
+                  key: {
+                    text: translationOf(
+                      'professions.show.qualification.ukRecognition',
+                    ),
+                  },
+                  value: {
+                    text: presenter.ukRecognition,
+                  },
                 },
-                value: {
-                  html: presenter.moreInformationUrl,
+                {
+                  key: {
+                    text: translationOf(
+                      'professions.show.qualification.ukRecognitionUrl',
+                    ),
+                  },
+                  value: {
+                    html: presenter.ukRecognitionUrl,
+                  },
                 },
-              },
-            ],
+              ],
+            });
           });
         });
       });
@@ -131,8 +204,14 @@ describe(QualificationPresenter, () => {
       describe('when a Qualification is missing fields', () => {
         describe('when `showEmptyFields` is true', () => {
           it('returns a summary list of all Qualification fields', async () => {
+            (formatMultilineString as jest.Mock).mockImplementation(
+              multilineOf,
+            );
+            (formatLink as jest.Mock).mockImplementation((link) =>
+              link ? linkOf(link) : '',
+            );
+
             const qualification = qualificationFactory.build({
-              otherCountriesRecognitionUrl: 'http://example.com',
               url: '',
             });
 
@@ -141,7 +220,7 @@ describe(QualificationPresenter, () => {
               createMockI18nService(),
             );
 
-            await expect(presenter.summaryList(true)).resolves.toEqual({
+            await expect(presenter.summaryList(true, false)).resolves.toEqual({
               classes: 'govuk-summary-list--no-border',
               rows: [
                 {
@@ -170,8 +249,14 @@ describe(QualificationPresenter, () => {
         });
         describe('when `showEmptyFields` is false', () => {
           it('returns a summary list of all non-empty Qualification fields', async () => {
+            (formatMultilineString as jest.Mock).mockImplementation(
+              multilineOf,
+            );
+            (formatLink as jest.Mock).mockImplementation((link) =>
+              link ? linkOf(link) : '',
+            );
+
             const qualification = qualificationFactory.build({
-              otherCountriesRecognitionUrl: 'http://example.com',
               url: '',
             });
 
@@ -180,7 +265,7 @@ describe(QualificationPresenter, () => {
               createMockI18nService(),
             );
 
-            await expect(presenter.summaryList(false)).resolves.toEqual({
+            await expect(presenter.summaryList(false, false)).resolves.toEqual({
               classes: 'govuk-summary-list--no-border',
               rows: [
                 {
@@ -193,7 +278,6 @@ describe(QualificationPresenter, () => {
                     html: presenter.routesToObtain,
                   },
                 },
-                undefined,
               ],
             });
           });

--- a/src/qualifications/presenters/qualification.presenter.spec.ts
+++ b/src/qualifications/presenters/qualification.presenter.spec.ts
@@ -69,25 +69,6 @@ describe(QualificationPresenter, () => {
       });
     });
 
-    describe('otherCountriesRecognitionUrl', () => {
-      it('returns a link', () => {
-        (formatLink as jest.Mock).mockImplementation(linkOf);
-
-        const qualification = qualificationFactory.build({
-          otherCountriesRecognitionUrl: 'http://example.com',
-        });
-
-        const presenter = new QualificationPresenter(
-          qualification,
-          createMockI18nService(),
-        );
-
-        expect(presenter.otherCountriesRecognitionUrl).toEqual(
-          linkOf('http://example.com'),
-        );
-      });
-    });
-
     describe('summaryList', () => {
       describe('when a Qualification has all fields', () => {
         describe('when the Qualifications are from a UK profession', () => {
@@ -297,8 +278,6 @@ describe(QualificationPresenter, () => {
         expect.objectContaining({
           routesToObtain: multilineOf(undefined),
           moreInformationUrl: linkOf(undefined),
-          otherCountriesRecognition: undefined,
-          otherCountriesRecognitionUrl: linkOf(undefined),
           qualification: undefined,
           ukRecognition: undefined,
           ukRecognitionUrl: linkOf(undefined),

--- a/src/qualifications/presenters/qualification.presenter.ts
+++ b/src/qualifications/presenters/qualification.presenter.ts
@@ -31,33 +31,71 @@ export default class QualificationPresenter {
     this.qualification && this.qualification.otherCountriesRecognitionUrl,
   );
 
-  async summaryList(showEmptyFields: boolean): Promise<SummaryList> {
-    return {
+  async summaryList(
+    showEmptyFields: boolean,
+    showUKRecognitionFields: boolean,
+  ): Promise<SummaryList> {
+    const summaryList: SummaryList = {
       classes: 'govuk-summary-list--no-border',
-      rows: [
-        {
-          key: {
-            text: await this.i18nService.translate(
-              'professions.show.qualification.routesToObtain',
-            ),
-          },
-          value: {
-            html: this.routesToObtain,
-          },
-        },
-        showEmptyFields || this.moreInformationUrl
-          ? {
-              key: {
-                text: await this.i18nService.translate(
-                  'professions.show.qualification.moreInformationUrl',
-                ),
-              },
-              value: {
-                html: this.moreInformationUrl,
-              },
-            }
-          : undefined,
-      ],
+      rows: [],
     };
+
+    if (showEmptyFields || this.routesToObtain) {
+      await this.addHtmlRow(
+        summaryList,
+        'professions.show.qualification.routesToObtain',
+        this.routesToObtain,
+      );
+    }
+
+    if (showEmptyFields || this.moreInformationUrl) {
+      await this.addHtmlRow(
+        summaryList,
+        'professions.show.qualification.moreInformationUrl',
+        this.moreInformationUrl,
+      );
+    }
+
+    if (showUKRecognitionFields) {
+      if (showEmptyFields || this.ukRecognition) {
+        await this.addTextRow(
+          summaryList,
+          'professions.show.qualification.ukRecognition',
+          this.ukRecognition,
+        );
+      }
+
+      if (showEmptyFields || this.ukRecognitionUrl) {
+        await this.addHtmlRow(
+          summaryList,
+          'professions.show.qualification.ukRecognitionUrl',
+          this.ukRecognitionUrl,
+        );
+      }
+    }
+
+    return summaryList;
+  }
+
+  private async addTextRow(
+    summaryList: SummaryList,
+    key: string,
+    value: string,
+  ): Promise<void> {
+    summaryList.rows.push({
+      key: { text: await this.i18nService.translate(key) },
+      value: { text: value },
+    });
+  }
+
+  private async addHtmlRow(
+    summaryList: SummaryList,
+    key: string,
+    value: string,
+  ): Promise<void> {
+    summaryList.rows.push({
+      key: { text: await this.i18nService.translate(key) },
+      value: { html: value },
+    });
   }
 }

--- a/src/qualifications/presenters/qualification.presenter.ts
+++ b/src/qualifications/presenters/qualification.presenter.ts
@@ -24,13 +24,6 @@ export default class QualificationPresenter {
     this.qualification && this.qualification.ukRecognitionUrl,
   );
 
-  readonly otherCountriesRecognition =
-    this.qualification && this.qualification.otherCountriesRecognition;
-
-  readonly otherCountriesRecognitionUrl = formatLink(
-    this.qualification && this.qualification.otherCountriesRecognitionUrl,
-  );
-
   async summaryList(
     showEmptyFields: boolean,
     showUKRecognitionFields: boolean,

--- a/src/qualifications/qualification.entity.ts
+++ b/src/qualifications/qualification.entity.ts
@@ -23,12 +23,6 @@ export class Qualification {
   @Column({ nullable: true })
   ukRecognitionUrl: string;
 
-  @Column({ nullable: true })
-  otherCountriesRecognition: string;
-
-  @Column({ nullable: true })
-  otherCountriesRecognitionUrl: string;
-
   @CreateDateColumn({
     type: 'timestamp',
     default: () => 'CURRENT_TIMESTAMP(6)',
@@ -47,14 +41,10 @@ export class Qualification {
     url?: string,
     ukRecognition?: string,
     ukRecognitionUrl?: string,
-    otherCountriesRecognition?: string,
-    otherCountriesRecognitionUrl?: string,
   ) {
     this.routesToObtain = routesToObtain || '';
     this.url = url || '';
     this.ukRecognition = ukRecognition || '';
     this.ukRecognitionUrl = ukRecognitionUrl || '';
-    this.otherCountriesRecognition = otherCountriesRecognition || '';
-    this.otherCountriesRecognitionUrl = otherCountriesRecognitionUrl || '';
   }
 }

--- a/src/testutils/factories/qualification.ts
+++ b/src/testutils/factories/qualification.ts
@@ -3,7 +3,7 @@ import { Qualification } from '../../qualifications/qualification.entity';
 
 export default Factory.define<Qualification>(({ sequence }) => ({
   id: sequence.toString(),
-  routesToObtain: '',
+  routesToObtain: 'Routes to obtain',
   url: 'http://www.example.com',
   professionVersion: undefined,
   ukRecognition: undefined,

--- a/src/testutils/factories/qualification.ts
+++ b/src/testutils/factories/qualification.ts
@@ -8,8 +8,6 @@ export default Factory.define<Qualification>(({ sequence }) => ({
   professionVersion: undefined,
   ukRecognition: undefined,
   ukRecognitionUrl: undefined,
-  otherCountriesRecognition: undefined,
-  otherCountriesRecognitionUrl: undefined,
   created_at: new Date(),
   updated_at: new Date(),
 }));

--- a/views/admin/professions/check-your-answers.njk
+++ b/views/admin/professions/check-your-answers.njk
@@ -257,7 +257,6 @@
                 }
               },
               {
-                classes: ("govuk-visually-hidden" if isUK else ""),
                 key: {
                   text: ("professions.form.label.qualifications.ukRecognition" | t)
                 },
@@ -273,9 +272,8 @@
                     }
                   ]
                 }
-              },
+              } if not isUK else undefined,
               {
-                classes: ("govuk-visually-hidden" if isUK else ""),
                 key: {
                   text: ("professions.form.label.qualifications.ukRecognitionUrl" | t)
                 },
@@ -291,7 +289,7 @@
                     }
                   ]
                 }
-              }
+              } if not isUK else undefined
             ]
           })
         }}

--- a/views/admin/professions/check-your-answers.njk
+++ b/views/admin/professions/check-your-answers.njk
@@ -291,40 +291,6 @@
                     }
                   ]
                 }
-              },
-              {
-                key: {
-                  text: ("professions.form.label.qualifications.otherCountriesRecognition" | t)
-                },
-                value: {
-                  text: qualification.otherCountriesRecognition
-                },
-                actions: {
-                  items: [
-                    {
-                      href: "/admin/professions/" + professionId + "/versions/" + versionId + "/qualifications/edit?change=true",
-                      text: ("app.change" | t),
-                      visuallyHiddenText: ("professions.form.label.qualifications.otherCountriesRecognition" | t)
-                    }
-                  ]
-                }
-              },
-              {
-                key: {
-                  text: ("professions.form.label.qualifications.otherCountriesRecognitionUrl" | t)
-                },
-                value: {
-                  html: qualification.otherCountriesRecognitionUrl
-                },
-                actions: {
-                  items: [
-                    {
-                      href: "/admin/professions/" + professionId + "/versions/" + versionId + "/qualifications/edit?change=true",
-                      text: ("app.change" | t),
-                      visuallyHiddenText: ("professions.form.label.qualifications.otherCountriesRecognitionUrl" | t)
-                    }
-                  ]
-                }
               }
             ]
           })

--- a/views/admin/professions/qualifications.njk
+++ b/views/admin/professions/qualifications.njk
@@ -90,40 +90,6 @@
 
         {% endif %}
 
-        <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible" />
-
-        {{
-          govukInput({
-            label: {
-              text: ("professions.form.label.qualifications.otherCountriesRecognition" | t),
-              classes: "govuk-label--m"
-            },
-            id: "otherCountriesRecognition",
-            name: "otherCountriesRecognition",
-            value: otherCountriesRecognition,
-            hint: {
-              text: ("professions.form.label.qualifications.otherCountriesRecognitionHint" | t)
-            },
-            errorMessage: errors.otherCountriesRecognition | tError
-          })
-        }}
-
-        {{
-          govukInput({
-            label: {
-              text: ("professions.form.label.qualifications.otherCountriesRecognitionUrl" | t),
-              classes: "govuk-label--m"
-            },
-            id: "otherCountriesRecognitionUrl",
-            name: "otherCountriesRecognitionUrl",
-            value: otherCountriesRecognitionUrl,
-            hint: {
-              text: ("professions.form.label.qualifications.otherCountriesRecognitionUrlHint" | t)
-            },
-            errorMessage: errors.otherCountriesRecognitionUrl | tError
-          })
-        }}
-
         {{
           govukButton({
             id: "submit-button",


### PR DESCRIPTION
# Changes in this PR

* Show UK qualification data for non-whole-UK Professions
* Remove overseas qualification data (contrary to the ticket, this PR removes it from the data model, though is trivial to restore)

## Screenshots of UI changes

### Before
![localhost_3000_admin_professions_eb9726f7-7517-40fe-bb75-a093bb63ab31_versions_670df367-08eb-408b-9114-bae328c644b0](https://user-images.githubusercontent.com/94137563/157491314-741addf1-59ba-4efd-904a-822de0785ed3.png)
![localhost_3000_admin_professions_eb9726f7-7517-40fe-bb75-a093bb63ab31_versions_6f9f5f77-04cf-4ce0-a645-673415e834d0_qualifications_edit_change=true](https://user-images.githubusercontent.com/94137563/157491325-0e01d37f-f63b-48f8-b728-c612513639e6.png)

### After
![localhost_3000_admin_professions_eb9726f7-7517-40fe-bb75-a093bb63ab31_versions_670df367-08eb-408b-9114-bae328c644b0 (1)](https://user-images.githubusercontent.com/94137563/157491340-2983fc09-05a5-423e-b4b8-9661275fed69.png)
![localhost_3000_admin_professions_eb9726f7-7517-40fe-bb75-a093bb63ab31_versions_d954020e-a136-4854-9566-0c423d5f6db4_qualifications_edit_change=true](https://user-images.githubusercontent.com/94137563/157491360-76a94404-8bb4-4fd0-8213-d1720534d405.png)

