### PR TITLE
2249 fix dashboard links for regulators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Display Profession registration data
 - Make consistent the formatting of lists of Organisations, nations, and sectors
 - Ensure missing data doesn't break public pages, if it somehow slips through
+- Fix wrong links on dashboard
 
 ## [release-007] - 2022-03-04
 

--- a/views/admin/dashboard.njk
+++ b/views/admin/dashboard.njk
@@ -29,7 +29,7 @@
           {% if (user.serviceOwner) %}
             <a class="govuk-link" href="/admin/organisations">{{ "app.pages.admin.dashboard.editRegulatorsCentralAdmin" | t }}</a>
           {% else %}
-            <a class="govuk-link" href="/admin/professions">{{ "app.pages.admin.dashboard.editRegulatorsRegulators" | t }}</a>
+            <a class="govuk-link" href="/admin/organisations">{{ "app.pages.admin.dashboard.editRegulatorsRegulators" | t }}</a>
           {% endif %}
         </li>
       {% endif %}
@@ -39,7 +39,7 @@
           {% if (user.serviceOwner) %}
             <a class="govuk-link" href="/admin/users">{{ "app.pages.admin.dashboard.manageAccessCentralAdmin" | t }}</a>
           {% else %}
-            <a class="govuk-link" href="/admin/professions">{{ "app.pages.admin.dashboard.manageAccessRegulators" | t }}</a>
+            <a class="govuk-link" href="/admin/users">{{ "app.pages.admin.dashboard.manageAccessRegulators" | t }}</a>
           {% endif %}
         </li>
       {% endif %}


### PR DESCRIPTION
# Changes in this PR
- Fixing wrong links on dashboard

The second and the three blue links on the dashboard are all pointing to `professions`. It's a mistake from my previous PR. Fixed now. 

## Screenshots of UI changes