### PR TITLE
(2204) Search Profession titles using opensearch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Index profession versions in Opensearch when publishing
 - Delete previously indexed profession versions from Opensearch when publishing
 - Delete profession versions from Opensearch when archiving
+- Search profession titles using Opensearch
 
 ## [release-009] - 2022-03-11
 

--- a/cypress/integration/admin/professions/archive.spec.ts
+++ b/cypress/integration/admin/professions/archive.spec.ts
@@ -146,6 +146,14 @@ describe('Archiving professions', () => {
       cy.visitAndCheckAccessibility('/professions/search');
 
       cy.get('body').should('not.contain', 'Registered Trademark Attorney');
+
+      cy.visit('/professions/search');
+
+      cy.get('input[name="keywords"]').type('Attorney');
+
+      cy.get('button').click();
+
+      cy.get('body').should('not.contain', 'Registered Trademark Attorney');
     });
   });
 });

--- a/cypress/integration/admin/professions/publish.spec.ts
+++ b/cypress/integration/admin/professions/publish.spec.ts
@@ -491,6 +491,14 @@ describe('Publishing professions', () => {
       );
 
       cy.visitAndCheckAccessibility('/professions/search');
+
+      cy.visit('/professions/search');
+
+      cy.get('input[name="keywords"]').type('Example');
+      cy.get('button').click();
+
+      cy.get('body').should('contain', 'Example Profession');
+
       cy.get('a').contains('Example Profession').click();
 
       cy.get('h1').should('contain', 'Example Profession');

--- a/src/professions/professions-search.service.spec.ts
+++ b/src/professions/professions-search.service.spec.ts
@@ -83,4 +83,39 @@ describe('ProfessionVersionsService', () => {
       });
     });
   });
+
+  describe('search', () => {
+    it('runs a search query', async () => {
+      (opensearchClient.search as jest.Mock).mockReturnValue({
+        body: {
+          hits: {
+            hits: [
+              {
+                _id: '123',
+              },
+              {
+                _id: '456',
+              },
+            ],
+          },
+        },
+      });
+
+      const result = await service.search('something');
+
+      expect(result).toEqual(['123', '456']);
+
+      expect(opensearchClient.search).toHaveBeenCalledWith({
+        index: service.indexName,
+        body: {
+          query: {
+            multi_match: {
+              query: 'something',
+              fields: ['name'],
+            },
+          },
+        },
+      });
+    });
+  });
 });

--- a/src/professions/professions-search.service.ts
+++ b/src/professions/professions-search.service.ts
@@ -1,7 +1,10 @@
 import { OpensearchClient } from 'nestjs-opensearch';
 import { Injectable } from '@nestjs/common';
+import {
+  SearchResponse,
+  SearchHit,
+} from '@opensearch-project/opensearch/api/types';
 import { ProfessionVersion } from './profession-version.entity';
-
 @Injectable()
 export class ProfessionsSearchService {
   readonly indexName: string = `professions_${process.env['NODE_ENV']}`;
@@ -38,5 +41,23 @@ export class ProfessionsSearchService {
         },
       },
     });
+  }
+
+  public async search(query: string): Promise<string[]> {
+    const response = await this.client.search<SearchResponse>({
+      index: this.indexName,
+      body: {
+        query: {
+          multi_match: {
+            query: query,
+            fields: ['name'],
+          },
+        },
+      },
+    });
+
+    const hits = response.body.hits.hits;
+
+    return hits.map((hit: SearchHit) => hit._id);
   }
 }

--- a/src/professions/search/search.controller.spec.ts
+++ b/src/professions/search/search.controller.spec.ts
@@ -56,7 +56,7 @@ describe('SearchController', () => {
         name: 'Trademark Attorney',
         industries: [industry2, industry3],
       });
-      professionVersionsService.allLive.mockResolvedValue([
+      professionVersionsService.searchLive.mockResolvedValue([
         schoolTeacher,
         trademarkAttorney,
       ]);
@@ -85,7 +85,7 @@ describe('SearchController', () => {
         nations: [],
       });
 
-      expect(professionVersionsService.allLive).toHaveBeenCalled();
+      expect(professionVersionsService.searchLive).toHaveBeenCalled();
     });
   });
 
@@ -105,7 +105,8 @@ describe('SearchController', () => {
         name: 'Trademark Attorney',
         industries: [industry2, industry3],
       });
-      professionVersionsService.allLive.mockResolvedValue([
+
+      professionVersionsService.searchLive.mockResolvedValue([
         schoolTeacher,
         trademarkAttorney,
       ]);
@@ -124,178 +125,34 @@ describe('SearchController', () => {
         },
         Nation.all(),
         industries,
-        [],
-        i18nService,
-      ).present();
-
-      expect(result).toEqual(expected);
-    });
-
-    it('should return filtered professions when searching by nation', async () => {
-      const industry1 = industryFactory.build();
-      const industry2 = industryFactory.build();
-      const industry3 = industryFactory.build();
-      const industries = [industry1, industry2, industry3];
-      industriesService.all.mockResolvedValue(industries);
-
-      const professionRegulatedInEngland = professionFactory.build({
-        name: 'Secondary School Teacher',
-        industries: [industry1],
-        occupationLocations: ['GB-ENG'],
-      });
-      const professionRegulatedInWales = professionFactory.build({
-        name: 'Trademark Attorney',
-        industries: [industry2, industry3],
-        occupationLocations: ['GB-WLS'],
-      });
-      professionVersionsService.allLive.mockResolvedValue([
-        professionRegulatedInEngland,
-        professionRegulatedInWales,
-      ]);
-
-      const result = await controller.create({
-        keywords: '',
-        industries: [],
-        nations: ['GB-WLS'],
-      });
-
-      const expected = await new SearchPresenter(
-        {
-          keywords: '',
-          industries: [],
-          nations: [Nation.find('GB-WLS')],
-        },
-        Nation.all(),
-        industries,
-        [professionRegulatedInWales],
-        i18nService,
-      ).present();
-
-      expect(result).toEqual(expected);
-    });
-
-    it('should return filtered professions when searching by industry', async () => {
-      const educationIndustry = industryFactory.build({
-        name: 'industries.education',
-      });
-      const lawIndustry = industryFactory.build({ name: 'industries.law' });
-      const industries = [educationIndustry, lawIndustry];
-      industriesService.all.mockResolvedValue(industries);
-
-      const schoolTeacher = professionFactory.build({
-        name: 'Secondary School Teacher',
-        industries: [educationIndustry],
-      });
-      const trademarkAttorney = professionFactory.build({
-        name: 'Trademark Attorney',
-        industries: [lawIndustry],
-      });
-      professionVersionsService.allLive.mockResolvedValue([
-        schoolTeacher,
-        trademarkAttorney,
-      ]);
-
-      const result = await controller.create({
-        keywords: '',
-        industries: [educationIndustry.id],
-        nations: [],
-      });
-
-      const expected = await new SearchPresenter(
-        {
-          keywords: '',
-          industries: [educationIndustry],
-          nations: [],
-        },
-        Nation.all(),
-        industries,
-        [schoolTeacher],
-        i18nService,
-      ).present();
-
-      expect(result).toEqual(expected);
-    });
-
-    it('should return filtered professions when searching by keyword', async () => {
-      const industry1 = industryFactory.build();
-      const industry2 = industryFactory.build();
-      const industry3 = industryFactory.build();
-      const industries = [industry1, industry2, industry3];
-      industriesService.all.mockResolvedValue(industries);
-
-      const schoolTeacher = professionFactory.build({
-        name: 'Secondary School Teacher',
-        industries: [industry1],
-      });
-      const trademarkAttorney = professionFactory.build({
-        name: 'Trademark Attorney',
-        industries: [industry2, industry3],
-      });
-      professionVersionsService.allLive.mockResolvedValue([
-        schoolTeacher,
-        trademarkAttorney,
-      ]);
-
-      const result = await controller.create({
-        keywords: 'Trademark',
-        industries: [],
-        nations: [],
-      });
-
-      const expected = await new SearchPresenter(
-        {
-          keywords: 'Trademark',
-          industries: [],
-          nations: [],
-        },
-        Nation.all(),
-        industries,
-        [trademarkAttorney],
-        i18nService,
-      ).present();
-
-      expect(result).toEqual(expected);
-    });
-
-    it('should return unfiltered professions when no search parameters are specified', async () => {
-      const industry1 = industryFactory.build();
-      const industry2 = industryFactory.build();
-      const industries = [industry1, industry2];
-      industriesService.all.mockResolvedValue(industries);
-
-      const schoolTeacher = professionFactory.build({
-        name: 'Secondary School Teacher',
-        industries: [industry1],
-      });
-      const trademarkAttorney = professionFactory.build({
-        name: 'Trademark Attorney',
-        industries: [industry2],
-      });
-
-      professionVersionsService.allLive.mockResolvedValue([
-        schoolTeacher,
-        trademarkAttorney,
-      ]);
-
-      const result = await controller.create({
-        keywords: '',
-        industries: [],
-        nations: [],
-      });
-
-      const expected = await new SearchPresenter(
-        {
-          keywords: '',
-          industries: [],
-          nations: [],
-        },
-        Nation.all(),
-        industries,
         [schoolTeacher, trademarkAttorney],
         i18nService,
       ).present();
 
       expect(result).toEqual(expected);
+
+      expect(professionVersionsService.searchLive).toHaveBeenCalledWith({
+        keywords: 'example search',
+        industries: [industry1, industry2],
+        nations: [Nation.find('GB-SCT')],
+      });
+    });
+
+    it('should call the search service with the provided filters', async () => {
+      const industry1 = industryFactory.build();
+      const industry2 = industryFactory.build();
+
+      await controller.create({
+        keywords: 'example search',
+        industries: [industry1.id, industry2.id],
+        nations: ['GB-SCT'],
+      });
+
+      expect(professionVersionsService.searchLive).toHaveBeenCalledWith({
+        keywords: 'example search',
+        industries: [industry1, industry2],
+        nations: [Nation.find('GB-SCT')],
+      });
     });
   });
 });

--- a/src/professions/search/search.controller.ts
+++ b/src/professions/search/search.controller.ts
@@ -3,7 +3,6 @@ import { I18nService } from 'nestjs-i18n';
 import { IndustriesService } from '../../industries/industries.service';
 import { Nation } from '../../nations/nation';
 import { FilterDto } from './dto/filter.dto';
-import { ProfessionsFilterHelper } from '../helpers/professions-filter.helper';
 import { IndexTemplate } from './interfaces/index-template.interface';
 import { SearchPresenter } from './search.presenter';
 import { BackLink } from '../../common/decorators/back-link.decorator';
@@ -36,17 +35,15 @@ export class SearchController {
     const allNations = Nation.all();
     const allIndustries = await this.industriesService.all();
 
-    const allProfessions = await this.professionVersionsService.allLive();
-
     const filterInput = createFilterInput({
       ...filter,
       allNations,
       allIndustries,
     });
 
-    const filteredProfessions = new ProfessionsFilterHelper(
-      allProfessions,
-    ).filter(filterInput);
+    const filteredProfessions = await this.professionVersionsService.searchLive(
+      filterInput,
+    );
 
     return new SearchPresenter(
       filterInput,


### PR DESCRIPTION
This pulls together the previous Opensearch-related PRs to add an endpoint that runs a search query against indexed data in Opensearch. We then have a database-level search method that gets the IDs of the versions that match a query and adds any other filters to it.

At the moment, this just replicates the functionality we already have. The next job is to index and search against other fields.