### PR TITLE
(2170) Make all searches GET requests

### DIFF
--- a/src/organisations/search/search.controller.spec.ts
+++ b/src/organisations/search/search.controller.spec.ts
@@ -88,38 +88,42 @@ describe('SearchController', () => {
   });
 
   describe('index', () => {
-    it('should return populated template params', async () => {
-      const result = await controller.index();
-
-      const expected = await new SearchPresenter(
-        {
+    describe('when no parameters are provided', () => {
+      it('should return populated template params', async () => {
+        const result = await controller.index({
           keywords: '',
           industries: [],
           nations: [],
-        },
-        Nation.all(),
-        industries,
-        [organisation1, organisation2],
-        i18nService,
-      ).present();
+        });
 
-      expect(result).toEqual(expected);
-    });
+        const expected = await new SearchPresenter(
+          {
+            keywords: '',
+            industries: [],
+            nations: [],
+          },
+          Nation.all(),
+          industries,
+          [organisation1, organisation2],
+          i18nService,
+        ).present();
 
-    it('should request organisations populated with professions from `OrganisationVersionsService`', async () => {
-      await controller.create({
-        keywords: '',
-        industries: [],
-        nations: [],
+        expect(result).toEqual(expected);
       });
 
-      expect(organisationVersionsService.allLive).toHaveBeenCalled();
-    });
-  });
+      it('should request organisations populated with professions from `OrganisationVersionsService`', async () => {
+        await controller.index({
+          keywords: '',
+          industries: [],
+          nations: [],
+        });
 
-  describe('create', () => {
+        expect(organisationVersionsService.allLive).toHaveBeenCalled();
+      });
+    });
+
     it('should return template params populated with provided search filters', async () => {
-      const result = await controller.create({
+      const result = await controller.index({
         keywords: 'example search',
         industries: [industry1.id, industry2.id],
         nations: ['GB-NIR'],
@@ -141,7 +145,7 @@ describe('SearchController', () => {
     });
 
     it('should return filtered organisations when searching by nation', async () => {
-      const result = await controller.create({
+      const result = await controller.index({
         keywords: '',
         industries: [],
         nations: ['GB-SCT'],
@@ -163,7 +167,7 @@ describe('SearchController', () => {
     });
 
     it('should return filtered organisations when searching by industry', async () => {
-      const result = await controller.create({
+      const result = await controller.index({
         keywords: '',
         industries: [industry2.id],
         nations: [],
@@ -185,7 +189,7 @@ describe('SearchController', () => {
     });
 
     it('should return filtered organisations when searching by keyword', async () => {
-      const result = await controller.create({
+      const result = await controller.index({
         keywords: 'Medical',
         industries: [],
         nations: [],
@@ -207,7 +211,7 @@ describe('SearchController', () => {
     });
 
     it('should return unfiltered organisations when no search parameters are specified', async () => {
-      const result = await controller.create({
+      const result = await controller.index({
         keywords: '',
         industries: [],
         nations: [],

--- a/src/organisations/search/search.controller.ts
+++ b/src/organisations/search/search.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Get, Post, Render } from '@nestjs/common';
+import { Query, Controller, Get, Render } from '@nestjs/common';
 import { I18nService } from 'nestjs-i18n';
 import { IndustriesService } from '../../industries/industries.service';
 import { Nation } from '../../nations/nation';
@@ -23,18 +23,7 @@ export class SearchController {
   @Get()
   @Render('organisations/search/index')
   @BackLink('/')
-  async index(): Promise<IndexTemplate> {
-    return this.createSearchResults(new FilterDto());
-  }
-
-  @Post()
-  @Render('organisations/search/index')
-  @BackLink('/')
-  async create(@Body() filter: FilterDto): Promise<IndexTemplate> {
-    return this.createSearchResults(filter);
-  }
-
-  private async createSearchResults(filter: FilterDto): Promise<IndexTemplate> {
+  async index(@Query() filter: FilterDto): Promise<IndexTemplate> {
     const allNations = Nation.all();
     const allIndustries = await this.industriesService.all();
 

--- a/src/professions/search/search.controller.spec.ts
+++ b/src/professions/search/search.controller.spec.ts
@@ -41,55 +41,59 @@ describe('SearchController', () => {
   });
 
   describe('index', () => {
-    it('should return populated template params', async () => {
-      const industry1 = industryFactory.build({ id: 'example-industry-1' });
-      const industry2 = industryFactory.build({ id: 'example-industry-2' });
-      const industry3 = industryFactory.build({ id: 'example-industry-3' });
-      const industries = [industry1, industry2, industry3];
-      industriesService.all.mockResolvedValue(industries);
+    describe('when no parameters are provided', () => {
+      it('should return populated template params', async () => {
+        const industry1 = industryFactory.build({ id: 'example-industry-1' });
+        const industry2 = industryFactory.build({ id: 'example-industry-2' });
+        const industry3 = industryFactory.build({ id: 'example-industry-3' });
+        const industries = [industry1, industry2, industry3];
+        industriesService.all.mockResolvedValue(industries);
 
-      const schoolTeacher = professionFactory.build({
-        name: 'Secondary School Teacher',
-        industries: [industry1],
-      });
-      const trademarkAttorney = professionFactory.build({
-        name: 'Trademark Attorney',
-        industries: [industry2, industry3],
-      });
-      professionVersionsService.searchLive.mockResolvedValue([
-        schoolTeacher,
-        trademarkAttorney,
-      ]);
+        const schoolTeacher = professionFactory.build({
+          name: 'Secondary School Teacher',
+          industries: [industry1],
+        });
+        const trademarkAttorney = professionFactory.build({
+          name: 'Trademark Attorney',
+          industries: [industry2, industry3],
+        });
+        professionVersionsService.searchLive.mockResolvedValue([
+          schoolTeacher,
+          trademarkAttorney,
+        ]);
 
-      const result = await controller.index();
-
-      const expected = await new SearchPresenter(
-        {
+        const result = await controller.index({
           keywords: '',
           industries: [],
           nations: [],
-        },
-        Nation.all(),
-        industries,
-        [schoolTeacher, trademarkAttorney],
-        i18nService,
-      ).present();
+        });
 
-      expect(result).toEqual(expected);
-    });
+        const expected = await new SearchPresenter(
+          {
+            keywords: '',
+            industries: [],
+            nations: [],
+          },
+          Nation.all(),
+          industries,
+          [schoolTeacher, trademarkAttorney],
+          i18nService,
+        ).present();
 
-    it('should request only complete professions from `ProfessionsService`', async () => {
-      await controller.create({
-        keywords: '',
-        industries: [],
-        nations: [],
+        expect(result).toEqual(expected);
       });
 
-      expect(professionVersionsService.searchLive).toHaveBeenCalled();
-    });
-  });
+      it('should request only complete professions from `ProfessionsService`', async () => {
+        await controller.index({
+          keywords: '',
+          industries: [],
+          nations: [],
+        });
 
-  describe('create', () => {
+        expect(professionVersionsService.searchLive).toHaveBeenCalled();
+      });
+    });
+
     it('should return template params populated with provided search filters', async () => {
       const industry1 = industryFactory.build();
       const industry2 = industryFactory.build();
@@ -111,7 +115,7 @@ describe('SearchController', () => {
         trademarkAttorney,
       ]);
 
-      const result = await controller.create({
+      const result = await controller.index({
         keywords: 'example search',
         industries: [industry1.id, industry2.id],
         nations: ['GB-SCT'],
@@ -142,7 +146,7 @@ describe('SearchController', () => {
       const industry1 = industryFactory.build();
       const industry2 = industryFactory.build();
 
-      await controller.create({
+      await controller.index({
         keywords: 'example search',
         industries: [industry1.id, industry2.id],
         nations: ['GB-SCT'],

--- a/src/professions/search/search.controller.ts
+++ b/src/professions/search/search.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Get, Post, Render } from '@nestjs/common';
+import { Controller, Get, Query, Render } from '@nestjs/common';
 import { I18nService } from 'nestjs-i18n';
 import { IndustriesService } from '../../industries/industries.service';
 import { Nation } from '../../nations/nation';
@@ -20,18 +20,7 @@ export class SearchController {
   @Get()
   @Render('professions/search/index')
   @BackLink('/')
-  async index(): Promise<IndexTemplate> {
-    return this.createSearchResults(new FilterDto());
-  }
-
-  @Post()
-  @Render('professions/search/index')
-  @BackLink('/')
-  async create(@Body() filter: FilterDto): Promise<IndexTemplate> {
-    return this.createSearchResults(filter);
-  }
-
-  private async createSearchResults(filter: FilterDto): Promise<IndexTemplate> {
+  async index(@Query() filter: FilterDto): Promise<IndexTemplate> {
     const allNations = Nation.all();
     const allIndustries = await this.industriesService.all();
 

--- a/views/shared/_filter.njk
+++ b/views/shared/_filter.njk
@@ -2,7 +2,7 @@
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
-<form action="" method="{{ filterFormMethod }}" class="form">
+<form action="" method="get" class="form">
   <div class="{{ filterRowClass }}">
      <div class="{{ filterColumnClass }}">
       {{ govukInput({
@@ -38,7 +38,7 @@
         }) }}
       </div>
     {% endif %}
-    
+
     {% if nationsCheckboxItems %}
       <div class="{{ filterColumnClass }}">
         {{ govukCheckboxes({

--- a/views/shared/_horizontal-filter.njk
+++ b/views/shared/_horizontal-filter.njk
@@ -2,7 +2,6 @@
 {% set filterButtonClasses = 'govuk-button--secondary rpr-internal-listing__filter-button'%}
 {% set filterRowClass = 'govuk-grid-row' %}
 {% set filterButtonColumnClass = 'govuk-grid-column-full' %}
-{% set filterFormMethod = 'get' %}
 
 {% set filterColumns = 1 %}
 {% if nationsCheckboxItems %}

--- a/views/shared/_vertical-filter.njk
+++ b/views/shared/_vertical-filter.njk
@@ -1,6 +1,5 @@
 {% set filterKeywordsWidthClass = 'govuk-input--width-10%' %}
 {% set filterCheckboxClasses = 'govuk-checkboxes--small rpr-listing__filter' %}
-{% set filterFormMethod = 'post' %}
 
 <div class="rpr-listing__filters-container">
   {% include "./_filter.njk" %}


### PR DESCRIPTION
This will ensure that we can track keyword searches more easily, as well as making sure that when people use the back link to go back, they’ll be presented with the search results they originally had.