### PR TITLE
(2115) Improve user editing constraints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Search profession titles using Opensearch
 - Allow central users to filter Profession and Organisation listings by regulation type
 
+### Changed
+
+- Improve constraints around editing users
+
 ## [release-009] - 2022-03-11
 
 ### Changed

--- a/src/users/helpers/check-can-view-organisation.spec.ts
+++ b/src/users/helpers/check-can-view-organisation.spec.ts
@@ -1,0 +1,99 @@
+import { UnauthorizedException } from '@nestjs/common';
+import { createDefaultMockRequest } from '../../testutils/factories/create-default-mock-request';
+import organisationFactory from '../../testutils/factories/organisation';
+import userFactory from '../../testutils/factories/user';
+import { checkCanViewOrganisation } from './check-can-view-organisation';
+import { getActingUser } from './get-acting-user.helper';
+
+jest.mock('./get-acting-user.helper');
+
+describe('checkCanViewOrganisation', () => {
+  describe('when called with a request from a non-service owner user', () => {
+    describe('when trying to view data from the same organisation', () => {
+      it('returns without throwing an Error', () => {
+        const organisation = organisationFactory.build();
+        const user = userFactory.build({
+          serviceOwner: false,
+          organisation: organisation,
+        });
+
+        (getActingUser as jest.Mock).mockReturnValue(user);
+
+        const request = createDefaultMockRequest({ user: user });
+
+        expect(() => {
+          checkCanViewOrganisation(request, organisation);
+        }).not.toThrowError();
+      });
+    });
+
+    describe('when trying to view data from a different organisation', () => {
+      it('throws an UnauthorisedException', () => {
+        const userOrganisation = organisationFactory.build();
+        const user = userFactory.build({
+          serviceOwner: false,
+          organisation: userOrganisation,
+        });
+        const otherOrganisation = organisationFactory.build();
+
+        (getActingUser as jest.Mock).mockReturnValue(user);
+
+        const request = createDefaultMockRequest({ user: user });
+
+        expect(() => {
+          checkCanViewOrganisation(request, otherOrganisation);
+        }).toThrowError(UnauthorizedException);
+      });
+    });
+
+    describe('when trying to view data with no organisation passed in e.g. for a service owner', () => {
+      it('throws an UnauthorisedException', () => {
+        const userOrganisation = organisationFactory.build();
+        const user = userFactory.build({
+          serviceOwner: false,
+          organisation: userOrganisation,
+        });
+
+        (getActingUser as jest.Mock).mockReturnValue(user);
+
+        const request = createDefaultMockRequest({ user: user });
+
+        expect(() => {
+          checkCanViewOrganisation(request, null);
+        }).toThrowError(UnauthorizedException);
+      });
+    });
+  });
+
+  describe('when called as a service owner user', () => {
+    it('returns without throwing an Error', () => {
+      const user = userFactory.build({ serviceOwner: true });
+      const otherOrganisation = organisationFactory.build();
+
+      (getActingUser as jest.Mock).mockReturnValue(user);
+
+      const request = createDefaultMockRequest({ user: user });
+
+      expect(() => {
+        checkCanViewOrganisation(request, otherOrganisation);
+      }).not.toThrowError();
+    });
+
+    describe('when trying to view data with no organisation passed in e.g. for a service owner', () => {
+      it('returns true without throwing an Error', () => {
+        const user = userFactory.build({
+          serviceOwner: true,
+          organisation: null,
+        });
+
+        (getActingUser as jest.Mock).mockReturnValue(user);
+
+        const request = createDefaultMockRequest({ user: user });
+
+        expect(() => {
+          checkCanViewOrganisation(request, null);
+        }).not.toThrowError(UnauthorizedException);
+      });
+    });
+  });
+});

--- a/src/users/helpers/check-can-view-organisation.ts
+++ b/src/users/helpers/check-can-view-organisation.ts
@@ -1,0 +1,20 @@
+import { UnauthorizedException } from '@nestjs/common/exceptions/unauthorized.exception';
+import { RequestWithAppSession } from '../../common/interfaces/request-with-app-session.interface';
+import { Organisation } from '../../organisations/organisation.entity';
+import { getActingUser } from './get-acting-user.helper';
+
+export function checkCanViewOrganisation(
+  request: RequestWithAppSession,
+  organisation?: Organisation | null,
+): void {
+  const actingUser = getActingUser(request);
+
+  if (
+    actingUser.serviceOwner ||
+    actingUser.organisation.id === organisation?.id
+  ) {
+    return;
+  }
+
+  throw new UnauthorizedException();
+}

--- a/src/users/helpers/check-can-view-user.spec.ts
+++ b/src/users/helpers/check-can-view-user.spec.ts
@@ -1,0 +1,25 @@
+import { createDefaultMockRequest } from '../../testutils/factories/create-default-mock-request';
+import organisationFactory from '../../testutils/factories/organisation';
+import userFactory from '../../testutils/factories/user';
+import { checkCanViewOrganisation } from './check-can-view-organisation';
+import { checkCanViewUser } from './check-can-view-user';
+
+jest.mock('./check-can-view-organisation');
+
+describe('checkCanViewUser', () => {
+  it('passes in a user with an organisation to call CheckCanViewOrganisation', () => {
+    const organisation = organisationFactory.build();
+    const user = userFactory.build({
+      serviceOwner: false,
+      organisation: organisation,
+    });
+
+    const request = createDefaultMockRequest({ user: user });
+    checkCanViewUser(request, user);
+
+    expect(checkCanViewOrganisation).toHaveBeenCalledWith(
+      request,
+      organisation,
+    );
+  });
+});

--- a/src/users/helpers/check-can-view-user.ts
+++ b/src/users/helpers/check-can-view-user.ts
@@ -1,0 +1,7 @@
+import { RequestWithAppSession } from '../../common/interfaces/request-with-app-session.interface';
+import { User } from '../user.entity';
+import { checkCanViewOrganisation } from './check-can-view-organisation';
+
+export function checkCanViewUser(request: RequestWithAppSession, user: User) {
+  checkCanViewOrganisation(request, user.organisation);
+}

--- a/src/users/role/role.controller.ts
+++ b/src/users/role/role.controller.ts
@@ -7,6 +7,7 @@ import {
   Res,
   UseGuards,
   Query,
+  Req,
 } from '@nestjs/common';
 import { Request, Response } from 'express';
 
@@ -28,6 +29,8 @@ import {
   getActionTypeFromUser,
   ActionType,
 } from '../helpers/get-action-type-from-user';
+import { RequestWithAppSession } from '../../common/interfaces/request-with-app-session.interface';
+import { checkCanViewUser } from '../helpers/check-can-view-user';
 
 @UseGuards(AuthenticationGuard)
 @Controller('/admin/users')
@@ -48,8 +51,11 @@ export class RoleController {
     @Res() res: Response,
     @Param('id') id,
     @Query('change') change: boolean,
+    @Req() request: RequestWithAppSession,
   ): Promise<void> {
     const user = await this.usersService.find(id);
+
+    checkCanViewUser(request, user);
 
     return this.renderForm(
       res,
@@ -72,8 +78,11 @@ export class RoleController {
     @Res() res: Response,
     @Param('id') id: string,
     @Body() permissionsDto,
+    @Req() request: RequestWithAppSession,
   ): Promise<void> {
     const user = await this.usersService.find(id);
+
+    checkCanViewUser(request, user);
 
     const validator = await Validator.validate(RoleDto, permissionsDto);
     const submittedValues = validator.obj;

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -29,6 +29,7 @@ import { RequestWithAppSession } from '../common/interfaces/request-with-app-ses
 import { getActingUser } from './helpers/get-acting-user.helper';
 import { CompleteTemplate } from './interfaces/complete-template';
 import { getUserOrganisation } from './helpers/get-user-organisation';
+import { checkCanViewUser } from './helpers/check-can-view-user';
 
 class UserAlreadyExistsError extends Error {}
 
@@ -71,8 +72,13 @@ export class UsersController {
   @Get('/admin/users/:id')
   @Permissions(UserPermission.EditUser, UserPermission.DeleteUser)
   @Render('admin/users/show')
-  async show(@Param('id') id): Promise<ShowTemplate> {
+  async show(
+    @Param('id') id,
+    @Req() request: RequestWithAppSession,
+  ): Promise<ShowTemplate> {
     const user = await this.usersService.find(id);
+
+    checkCanViewUser(request, user);
 
     return {
       ...user,
@@ -102,9 +108,14 @@ export class UsersController {
   @Permissions(UserPermission.CreateUser, UserPermission.EditUser)
   @Render('admin/users/confirm')
   @BackLink('/admin/users/:id/permissions/edit')
-  async confirm(@Param('id') id): Promise<ConfirmTemplate> {
+  async confirm(
+    @Req() request: RequestWithAppSession,
+    @Param('id') id,
+  ): Promise<ConfirmTemplate> {
     const user = await this.usersService.find(id);
     const action = getActionTypeFromUser(user);
+
+    checkCanViewUser(request, user);
 
     return {
       ...user,
@@ -114,9 +125,15 @@ export class UsersController {
 
   @Post('/admin/users/:id/confirm')
   @Permissions(UserPermission.CreateUser, UserPermission.EditUser)
-  async complete(@Res() res, @Param('id') id): Promise<void> {
+  async complete(
+    @Res() res,
+    @Param('id') id,
+    @Req() request: RequestWithAppSession,
+  ): Promise<void> {
     const user = await this.usersService.find(id);
     const action = getActionTypeFromUser(user);
+
+    checkCanViewUser(request, user);
 
     if (action == 'new') {
       try {


### PR DESCRIPTION
# Changes in this PR

Before this change, users could theoretically edit other users if they had a url containing a UUID of that user. This prevents that with a new `checkCanViewOrganisationData` function.