### PR TITLE
(2274) Improve Organisation editing constraints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - Improve constraints around editing users
+- Improve constraints around editing organisations
 
 ### Changed
 

--- a/src/organisations/admin/organisation-archive.controller.ts
+++ b/src/organisations/admin/organisation-archive.controller.ts
@@ -14,6 +14,7 @@ import { flashMessage } from '../../common/flash-message';
 import { RequestWithAppSession } from '../../common/interfaces/request-with-app-session.interface';
 import { Permissions } from '../../common/permissions.decorator';
 import { escape } from '../../helpers/escape.helper';
+import { checkCanViewOrganisation } from '../../users/helpers/check-can-view-organisation';
 import { getActingUser } from '../../users/helpers/get-acting-user.helper';
 import { UserPermission } from '../../users/user-permission';
 import { OrganisationVersionsService } from '../organisation-versions.service';
@@ -33,6 +34,7 @@ export class OrganisationArchiveController {
   async new(
     @Param('organisationId') organisationId: string,
     @Param('versionId') versionId: string,
+    @Req() req: RequestWithAppSession,
   ) {
     const version =
       await this.organisationVersionsService.findByIdWithOrganisation(
@@ -44,6 +46,8 @@ export class OrganisationArchiveController {
       version.organisation,
       version,
     );
+
+    checkCanViewOrganisation(req, organisation);
 
     return { organisation };
   }
@@ -61,6 +65,8 @@ export class OrganisationArchiveController {
         organisationId,
         versionId,
       );
+
+    checkCanViewOrganisation(req, version.organisation);
 
     const user = getActingUser(req);
 

--- a/src/organisations/admin/organisation-publication.controller.ts
+++ b/src/organisations/admin/organisation-publication.controller.ts
@@ -7,6 +7,7 @@ import { RequestWithAppSession } from '../../common/interfaces/request-with-app-
 import { Permissions } from '../../common/permissions.decorator';
 import { escape } from '../../helpers/escape.helper';
 import { isConfirmed } from '../../helpers/is-confirmed';
+import { checkCanViewOrganisation } from '../../users/helpers/check-can-view-organisation';
 import { getActingUser } from '../../users/helpers/get-acting-user.helper';
 import { UserPermission } from '../../users/user-permission';
 import { OrganisationVersionsService } from '../organisation-versions.service';
@@ -32,6 +33,7 @@ export class OrganisationPublicationController {
   async new(
     @Param('organisationId') organisationId: string,
     @Param('versionId') versionId: string,
+    @Req() req: RequestWithAppSession,
   ) {
     const version =
       await this.organisationVersionsService.findByIdWithOrganisation(
@@ -43,6 +45,8 @@ export class OrganisationPublicationController {
       version.organisation,
       version,
     );
+
+    checkCanViewOrganisation(req, organisation);
 
     return { organisation };
   }
@@ -56,6 +60,8 @@ export class OrganisationPublicationController {
     @Param('versionId') versionId: string,
   ): Promise<void> {
     const organisation = await this.organisationsService.find(organisationId);
+
+    checkCanViewOrganisation(req, organisation);
 
     const version =
       await this.organisationVersionsService.findByIdWithOrganisation(

--- a/src/organisations/admin/organisation-versions.controller.ts
+++ b/src/organisations/admin/organisation-versions.controller.ts
@@ -28,6 +28,7 @@ import { Permissions } from '../../common/permissions.decorator';
 import { UserPermission } from '../../users/user-permission';
 
 import { getActingUser } from '../../users/helpers/get-acting-user.helper';
+import { checkCanViewOrganisation } from '../../users/helpers/check-can-view-organisation';
 
 @UseGuards(AuthenticationGuard)
 @Controller('/admin/organisations')
@@ -48,6 +49,8 @@ export class OrganisationVersionsController {
       await this.organisationVersionsService.findLatestForOrganisationId(
         organisationID,
       );
+
+    checkCanViewOrganisation(req, latestVersion.organisation);
 
     const newVersion = await this.organisationVersionsService.create(
       latestVersion,
@@ -70,6 +73,7 @@ export class OrganisationVersionsController {
   async show(
     @Param('organisationId') organisationId: string,
     @Param('versionId') versionId: string,
+    @Req() req: RequestWithAppSession,
   ): Promise<ShowTemplate> {
     const version =
       await this.organisationVersionsService.findByIdWithOrganisation(
@@ -82,6 +86,8 @@ export class OrganisationVersionsController {
       version,
       true,
     );
+
+    checkCanViewOrganisation(req, organisation);
 
     const hasLiveVersion =
       await this.organisationVersionsService.hasLiveVersion(organisation);

--- a/src/organisations/admin/organisations.controller.ts
+++ b/src/organisations/admin/organisations.controller.ts
@@ -46,6 +46,7 @@ import { Permissions } from '../../common/permissions.decorator';
 import { getActingUser } from '../../users/helpers/get-acting-user.helper';
 import { escape } from '../../helpers/escape.helper';
 import { Nation } from '../../nations/nation';
+import { checkCanViewOrganisation } from '../../users/helpers/check-can-view-organisation';
 
 @UseGuards(AuthenticationGuard)
 @Controller('/admin/organisations')
@@ -146,11 +147,14 @@ export class OrganisationsController {
   async edit(
     @Param('organisationId') organisationId: string,
     @Param('versionId') versionId: string,
+    @Req() request: RequestWithAppSession,
   ): Promise<Organisation> {
     const organisation = await this.organisationsService.findWithVersion(
       organisationId,
       versionId,
     );
+
+    checkCanViewOrganisation(request, organisation);
 
     return organisation;
   }
@@ -166,10 +170,12 @@ export class OrganisationsController {
     @Param('versionId') versionId: string,
     @Body() body: OrganisationDto,
     @Res() res: Response,
-    @Req() req: Request,
+    @Req() req: RequestWithAppSession,
   ): Promise<void> {
     const organisation = await this.organisationsService.find(organisationId);
     const version = await this.organisationVersionsService.find(versionId);
+
+    checkCanViewOrganisation(req, organisation);
 
     if (body.confirm) {
       return this.confirm(res, req, organisation, version);


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR

Ensures users can't view other Organisation admin pages unless they're central admins. They could only do this if they had the UUID of the organisation and the version, so it was very unlikely that they'd have been able to do this anyway.
