### PR TITLE
(2062) Make formatting of industries and nations lists consistent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Update dashboard content
 - Update content on the public facing start page
 - Display Profession registration data
+- Make consistent the formatting of lists of Organisations, nations, and sectors
 
 ## [release-007] - 2022-03-04
 

--- a/views/admin/professions/check-your-answers.njk
+++ b/views/admin/professions/check-your-answers.njk
@@ -83,17 +83,17 @@
         <h2 class="govuk-heading-m">{{ ("professions.form.headings.scope" | t) }}</h2>
 
         {% set selectedNationsSummaryListHtml %}
-          <ul>
+          <ul class="govuk-list">
             {% for nation in nations %}
-              <li class='govuk-body-m'>{{ nation }}</li>
+              <li>{{ nation }}</li>
             {% endfor %}
           </ul>
         {% endset %}
 
         {% set selectedIndustriesSummaryListHtml %}
-          <ul>
+          <ul class="govuk-list">
             {% for industry in industries %}
-              <li class='govuk-body-m'>{{ industry }}</li>
+              <li>{{ industry }}</li>
             {% endfor %}
           </ul>
         {% endset %}

--- a/views/professions/_profession-details.njk
+++ b/views/professions/_profession-details.njk
@@ -7,15 +7,19 @@
 <h2 class="govuk-heading-m rpr-details__section-title">{{ "professions.show.overview.heading" | t }}</h2>
 
 {% set nationsHtml %}
+  <ul class="govuk-list">
     {% for nation in nations %}
-      <p class="govuk-body-m"> {{ nation }}</p>
+      <li>{{ nation }}</li>
     {% endfor %}
+  </ul>
 {% endset %}
 
 {% set industriesHtml %}
-  {% for industry in industries %}
-    <p class="govuk-body-m"> {{ industry }}</p>
+  <ul class="govuk-list">
+    {% for industry in industries %}
+    <li>{{ industry }}</li>
   {% endfor %}
+  </ul>
 {% endset %}
 
 {{

--- a/views/professions/search/index.njk
+++ b/views/professions/search/index.njk
@@ -34,15 +34,19 @@
         {% for profession in professions %}
 
           {% set industriesHtml %}
-            {% for industry in profession.industries %}
-              <p class="govuk-body-m">{{ industry }}</p>
-            {% endfor %}
+            <ul class="govuk-list">
+              {% for industry in profession.industries %}
+                <li>{{ industry }}</li>
+              {% endfor %}
+            </ul>
           {% endset %}
 
           {% set organisationsHtml %}
-            {% for organisation in profession.organisations %}
-              <p class="govuk-body-m">{{ organisation }}</p>
-            {% endfor %}
+            <ul class="govuk-list">
+              {% for organisation in profession.organisations %}
+                <li>{{ organisation }}</li>
+              {% endfor %}
+            </ul>
           {% endset %}
 
           <div>


### PR DESCRIPTION
# Changes in this PR

Consistently use `<ul>` lists when displaying a list of nations, sector, or Organisations

We use the `govuk-list` class to eliminate the previously visible bullet points

## Screenshots of UI changes

### Before
![localhost_3000_admin_professions_30a54b17-724a-477f-b356-605566643b22_versions_68800e87-7ae2-4da6-9224-e1a8ff55e905_check-your-answers_edit=true](https://user-images.githubusercontent.com/94137563/157721859-f8348302-8bb5-46fe-8ab2-2e120979f60c.png)
![localhost_3000_professions_registered-trademark-attorney (1)](https://user-images.githubusercontent.com/94137563/157721874-d3409cd4-a25a-4d58-aeb2-2008a485b111.png)
![localhost_3000_professions_search (1)](https://user-images.githubusercontent.com/94137563/157721883-343d3459-3966-4d77-98cf-f17f3095776b.png)

### After
![localhost_3000_admin_professions_30a54b17-724a-477f-b356-605566643b22_versions_d5445571-5cd4-4358-b3eb-b62f33510ed7_check-your-answers_edit=true](https://user-images.githubusercontent.com/94137563/157721895-ff7bfe32-cf6a-42ab-933b-2d6c915d229c.png)
![localhost_3000_professions_registered-trademark-attorney](https://user-images.githubusercontent.com/94137563/157721906-14719df4-85af-4509-94f7-a70dc7a8548c.png)
![localhost_3000_professions_search](https://user-images.githubusercontent.com/94137563/157721916-41753f16-12e8-406a-9efa-bf09644ac6bf.png)

