### PR TITLE
Ensure profession pages render if occupation locations and industry data is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Update content on the public facing start page
 - Display Profession registration data
 - Make consistent the formatting of lists of Organisations, nations, and sectors
+- Ensure missing data doesn't break public pages, if it somehow slips through
 
 ## [release-007] - 2022-03-04
 

--- a/cypress/integration/admin/professions/publish.spec.ts
+++ b/cypress/integration/admin/professions/publish.spec.ts
@@ -225,6 +225,80 @@ describe('Publishing professions', () => {
           });
         });
     });
+
+    it('Allows me to publish a draft profession with the bare minimum fields, without breaking the view', () => {
+      cy.get('a').contains('Regulated professions').click();
+      cy.checkAccessibility();
+
+      cy.contains('Draft Profession')
+        .parent('tr')
+        .within(() => {
+          cy.get('a').contains('View details').click();
+        });
+
+      cy.translate('app.status.draft').then((status) => {
+        cy.get('h2[data-status]').should('contain', status);
+      });
+
+      cy.translate('professions.form.button.publish').then((publishButton) => {
+        cy.get('a').contains(publishButton).click();
+      });
+
+      cy.checkAccessibility();
+
+      cy.translate('professions.form.button.publish').then((buttonText) => {
+        cy.get('button').contains(buttonText).click();
+      });
+
+      cy.checkAccessibility();
+
+      cy.translate('professions.admin.publish.confirmation.heading').then(
+        (confirmation) => {
+          cy.get('html').should('contain', confirmation);
+        },
+      );
+
+      cy.translate('professions.admin.button.edit.live').then((buttonText) => {
+        cy.get('html').should('contain', buttonText);
+      });
+
+      cy.translate('professions.admin.changed.by').then((changedByText) => {
+        cy.get('[data-cy=changed-by-text]').should('contain', changedByText);
+      });
+      cy.get('[data-cy=changed-by-user-name]').should('contain', 'Editor');
+      cy.get('[data-cy=changed-by-user-email]').should(
+        'contain',
+        'beis-rpr+editor@dxw.com',
+      );
+      cy.get('[data-cy=last-modified]').should(
+        'contain',
+        format(new Date(), 'd MMM yyyy'),
+      );
+
+      cy.get('[data-cy=currently-published-version-text]').within(() => {
+        cy.translate('professions.admin.publicFacingLink.label').then(
+          (publicFacingLinkLabel) => {
+            cy.get('a').should('contain', publicFacingLinkLabel);
+          },
+        );
+
+        cy.get('a').click();
+      });
+      cy.get('body').should('contain', 'Draft Profession');
+      cy.go('back');
+
+      cy.visitAndCheckAccessibility('/admin/professions');
+
+      cy.get('tr')
+        .contains('Draft Profession')
+        .then(($header) => {
+          const $row = $header.parent();
+
+          cy.translate('app.status.live').then((status) => {
+            cy.wrap($row).should('contain', status);
+          });
+        });
+    });
   });
 
   context('When I am logged in as a registrar', () => {

--- a/src/professions/professions.controller.spec.ts
+++ b/src/professions/professions.controller.spec.ts
@@ -135,28 +135,80 @@ describe('ProfessionsController', () => {
       });
     });
 
-    describe('when the Profession has no qualification set', () => {
-      it('passes a null value for the qualification', async () => {
-        const profession = professionFactory.build({
-          qualification: null,
-          occupationLocations: ['GB-ENG'],
-          industries: [industryFactory.build({ name: 'industries.example' })],
+    describe('publishing with missing data', () => {
+      describe('when the Profession has no industries set', () => {
+        it('passes an empty array for the industries', async () => {
+          const profession = professionFactory.build({
+            industries: [],
+          });
+
+          professionVersionsService.findLiveBySlug.mockResolvedValue(
+            profession,
+          );
+
+          (Organisation.withLatestLiveVersion as jest.Mock).mockImplementation(
+            (organisation) => organisation,
+          );
+
+          const result = await controller.show('example-slug');
+
+          expect(result).toEqual(
+            expect.objectContaining({
+              industries: [],
+            }),
+          );
         });
+      });
 
-        professionVersionsService.findLiveBySlug.mockResolvedValue(profession);
+      describe('when the Profession has no nations set', () => {
+        it('passes an empty array for the industries', async () => {
+          const profession = professionFactory.build({
+            occupationLocations: [],
+          });
 
-        (Organisation.withLatestLiveVersion as jest.Mock).mockImplementation(
-          (organisation) => organisation,
-        );
+          professionVersionsService.findLiveBySlug.mockResolvedValue(
+            profession,
+          );
 
-        const result = await controller.show('example-slug');
+          (Organisation.withLatestLiveVersion as jest.Mock).mockImplementation(
+            (organisation) => organisation,
+          );
 
-        expect(result).toEqual({
-          profession: profession,
-          qualificationSummaryList: null,
-          nations: [translationOf('nations.england')],
-          industries: [translationOf('industries.example')],
-          organisations: [profession.organisation],
+          const result = await controller.show('example-slug');
+
+          expect(result).toEqual(
+            expect.objectContaining({
+              nations: [],
+            }),
+          );
+        });
+      });
+
+      describe('when the Profession has no qualification set', () => {
+        it('passes a null value for the qualification', async () => {
+          const profession = professionFactory.build({
+            qualification: null,
+            occupationLocations: ['GB-ENG'],
+            industries: [industryFactory.build({ name: 'industries.example' })],
+          });
+
+          professionVersionsService.findLiveBySlug.mockResolvedValue(
+            profession,
+          );
+
+          (Organisation.withLatestLiveVersion as jest.Mock).mockImplementation(
+            (organisation) => organisation,
+          );
+
+          const result = await controller.show('example-slug');
+
+          expect(result).toEqual({
+            profession: profession,
+            qualificationSummaryList: null,
+            nations: [translationOf('nations.england')],
+            industries: [translationOf('industries.example')],
+            organisations: [profession.organisation],
+          });
         });
       });
     });

--- a/src/professions/professions.controller.ts
+++ b/src/professions/professions.controller.ts
@@ -41,13 +41,13 @@ export class ProfessionsController {
     );
 
     const nations = await Promise.all(
-      profession.occupationLocations.map(async (code) =>
+      (profession.occupationLocations || []).map(async (code) =>
         Nation.find(code).translatedName(this.i18nService),
       ),
     );
 
     const industries = await Promise.all(
-      profession.industries.map(
+      (profession.industries || []).map(
         async (industry) => await this.i18nService.translate(industry.name),
       ),
     );

--- a/src/professions/search/profession-search-result.presenter.spec.ts
+++ b/src/professions/search/profession-search-result.presenter.spec.ts
@@ -60,6 +60,36 @@ describe('ProfessionSearchResultPresenter', () => {
         exampleProfession,
       );
     });
+
+    describe('when the Profession is missing some fields', () => {
+      it('returns empty values', async () => {
+        const exampleProfession = professionFactory.build({
+          occupationLocations: undefined,
+          industries: undefined,
+        });
+
+        const getOrganisationsFromProfessionSpy = jest.spyOn(
+          getOrganisationsFromProfessionModule,
+          'getOrganisationsFromProfession',
+        );
+
+        const result = await new ProfessionSearchResultPresenter(
+          exampleProfession,
+          i18nService,
+        ).present();
+
+        expect(result).toEqual(
+          expect.objectContaining({
+            nations: '',
+            industries: [],
+          }),
+        );
+
+        expect(getOrganisationsFromProfessionSpy).toBeCalledWith(
+          exampleProfession,
+        );
+      });
+    });
   });
 
   afterEach(() => {

--- a/src/professions/search/profession-search-result.presenter.ts
+++ b/src/professions/search/profession-search-result.presenter.ts
@@ -13,12 +13,14 @@ export class ProfessionSearchResultPresenter {
 
   async present(): Promise<ProfessionSearchResultTemplate> {
     const nations = await stringifyNations(
-      this.profession.occupationLocations.map((code) => Nation.find(code)),
+      (this.profession.occupationLocations || []).map((code) =>
+        Nation.find(code),
+      ),
       this.i18nService,
     );
 
     const industries = await Promise.all(
-      this.profession.industries.map(
+      (this.profession.industries || []).map(
         async (industry) => await this.i18nService.translate(industry.name),
       ),
     );

--- a/views/professions/_profession-details.njk
+++ b/views/professions/_profession-details.njk
@@ -21,7 +21,6 @@
   {% endfor %}
   </ul>
 {% endset %}
-
 {{
   govukSummaryList({
   classes: 'govuk-summary-list--no-border',
@@ -33,7 +32,7 @@
       value: {
         html: nationsHtml
       }
-    },
+    } if nations | length > 0 else undefined,
     {
       key: {
         text: ("professions.show.overview.industry" | t)
@@ -41,7 +40,7 @@
       value: {
         html: industriesHtml
       }
-    }
+    } if nations | length > 0 else undefined
   ]
 }) }}
 
@@ -92,48 +91,48 @@
   </div>
 {% endfor %}
 
-<hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+{% if profession.description or showEmptyProfessionDetails %}
+  <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
-<div>
-  <h2 class="govuk-heading-m rpr-details__section-title">{{ "professions.show.regulatedActivities.heading" | t }}</h2>
+  <div>
+    <h2 class="govuk-heading-m rpr-details__section-title">{{ "professions.show.regulatedActivities.heading" | t }}</h2>
 
-  {% if profession.description or showEmptyProfessionDetails %}
     <div>
       <h3 class="govuk-heading-s">{{ "professions.show.regulatedActivities.regulationSummary" | t }}</h3>
       {{ profession.description | multiline('govuk-body') }}
     </div>
-  {% endif %}
 
-  {% if profession.reservedActivities or showEmptyProfessionDetails %}
-    <div>
-      <h3 class="govuk-heading-s">{{ "professions.show.regulatedActivities.reservedActivities" | t }}</h3>
-      {{ profession.reservedActivities | multiline('govuk-body') }}
-    </div>
-  {% endif %}
+    {% if profession.reservedActivities or showEmptyProfessionDetails %}
+      <div>
+        <h3 class="govuk-heading-s">{{ "professions.show.regulatedActivities.reservedActivities" | t }}</h3>
+        {{ profession.reservedActivities | multiline('govuk-body') }}
+      </div>
+    {% endif %}
 
-  {% if profession.protectedTitles or showEmptyProfessionDetails %}
-    <div>
-      <h3 class="govuk-heading-s">{{ "professions.show.regulatedActivities.protectedTitles" | t }}</h3>
-      {{ profession.protectedTitles | multiline('govuk-body') }}
-    </div>
-  {% endif %}
+    {% if profession.protectedTitles or showEmptyProfessionDetails %}
+      <div>
+        <h3 class="govuk-heading-s">{{ "professions.show.regulatedActivities.protectedTitles" | t }}</h3>
+        {{ profession.protectedTitles | multiline('govuk-body') }}
+      </div>
+    {% endif %}
 
-  {% if profession.regulationUrl or showEmptyProfessionDetails %}
-    {{ govukSummaryList({
-      classes: 'govuk-summary-list--no-border',
-      rows: [
-        {
-          key: {
-            text: ("professions.show.regulatedActivities.regulationUrl" | t)
-          },
-          value: {
-            html: profession.regulationUrl | link
+    {% if profession.regulationUrl or showEmptyProfessionDetails %}
+      {{ govukSummaryList({
+        classes: 'govuk-summary-list--no-border',
+        rows: [
+          {
+            key: {
+              text: ("professions.show.regulatedActivities.regulationUrl" | t)
+            },
+            value: {
+              html: profession.regulationUrl | link
+            }
           }
-        }
-      ]
-    }) }}
-  {% endif %}
-</div>
+        ]
+      }) }}
+    {% endif %}
+  </div>
+{% endif %}
 
 {% if qualificationSummaryList %}
 

--- a/views/professions/_profession-details.njk
+++ b/views/professions/_profession-details.njk
@@ -32,7 +32,7 @@
       value: {
         html: nationsHtml
       }
-    } if nations | length > 0 else undefined,
+    } if nations | length > 0 or showEmptyProfessionDetails else undefined,
     {
       key: {
         text: ("professions.show.overview.industry" | t)
@@ -40,7 +40,7 @@
       value: {
         html: industriesHtml
       }
-    } if nations | length > 0 else undefined
+    } if nations | length > 0 or showEmptyProfessionDetails else undefined
   ]
 }) }}
 


### PR DESCRIPTION
# Changes in this PR

- Adds safety net for industries and occupation locations not being set on a Profession, as we don't currently have pre-publish validation. This will at least stop a broken experience for members of the public, and is a temporary stopgap until we implement the pre-publish validation.
- Doesn't render regulation heading when no regulation data is set.

## Screenshots of UI changes

### Before

[ERROR PAGE]

### After

![image](https://user-images.githubusercontent.com/19826940/157854241-92701856-c25a-4ac5-b9aa-c214e8d5bb9e.png)
