### PR TITLE
Send the request to Rollbar

### DIFF
--- a/src/common/global-exception.filter.spec.ts
+++ b/src/common/global-exception.filter.spec.ts
@@ -252,7 +252,7 @@ describe('GlobalExceptionFilter', () => {
           exception = new InternalServerErrorException();
           service.catch(exception, host);
 
-          expect(rollbarClient.error).toHaveBeenCalledWith(exception);
+          expect(rollbarClient.error).toHaveBeenCalledWith(exception, request);
         });
 
         it('should log the error', () => {

--- a/src/common/global-exception.filter.ts
+++ b/src/common/global-exception.filter.ts
@@ -66,6 +66,7 @@ export class GlobalExceptionFilter implements ExceptionFilter {
     return new Rollbar({
       accessToken: process.env['ROLLBAR_TOKEN'],
       captureUncaught: true,
+      captureIp: false,
       captureUnhandledRejections: true,
       payload: {
         environment: process.env['ENVIRONMENT'],


### PR DESCRIPTION
Initially, we weren't sending any data about the request when an error occurred, so it's difficult to track down exactly what's caused an error. I've also ensured any IP addresses aren't sent with errors, to keep us in line with GDPR.

## Screenshots

### Before

![image](https://user-images.githubusercontent.com/109774/157689815-87480e1d-b880-464b-a9d7-0cda6fac42f3.png)

### After

![image](https://user-images.githubusercontent.com/109774/157689864-9f9b3c02-cc7f-4b66-ab4f-90f9e58159e9.png)
