### PR TITLE
(2273) Regulators should only be able to edit professions for which they are the primary regulators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Improve constraints around editing users
 
+### Changed
+
+- Only allow users to edit a Profession if they are a central user, or in that Profession's primary Organisation
+
 ## [release-009] - 2022-03-11
 
 ### Changed

--- a/cypress/integration/admin/professions/index.spec.ts
+++ b/cypress/integration/admin/professions/index.spec.ts
@@ -254,6 +254,7 @@ describe('Listing professions', () => {
         'Secondary School Teacher in State maintained schools (England)',
       );
       cy.get('body').should('not.contain', 'Registered Trademark Attorney');
+      cy.get('body').should('not.contain', 'Draft Profession');
     });
   });
 

--- a/seeds/development/professions.json
+++ b/seeds/development/professions.json
@@ -117,7 +117,7 @@
     "name": "Draft Profession",
     "slug": "draft-profession",
     "organisation": "Council of Registered Gas Installers",
-    "additionalOrganisation": null,
+    "additionalOrganisation": "Department for Education",
     "versions": [
       {
         "status": "draft"

--- a/seeds/test/professions.json
+++ b/seeds/test/professions.json
@@ -117,7 +117,7 @@
     "name": "Draft Profession",
     "slug": "draft-profession",
     "organisation": "Council of Registered Gas Installers",
-    "additionalOrganisation": null,
+    "additionalOrganisation": "Department for Education",
     "versions": [
       {
         "status": "draft"

--- a/src/professions/admin/professions.controller.spec.ts
+++ b/src/professions/admin/professions.controller.spec.ts
@@ -103,6 +103,10 @@ describe('ProfessionsController', () => {
       profession3,
     ]);
 
+    professionVersionsService.allWithLatestVersionForOrganisation.mockResolvedValue(
+      [profession1, profession2],
+    );
+
     organisationVersionsService.allWithLatestVersion.mockResolvedValue(
       organisations,
     );
@@ -238,6 +242,11 @@ describe('ProfessionsController', () => {
         ).present('overview');
 
         expect(result).toEqual(expected);
+
+        expect(professionVersionsService.allWithLatestVersion).toBeCalled();
+        expect(
+          professionVersionsService.allWithLatestVersionForOrganisation,
+        ).not.toBeCalled();
       });
 
       it('returns filtered professions when searching by nation', async () => {
@@ -262,6 +271,11 @@ describe('ProfessionsController', () => {
         ).present('overview');
 
         expect(result).toEqual(expected);
+
+        expect(professionVersionsService.allWithLatestVersion).toBeCalled();
+        expect(
+          professionVersionsService.allWithLatestVersionForOrganisation,
+        ).not.toBeCalled();
       });
 
       it('returns filtered professions when searching by organisation', async () => {
@@ -286,6 +300,11 @@ describe('ProfessionsController', () => {
         ).present('overview');
 
         expect(result).toEqual(expected);
+
+        expect(professionVersionsService.allWithLatestVersion).toBeCalled();
+        expect(
+          professionVersionsService.allWithLatestVersionForOrganisation,
+        ).not.toBeCalled();
       });
 
       it('returns filtered professions when searching by industry', async () => {
@@ -310,6 +329,11 @@ describe('ProfessionsController', () => {
         ).present('overview');
 
         expect(result).toEqual(expected);
+
+        expect(professionVersionsService.allWithLatestVersion).toBeCalled();
+        expect(
+          professionVersionsService.allWithLatestVersionForOrganisation,
+        ).not.toBeCalled();
       });
 
       it('returns filtered professions when searching by regulation type', async () => {
@@ -354,7 +378,7 @@ describe('ProfessionsController', () => {
           {
             keywords: '',
             nations: [],
-            organisations: [organisation1],
+            organisations: [],
             changedBy: [],
           },
           organisation1,
@@ -362,6 +386,11 @@ describe('ProfessionsController', () => {
         ).present('single-organisation');
 
         expect(result).toEqual(expected);
+
+        expect(
+          professionVersionsService.allWithLatestVersionForOrganisation,
+        ).toBeCalledWith(organisation1);
+        expect(professionVersionsService.allWithLatestVersion).not.toBeCalled();
       });
 
       it('returns filtered professions when searching by keyword', async () => {
@@ -375,7 +404,7 @@ describe('ProfessionsController', () => {
           {
             keywords: 'primary',
             nations: [],
-            organisations: [organisation1],
+            organisations: [],
             changedBy: [],
           },
           organisation1,
@@ -383,6 +412,11 @@ describe('ProfessionsController', () => {
         ).present('single-organisation');
 
         expect(result).toEqual(expected);
+
+        expect(
+          professionVersionsService.allWithLatestVersionForOrganisation,
+        ).toBeCalledWith(organisation1);
+        expect(professionVersionsService.allWithLatestVersion).not.toBeCalled();
       });
 
       it('returns filtered professions when searching by nation', async () => {
@@ -396,7 +430,7 @@ describe('ProfessionsController', () => {
           {
             keywords: '',
             nations: [Nation.find('GB-NIR')],
-            organisations: [organisation1],
+            organisations: [],
             changedBy: [],
           },
           organisation1,
@@ -404,6 +438,11 @@ describe('ProfessionsController', () => {
         ).present('single-organisation');
 
         expect(result).toEqual(expected);
+
+        expect(
+          professionVersionsService.allWithLatestVersionForOrganisation,
+        ).toBeCalledWith(organisation1);
+        expect(professionVersionsService.allWithLatestVersion).not.toBeCalled();
       });
     });
   });

--- a/src/professions/admin/professions.controller.ts
+++ b/src/professions/admin/professions.controller.ts
@@ -92,9 +92,6 @@ export class ProfessionsController {
       await this.organisationVersionsService.allWithLatestVersion();
     const allIndustries = await this.industriesService.all();
 
-    const allProfessions =
-      await this.professionVersionsService.allWithLatestVersion();
-
     const actingUser = getActingUser(request);
 
     const showAllOrgs = actingUser.serviceOwner;
@@ -105,16 +102,18 @@ export class ProfessionsController {
 
     const userOrganisation = showAllOrgs ? null : actingUser.organisation;
 
+    const allProfessions = await (showAllOrgs
+      ? this.professionVersionsService.allWithLatestVersion()
+      : this.professionVersionsService.allWithLatestVersionForOrganisation(
+          userOrganisation,
+        ));
+
     const filterInput = createFilterInput({
       ...filter,
       allNations,
       allOrganisations,
       allIndustries,
     });
-
-    if (userOrganisation) {
-      filterInput.organisations = [userOrganisation];
-    }
 
     const filteredProfessions = new ProfessionsFilterHelper(
       allProfessions,

--- a/src/professions/profession-versions.service.ts
+++ b/src/professions/profession-versions.service.ts
@@ -11,6 +11,7 @@ import { Legislation } from '../legislations/legislation.entity';
 import { Qualification } from '../qualifications/qualification.entity';
 import { User } from '../users/user.entity';
 import { FilterInput } from '../common/interfaces/filter-input.interface';
+import { Organisation } from '../organisations/organisation.entity';
 
 @Injectable()
 export class ProfessionVersionsService {
@@ -223,6 +224,32 @@ export class ProfessionVersionsService {
           ProfessionVersionStatus.Draft,
           ProfessionVersionStatus.Archived,
         ],
+      })
+      .orderBy(
+        'professionVersion.profession, professionVersion.created_at',
+        'DESC',
+      )
+      .getMany();
+
+    return versions.map((version) =>
+      Profession.withVersion(version.profession, version),
+    );
+  }
+
+  async allWithLatestVersionForOrganisation(
+    organisation: Organisation,
+  ): Promise<Profession[]> {
+    const versions = await this.versionsWithJoins()
+      .distinctOn(['professionVersion.profession'])
+      .where('professionVersion.status IN(:...status)', {
+        status: [
+          ProfessionVersionStatus.Live,
+          ProfessionVersionStatus.Draft,
+          ProfessionVersionStatus.Archived,
+        ],
+      })
+      .andWhere('organisation.id = :organisationId', {
+        organisationId: organisation.id,
       })
       .orderBy(
         'professionVersion.profession, professionVersion.created_at',


### PR DESCRIPTION
# Changes in this PR
- Only allow users to edit a Profession if they are a central user, or in that Profession's primary Organisation