### PR TITLE
(2239) Hide name field when submitting org with errors

### DIFF
--- a/views/admin/organisations/edit.njk
+++ b/views/admin/organisations/edit.njk
@@ -3,6 +3,8 @@
 {% from "govuk/components/textarea/macro.njk" import govukTextarea %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
+{% set name = name or submittedName %}
+
 {% if slug|length == 0 %}
   {% set title = ("organisations.admin.create.heading" | t) %}
 {% else %}
@@ -22,6 +24,8 @@
       {% set targetUrl = ( currentUrl if errors else "/admin/organisations/"+ id +"/versions/" + versionId + "?_method=PUT" ) %}
 
       <form method="post" action="{{ targetUrl }}">
+        <input type="hidden" name="slug" value="{{ slug }}" />
+        <input type="hidden" name="submittedName" value="{{ name or submittedName }}"/>
         {% if slug|length == 0 %}
           {{
             govukInput({


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR

Before this change, a slug value wouldn't be sent on a form submittion
error due to the way we use a `ValidationExceptionFilter` here (rather
than passing the values through like we do on the Profession side of
things).

On an error, the page is reloaded, but as the `slug` value is null,
`slug|length == 0` always evaluates to `true` and the `name` field is
shown.

This approach is a bit of a quick, hacky fix - as I think ideally we'd
either look up the Organisation from the database and handle this like
we do for Professions (which is a big change and feels a bit risky to do
at this stage), or modify the `ValidationExceptionFilter` to look up the
entity for us (which I haven't been able to do yet).

I've had to add a `submittedName` field here to also correctly render
the `name` of the organisation, otherwise that comes through as blank.

## Screenshots of UI changes

### Before

![image](https://user-images.githubusercontent.com/19826940/157504169-21f9a44d-99aa-47b3-9b0f-ba2f6e235810.png)

### After

![image](https://user-images.githubusercontent.com/19826940/157503983-367c2619-cf81-4b3a-b6a3-51e3f468e5da.png)

