### PR TITLE
Add Opensearch config for Terraform

### DIFF
--- a/terraform/app.tf
+++ b/terraform/app.tf
@@ -1,11 +1,11 @@
 # Create the web app.
 
 resource "cloudfoundry_app" "beis-rpr-app" {
-  name                       = "beis-rpr-${var.environment}"
-  space                      = cloudfoundry_space.space.id
-  instances                  = 2
-  disk_quota                 = 3072
-  timeout                    = 300
+  name         = "beis-rpr-${var.environment}"
+  space        = cloudfoundry_space.space.id
+  instances    = 2
+  disk_quota   = 3072
+  timeout      = 300
   docker_image = "thedxw/beis-rpr:${var.docker_tag}"
   docker_credentials = {
     username = var.docker_username

--- a/terraform/app.tf
+++ b/terraform/app.tf
@@ -14,6 +14,7 @@ resource "cloudfoundry_app" "beis-rpr-app" {
   strategy                   = "blue-green-v2"
   health_check_http_endpoint = "/"
   service_binding { service_instance = cloudfoundry_service_instance.beis-rpr-postgres.id }
+  service_binding { service_instance = cloudfoundry_service_instance.beis-rpr-opensearch.id }
   service_binding { service_instance = cloudfoundry_user_provided_service.papertrail.id }
   service_binding { service_instance = cloudfoundry_service_instance.beis-rpr-redis.id }
   environment = {

--- a/terraform/opensearch.tf
+++ b/terraform/opensearch.tf
@@ -1,0 +1,15 @@
+# Get data about the opensearch service on the PaaS
+# so we can get the guid of the service plan we want to use.
+data "cloudfoundry_service" "opensearch" {
+  name = "opensearch"
+}
+
+# Create an opensearch instance named with the environment.
+
+resource "cloudfoundry_service_instance" "beis-rpr-opensearch" {
+  name                           = "beis-rpr-${var.environment}-opensearch"
+  space                          = cloudfoundry_space.space.id
+  service_plan                   = data.cloudfoundry_service.opensearch.service_plans["small-ha-1"]
+  replace_on_params_change       = false
+  replace_on_service_plan_change = false
+}


### PR DESCRIPTION
This adds a new small, high availability Opensearch (i.e. Elasticsearch) instance and binds it to the app. I've run `terraform plan` and it seems to do what I'd expect, but I'd appreciate some ops input first.