### PR TITLE
(2184) Alphabetical Profession search results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - Fix wrong links on dashboard
+- Sort professions alphabetically in search results
 
 ## [release-008] - 2022-03-11
 

--- a/cypress/integration/professions/search/search.spec.ts
+++ b/cypress/integration/professions/search/search.spec.ts
@@ -32,7 +32,7 @@ describe('Searching a profession', () => {
     });
   });
 
-  it('Organisations are sorted alphabetically', () => {
+  it('Professions are sorted alphabetically', () => {
     cy.get('h2').then((elements) => {
       const names = elements.map((_, element) => element.innerText).toArray();
       cy.wrap(names).should('deep.equal', names.sort());

--- a/src/i18n/en/professions.json
+++ b/src/i18n/en/professions.json
@@ -298,7 +298,7 @@
     "labels": {
       "keywords": "Keywords:",
       "nations": "Nations:",
-      "industries": "Industries:"
+      "industries": "Sectors:"
     },
     "profession": {
       "regulators": "Regulators",

--- a/src/professions/profession-versions.service.spec.ts
+++ b/src/professions/profession-versions.service.spec.ts
@@ -451,6 +451,7 @@ describe('ProfessionVersionsService', () => {
       const queryBuilder = createMock<SelectQueryBuilder<ProfessionVersion>>({
         leftJoinAndSelect: () => queryBuilder,
         where: () => queryBuilder,
+        orderBy: () => queryBuilder,
         getMany: async () => versions,
       });
 
@@ -482,6 +483,7 @@ describe('ProfessionVersionsService', () => {
           status: ProfessionVersionStatus.Live,
         },
       );
+      expect(queryBuilder.orderBy).toHaveBeenCalledWith('profession.name');
     });
   });
 

--- a/src/professions/profession-versions.service.ts
+++ b/src/professions/profession-versions.service.ts
@@ -166,6 +166,7 @@ export class ProfessionVersionsService {
       .where('professionVersion.status = :status', {
         status: ProfessionVersionStatus.Live,
       })
+      .orderBy('profession.name')
       .getMany();
 
     return versions.map((version) =>


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR

Sorts professions at service level - we didn't move the sorting logic across when we started using Profession Versions here.

Updates selected "Sector" filter text to read "Sectors:" rather than "Industries" for consistency.

## Screenshots of UI changes

### Before

![image](https://user-images.githubusercontent.com/19826940/158374747-9ee7fb71-8846-411b-8381-87c8369a1076.png)


#### Filter text

![image](https://user-images.githubusercontent.com/19826940/158374671-c83f106e-f22f-4f27-ad3e-65a957b1b4f9.png)

### After

![image](https://user-images.githubusercontent.com/19826940/158374389-029f9d84-d25f-445b-a611-46efb09aaff6.png)

#### Filter text

![image](https://user-images.githubusercontent.com/19826940/158374436-f71074b2-d498-4276-a1d4-60f7130aac8d.png)

