### PR TITLE
(2204) Delete from Opensearch when archiving

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Index profession versions in Opensearch when publishing
 - Delete previously indexed profession versions from Opensearch when publishing
+- Delete profession versions from Opensearch when archiving
 
 ## [release-009] - 2022-03-11
 

--- a/cypress/support/index.ts
+++ b/cypress/support/index.ts
@@ -67,14 +67,11 @@ declare global {
 // Import commands.js using ES2015 syntax:
 import './commands';
 
-// Seed the database before running the specs
-before(() => {
-  cy.exec('npm run seed:test');
-});
-
-// Purge the Opensearch index before running the specs
+// Purge the Opensearch index and seed the database
+// before running the specs
 before(() => {
   cy.exec('npm run opensearch:test:purge');
+  cy.exec('npm run seed:test');
 });
 
 // Alternatively you can use CommonJS syntax:

--- a/src/professions/profession-versions.service.spec.ts
+++ b/src/professions/profession-versions.service.spec.ts
@@ -368,6 +368,23 @@ describe('ProfessionVersionsService', () => {
       expect(queryRunner.release).toHaveBeenCalled();
     });
 
+    it('deletes all versions from opensearch', async () => {
+      const version = professionVersionFactory.build({
+        status: ProfessionVersionStatus.Draft,
+      });
+
+      const otherVersions = professionVersionFactory.buildList(3);
+
+      (repo.find as jest.Mock).mockReturnValue(otherVersions);
+
+      await service.archive(version);
+
+      expect(searchService.bulkDelete).toHaveBeenCalledWith(otherVersions);
+
+      expect(queryRunner.commitTransaction).toHaveBeenCalled();
+      expect(queryRunner.release).toHaveBeenCalled();
+    });
+
     it('rolls back the transaction if an error occurs', async () => {
       const version = professionVersionFactory.build({
         status: ProfessionVersionStatus.Draft,

--- a/src/professions/profession-versions.service.ts
+++ b/src/professions/profession-versions.service.ts
@@ -136,6 +136,12 @@ export class ProfessionVersionsService {
       await queryRunner.release();
     }
 
+    const versions = await this.repository.find({
+      where: { profession: profession },
+    });
+
+    await this.searchService.bulkDelete(versions);
+
     return version;
   }
 

--- a/src/professions/professions-search.service.spec.ts
+++ b/src/professions/professions-search.service.spec.ts
@@ -48,7 +48,7 @@ describe('ProfessionVersionsService', () => {
   });
 
   describe('delete', () => {
-    it('delete the entity', async () => {
+    it('deletes the entity', async () => {
       const professionVersion = professionVersionFactory.build();
 
       service.delete(professionVersion);
@@ -56,6 +56,30 @@ describe('ProfessionVersionsService', () => {
       expect(opensearchClient.delete).toHaveBeenCalledWith({
         index: service.indexName,
         id: professionVersion.id,
+      });
+    });
+  });
+
+  describe('bulkDelete', () => {
+    it('deletes all entities with given ids', async () => {
+      const professionVersion1 = professionVersionFactory.build({
+        id: 'some-uuid',
+      });
+      const professionVersion2 = professionVersionFactory.build({
+        id: 'some-other-uuid',
+      });
+
+      service.bulkDelete([professionVersion1, professionVersion2]);
+
+      expect(opensearchClient.deleteByQuery).toHaveBeenCalledWith({
+        index: service.indexName,
+        body: {
+          query: {
+            ids: {
+              values: ['some-uuid', 'some-other-uuid'],
+            },
+          },
+        },
       });
     });
   });

--- a/src/professions/professions-search.service.ts
+++ b/src/professions/professions-search.service.ts
@@ -24,4 +24,19 @@ export class ProfessionsSearchService {
       id: professionVersion.id,
     });
   }
+
+  public async bulkDelete(versions: ProfessionVersion[]): Promise<any> {
+    const ids = versions.map((version) => version.id);
+
+    await this.client.deleteByQuery({
+      index: this.indexName,
+      body: {
+        query: {
+          ids: {
+            values: ids,
+          },
+        },
+      },
+    });
+  }
 }


### PR DESCRIPTION
This adds an action to delete all a profession's versions when archiving a profession. 

I originally wanted to refactor the whole archive method to create a the version we're about to archive, and then create an archived version within the archive service method, because I wanted to have a reference to the most recently indexed version. However:

a) We have to guarantee that the version we're archiving is indexed (it could be a draft version)
b) It makes more sense to ensure there are no versions hanging around