### PR TITLE
(2064) Use translated text for users table

### DIFF
--- a/src/i18n/en/users.json
+++ b/src/i18n/en/users.json
@@ -71,6 +71,13 @@
     "confirmation": "We have sent the user a confirmation email.",
     "backToDashboard": "Back to the dashboard"
   },
+  "table": {
+    "headings": {
+      "name": "Name",
+      "email": "Email",
+      "actions": "Actions"
+    }
+  },
   "roles": {
     "administrator": "Administrator",
     "registrar": "Registrar",

--- a/views/admin/users/index.njk
+++ b/views/admin/users/index.njk
@@ -43,13 +43,13 @@
             firstCellIsHeader: true,
             head: [
               {
-                text: "Name"
+                text: ("users.table.headings.name" | t)
               },
               {
-                text: "Email"
+                text: ("users.table.headings.email" | t)
               },
               {
-                text: "Actions"
+                text: ("users.table.headings.actions" | t)
               }
 
             ],


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR

Uses localisation id rather than hardcoded text in the users table, which will make it easier for content people to make changes, or to translate the site in future.
