### PR TITLE
(2182) Add a new field for regulation type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Allow users to publish professions and organisations when editing
 - Add link to feedback form for internal and public users
 - Add cookie and privacy policies
+- Allow editors to enter a regulation type for a Profession
 
 ### Changed
 
@@ -42,6 +43,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Display Profession registration data
 - Make consistent the formatting of lists of Organisations, nations, and sectors
 - Ensure missing data doesn't break public pages, if it somehow slips through
+- Display regulation type on internal and public Profession pages
 
 ## [release-007] - 2022-03-04
 

--- a/cypress/integration/admin/professions/edit.spec.ts
+++ b/cypress/integration/admin/professions/edit.spec.ts
@@ -141,12 +141,21 @@ describe('Editing an existing profession', () => {
       cy.get('textarea[name="regulationSummary"]')
         .clear()
         .type('Updated summary of the regulation');
+      cy.get('input[name="regulationType"][value="licensing"]').check();
       cy.translate('app.continue').then((buttonText) => {
         cy.get('button').contains(buttonText).click();
       });
       cy.checkSummaryListRowValue(
         'professions.form.label.regulatedActivities.regulationSummary',
         'Updated summary of the regulation',
+      );
+      cy.translate('professions.regulationTypes.licensing.name').then(
+        (licensingText) => {
+          cy.checkSummaryListRowValue(
+            'professions.form.label.regulatedActivities.regulationType',
+            licensingText,
+          );
+        },
       );
 
       cy.clickSummaryListRowAction(

--- a/cypress/integration/admin/professions/new.spec.ts
+++ b/cypress/integration/admin/professions/new.spec.ts
@@ -125,6 +125,7 @@ describe('Adding a new profession', () => {
       cy.get('textarea[name="regulationSummary"]').type(
         'A summary of the regulation',
       );
+      cy.get('input[name="regulationType"][value="accreditation"]').check();
       cy.get('textarea[name="reservedActivities"]').type('An example activity');
       cy.get('textarea[name="protectedTitles"]').type(
         'An example protected title',

--- a/cypress/integration/admin/professions/new.spec.ts
+++ b/cypress/integration/admin/professions/new.spec.ts
@@ -236,6 +236,15 @@ describe('Adding a new profession', () => {
         'A summary of the regulation',
       );
 
+      cy.translate('professions.regulationTypes.accreditation.name').then(
+        (accreditationText) => {
+          cy.checkSummaryListRowValue(
+            'professions.form.label.regulatedActivities.regulationType',
+            accreditationText,
+          );
+        },
+      );
+
       cy.checkSummaryListRowValue(
         'professions.form.label.regulatedActivities.reservedActivities',
         'An example activity',

--- a/cypress/integration/admin/professions/publish.spec.ts
+++ b/cypress/integration/admin/professions/publish.spec.ts
@@ -393,6 +393,7 @@ describe('Publishing professions', () => {
       cy.get('textarea[name="regulationSummary"]').type(
         'A summary of the regulation',
       );
+      cy.get('input[name="regulationType"][value="certification"]').check();
       cy.get('textarea[name="reservedActivities"]').type('An example activity');
       cy.get('textarea[name="protectedTitles"]').type(
         'An example protected title',

--- a/cypress/integration/admin/professions/show.spec.ts
+++ b/cypress/integration/admin/professions/show.spec.ts
@@ -96,6 +96,23 @@ describe('Listing professions', () => {
               });
 
               cy.translate(
+                'professions.regulationTypes.certification.name',
+              ).then((certificationText) => {
+                cy.translate(
+                  'professions.show.regulatedActivities.regulationType',
+                ).then((regulationTypeHeading) => {
+                  cy.get('h3').should('contain', regulationTypeHeading);
+
+                  cy.get('h3')
+                    .contains(regulationTypeHeading)
+                    .parent()
+                    .within(() => {
+                      cy.get('p').should('contain', certificationText);
+                    });
+                });
+              });
+
+              cy.translate(
                 'professions.show.regulatedActivities.protectedTitles',
               ).then((protectedTitlesHeading) => {
                 cy.get('h3').should('contain', protectedTitlesHeading);
@@ -210,6 +227,12 @@ describe('Listing professions', () => {
                       'A description of the profession',
                     );
                   });
+              });
+
+              cy.translate(
+                'professions.show.regulatedActivities.regulationType',
+              ).then((regulationTypeHeading) => {
+                cy.wrap($div).should('contain', regulationTypeHeading);
               });
 
               cy.translate(

--- a/cypress/integration/professions/show.spec.ts
+++ b/cypress/integration/professions/show.spec.ts
@@ -82,6 +82,23 @@ describe('Showing a profession', () => {
                 });
             });
 
+            cy.translate('professions.regulationTypes.certification.name').then(
+              (certificationText) => {
+                cy.translate(
+                  'professions.show.regulatedActivities.regulationType',
+                ).then((regulationTypeHeading) => {
+                  cy.get('h3').should('contain', regulationTypeHeading);
+
+                  cy.get('h3')
+                    .contains(regulationTypeHeading)
+                    .parent()
+                    .within(() => {
+                      cy.get('p').should('contain', certificationText);
+                    });
+                });
+              },
+            );
+
             cy.translate(
               'professions.show.regulatedActivities.protectedTitles',
             ).then((protectedTitlesHeading) => {
@@ -197,6 +214,12 @@ describe('Showing a profession', () => {
                     'A description of the profession',
                   );
                 });
+            });
+
+            cy.translate(
+              'professions.show.regulatedActivities.regulationType',
+            ).then((regulationTypeHeading) => {
+              cy.wrap($div).should('not.contain', regulationTypeHeading);
             });
 
             cy.translate(

--- a/src/i18n/en/professions.json
+++ b/src/i18n/en/professions.json
@@ -175,6 +175,7 @@
     "regulatedActivities": {
       "heading": "Regulation",
       "regulationSummary": "Regulation summary",
+      "regulationType": "Regulation type",
       "reservedActivities": "Reserved activities",
       "protectedTitles": "Protected titles",
       "regulationUrl": "More about regulated activities and titles"

--- a/src/i18n/en/professions.json
+++ b/src/i18n/en/professions.json
@@ -59,6 +59,7 @@
         "registrationUrl": "More about registration (optional)"
       },
       "regulatedActivities": {
+        "regulationType": "Regulation type",
         "regulationSummary": "Introduction",
         "reservedActivities": "Reserved activities",
         "protectedTitles": "Protected titles (optional)",
@@ -116,6 +117,9 @@
       },
       "regulationSummary": {
         "empty": "Enter a regulation summary"
+      },
+      "regulationType": {
+        "empty": "Select a regulation type"
       },
       "reservedActivities": {
         "empty": "Enter reserved activities"

--- a/src/i18n/en/professions.json
+++ b/src/i18n/en/professions.json
@@ -322,5 +322,19 @@
       "removeFilters": "remove any filters you’ve used",
       "sectorOnly": "leave the profession blank and search by sector only"
     }
+  },
+  "regulationTypes": {
+    "licensing": {
+      "name": "Licence",
+      "hint": "By law, only recognised professionals can carry out reserved activities and use a professional title"
+    },
+    "certification": {
+      "name": "Certification",
+      "hint": "There are no restrictions on who can carry out activities, but by law only certified professionals can use a professional title"
+    },
+    "accreditation": {
+      "name": "Accreditation",
+      "hint": "There are no restrictions on who can carry out activities or use titles, but accreditation may demonstrate that individuals have achieved certain qualifications or experience"
+    }
   }
 }

--- a/src/professions/admin/check-your-answers.controller.spec.ts
+++ b/src/professions/admin/check-your-answers.controller.spec.ts
@@ -10,6 +10,7 @@ import professionFactory from '../../testutils/factories/profession';
 import professionVersionFactory from '../../testutils/factories/profession-version';
 import qualificationFactory from '../../testutils/factories/qualification';
 import { translationOf } from '../../testutils/translation-of';
+import { RegulationType } from '../profession-version.entity';
 import { ProfessionVersionsService } from '../profession-versions.service';
 import { ProfessionsService } from '../professions.service';
 import { CheckYourAnswersController } from './check-your-answers.controller';
@@ -73,6 +74,7 @@ describe('CheckYourAnswersController', () => {
             industryFactory.build({ name: 'industries.construction' }),
           ],
           description: 'A summary of the regulation',
+          regulationType: RegulationType.Certification,
           reservedActivities: 'Some reserved activities',
           protectedTitles: 'Some protected titles',
           regulationUrl: 'http://example.com/regulations',
@@ -106,6 +108,9 @@ describe('CheckYourAnswersController', () => {
         );
         expect(templateParams.regulationSummary).toEqual(
           'A summary of the regulation',
+        );
+        expect(templateParams.regulationType).toEqual(
+          RegulationType.Certification,
         );
         expect(templateParams.reservedActivities).toEqual(
           'Some reserved activities',
@@ -173,6 +178,7 @@ describe('CheckYourAnswersController', () => {
         expect(templateParams.registrationRequirements).toEqual(undefined);
         expect(templateParams.registrationUrl).toEqual(undefined);
         expect(templateParams.regulationSummary).toEqual(undefined);
+        expect(templateParams.regulationType).toEqual(undefined);
         expect(templateParams.reservedActivities).toEqual(undefined);
         expect(templateParams.protectedTitles).toEqual(undefined);
         expect(templateParams.regulationUrl).toEqual(undefined);

--- a/src/professions/admin/check-your-answers.controller.ts
+++ b/src/professions/admin/check-your-answers.controller.ts
@@ -87,6 +87,7 @@ export class CheckYourAnswersController {
       registrationRequirements: version.registrationRequirements,
       registrationUrl: version.registrationUrl,
       regulationSummary: version.description,
+      regulationType: version.regulationType,
       reservedActivities: version.reservedActivities,
       protectedTitles: version.protectedTitles,
       regulationUrl: version.regulationUrl,

--- a/src/professions/admin/dto/regulated-activities.dto.ts
+++ b/src/professions/admin/dto/regulated-activities.dto.ts
@@ -5,10 +5,14 @@ import {
   preprocessUrl,
   urlOptions,
 } from '../../../helpers/preprocess-url.helper';
+import { RegulationType } from '../../profession-version.entity';
 
 export class RegulatedActivitiesDto {
   @IsNotEmpty({ message: 'professions.form.errors.regulationSummary.empty' })
   regulationSummary: string;
+
+  @IsNotEmpty({ message: 'professions.form.errors.regulationType.empty' })
+  regulationType: RegulationType;
 
   @IsNotEmpty({ message: 'professions.form.errors.reservedActivities.empty' })
   reservedActivities: string;

--- a/src/professions/admin/interfaces/check-your-answers.template.ts
+++ b/src/professions/admin/interfaces/check-your-answers.template.ts
@@ -1,5 +1,6 @@
 import { Legislation } from '../../../legislations/legislation.entity';
 import QualificationPresenter from '../../../qualifications/presenters/qualification.presenter';
+import { RegulationType } from '../../profession-version.entity';
 
 export interface CheckYourAnswersTemplate {
   name: string;
@@ -12,6 +13,7 @@ export interface CheckYourAnswersTemplate {
   registrationRequirements: string;
   registrationUrl: string;
   regulationSummary: string;
+  regulationType: RegulationType;
   reservedActivities: string;
   protectedTitles: string;
   regulationUrl: string;

--- a/src/professions/admin/interfaces/regulated-activities.template.ts
+++ b/src/professions/admin/interfaces/regulated-activities.template.ts
@@ -1,5 +1,8 @@
+import { RadioButtonArgs } from '../../../common/interfaces/radio-button-args.interface';
+
 export interface RegulatedActivitiesTemplate {
   regulationSummary: string;
+  regulationTypeRadioButtonArgs: RadioButtonArgs[];
   reservedActivities: string;
   protectedTitles: string;
   regulationUrl: string;

--- a/src/professions/admin/presenters/regulation-type-radio-buttons.presenter.spec.ts
+++ b/src/professions/admin/presenters/regulation-type-radio-buttons.presenter.spec.ts
@@ -1,0 +1,105 @@
+import { RadioButtonArgs } from '../../../common/interfaces/radio-button-args.interface';
+import { createMockI18nService } from '../../../testutils/create-mock-i18n-service';
+import { translationOf } from '../../../testutils/translation-of';
+import { RegulationType } from '../../profession-version.entity';
+import { RegulationTypeRadioButtonsPresenter } from './regulation-type-radio-buttons.presenter';
+
+describe('RegulationTypeRadioButtonsPresenter', () => {
+  describe('radioButtonArgs', () => {
+    describe('when the current regulation type is empty', () => {
+      it('returns an array of `RadioButtonArgs`, with no option checked', async () => {
+        const i18nService = createMockI18nService();
+
+        const presenter = new RegulationTypeRadioButtonsPresenter(
+          null,
+          i18nService,
+        );
+
+        const expected: RadioButtonArgs[] = [
+          {
+            text: translationOf('professions.regulationTypes.licensing.name'),
+            value: 'licensing',
+            checked: false,
+            hint: {
+              text: translationOf('professions.regulationTypes.licensing.hint'),
+            },
+          },
+          {
+            text: translationOf(
+              'professions.regulationTypes.certification.name',
+            ),
+            value: 'certification',
+            checked: false,
+            hint: {
+              text: translationOf(
+                'professions.regulationTypes.certification.hint',
+              ),
+            },
+          },
+          {
+            text: translationOf(
+              'professions.regulationTypes.accreditation.name',
+            ),
+            value: 'accreditation',
+            checked: false,
+            hint: {
+              text: translationOf(
+                'professions.regulationTypes.accreditation.hint',
+              ),
+            },
+          },
+        ];
+
+        await expect(presenter.radioButtonArgs()).resolves.toEqual(expected);
+      });
+    });
+
+    describe('when the current regulation type is non-empty', () => {
+      it('returns an array of `RadioButtonArgs`, with the current regulation type checked', async () => {
+        const i18nService = createMockI18nService();
+
+        const presenter = new RegulationTypeRadioButtonsPresenter(
+          RegulationType.Certification,
+          i18nService,
+        );
+
+        const expected: RadioButtonArgs[] = [
+          {
+            text: translationOf('professions.regulationTypes.licensing.name'),
+            value: 'licensing',
+            checked: false,
+            hint: {
+              text: translationOf('professions.regulationTypes.licensing.hint'),
+            },
+          },
+          {
+            text: translationOf(
+              'professions.regulationTypes.certification.name',
+            ),
+            value: 'certification',
+            checked: true,
+            hint: {
+              text: translationOf(
+                'professions.regulationTypes.certification.hint',
+              ),
+            },
+          },
+          {
+            text: translationOf(
+              'professions.regulationTypes.accreditation.name',
+            ),
+            value: 'accreditation',
+            checked: false,
+            hint: {
+              text: translationOf(
+                'professions.regulationTypes.accreditation.hint',
+              ),
+            },
+          },
+        ];
+
+        await expect(presenter.radioButtonArgs()).resolves.toEqual(expected);
+      });
+    });
+  });
+});

--- a/src/professions/admin/presenters/regulation-type-radio-buttons.presenter.ts
+++ b/src/professions/admin/presenters/regulation-type-radio-buttons.presenter.ts
@@ -1,0 +1,27 @@
+import { I18nService } from 'nestjs-i18n';
+import { RadioButtonArgs } from '../../../common/interfaces/radio-button-args.interface';
+import { RegulationType } from '../../profession-version.entity';
+
+export class RegulationTypeRadioButtonsPresenter {
+  constructor(
+    private readonly selectedRegulationType: RegulationType | null,
+    private readonly i18nService: I18nService,
+  ) {}
+
+  async radioButtonArgs(): Promise<RadioButtonArgs[]> {
+    return Promise.all(
+      Object.values(RegulationType).map(async (regulationType) => ({
+        text: await this.i18nService.translate(
+          `professions.regulationTypes.${regulationType}.name`,
+        ),
+        value: regulationType,
+        checked: this.selectedRegulationType === regulationType,
+        hint: {
+          text: await this.i18nService.translate(
+            `professions.regulationTypes.${regulationType}.hint`,
+          ),
+        },
+      })),
+    );
+  }
+}

--- a/src/professions/admin/regulated-activities.controller.spec.ts
+++ b/src/professions/admin/regulated-activities.controller.spec.ts
@@ -2,14 +2,18 @@ import { createMock, DeepMocked } from '@golevelup/ts-jest';
 import { Test, TestingModule } from '@nestjs/testing';
 import { Response } from 'express';
 import { I18nService } from 'nestjs-i18n';
+import { RadioButtonArgs } from '../../common/interfaces/radio-button-args.interface';
 import { createMockI18nService } from '../../testutils/create-mock-i18n-service';
 import professionFactory from '../../testutils/factories/profession';
 import professionVersionFactory from '../../testutils/factories/profession-version';
 import { translationOf } from '../../testutils/translation-of';
+import { RegulationType } from '../profession-version.entity';
 import { ProfessionVersionsService } from '../profession-versions.service';
 import { ProfessionsService } from '../professions.service';
 import { RegulatedActivitiesDto } from './dto/regulated-activities.dto';
+import { RegulatedActivitiesTemplate } from './interfaces/regulated-activities.template';
 import { RegulatedActivitiesController } from './regulated-activities.controller';
+import { RegulationTypeRadioButtonsPresenter } from './presenters/regulation-type-radio-buttons.presenter';
 
 describe(RegulatedActivitiesController, () => {
   let controller: RegulatedActivitiesController;
@@ -55,11 +59,24 @@ describe(RegulatedActivitiesController, () => {
         id: 'version-id',
         profession: profession,
         description: 'Example regulation summary',
+        regulationType: RegulationType.Certification,
         reservedActivities: 'Example reserved activities',
       });
 
       professionsService.findWithVersions.mockResolvedValue(profession);
       professionVersionsService.findWithProfession.mockResolvedValue(version);
+
+      const mockRegulationTypeRadioButtonArgs: RadioButtonArgs[] = [
+        {
+          text: 'Example regulation type',
+          value: 'example',
+          checked: false,
+        },
+      ];
+
+      const regulationTypeRadioButtonArgsSpy = jest
+        .spyOn(RegulationTypeRadioButtonsPresenter.prototype, 'radioButtonArgs')
+        .mockResolvedValue(mockRegulationTypeRadioButtonArgs);
 
       await controller.edit(response, 'profession-id', 'version-id', 'false');
 
@@ -67,10 +84,13 @@ describe(RegulatedActivitiesController, () => {
         'admin/professions/regulated-activities',
         expect.objectContaining({
           regulationSummary: 'Example regulation summary',
+          regulationTypeRadioButtonArgs: mockRegulationTypeRadioButtonArgs,
           reservedActivities: 'Example reserved activities',
           captionText: translationOf('professions.form.captions.edit'),
-        }),
+        } as RegulatedActivitiesTemplate),
       );
+
+      expect(regulationTypeRadioButtonArgsSpy).toBeCalled();
     });
   });
 
@@ -95,6 +115,7 @@ describe(RegulatedActivitiesController, () => {
 
           const regulatedActivitiesDto: RegulatedActivitiesDto = {
             regulationSummary: 'Example regulation summary',
+            regulationType: RegulationType.Accreditation,
             reservedActivities: 'Example reserved activities',
             protectedTitles: 'Example protected titles',
             regulationUrl: 'https://example.com/regulation',
@@ -112,6 +133,7 @@ describe(RegulatedActivitiesController, () => {
             expect.objectContaining({
               id: 'version-id',
               description: 'Example regulation summary',
+              regulationType: RegulationType.Accreditation,
               reservedActivities: 'Example reserved activities',
               protectedTitles: 'Example protected titles',
               regulationUrl: 'https://example.com/regulation',
@@ -143,6 +165,7 @@ describe(RegulatedActivitiesController, () => {
 
           const regulatedActivitiesDto: RegulatedActivitiesDto = {
             regulationSummary: 'Example regulation summary',
+            regulationType: RegulationType.Certification,
             reservedActivities: 'Example reserved activities',
             protectedTitles: 'Example protected titles',
             regulationUrl: ' example.com/regulation',
@@ -160,6 +183,7 @@ describe(RegulatedActivitiesController, () => {
             expect.objectContaining({
               id: 'version-id',
               description: 'Example regulation summary',
+              regulationType: RegulationType.Certification,
               reservedActivities: 'Example reserved activities',
               protectedTitles: 'Example protected titles',
               regulationUrl: 'http://example.com/regulation',
@@ -179,6 +203,7 @@ describe(RegulatedActivitiesController, () => {
             id: 'version-id',
             profession: profession,
             description: 'Example regulation summary',
+            regulationType: RegulationType.Licensing,
             reservedActivities: 'Example reserved activities',
             protectedTitles: 'Example protected titles',
             regulationUrl: 'https://example.com/regulation',
@@ -191,6 +216,7 @@ describe(RegulatedActivitiesController, () => {
 
           const regulatedActivitiesDto: RegulatedActivitiesDto = {
             regulationSummary: 'Example regulation summary',
+            regulationType: RegulationType.Licensing,
             reservedActivities: 'Example reserved activities',
             protectedTitles: 'Example protected titles',
             regulationUrl: 'https://example.com/regulation',
@@ -229,6 +255,7 @@ describe(RegulatedActivitiesController, () => {
           id: 'version-id',
           profession: profession,
           description: 'Example regulation summary',
+          regulationType: RegulationType.Accreditation,
           reservedActivities: 'Example reserved activities',
           protectedTitles: 'Example protected titles',
           regulationUrl: 'https://example.com/regulation',
@@ -239,6 +266,7 @@ describe(RegulatedActivitiesController, () => {
 
         const regulatedActivitiesDto: RegulatedActivitiesDto = {
           regulationSummary: undefined,
+          regulationType: undefined,
           reservedActivities: undefined,
           protectedTitles: undefined,
           regulationUrl: undefined,
@@ -258,11 +286,14 @@ describe(RegulatedActivitiesController, () => {
           'admin/professions/regulated-activities',
           expect.objectContaining({
             errors: {
-              reservedActivities: {
-                text: 'professions.form.errors.reservedActivities.empty',
-              },
               regulationSummary: {
                 text: 'professions.form.errors.regulationSummary.empty',
+              },
+              regulationType: {
+                text: 'professions.form.errors.regulationType.empty',
+              },
+              reservedActivities: {
+                text: 'professions.form.errors.reservedActivities.empty',
               },
             },
           }),

--- a/src/professions/admin/regulated-activities.controller.ts
+++ b/src/professions/admin/regulated-activities.controller.ts
@@ -21,9 +21,14 @@ import { BackLink } from '../../common/decorators/back-link.decorator';
 
 import ViewUtils from './viewUtils';
 import { ProfessionVersionsService } from '../profession-versions.service';
-import { ProfessionVersion } from '../profession-version.entity';
+import {
+  ProfessionVersion,
+  RegulationType,
+} from '../profession-version.entity';
 import { Profession } from '../profession.entity';
 import { I18nService } from 'nestjs-i18n';
+import { RegulationTypeRadioButtonsPresenter } from './presenters/regulation-type-radio-buttons.presenter';
+
 @UseGuards(AuthenticationGuard)
 @Controller('admin/professions')
 export class RegulatedActivitiesController {
@@ -57,6 +62,7 @@ export class RegulatedActivitiesController {
     return this.renderForm(
       res,
       version.description,
+      version.regulationType,
       version.reservedActivities,
       version.protectedTitles,
       version.regulationUrl,
@@ -98,6 +104,7 @@ export class RegulatedActivitiesController {
       return this.renderForm(
         res,
         submittedValues.regulationSummary,
+        submittedValues.regulationType,
         submittedValues.reservedActivities,
         submittedValues.protectedTitles,
         submittedValues.regulationUrl,
@@ -110,6 +117,7 @@ export class RegulatedActivitiesController {
     const updatedVersion: ProfessionVersion = {
       ...version,
       ...{
+        regulationType: submittedValues.regulationType,
         description: submittedValues.regulationSummary,
         reservedActivities: submittedValues.reservedActivities,
         protectedTitles: submittedValues.protectedTitles,
@@ -133,6 +141,7 @@ export class RegulatedActivitiesController {
   private async renderForm(
     res: Response,
     regulationSummary: string | null,
+    regulationType: RegulationType | null,
     reservedActivities: string | null,
     protectedTitles: string | null,
     regulationUrl: string | null,
@@ -140,8 +149,17 @@ export class RegulatedActivitiesController {
     change: boolean,
     errors: object | undefined = undefined,
   ): Promise<void> {
+    const regulationTypePresenter = new RegulationTypeRadioButtonsPresenter(
+      regulationType,
+      this.i18nService,
+    );
+
+    const regulationTypeRadioButtonArgs =
+      await regulationTypePresenter.radioButtonArgs();
+
     const templateArgs: RegulatedActivitiesTemplate = {
       regulationSummary,
+      regulationTypeRadioButtonArgs,
       reservedActivities,
       protectedTitles,
       regulationUrl,

--- a/views/admin/professions/check-your-answers.njk
+++ b/views/admin/professions/check-your-answers.njk
@@ -163,6 +163,23 @@
               },
               {
                 key: {
+                  text: ("professions.form.label.regulatedActivities.regulationType" | t)
+                },
+                value: {
+                  text: (("professions.regulationTypes." + regulationType + ".name") | t) if regulationType else ""
+                },
+                actions: {
+                  items: [
+                    {
+                      href: "/admin/professions/" + professionId + "/versions/" + versionId + "/regulated-activities/edit?change=true",
+                      text: ("app.change" | t),
+                      visuallyHiddenText: ("professions.form.label.regulatedActivities.regulationType" | t)
+                    }
+                  ]
+                }
+              },
+              {
+                key: {
                   text: ("professions.form.label.regulatedActivities.reservedActivities" | t)
                 },
                 value: {

--- a/views/admin/professions/regulated-activities.njk
+++ b/views/admin/professions/regulated-activities.njk
@@ -4,6 +4,7 @@
 {% from "govuk/components/textarea/macro.njk" import govukTextarea %}
 {% from "govuk/components/details/macro.njk" import govukDetails %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
 
 {% set heading = ("professions.form.headings.regulatedActivities" | t) %}
 {% set title =  captionText + " | " + heading %}
@@ -37,6 +38,19 @@
             errorMessage: errors.regulationSummary | tError
           })
         }}
+
+        {{ govukRadios({
+          name: "regulationType",
+          fieldset: {
+            legend: {
+              text: ("professions.form.label.regulatedActivities.regulationType" | t),
+              classes: "govuk-fieldset__legend--m",
+              isPageHeading: false
+            }
+          },
+          items: regulationTypeRadioButtonArgs,
+          errorMessage: errors.regulationType | tError
+        }) }}
 
         {{
           govukTextarea({

--- a/views/professions/_profession-details.njk
+++ b/views/professions/_profession-details.njk
@@ -96,11 +96,17 @@
 
   <div>
     <h2 class="govuk-heading-m rpr-details__section-title">{{ "professions.show.regulatedActivities.heading" | t }}</h2>
-
     <div>
       <h3 class="govuk-heading-s">{{ "professions.show.regulatedActivities.regulationSummary" | t }}</h3>
       {{ profession.description | multiline('govuk-body') }}
     </div>
+
+    {% if profession.regulationType or showEmptyProfessionDetails %}
+      <div>
+        <h3 class="govuk-heading-s">{{ "professions.show.regulatedActivities.regulationType" | t }}</h3>
+        <p class="govuk-body">{{ (("professions.regulationTypes." + profession.regulationType + ".name") | t) if profession.regulationType else "" }}</p>
+      </div>
+    {% endif %}
 
     {% if profession.reservedActivities or showEmptyProfessionDetails %}
       <div>


### PR DESCRIPTION
# Changes in this PR

## Screenshots of UI changes
- Allow editors to enter a regulation type for a Profession
- Display regulation type on internal and public Profession pages

### Before
![localhost_3000_admin_professions_03bec1c4-4744-4c0f-a1c7-855522bd919e_versions_b8011153-237e-41a2-98c6-e19963d47be9_regulated-activities_edit_change=true](https://user-images.githubusercontent.com/94137563/158204731-0f43dd72-c741-4df2-9934-446d2c17567c.png)

### After
![localhost_3000_admin_professions_03bec1c4-4744-4c0f-a1c7-855522bd919e_versions_b8011153-237e-41a2-98c6-e19963d47be9_regulated-activities_edit_change=true (1)](https://user-images.githubusercontent.com/94137563/158204743-ce0eb84a-43fb-4c48-9be7-de0d9ad917d2.png)

