### PR TITLE
(2237) Display organisation name on admin dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Show user's name rather than username in welcome message
 - Display additional UK qualification data where the Profession itself is not a whole-UK Profession
 - Remove non-UK qualification data
+- Show user's organisation on dashboard
 
 ## [release-007] - 2022-03-04
 

--- a/cypress/integration/application.spec.ts
+++ b/cypress/integration/application.spec.ts
@@ -7,18 +7,37 @@ describe('/', () => {
     });
   });
 
-  context('when I am logged in', () => {
+  context('when I am logged in as BEIS user', () => {
     beforeEach(() => {
       cy.loginAuth0('admin');
       cy.visitAndCheckAccessibility('/admin');
     });
 
-    it('shows my name', () => {
+    it('shows my name and the BEIS organisation name', () => {
       cy.translate('app.welcome', { name: 'beis-rpr' }).then(
         (welcomeMessage) => {
           cy.get('body').should('contain', welcomeMessage);
         },
       );
+      cy.translate('app.beis').then((beis) => {
+        cy.get('span').should('contain', beis);
+      });
+    });
+  });
+
+  context('when I am logged in as a non BEIS user', () => {
+    beforeEach(() => {
+      cy.loginAuth0('orgadmin');
+      cy.visitAndCheckAccessibility('/admin');
+    });
+
+    it('shows my name and organisation', () => {
+      cy.translate('app.welcome', { name: 'Organisation Admin' }).then(
+        (welcomeMessage) => {
+          cy.get('body').should('contain', welcomeMessage);
+        },
+      );
+      cy.get('span').should('contain', 'Department for Education');
     });
   });
 });

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -1,5 +1,8 @@
-import { Controller, Get, Render, UseGuards } from '@nestjs/common';
+import { Controller, Get, Render, Req, UseGuards } from '@nestjs/common';
 import { AuthenticationGuard } from './common/authentication.guard';
+import { RequestWithAppSession } from './common/interfaces/request-with-app-session.interface';
+import { getActingUser } from './users/helpers/get-acting-user.helper';
+import { getUserOrganisation } from './users/helpers/get-user-organisation';
 @Controller()
 export class AppController {
   @Get()
@@ -11,8 +14,12 @@ export class AppController {
   @Get('/admin')
   @UseGuards(AuthenticationGuard)
   @Render('admin/dashboard')
-  admin() {
-    // do nothing.
+  admin(@Req() request: RequestWithAppSession) {
+    const actingUser = getActingUser(request);
+
+    return {
+      organisation: getUserOrganisation(actingUser),
+    };
   }
 
   @Get('/health-check')

--- a/src/users/helpers/get-user-organisation.spec.ts
+++ b/src/users/helpers/get-user-organisation.spec.ts
@@ -1,0 +1,26 @@
+import organisationFactory from '../../testutils/factories/organisation';
+import userFactory from '../../testutils/factories/user';
+import { getUserOrganisation } from './get-user-organisation';
+
+describe('getUserOrganisation', () => {
+  describe('when the user is a service owner', () => {
+    it('returns the BEIS team translation string', () => {
+      const user = userFactory.build({ serviceOwner: true });
+
+      expect(getUserOrganisation(user)).toEqual('app.beis');
+    });
+  });
+
+  describe('when the user is not a service owner', () => {
+    it('returns the BEIS team translation string', () => {
+      const user = userFactory.build({
+        serviceOwner: false,
+        organisation: organisationFactory.build({
+          name: 'Department for Education',
+        }),
+      });
+
+      expect(getUserOrganisation(user)).toEqual('Department for Education');
+    });
+  });
+});

--- a/src/users/helpers/get-user-organisation.ts
+++ b/src/users/helpers/get-user-organisation.ts
@@ -1,0 +1,7 @@
+import { User } from '../user.entity';
+
+export function getUserOrganisation(user: User): string {
+  const isBEISUser = user.serviceOwner;
+
+  return isBEISUser ? 'app.beis' : user.organisation.name;
+}

--- a/views/admin/dashboard.njk
+++ b/views/admin/dashboard.njk
@@ -29,6 +29,7 @@
     </nav>
   </div>
   <div class="govuk-grid-column-two-thirds">
+    <span class="govuk-caption-l">{{ organisation | t }}</span>
     <h1 class="govuk-heading-l">{{ "app.welcome" | t({name: user.name}) }}</h1>
   </div>
 </div>


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR

- Displays user's organisation (or BEIS for service owners) on dashboard

## Screenshots of UI changes

### Before

![image](https://user-images.githubusercontent.com/19826940/157643346-99093007-b6a7-48e3-aa5a-ce753a205ce9.png)


### After

#### BEIS user

![image](https://user-images.githubusercontent.com/19826940/157643133-e33a3edd-47dd-4549-a629-66672c2e1bbf.png)

#### Organisation user

![image](https://user-images.githubusercontent.com/19826940/157643583-983f77b3-99fa-4463-a8f7-ac5f5327ef86.png)



