### PR TITLE
(2195) Add the nations filter to the internal Organisations list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Display additional UK qualification data where the Profession itself is not a whole-UK Profession
 - Remove non-UK qualification data
 - Show user's organisation on dashboard
+- Internal Orgnaisation listing can be filtered by nation
 
 ## [release-007] - 2022-03-04
 

--- a/cypress/integration/admin/organisations/index.spec.ts
+++ b/cypress/integration/admin/organisations/index.spec.ts
@@ -91,6 +91,45 @@ describe('Listing organisations', () => {
       cy.get('tbody tr').should('have.length.at.least', 1);
     });
 
+    it('I can filter by nation', () => {
+      expandFilters();
+
+      cy.translate('nations.wales').then((wales) => {
+        cy.translate('app.unitedKingdom').then((unitedKingdom) => {
+          cy.get('label')
+            .contains(wales)
+            .parent()
+            .within(() => {
+              cy.get('input[name="nations[]"]').check();
+            });
+
+          clickFilterButtonAndCheckAccessibility();
+
+          cy.get('label')
+            .contains(wales)
+            .parent()
+            .within(() => {
+              cy.get('input[name="nations[]"]').should('be.checked');
+            });
+
+          cy.get('tbody tr').each(($tr) => {
+            cy.wrap($tr).within(() => {
+              cy.get('td')
+                .eq(0)
+                .invoke('text')
+                .then((cellText) => {
+                  expect(cellText).to.match(
+                    new RegExp(`(${wales}|${unitedKingdom})`, 'g'),
+                  );
+                });
+            });
+          });
+
+          cy.get('tbody tr').should('have.length.at.least', 1);
+        });
+      });
+    });
+
     it('I can filter by industry', () => {
       expandFilters();
 

--- a/cypress/integration/admin/organisations/index.spec.ts
+++ b/cypress/integration/admin/organisations/index.spec.ts
@@ -31,12 +31,6 @@ describe('Listing organisations', () => {
 
                   cy.wrap($row).should('contain', organisation.name);
 
-                  if (latestVersion.alternateName) {
-                    cy.wrap($row).should(
-                      'contain',
-                      latestVersion.alternateName,
-                    );
-                  }
                   cy.get('[data-cy=changed-by-text]').should('not.exist');
                   cy.wrap($row).should(
                     'contain',

--- a/src/i18n/en/organisations.json
+++ b/src/i18n/en/organisations.json
@@ -6,6 +6,7 @@
     "viewDetails": "View details <span class='govuk-visually-hidden'>about {name}</span>",
     "labels": {
       "keywords": "Keywords:",
+      "nations": "Nations:",
       "industries": "Industries:"
     },
     "filter": {
@@ -76,7 +77,7 @@
     },
     "tableHeading": {
       "name": "Name",
-      "alternateName": "Alternate name",
+      "nations": "Nations",
       "industries": "Sectors",
       "status": "Status",
       "lastModified": "Last updated",

--- a/src/organisations/admin/dto/filter.dto.ts
+++ b/src/organisations/admin/dto/filter.dto.ts
@@ -1,4 +1,5 @@
 export class FilterDto {
   keywords = '';
+  nations: string[] = [];
   industries: string[] = [];
 }

--- a/src/organisations/admin/interfaces/index-template.interface.ts
+++ b/src/organisations/admin/interfaces/index-template.interface.ts
@@ -7,8 +7,10 @@ export interface IndexTemplate {
 
   filters: {
     keywords: string;
+    nations: string[];
     industries: string[];
   };
 
+  nationsCheckboxItems: CheckboxItems[];
   industriesCheckboxItems: CheckboxItems[];
 }

--- a/src/organisations/admin/organisations.controller.spec.ts
+++ b/src/organisations/admin/organisations.controller.spec.ts
@@ -31,6 +31,7 @@ import { createDefaultMockRequest } from '../../testutils/factories/create-defau
 import { getActingUser } from '../../users/helpers/get-acting-user.helper';
 import { escape } from '../../helpers/escape.helper';
 import { translationOf } from '../../testutils/translation-of';
+import { Nation } from '../../nations/nation';
 
 jest.mock('./presenters/organisations.presenter');
 jest.mock('../presenters/organisation.presenter');
@@ -103,12 +104,15 @@ describe('OrganisationsController', () => {
             },
             filters: {
               keywords: '',
+              nations: [],
               industries: [],
             },
+            nationsCheckboxItems: [],
             industriesCheckboxItems: [],
           };
 
           const organisations = createOrganisations();
+          const nations = Nation.all();
           const industries = industryFactory.buildList(5);
 
           (
@@ -128,14 +132,17 @@ describe('OrganisationsController', () => {
           expect(OrganisationsFilterHelper).toBeCalledWith(organisations);
           expect(OrganisationsFilterHelper.prototype.filter).toBeCalledWith({
             keywords: '',
+            nations: [],
             industries: [],
           } as FilterInput);
 
           expect(OrganisationsPresenter).toHaveBeenCalledWith(
             translationOf('app.beis'),
+            nations,
             industries,
             {
               keywords: '',
+              nations: [],
               industries: [],
             },
             organisations,
@@ -164,12 +171,15 @@ describe('OrganisationsController', () => {
             },
             filters: {
               keywords: '',
+              nations: [],
               industries: [],
             },
+            nationsCheckboxItems: [],
             industriesCheckboxItems: [],
           };
 
           const organisations = createOrganisations();
+          const nations = Nation.all();
           const industries = industryFactory.buildList(5);
 
           (
@@ -183,6 +193,7 @@ describe('OrganisationsController', () => {
           expect(
             await controller.index(request, {
               keywords: 'example keywords',
+              nations: [nations[2].code],
               industries: [industries[1].id],
             } as FilterDto),
           ).toEqual(templateParams);
@@ -194,14 +205,17 @@ describe('OrganisationsController', () => {
           expect(OrganisationsFilterHelper).toBeCalledWith(organisations);
           expect(OrganisationsFilterHelper.prototype.filter).toBeCalledWith({
             keywords: 'example keywords',
+            nations: [nations[2]],
             industries: [industries[1]],
           } as FilterInput);
 
           expect(OrganisationsPresenter).toHaveBeenCalledWith(
             translationOf('app.beis'),
+            nations,
             industries,
             {
               keywords: 'example keywords',
+              nations: [nations[2]],
               industries: [industries[1]],
             },
             [organisations[1], organisations[3]],
@@ -229,11 +243,14 @@ describe('OrganisationsController', () => {
           },
           filters: {
             keywords: '',
+            nations: [],
             industries: [],
           },
+          nationsCheckboxItems: [],
           industriesCheckboxItems: [],
         };
 
+        const nations = Nation.all();
         const industries = industryFactory.buildList(5);
 
         const request = createDefaultMockRequest();
@@ -261,15 +278,18 @@ describe('OrganisationsController', () => {
         expect(OrganisationsFilterHelper).toBeCalledWith(organisations);
         expect(OrganisationsFilterHelper.prototype.filter).toBeCalledWith({
           keywords: '',
+          nations: [],
           industries: [],
           organisations: [userOrganisation],
         } as FilterInput);
 
         expect(OrganisationsPresenter).toHaveBeenCalledWith(
           userOrganisation.name,
+          nations,
           industries,
           {
             keywords: '',
+            nations: [],
             industries: [],
             organisations: [userOrganisation],
           },

--- a/src/organisations/admin/organisations.controller.ts
+++ b/src/organisations/admin/organisations.controller.ts
@@ -42,6 +42,7 @@ import { UserPermission } from '../../users/user-permission';
 import { Permissions } from '../../common/permissions.decorator';
 import { getActingUser } from '../../users/helpers/get-acting-user.helper';
 import { escape } from '../../helpers/escape.helper';
+import { Nation } from '../../nations/nation';
 
 @UseGuards(AuthenticationGuard)
 @Controller('/admin/organisations')
@@ -70,13 +71,18 @@ export class OrganisationsController {
 
     const showAllOrgs = actingUser.serviceOwner;
 
+    const allNations = Nation.all();
     const allOrganisations =
       await this.organisationVersionsService.allWithLatestVersion();
     const allIndustries = await this.industriesService.all();
 
     const filter = query || new FilterDto();
 
-    const filterInput = createFilterInput({ ...filter, allIndustries });
+    const filterInput = createFilterInput({
+      ...filter,
+      allNations,
+      allIndustries,
+    });
 
     if (!showAllOrgs) {
       filterInput.organisations = [actingUser.organisation];
@@ -92,6 +98,7 @@ export class OrganisationsController {
 
     const presenter = new OrganisationsPresenter(
       userOrganisation,
+      allNations,
       allIndustries,
       filterInput,
       filteredOrganisations,

--- a/src/organisations/admin/presenters/organisations.presenter.spec.ts
+++ b/src/organisations/admin/presenters/organisations.presenter.spec.ts
@@ -6,6 +6,8 @@ import industryFactory from '../../../testutils/factories/industry';
 import { FilterInput } from '../../../common/interfaces/filter-input.interface';
 import { IndustriesCheckboxPresenter } from '../../../industries/industries-checkbox.presenter';
 import { OrganisationPresenter } from '../../presenters/organisation.presenter';
+import { Nation } from '../../../nations/nation';
+import { NationsCheckboxPresenter } from '../../../nations/nations-checkbox.presenter';
 
 const mockTableRow = jest.fn();
 const mockCheckboxItems = jest.fn();
@@ -23,6 +25,16 @@ jest.mock('../../presenters/organisation.presenter', () => {
 jest.mock('../../../industries/industries-checkbox.presenter', () => {
   return {
     IndustriesCheckboxPresenter: jest.fn().mockImplementation(() => {
+      return {
+        checkboxItems: mockCheckboxItems,
+      };
+    }),
+  };
+});
+
+jest.mock('../../../nations/nations-checkbox.presenter', () => {
+  return {
+    NationsCheckboxPresenter: jest.fn().mockImplementation(() => {
       return {
         checkboxItems: mockCheckboxItems,
       };
@@ -50,6 +62,7 @@ describe('OrganisationsPresenter', () => {
 
         const i18nService = createMockI18nService();
 
+        const nations = Nation.all();
         const industries = industryFactory.buildList(3);
         const organisations = organisationFactory.buildList(5);
 
@@ -57,6 +70,7 @@ describe('OrganisationsPresenter', () => {
 
         const presenter = new OrganisationsPresenter(
           'Organisation Name',
+          nations,
           industries,
           filterInput,
           organisations,
@@ -111,6 +125,7 @@ describe('OrganisationsPresenter', () => {
 
         const i18nService = createMockI18nService();
 
+        const nations = Nation.all();
         const industries = industryFactory.buildList(3);
         const organisations = organisationFactory.buildList(5);
 
@@ -118,6 +133,7 @@ describe('OrganisationsPresenter', () => {
 
         const presenter = new OrganisationsPresenter(
           'Organisation name',
+          nations,
           industries,
           filterInput,
           organisations,
@@ -125,6 +141,12 @@ describe('OrganisationsPresenter', () => {
         );
 
         const result = await presenter.present();
+
+        expect(NationsCheckboxPresenter).toBeCalledWith(
+          nations,
+          [],
+          i18nService,
+        );
 
         expect(IndustriesCheckboxPresenter).toBeCalledWith(
           industries,
@@ -134,6 +156,7 @@ describe('OrganisationsPresenter', () => {
 
         expect(result.filters).toEqual({
           keywords: '',
+          nations: [],
           industries: [],
         });
       });
@@ -146,16 +169,19 @@ describe('OrganisationsPresenter', () => {
 
         const i18nService = createMockI18nService();
 
+        const nations = Nation.all();
         const industries = industryFactory.buildList(3);
         const organisations = organisationFactory.buildList(5);
 
         const filterInput: FilterInput = {
           keywords: 'example keywords',
+          nations: [nations[1], nations[3]],
           industries: [industries[0], industries[2]],
         };
 
         const presenter = new OrganisationsPresenter(
           'Organisation name',
+          nations,
           industries,
           filterInput,
           organisations,
@@ -163,6 +189,12 @@ describe('OrganisationsPresenter', () => {
         );
 
         const result = await presenter.present();
+
+        expect(NationsCheckboxPresenter).toBeCalledWith(
+          nations,
+          [nations[1], nations[3]],
+          i18nService,
+        );
 
         expect(IndustriesCheckboxPresenter).toBeCalledWith(
           industries,
@@ -172,6 +204,7 @@ describe('OrganisationsPresenter', () => {
 
         expect(result.filters).toEqual({
           keywords: 'example keywords',
+          nations: [nations[1].name, nations[3].name],
           industries: [industries[0].name, industries[2].name],
         });
       });
@@ -195,6 +228,8 @@ describe('OrganisationsPresenter', () => {
           ]);
 
           const i18nService = createMockI18nService();
+
+          const nations = Nation.all();
           const industries = industryFactory.buildList(3);
           const filterInput: FilterInput = {};
 
@@ -202,6 +237,7 @@ describe('OrganisationsPresenter', () => {
 
           const presenter = new OrganisationsPresenter(
             'Organisation name',
+            nations,
             industries,
             filterInput,
             foundOrganisations,
@@ -232,6 +268,8 @@ describe('OrganisationsPresenter', () => {
           ]);
 
           const i18nService = createMockI18nService();
+
+          const nations = Nation.all();
           const industries = industryFactory.buildList(3);
           const filterInput: FilterInput = {};
 
@@ -239,6 +277,7 @@ describe('OrganisationsPresenter', () => {
 
           const presenter = new OrganisationsPresenter(
             'Organisation name',
+            nations,
             industries,
             filterInput,
             foundOrganisations,

--- a/src/organisations/admin/presenters/organisations.presenter.spec.ts
+++ b/src/organisations/admin/presenters/organisations.presenter.spec.ts
@@ -76,9 +76,7 @@ describe('OrganisationsPresenter', () => {
         expect(result.organisationsTable.head).toEqual([
           { text: translationOf('organisations.admin.tableHeading.name') },
           {
-            text: translationOf(
-              'organisations.admin.tableHeading.alternateName',
-            ),
+            text: translationOf('organisations.admin.tableHeading.nations'),
           },
           {
             text: translationOf('organisations.admin.tableHeading.industries'),

--- a/src/organisations/admin/presenters/organisations.presenter.ts
+++ b/src/organisations/admin/presenters/organisations.presenter.ts
@@ -7,6 +7,8 @@ import { Industry } from '../../../industries/industry.entity';
 import { FilterInput } from '../../../common/interfaces/filter-input.interface';
 import { IndexTemplate } from '../interfaces/index-template.interface';
 import { IndustriesCheckboxPresenter } from '../../../industries/industries-checkbox.presenter';
+import { Nation } from '../../../nations/nation';
+import { NationsCheckboxPresenter } from '../../../nations/nations-checkbox.presenter';
 
 type Field =
   | 'name'
@@ -29,6 +31,7 @@ const fields = [
 export class OrganisationsPresenter {
   constructor(
     private readonly userOrganisation: string,
+    private readonly allNations: Nation[],
     private readonly allIndustries: Industry[],
     private readonly filterInput: FilterInput,
     private readonly filteredOrganisations: Organisation[],
@@ -36,6 +39,12 @@ export class OrganisationsPresenter {
   ) {}
 
   async present(): Promise<IndexTemplate> {
+    const nationsCheckboxItems = await new NationsCheckboxPresenter(
+      this.allNations,
+      this.filterInput.nations || [],
+      this.i18nService,
+    ).checkboxItems();
+
     const industriesCheckboxItems = await new IndustriesCheckboxPresenter(
       this.allIndustries,
       this.filterInput.industries || [],
@@ -44,10 +53,12 @@ export class OrganisationsPresenter {
 
     return {
       userOrganisation: this.userOrganisation,
+      nationsCheckboxItems,
       industriesCheckboxItems,
       organisationsTable: await this.table(),
       filters: {
         keywords: this.filterInput.keywords || '',
+        nations: (this.filterInput.nations || []).map((nation) => nation.name),
         industries: (this.filterInput.industries || []).map(
           (industry) => industry.name,
         ),

--- a/src/organisations/admin/presenters/organisations.presenter.ts
+++ b/src/organisations/admin/presenters/organisations.presenter.ts
@@ -10,7 +10,7 @@ import { IndustriesCheckboxPresenter } from '../../../industries/industries-chec
 
 type Field =
   | 'name'
-  | 'alternateName'
+  | 'nations'
   | 'industries'
   | 'lastModified'
   | 'changedBy'
@@ -18,7 +18,7 @@ type Field =
   | 'actions';
 const fields = [
   'name',
-  'alternateName',
+  'nations',
   'industries',
   'lastModified',
   'changedBy',

--- a/src/organisations/presenters/organisation.presenter.spec.ts
+++ b/src/organisations/presenters/organisation.presenter.spec.ts
@@ -70,7 +70,7 @@ describe('OrganisationPresenter', () => {
             )}`,
           });
           expect(tableRow[2]).toEqual({
-            html: `Translation of \`${industries[0].name}\``,
+            text: translationOf(industries[0].name),
           });
           expect(tableRow[3]).toEqual({
             text: presenter.lastModified,
@@ -149,11 +149,11 @@ describe('OrganisationPresenter', () => {
             )}`,
           });
           expect(tableRow[2]).toEqual({
-            html: [
-              `Translation of \`${industries[0].name}\``,
-              `Translation of \`${industries[1].name}\``,
-              `Translation of \`${industries[2].name}\``,
-            ].join('<br />'),
+            text: [
+              translationOf(industries[0].name),
+              translationOf(industries[1].name),
+              translationOf(industries[2].name),
+            ].join(', '),
           });
           expect(tableRow[3]).toEqual({
             text: presenter.lastModified,

--- a/src/organisations/presenters/organisation.presenter.spec.ts
+++ b/src/organisations/presenters/organisation.presenter.spec.ts
@@ -40,6 +40,7 @@ describe('OrganisationPresenter', () => {
           const professions = professionFactory.buildList(4, {
             versions: [
               professionVersionFactory.build({
+                occupationLocations: ['GB-ENG', 'GB-WLS'],
                 industries: [industries[0]],
                 status: ProfessionVersionStatus.Draft,
               }),
@@ -63,7 +64,11 @@ describe('OrganisationPresenter', () => {
           const tableRow = await presenter.tableRow();
 
           expect(tableRow[0]).toEqual({ text: organisation.name });
-          expect(tableRow[1]).toEqual({ text: organisation.alternateName });
+          expect(tableRow[1]).toEqual({
+            text: `${translationOf('nations.england')}, ${translationOf(
+              'nations.wales',
+            )}`,
+          });
           expect(tableRow[2]).toEqual({
             html: `Translation of \`${industries[0].name}\``,
           });
@@ -105,6 +110,7 @@ describe('OrganisationPresenter', () => {
             professionFactory.buildList(4, {
               versions: [
                 professionVersionFactory.build({
+                  occupationLocations: ['GB-WLS'],
                   industries: [industries[0]],
                   status: ProfessionVersionStatus.Draft,
                 }),
@@ -113,6 +119,7 @@ describe('OrganisationPresenter', () => {
             professionFactory.buildList(2, {
               versions: [
                 professionVersionFactory.build({
+                  occupationLocations: ['GB-SCT'],
                   industries: [industries[1], industries[2]],
                   status: ProfessionVersionStatus.Draft,
                 }),
@@ -136,7 +143,11 @@ describe('OrganisationPresenter', () => {
           const tableRow = await presenter.tableRow();
 
           expect(tableRow[0]).toEqual({ text: organisation.name });
-          expect(tableRow[1]).toEqual({ text: organisation.alternateName });
+          expect(tableRow[1]).toEqual({
+            text: `${translationOf('nations.wales')}, ${translationOf(
+              'nations.scotland',
+            )}`,
+          });
           expect(tableRow[2]).toEqual({
             html: [
               `Translation of \`${industries[0].name}\``,

--- a/src/organisations/presenters/organisation.presenter.ts
+++ b/src/organisations/presenters/organisation.presenter.ts
@@ -9,6 +9,8 @@ import { formatLink } from '../../helpers/format-link.helper';
 import { formatEmail } from '../../helpers/format-email.helper';
 import { Profession } from '../../professions/profession.entity';
 import { formatStatus } from '../../helpers/format-status.helper';
+import { Nation } from '../../nations/nation';
+import { stringifyNations } from '../../nations/helpers/stringifyNations';
 
 interface OrganisationSummaryListOptions {
   classes?: string;
@@ -29,7 +31,7 @@ export class OrganisationPresenter {
         text: this.organisation.name,
       },
       {
-        text: this.organisation.alternateName,
+        text: await this.nations(),
       },
       {
         html: await this.industries(),
@@ -201,5 +203,18 @@ export class OrganisationPresenter {
     );
 
     return [...new Set(industryNames)].join('<br />');
+  }
+
+  public async nations(): Promise<string> {
+    const professions = this.organisation.professions.map((profession) =>
+      Profession.withLatestLiveOrDraftVersion(profession),
+    );
+
+    const nationCodes = professions
+      .map((profession) => profession.occupationLocations || [])
+      .flat();
+    const nations = [...new Set(nationCodes)].map((code) => Nation.find(code));
+
+    return await stringifyNations(nations, this.i18nService);
   }
 }

--- a/src/organisations/presenters/organisation.presenter.ts
+++ b/src/organisations/presenters/organisation.presenter.ts
@@ -34,7 +34,7 @@ export class OrganisationPresenter {
         text: await this.nations(),
       },
       {
-        html: await this.industries(),
+        text: await this.industries(),
       },
       {
         text: this.lastModified,
@@ -202,7 +202,7 @@ export class OrganisationPresenter {
       ),
     );
 
-    return [...new Set(industryNames)].join('<br />');
+    return [...new Set(industryNames)].join(', ');
   }
 
   public async nations(): Promise<string> {

--- a/views/shared/_horizontal-filter.njk
+++ b/views/shared/_horizontal-filter.njk
@@ -5,16 +5,13 @@
 {% set filterFormMethod = 'get' %}
 
 {% set filterColumns = 1 %}
-  {% if nationsCheckboxItems %}
+{% if nationsCheckboxItems %}
   {% set filterColumns = filterColumns + 1 %}
 {% endif %}
-  {% if organisationsCheckboxItems %}
+{% if organisationsCheckboxItems %}
   {% set filterColumns = filterColumns + 1 %}
 {% endif %}
-  {% if industriesCheckboxItems %}
-  {% set filterColumns = filterColumns + 1 %}
-{% endif %}
-  {% if nationsCheckboxItems %}
+{% if industriesCheckboxItems %}
   {% set filterColumns = filterColumns + 1 %}
 {% endif %}
 


### PR DESCRIPTION
# Changes in this PR
- Add nations filter to internal Organisations list
- Show nation rather than alternative name in Organisations list

## Screenshots of UI changes

### Before
![localhost_3000_admin_organisations (1)](https://user-images.githubusercontent.com/94137563/157672472-acb85ca8-5059-4d7f-9681-3ac21d661fe2.png)

### After
![localhost_3000_admin_organisations](https://user-images.githubusercontent.com/94137563/157672455-e78fd637-b1fb-4e78-a52a-e8267459d9c3.png)

