### PR TITLE
(2271) Remove the changed by filter from regulator logins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Fix wrong links on dashboard
 - Sort professions alphabetically in search results
+- Remove unimplemented "changed by" filter from internal filters
 
 ## [release-008] - 2022-03-11
 

--- a/src/common/interfaces/filter-input.interface.ts
+++ b/src/common/interfaces/filter-input.interface.ts
@@ -1,4 +1,3 @@
-import { User } from 'src/users/user.entity';
 import { Industry } from '../../industries/industry.entity';
 import { Nation } from '../../nations/nation';
 import { Organisation } from '../../organisations/organisation.entity';
@@ -10,5 +9,4 @@ export interface FilterInput {
   organisations?: Organisation[];
   industries?: Industry[];
   regulationTypes?: RegulationType[];
-  changedBy?: User[];
 }

--- a/src/i18n/en/professions.json
+++ b/src/i18n/en/professions.json
@@ -223,8 +223,7 @@
       "nations": "Nations:",
       "organisations": "Regulators:",
       "industries": "Industries:",
-      "regulationTypes": "Regulation types:",
-      "changedBy": "Changed by:"
+      "regulationTypes": "Regulation types:"
     },
     "filter": {
       "keywords": {
@@ -245,10 +244,6 @@
       },
       "regulationTypes": {
         "label": "Regulation types",
-        "hint": "Select all that apply."
-      },
-      "changedBy": {
-        "label": "Changed by",
         "hint": "Select all that apply."
       },
       "button": "Filter results"

--- a/src/professions/admin/dto/filter.dto.ts
+++ b/src/professions/admin/dto/filter.dto.ts
@@ -6,5 +6,4 @@ export class FilterDto {
   organisations?: string[] = [];
   industries?: string[] = [];
   regulationTypes?: RegulationType[] = [];
-  changedBy?: string[] = [];
 }

--- a/src/professions/admin/interfaces/index-template.interface.ts
+++ b/src/professions/admin/interfaces/index-template.interface.ts
@@ -16,12 +16,10 @@ export interface IndexTemplate {
     organisations: string[];
     industries: string[];
     regulationTypes: RegulationType[];
-    changedBy: string[];
   };
 
   nationsCheckboxItems: CheckboxItems[];
   organisationsCheckboxItems: CheckboxItems[];
   industriesCheckboxItems: CheckboxItems[];
   regulationTypesCheckboxItems: CheckboxItems[];
-  changedByCheckboxItems: CheckboxItems[];
 }

--- a/src/professions/admin/professions.controller.spec.ts
+++ b/src/professions/admin/professions.controller.spec.ts
@@ -379,7 +379,6 @@ describe('ProfessionsController', () => {
             keywords: '',
             nations: [],
             organisations: [],
-            changedBy: [],
           },
           organisation1,
           [profession1, profession2],
@@ -397,7 +396,6 @@ describe('ProfessionsController', () => {
         const result = await controller.index(request, {
           keywords: 'primary',
           nations: [],
-          changedBy: [],
         });
 
         const expected = await createPresenter(
@@ -405,7 +403,6 @@ describe('ProfessionsController', () => {
             keywords: 'primary',
             nations: [],
             organisations: [],
-            changedBy: [],
           },
           organisation1,
           [profession1],
@@ -423,7 +420,6 @@ describe('ProfessionsController', () => {
         const result = await controller.index(request, {
           keywords: '',
           nations: ['GB-NIR'],
-          changedBy: [],
         });
 
         const expected = await createPresenter(
@@ -431,7 +427,6 @@ describe('ProfessionsController', () => {
             keywords: '',
             nations: [Nation.find('GB-NIR')],
             organisations: [],
-            changedBy: [],
           },
           organisation1,
           [profession2],

--- a/src/professions/admin/professions.presenter.spec.ts
+++ b/src/professions/admin/professions.presenter.spec.ts
@@ -116,7 +116,6 @@ describe('ProfessionsPresenter', () => {
           organisations: ['Example Organisation 1'],
           industries: ['industries.transport'],
           regulationTypes: [RegulationType.Certification],
-          changedBy: [],
         },
 
         nationsCheckboxItems: await new NationsCheckboxPresenter(
@@ -138,7 +137,6 @@ describe('ProfessionsPresenter', () => {
             [RegulationType.Certification],
             i18nService,
           ).checkboxItems(),
-        changedByCheckboxItems: [],
       };
 
       expect(result).toEqual(expected);
@@ -174,7 +172,6 @@ describe('ProfessionsPresenter', () => {
           organisations: ['Example Organisation 1'],
           industries: ['industries.transport'],
           regulationTypes: [RegulationType.Certification],
-          changedBy: [],
         },
         nationsCheckboxItems: await new NationsCheckboxPresenter(
           nations,
@@ -195,7 +192,6 @@ describe('ProfessionsPresenter', () => {
             [RegulationType.Certification],
             i18nService,
           ).checkboxItems(),
-        changedByCheckboxItems: [],
       };
 
       expect(result).toEqual(expected);

--- a/src/professions/admin/professions.presenter.ts
+++ b/src/professions/admin/professions.presenter.ts
@@ -62,7 +62,6 @@ export class ProfessionsPresenter {
       organisationsCheckboxItems,
       industriesCheckboxItems,
       regulationTypesCheckboxItems,
-      changedByCheckboxItems: [],
       filters: {
         keywords: this.filterInput.keywords || '',
         nations: (this.filterInput.nations || []).map((nation) => nation.name),
@@ -73,7 +72,6 @@ export class ProfessionsPresenter {
           (industry) => industry.name,
         ),
         regulationTypes: this.filterInput.regulationTypes || [],
-        changedBy: [],
       },
     };
   }

--- a/views/admin/professions/index.njk
+++ b/views/admin/professions/index.njk
@@ -33,9 +33,7 @@
         </div>
       </div>
 
-      {% if view === 'overview' %}
-        {% set changedByCheckboxItems = false %}
-      {% else %}
+      {% if view !== 'overview' %}
         {% set organisationsCheckboxItems = false %}
         {% set industriesCheckboxItems = false %}
         {% set regulationTypesCheckboxItems = false %}

--- a/views/shared/_filter-criteria.njk
+++ b/views/shared/_filter-criteria.njk
@@ -33,11 +33,3 @@
     {% endfor %}
   </p>
 {% endif %}
-
-{% if filters.changedBy | length %}
-  <p class="govuk-body-m rpr-listing__search-criteria-container"><span class="govuk-!-font-weight-bold">{{ (filterCriteriaTextPrefix + ".labels.changedBy") | t }}</span>
-    {% for name in filters.changedBy %}
-      <strong class="govuk-tag">{{ name }}</strong>
-    {% endfor %}
-  </p>
-{% endif %}

--- a/views/shared/_filter.njk
+++ b/views/shared/_filter.njk
@@ -77,25 +77,6 @@
       </div>
     {% endif %}
 
-    {% if changedByCheckboxItems %}
-      <div class="{{ filterColumnClass }}">
-        {{ govukCheckboxes({
-          name: "changedBy[]",
-          classes: filterCheckboxClasses,
-          fieldset: {
-            legend: {
-            text: (filterTextPrefix + ".filter.changedBy.label") | t,
-            classes: "govuk-fieldset__legend--s"
-            }
-          },
-          hint: {
-            text: (filterTextPrefix + ".filter.changedBy.hint") | t
-          },
-          items: changedByCheckboxItems
-        }) }}
-      </div>
-    {% endif %}
-
     {% if regulationTypesCheckboxItems %}
       <div class="{{ filterColumnClass }}">
         {{ govukCheckboxes({

--- a/views/shared/_horizontal-filter.njk
+++ b/views/shared/_horizontal-filter.njk
@@ -17,9 +17,6 @@
 {% if regulationTypesCheckboxItems %}
   {% set filterColumns = filterColumns + 1 %}
 {% endif %}
-{% if changedByCheckboxItems %}
-  {% set filterColumns = filterColumns + 1 %}
-{% endif %}
 
 {% if ((filterColumns / 4) | round(0, "ceil")) < ((filterColumns / 3) | round(0, "ceil")) %}
   {% set filterColumnClass = 'govuk-grid-column-one-quarter' %}


### PR DESCRIPTION
Keeping as a draft until (2121) is in, as there will be conflicts

# Changes in this PR
- Remove unimplemented "changed by" filter from internal filters


## Screenshots of UI changes

### Before
![localhost_3000_admin_professions (5)](https://user-images.githubusercontent.com/94137563/158598021-ae188d08-adf9-4e1d-bb9f-56bed6a071fc.png)

### After
![localhost_3000_admin_professions (4)](https://user-images.githubusercontent.com/94137563/158598013-cf53fa08-8c78-4a35-a28b-c93fa084d3b5.png)

