### PR TITLE
(2204) Add a script to reseed search data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Search profession titles using Opensearch
 - Allow central users to filter Profession and Organisation listings by regulation type
 - Search profession keywords using Opensearch
+- Add a script to reindex professions in Opensearch
 
 ### Changed
 

--- a/doc/architecture/decisions/0017-use-opensearch-to-search-professions.md
+++ b/doc/architecture/decisions/0017-use-opensearch-to-search-professions.md
@@ -1,0 +1,33 @@
+# 17. use-opensearch-to-search-professions
+
+Date: 2022-03-17
+
+## Status
+
+Accepted
+
+## Context
+
+The current search on the public-facing side of the product does not always return satisfactory results. For example
+a search for 'lawyer' will not return results for Solicitors.
+
+All professions we have imported have an Office for National Statistics SOC (Standard Occupational Classification)
+code assigned. As part of the import process, we've also imported all of the SOC index terms into a field called
+`Keywords`, which will allow searches for alternative keywords to be possible.
+
+## Decision
+
+To allow searches for alternative keywords, we will implement an Opensearch service on the GOV.UK PaaS infrastructure.
+When a profession is published, we will add the profession version's ID, name and keywords to the Opensearch index.
+When a public user searches for a keyword, we will search the opensearch index for that keyword, and then filter the
+database for profession versions that match that keyword.
+
+## Consequences
+
+This will involve some further infrastructure work in spinning up a new service. We also need to think further about
+how we present SOC codes to users when adding a new profession - currently there is no way in the UI to add SOC codes
+to a new profession, but given this is unlikely to be a common task, we think it will be OK to implement this at a
+later date.
+
+We should also think about whether it is worth implementing Opensearch on the admin side of the application, as we
+use keywords when searching there too.

--- a/doc/opensearch.md
+++ b/doc/opensearch.md
@@ -1,0 +1,19 @@
+# Opensearch
+
+We use Opensearch to assist with searching for professions on the public-facing side of the
+site.
+
+At the point of publication, professions are indexed in the Opensearch database. When users
+search for keywords, we search Opensearch for them and return the IDs of the matching
+professions.
+
+## Reindexing professions
+
+If, for some reason, we need to reindex the professions, we can do so with the following
+command:
+
+```bash
+script/npm run opensearch:reseed:professions
+```
+
+This will clear out the index, and reindex the all the live professions.

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,6 +49,7 @@
         "sass": "^1.49.9",
         "sass-loader": "^12.6.0",
         "slugify": "^1.6.5",
+        "ts-node": "^10.7.0",
         "typeorm": "^0.2.45"
       },
       "devDependencies": {
@@ -79,7 +80,6 @@
         "supertest": "^6.2.2",
         "ts-jest": "^27.1.3",
         "ts-loader": "^9.2.8",
-        "ts-node": "^10.7.0",
         "tsconfig-paths": "^3.14.0",
         "typescript": "^4.6.2"
       }
@@ -1906,7 +1906,6 @@
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/@cspotcode/source-map-consumer/-/source-map-consumer-0.8.0.tgz",
       "integrity": "sha512-41qniHzTU8yAGbCp04ohlmSrZf8bkf/iJsl3V0dRGsQN/5GFfx+LbCSsCpp2gqrqjTVg/K6O8ycoV35JIwAzAg==",
-      "dev": true,
       "engines": {
         "node": ">= 12"
       }
@@ -1915,7 +1914,6 @@
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.7.0.tgz",
       "integrity": "sha512-X4xqRHqN8ACt2aHVe51OxeA2HjbcL4MqFqXkrmQszJ1NOUuUu5u6Vqx/0lZSVNku7velL5FC/s5uEAj1lsBMhA==",
-      "dev": true,
       "dependencies": {
         "@cspotcode/source-map-consumer": "0.8.0"
       },
@@ -3777,26 +3775,22 @@
     "node_modules/@tsconfig/node10": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.8.tgz",
-      "integrity": "sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg==",
-      "dev": true
+      "integrity": "sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg=="
     },
     "node_modules/@tsconfig/node12": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.9.tgz",
-      "integrity": "sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw==",
-      "dev": true
+      "integrity": "sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw=="
     },
     "node_modules/@tsconfig/node14": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.1.tgz",
-      "integrity": "sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg==",
-      "dev": true
+      "integrity": "sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg=="
     },
     "node_modules/@tsconfig/node16": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.2.tgz",
-      "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
-      "dev": true
+      "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA=="
     },
     "node_modules/@types/auth0": {
       "version": "2.34.13",
@@ -4946,8 +4940,7 @@
     "node_modules/arg": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-      "dev": true
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA=="
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -7046,8 +7039,7 @@
     "node_modules/create-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
-      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-      "dev": true
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ=="
     },
     "node_modules/cron-parser": {
       "version": "4.2.1",
@@ -8304,7 +8296,6 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
       "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-      "dev": true,
       "engines": {
         "node": ">=0.3.1"
       }
@@ -21709,7 +21700,6 @@
       "version": "10.7.0",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.7.0.tgz",
       "integrity": "sha512-TbIGS4xgJoX2i3do417KSaep1uRAW/Lu+WAL2doDHC0D6ummjirVOXU5/7aiZotbQ5p1Zp9tP7U6cYhA0O7M8A==",
-      "dev": true,
       "dependencies": {
         "@cspotcode/source-map-support": "0.7.0",
         "@tsconfig/node10": "^1.0.7",
@@ -21752,7 +21742,6 @@
       "version": "8.2.0",
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
       "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
-      "dev": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -22313,8 +22302,7 @@
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.0.tgz",
-      "integrity": "sha512-mpSYqfsFvASnSn5qMiwrr4VKfumbPyONLCOPmsR3A6pTY/r0+tSaVbgPWSAIuzbk3lCTa+FForeTiO+wBQGkjA==",
-      "dev": true
+      "integrity": "sha512-mpSYqfsFvASnSn5qMiwrr4VKfumbPyONLCOPmsR3A6pTY/r0+tSaVbgPWSAIuzbk3lCTa+FForeTiO+wBQGkjA=="
     },
     "node_modules/v8-to-istanbul": {
       "version": "8.1.1",
@@ -23217,7 +23205,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
       "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -24508,14 +24495,12 @@
     "@cspotcode/source-map-consumer": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/@cspotcode/source-map-consumer/-/source-map-consumer-0.8.0.tgz",
-      "integrity": "sha512-41qniHzTU8yAGbCp04ohlmSrZf8bkf/iJsl3V0dRGsQN/5GFfx+LbCSsCpp2gqrqjTVg/K6O8ycoV35JIwAzAg==",
-      "dev": true
+      "integrity": "sha512-41qniHzTU8yAGbCp04ohlmSrZf8bkf/iJsl3V0dRGsQN/5GFfx+LbCSsCpp2gqrqjTVg/K6O8ycoV35JIwAzAg=="
     },
     "@cspotcode/source-map-support": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.7.0.tgz",
       "integrity": "sha512-X4xqRHqN8ACt2aHVe51OxeA2HjbcL4MqFqXkrmQszJ1NOUuUu5u6Vqx/0lZSVNku7velL5FC/s5uEAj1lsBMhA==",
-      "dev": true,
       "requires": {
         "@cspotcode/source-map-consumer": "0.8.0"
       }
@@ -25949,26 +25934,22 @@
     "@tsconfig/node10": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.8.tgz",
-      "integrity": "sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg==",
-      "dev": true
+      "integrity": "sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg=="
     },
     "@tsconfig/node12": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.9.tgz",
-      "integrity": "sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw==",
-      "dev": true
+      "integrity": "sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw=="
     },
     "@tsconfig/node14": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.1.tgz",
-      "integrity": "sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg==",
-      "dev": true
+      "integrity": "sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg=="
     },
     "@tsconfig/node16": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.2.tgz",
-      "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
-      "dev": true
+      "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA=="
     },
     "@types/auth0": {
       "version": "2.34.13",
@@ -26918,8 +26899,7 @@
     "arg": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-      "dev": true
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA=="
     },
     "argparse": {
       "version": "2.0.1",
@@ -28565,8 +28545,7 @@
     "create-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
-      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-      "dev": true
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ=="
     },
     "cron-parser": {
       "version": "4.2.1",
@@ -29519,8 +29498,7 @@
     "diff": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-      "dev": true
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A=="
     },
     "diff-sequences": {
       "version": "27.5.1",
@@ -39452,7 +39430,6 @@
       "version": "10.7.0",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.7.0.tgz",
       "integrity": "sha512-TbIGS4xgJoX2i3do417KSaep1uRAW/Lu+WAL2doDHC0D6ummjirVOXU5/7aiZotbQ5p1Zp9tP7U6cYhA0O7M8A==",
-      "dev": true,
       "requires": {
         "@cspotcode/source-map-support": "0.7.0",
         "@tsconfig/node10": "^1.0.7",
@@ -39472,8 +39449,7 @@
         "acorn-walk": {
           "version": "8.2.0",
           "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
-          "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
-          "dev": true
+          "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA=="
         }
       }
     },
@@ -39855,8 +39831,7 @@
     "v8-compile-cache-lib": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.0.tgz",
-      "integrity": "sha512-mpSYqfsFvASnSn5qMiwrr4VKfumbPyONLCOPmsR3A6pTY/r0+tSaVbgPWSAIuzbk3lCTa+FForeTiO+wBQGkjA==",
-      "dev": true
+      "integrity": "sha512-mpSYqfsFvASnSn5qMiwrr4VKfumbPyONLCOPmsR3A6pTY/r0+tSaVbgPWSAIuzbk3lCTa+FForeTiO+wBQGkjA=="
     },
     "v8-to-istanbul": {
       "version": "8.1.1",
@@ -40498,8 +40473,7 @@
     "yn": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
-      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-      "dev": true
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q=="
     },
     "yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "sass": "^1.49.9",
     "sass-loader": "^12.6.0",
     "slugify": "^1.6.5",
+    "ts-node": "^10.7.0",
     "typeorm": "^0.2.45"
   },
   "devDependencies": {
@@ -115,7 +116,6 @@
     "supertest": "^6.2.2",
     "ts-jest": "^27.1.3",
     "ts-loader": "^9.2.8",
-    "ts-node": "^10.7.0",
     "tsconfig-paths": "^3.14.0",
     "typescript": "^4.6.2"
   },

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "seed:production": "NODE_ENV=production node dist/seeder",
     "seed:test:refresh": "npm run build && NODE_ENV=test node dist/seeder --refresh",
     "opensearch:test:purge": "curl -X DELETE 'http://admin:admin@localhost:9200/professions_test' &> /dev/null",
+    "opensearch:reseed:professions": "ts-node ./src/console.ts opensearch:reseed:professions",
     "heroku:set-callback-urls": "ts-node util/set-callback-urls.ts",
     "bull:repl": "bull-repl"
   },

--- a/src/config/db.config.ts
+++ b/src/config/db.config.ts
@@ -3,11 +3,13 @@ import { config as setConfig } from 'dotenv';
 
 setConfig({ path: `.env.${process.env.NODE_ENV}` });
 
+const entities = process.env['ENTITIES'] || './dist/**/*.entity.js';
+
 export default registerAs('database', () => {
   return {
     type: 'postgres',
     url: process.env.DATABASE_URL,
-    entities: ['./dist/**/*.entity.js'],
+    entities: [entities],
     synchronize: false,
     migrations: ['./dist/db/migrate/*.js'],
     migrationsRun: true,

--- a/src/console.ts
+++ b/src/console.ts
@@ -1,0 +1,23 @@
+process.env['ENTITIES'] = __dirname + '/**/*.entity.ts';
+
+import { NestFactory } from '@nestjs/core';
+import { AppModule } from './app.module';
+import { ProfessionVersionsService } from './professions/profession-versions.service';
+import { ProfessionsSearchService } from './professions/professions-search.service';
+
+async function bootstrap() {
+  const application = await NestFactory.createApplicationContext(AppModule);
+
+  const command = process.argv[2];
+
+  switch (command) {
+    default:
+      console.log('Command not found');
+      process.exit(1);
+  }
+
+  await application.close();
+  process.exit(0);
+}
+
+bootstrap();

--- a/src/console.ts
+++ b/src/console.ts
@@ -11,6 +11,25 @@ async function bootstrap() {
   const command = process.argv[2];
 
   switch (command) {
+    case 'opensearch:reseed:professions':
+      console.log('Reseeding professions...');
+
+      const professionVersionsService = application.get(
+        ProfessionVersionsService,
+      );
+      const professionsSearchService = application.get(
+        ProfessionsSearchService,
+      );
+
+      await professionsSearchService.deleteAll();
+
+      const professions = await professionVersionsService.allLive();
+
+      for (const profession of professions) {
+        professionsSearchService.index(profession);
+      }
+
+      break;
     default:
       console.log('Command not found');
       process.exit(1);

--- a/src/professions/profession-versions.service.spec.ts
+++ b/src/professions/profession-versions.service.spec.ts
@@ -464,11 +464,7 @@ describe('ProfessionVersionsService', () => {
 
       const result = await service.allLive();
 
-      const expectedProfessions = versions.map((version) =>
-        Profession.withVersion(version.profession, version),
-      );
-
-      expect(result).toEqual(expectedProfessions);
+      expect(result).toEqual(versions);
 
       expect(queryBuilder).toHaveJoined([
         'professionVersion.profession',

--- a/src/professions/profession-versions.service.ts
+++ b/src/professions/profession-versions.service.ts
@@ -202,17 +202,13 @@ export class ProfessionVersionsService {
     );
   }
 
-  async allLive(): Promise<Profession[]> {
-    const versions = await this.versionsWithJoins()
+  async allLive(): Promise<ProfessionVersion[]> {
+    return await this.versionsWithJoins()
       .where('professionVersion.status = :status', {
         status: ProfessionVersionStatus.Live,
       })
       .orderBy('profession.name')
       .getMany();
-
-    return versions.map((version) =>
-      Profession.withVersion(version.profession, version),
-    );
   }
 
   async allWithLatestVersion(): Promise<Profession[]> {

--- a/src/professions/professions-search.service.spec.ts
+++ b/src/professions/professions-search.service.spec.ts
@@ -10,7 +10,11 @@ describe('ProfessionVersionsService', () => {
   let opensearchClient: DeepMocked<OpensearchClient>;
 
   beforeEach(async () => {
-    opensearchClient = createMock<OpensearchClient>();
+    opensearchClient = createMock<OpensearchClient>({
+      indices: {
+        delete: jest.fn(),
+      },
+    });
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -116,6 +120,17 @@ describe('ProfessionVersionsService', () => {
             },
           },
         },
+      });
+    });
+  });
+
+  describe('deleteAll', () => {
+    it('deletes all documents in an index', async () => {
+      await service.deleteAll();
+
+      expect(opensearchClient.indices.delete).toHaveBeenCalledWith({
+        index: service.indexName,
+        ignore_unavailable: true,
       });
     });
   });

--- a/src/professions/professions-search.service.ts
+++ b/src/professions/professions-search.service.ts
@@ -44,6 +44,13 @@ export class ProfessionsSearchService {
     });
   }
 
+  public async deleteAll(): Promise<any> {
+    await this.client.indices.delete({
+      index: this.indexName,
+      ignore_unavailable: true,
+    });
+  }
+
   public async search(query: string): Promise<string[]> {
     const response = await this.client.search<SearchResponse>({
       index: this.indexName,


### PR DESCRIPTION
This adds a new npm script to delete all professions data from an index and reindex it all. I've also added some documentation, as well as an ADR, as we hadn't yet added one.