### PR TITLE
Release 008

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+## [release-008] - 2022-03-11
+
 ### Added
 
 - Allow users to publish professions and organisations when editing
@@ -182,7 +184,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix links in error messages when adding a new profession
 - Make validation errors more human readable
 
-[unreleased]: https://github.com/UKGovernmentBEIS/regulated-professions-register/compare/release-007...HEAD
+[unreleased]: https://github.com/UKGovernmentBEIS/regulated-professions-register/compare/release-008...HEAD
+[release-008]: https://github.com/UKGovernmentBEIS/regulated-professions-register/compare/release007...release-008
 [release-007]: https://github.com/UKGovernmentBEIS/regulated-professions-register/compare/release006...release-007
 [release-006]: https://github.com/UKGovernmentBEIS/regulated-professions-register/compare/release005...release-006
 [release-005]: https://github.com/UKGovernmentBEIS/regulated-professions-register/compare/release004...release-005


### PR DESCRIPTION
# Release notes

## Added

- Allow users to publish professions and organisations when editing
- Add link to feedback form for internal and public users
- Add cookie and privacy policies

## Changed

- Display a second Regulatory Authority if specified for a profession
- Inpsect a second Regulatory Authority when searching, if specified for
  a profession
 - Change visible columns in internal Professions listing
 - Audit optional fields and ensure correct messaging is used
 - Move registration section further down the edit page to encourage
   more detail elsewhere
 - Improve sidebar in the internal Organisation and Profession views
 - Hide empty fields in public Organisation and Profession views
 - Replace UKCPQ text with BEIS organisation name
 - Show user's name rather than username in welcome message
 - Display additional UK qualification data where the Profession
   itself is not a whole-UK Profession
 - Remove non-UK qualification data
 - Show user's organisation on dashboard
 - Internal Orgnaisation listing can be filtered by nation
 - Reorganise sector list and add missing sectors
 - Change the sidenav to a topnav
 - Update dashboard content
 - Update content on the public facing start page
 - Display Profession registration data
 - Make consistent the formatting of lists of Organisations,
   nations, and sectors
 - Ensure missing data doesn't break public pages, if it somehow
    slips through
