### PR TITLE
(2275) Improve constraints around setting Professions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Improve constraints around editing users
 - Improve constraints around editing organisations
+- Improve constraints around editing professions
 
 ### Changed
 

--- a/src/professions/admin/check-your-answers.controller.ts
+++ b/src/professions/admin/check-your-answers.controller.ts
@@ -4,6 +4,7 @@ import {
   Param,
   Query,
   Render,
+  Req,
   UseGuards,
 } from '@nestjs/common';
 import { Request } from 'express';
@@ -22,6 +23,8 @@ import { BackLink } from '../../common/decorators/back-link.decorator';
 import { ProfessionVersionsService } from '../profession-versions.service';
 import { isConfirmed } from '../../helpers/is-confirmed';
 import { isUK } from '../../helpers/nations.helper';
+import { RequestWithAppSession } from '../../common/interfaces/request-with-app-session.interface';
+import { checkCanViewProfession } from '../../users/helpers/check-can-view-profession';
 
 @UseGuards(AuthenticationGuard)
 @Controller('admin/professions')
@@ -40,10 +43,13 @@ export class CheckYourAnswersController {
     @Param('professionId') professionId: string,
     @Param('versionId') versionId: string,
     @Query('edit') edit: string,
+    @Req() request: RequestWithAppSession,
   ): Promise<CheckYourAnswersTemplate> {
     const draftProfession = await this.professionsService.findWithVersions(
       professionId,
     );
+
+    checkCanViewProfession(request, draftProfession);
 
     if (!draftProfession) {
       throw new Error('Draft profession not found');

--- a/src/professions/admin/confirmation.controller.ts
+++ b/src/professions/admin/confirmation.controller.ts
@@ -1,5 +1,5 @@
 import { Controller, Param, Post, Req, Res, UseGuards } from '@nestjs/common';
-import { Request, Response } from 'express';
+import { Response } from 'express';
 import { AuthenticationGuard } from '../../common/authentication.guard';
 import { ProfessionsService } from '../professions.service';
 import { Permissions } from '../../common/permissions.decorator';
@@ -8,6 +8,8 @@ import { ProfessionVersionsService } from '../profession-versions.service';
 import { I18nService } from 'nestjs-i18n';
 import { flashMessage } from '../../common/flash-message';
 import { escape } from '../../helpers/escape.helper';
+import { RequestWithAppSession } from '../../common/interfaces/request-with-app-session.interface';
+import { checkCanViewProfession } from '../../users/helpers/check-can-view-profession';
 @UseGuards(AuthenticationGuard)
 @Controller('admin/professions')
 export class ConfirmationController {
@@ -21,13 +23,15 @@ export class ConfirmationController {
   @Permissions(UserPermission.CreateProfession, UserPermission.EditProfession)
   async create(
     @Res() res: Response,
-    @Req() req: Request,
+    @Req() req: RequestWithAppSession,
     @Param('professionId') professionId: string,
     @Param('versionId') versionId: string,
   ): Promise<void> {
     const profession = await this.professionsService.findWithVersions(
       professionId,
     );
+
+    checkCanViewProfession(req, profession);
 
     const version = await this.professionVersionsService.findWithProfession(
       versionId,

--- a/src/professions/admin/legislation.controller.spec.ts
+++ b/src/professions/admin/legislation.controller.spec.ts
@@ -3,14 +3,19 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { Response } from 'express';
 import { I18nService } from 'nestjs-i18n';
 import { createMockI18nService } from '../../testutils/create-mock-i18n-service';
+import { createDefaultMockRequest } from '../../testutils/factories/create-default-mock-request';
 import legislationFactory from '../../testutils/factories/legislation';
 import professionFactory from '../../testutils/factories/profession';
 import professionVersionFactory from '../../testutils/factories/profession-version';
+import userFactory from '../../testutils/factories/user';
 import { translationOf } from '../../testutils/translation-of';
+import { checkCanViewProfession } from '../../users/helpers/check-can-view-profession';
 import { ProfessionVersionsService } from '../profession-versions.service';
 import { ProfessionsService } from '../professions.service';
 import LegislationDto from './dto/legislation.dto';
 import { LegislationController } from './legislation.controller';
+
+jest.mock('../../users/helpers/check-can-view-profession');
 
 describe(LegislationController, () => {
   let controller: LegislationController;
@@ -60,7 +65,17 @@ describe(LegislationController, () => {
         professionsService.findWithVersions.mockResolvedValue(profession);
         professionVersionsService.findWithProfession.mockResolvedValue(version);
 
-        await controller.edit(response, 'profession-id', 'version-id', 'false');
+        const request = createDefaultMockRequest({
+          user: userFactory.build(),
+        });
+
+        await controller.edit(
+          response,
+          'profession-id',
+          'version-id',
+          'false',
+          request,
+        );
 
         expect(response.render).toHaveBeenCalledWith(
           'admin/professions/legislation',
@@ -68,6 +83,31 @@ describe(LegislationController, () => {
             legislation: legislation,
             captionText: translationOf('professions.form.captions.edit'),
           }),
+        );
+      });
+
+      it('checks the user has permission to view the Profession', async () => {
+        const profession = professionFactory.build({
+          id: 'profession-id',
+        });
+
+        professionsService.findWithVersions.mockResolvedValue(profession);
+
+        const request = createDefaultMockRequest({
+          user: userFactory.build(),
+        });
+
+        await controller.edit(
+          response,
+          'profession-id',
+          'version-id',
+          'false',
+          request,
+        );
+
+        expect(checkCanViewProfession).toHaveBeenCalledWith(
+          request,
+          profession,
         );
       });
     });
@@ -96,7 +136,17 @@ describe(LegislationController, () => {
         professionsService.findWithVersions.mockResolvedValue(profession);
         professionVersionsService.findWithProfession.mockResolvedValue(version);
 
-        await controller.edit(response, 'profession-id', 'version-id', 'false');
+        const request = createDefaultMockRequest({
+          user: userFactory.build(),
+        });
+
+        await controller.edit(
+          response,
+          'profession-id',
+          'version-id',
+          'false',
+          request,
+        );
 
         expect(response.render).toHaveBeenCalledWith(
           'admin/professions/legislation',
@@ -128,7 +178,17 @@ describe(LegislationController, () => {
         professionsService.findWithVersions.mockResolvedValue(profession);
         professionVersionsService.findWithProfession.mockResolvedValue(version);
 
-        await controller.update(response, 'profession-id', 'version-id', dto);
+        const request = createDefaultMockRequest({
+          user: userFactory.build(),
+        });
+
+        await controller.update(
+          response,
+          'profession-id',
+          'version-id',
+          dto,
+          request,
+        );
 
         expect(professionVersionsService.save).toHaveBeenCalledWith(
           expect.objectContaining({
@@ -167,7 +227,17 @@ describe(LegislationController, () => {
         professionsService.findWithVersions.mockResolvedValue(profession);
         professionVersionsService.findWithProfession.mockResolvedValue(version);
 
-        await controller.update(response, 'profession-id', 'version-id', dto);
+        const request = createDefaultMockRequest({
+          user: userFactory.build(),
+        });
+
+        await controller.update(
+          response,
+          'profession-id',
+          'version-id',
+          dto,
+          request,
+        );
 
         expect(professionVersionsService.save).toHaveBeenCalledWith(
           expect.objectContaining({
@@ -210,7 +280,17 @@ describe(LegislationController, () => {
         professionsService.findWithVersions.mockResolvedValue(profession);
         professionVersionsService.findWithProfession.mockResolvedValue(version);
 
-        await controller.update(response, 'profession-id', 'version-id', dto);
+        const request = createDefaultMockRequest({
+          user: userFactory.build(),
+        });
+
+        await controller.update(
+          response,
+          'profession-id',
+          'version-id',
+          dto,
+          request,
+        );
 
         expect(professionVersionsService.save).toHaveBeenCalledWith(
           expect.objectContaining({
@@ -254,7 +334,17 @@ describe(LegislationController, () => {
             version,
           );
 
-          await controller.update(response, 'profession-id', 'version-id', dto);
+          const request = createDefaultMockRequest({
+            user: userFactory.build(),
+          });
+
+          await controller.update(
+            response,
+            'profession-id',
+            'version-id',
+            dto,
+            request,
+          );
 
           expect(professionVersionsService.save).not.toHaveBeenCalled();
 
@@ -290,7 +380,17 @@ describe(LegislationController, () => {
             version,
           );
 
-          await controller.update(response, 'profession-id', 'version-id', dto);
+          const request = createDefaultMockRequest({
+            user: userFactory.build(),
+          });
+
+          await controller.update(
+            response,
+            'profession-id',
+            'version-id',
+            dto,
+            request,
+          );
 
           expect(professionVersionsService.save).not.toHaveBeenCalled();
 
@@ -306,6 +406,34 @@ describe(LegislationController, () => {
           );
         });
       });
+    });
+
+    it('checks the user has permission to update the Profession', async () => {
+      const profession = professionFactory.build({
+        id: 'profession-id',
+      });
+
+      professionsService.findWithVersions.mockResolvedValue(profession);
+
+      const request = createDefaultMockRequest({
+        user: userFactory.build(),
+      });
+
+      const dto: LegislationDto = {
+        link: 'www.legal-legislation.com',
+        nationalLegislation: 'Legal Services Act 2008',
+        change: false,
+      };
+
+      await controller.update(
+        response,
+        'profession-id',
+        'version-id',
+        dto,
+        request,
+      );
+
+      expect(checkCanViewProfession).toHaveBeenCalledWith(request, profession);
     });
   });
 

--- a/src/professions/admin/legislation.controller.ts
+++ b/src/professions/admin/legislation.controller.ts
@@ -5,6 +5,7 @@ import {
   Param,
   Post,
   Query,
+  Req,
   Res,
   UseGuards,
 } from '@nestjs/common';
@@ -23,6 +24,8 @@ import { BackLink } from '../../common/decorators/back-link.decorator';
 import { ProfessionVersionsService } from '../profession-versions.service';
 import { I18nService } from 'nestjs-i18n';
 import { Profession } from '../profession.entity';
+import { RequestWithAppSession } from '../../common/interfaces/request-with-app-session.interface';
+import { checkCanViewProfession } from '../../users/helpers/check-can-view-profession';
 
 @UseGuards(AuthenticationGuard)
 @Controller('admin/professions')
@@ -45,10 +48,13 @@ export class LegislationController {
     @Param('professionId') professionId: string,
     @Param('versionId') versionId: string,
     @Query('change') change: string,
+    @Req() request: RequestWithAppSession,
   ): Promise<void> {
     const profession = await this.professionsService.findWithVersions(
       professionId,
     );
+
+    checkCanViewProfession(request, profession);
 
     const version = await this.professionVersionsService.findWithProfession(
       versionId,
@@ -75,13 +81,16 @@ export class LegislationController {
     @Param('professionId') professionId: string,
     @Param('versionId') versionId: string,
     @Body() legislationDto,
+    @Req() request: RequestWithAppSession,
   ): Promise<void> {
-    const validator = await Validator.validate(LegislationDto, legislationDto);
-    const submittedValues = validator.obj;
-
     const profession = await this.professionsService.findWithVersions(
       professionId,
     );
+
+    checkCanViewProfession(request, profession);
+
+    const validator = await Validator.validate(LegislationDto, legislationDto);
+    const submittedValues = validator.obj;
 
     const version = await this.professionVersionsService.findWithProfession(
       versionId,

--- a/src/professions/admin/profession-archive.controller.ts
+++ b/src/professions/admin/profession-archive.controller.ts
@@ -14,6 +14,7 @@ import { flashMessage } from '../../common/flash-message';
 import { RequestWithAppSession } from '../../common/interfaces/request-with-app-session.interface';
 import { Permissions } from '../../common/permissions.decorator';
 import { escape } from '../../helpers/escape.helper';
+import { checkCanViewProfession } from '../../users/helpers/check-can-view-profession';
 import { getActingUser } from '../../users/helpers/get-acting-user.helper';
 import { UserPermission } from '../../users/user-permission';
 import { ProfessionVersionsService } from '../profession-versions.service';
@@ -33,6 +34,7 @@ export class ProfessionArchiveController {
   async new(
     @Param('professionId') professionId: string,
     @Param('versionId') versionId: string,
+    @Req() req: RequestWithAppSession,
   ) {
     const version = await this.professionVersionsService.findByIdWithProfession(
       professionId,
@@ -40,6 +42,8 @@ export class ProfessionArchiveController {
     );
 
     const profession = Profession.withVersion(version.profession, version);
+
+    checkCanViewProfession(req, profession);
 
     return { profession };
   }
@@ -56,6 +60,8 @@ export class ProfessionArchiveController {
       professionId,
       versionId,
     );
+
+    checkCanViewProfession(req, version.profession);
 
     const versionToBeArchived = await this.professionVersionsService.create(
       version,

--- a/src/professions/admin/profession-publication.controller.ts
+++ b/src/professions/admin/profession-publication.controller.ts
@@ -7,6 +7,7 @@ import { RequestWithAppSession } from '../../common/interfaces/request-with-app-
 import { Permissions } from '../../common/permissions.decorator';
 import { escape } from '../../helpers/escape.helper';
 import { isConfirmed } from '../../helpers/is-confirmed';
+import { checkCanViewProfession } from '../../users/helpers/check-can-view-profession';
 import { getActingUser } from '../../users/helpers/get-acting-user.helper';
 import { UserPermission } from '../../users/user-permission';
 import { ProfessionVersionsService } from '../profession-versions.service';
@@ -32,6 +33,7 @@ export class ProfessionPublicationController {
   async new(
     @Param('professionId') professionId: string,
     @Param('versionId') versionId: string,
+    @Req() req: RequestWithAppSession,
   ) {
     const version = await this.professionVersionsService.findByIdWithProfession(
       professionId,
@@ -39,6 +41,8 @@ export class ProfessionPublicationController {
     );
 
     const profession = Profession.withVersion(version.profession, version);
+
+    checkCanViewProfession(req, profession);
 
     return { profession };
   }
@@ -52,6 +56,8 @@ export class ProfessionPublicationController {
     @Param('versionId') versionId: string,
   ): Promise<void> {
     const profession = await this.professionsService.find(professionId);
+
+    checkCanViewProfession(req, profession);
 
     const version = await this.professionVersionsService.findByIdWithProfession(
       professionId,

--- a/src/professions/admin/profession-versions.controller.ts
+++ b/src/professions/admin/profession-versions.controller.ts
@@ -26,6 +26,7 @@ import { getActingUser } from '../../users/helpers/get-acting-user.helper';
 import { getOrganisationsFromProfession } from '../helpers/get-organisations-from-profession.helper';
 import { ShowTemplate } from './interfaces/show-template.interface';
 import { isUK } from '../../helpers/nations.helper';
+import { checkCanViewProfession } from '../../users/helpers/check-can-view-profession';
 
 @UseGuards(AuthenticationGuard)
 @Controller('/admin/professions')
@@ -46,6 +47,7 @@ export class ProfessionVersionsController {
   async show(
     @Param('professionId') professionId: string,
     @Param('versionId') versionId: string,
+    @Req() req: RequestWithAppSession,
   ): Promise<ShowTemplate> {
     const version = await this.professionVersionsService.findByIdWithProfession(
       professionId,
@@ -59,6 +61,9 @@ export class ProfessionVersionsController {
     }
 
     const profession = Profession.withVersion(version.profession, version);
+
+    checkCanViewProfession(req, profession);
+
     const presenter = new ProfessionPresenter(profession, this.i18nService);
 
     const hasLiveVersion = await this.professionVersionsService.hasLiveVersion(
@@ -113,6 +118,8 @@ export class ProfessionVersionsController {
       await this.professionVersionsService.findLatestForProfessionId(
         professionId,
       );
+
+    checkCanViewProfession(req, latestVersion.profession);
 
     const version = await this.professionVersionsService.create(
       latestVersion,

--- a/src/professions/admin/qualifications.controller.spec.ts
+++ b/src/professions/admin/qualifications.controller.spec.ts
@@ -14,8 +14,12 @@ import professionVersionFactory from '../../testutils/factories/profession-versi
 import qualificationFactory from '../../testutils/factories/qualification';
 import organisationFactory from '../../testutils/factories/organisation';
 import { translationOf } from '../../testutils/translation-of';
+import userFactory from '../../testutils/factories/user';
+import { createDefaultMockRequest } from '../../testutils/factories/create-default-mock-request';
+import { checkCanViewProfession } from '../../users/helpers/check-can-view-profession';
 
 jest.mock('../../helpers/nations.helper');
+jest.mock('../../users/helpers/check-can-view-profession');
 
 describe(QualificationsController, () => {
   let controller: QualificationsController;
@@ -63,7 +67,17 @@ describe(QualificationsController, () => {
         professionVersionsService.findWithProfession.mockResolvedValue(version);
         (isUK as jest.Mock).mockImplementation(() => false);
 
-        await controller.edit(response, 'profession-id', 'version-id', false);
+        const request = createDefaultMockRequest({
+          user: userFactory.build(),
+        });
+
+        await controller.edit(
+          response,
+          'profession-id',
+          'version-id',
+          false,
+          request,
+        );
 
         expect(response.render).toHaveBeenCalledWith(
           'admin/professions/qualifications',
@@ -99,7 +113,17 @@ describe(QualificationsController, () => {
         professionVersionsService.findWithProfession.mockResolvedValue(version);
         (isUK as jest.Mock).mockImplementation(() => false);
 
-        await controller.edit(response, 'profession-id', 'version-id', false);
+        const request = createDefaultMockRequest({
+          user: userFactory.build(),
+        });
+
+        await controller.edit(
+          response,
+          'profession-id',
+          'version-id',
+          false,
+          request,
+        );
 
         expect(response.render).toHaveBeenCalledWith(
           'admin/professions/qualifications',
@@ -113,6 +137,26 @@ describe(QualificationsController, () => {
           }),
         );
       });
+    });
+
+    it('should check the user has permission to view the Profession', async () => {
+      const profession = professionFactory.build();
+
+      professionsService.findWithVersions.mockResolvedValue(profession);
+
+      const request = createDefaultMockRequest({
+        user: userFactory.build(),
+      });
+
+      await controller.edit(
+        response,
+        'profession-id',
+        'version-id',
+        false,
+        request,
+      );
+
+      expect(checkCanViewProfession).toHaveBeenCalledWith(request, profession);
     });
   });
 
@@ -141,7 +185,17 @@ describe(QualificationsController, () => {
             version,
           );
 
-          await controller.update(response, 'profession-id', 'version-id', dto);
+          const request = createDefaultMockRequest({
+            user: userFactory.build(),
+          });
+
+          await controller.update(
+            response,
+            'profession-id',
+            'version-id',
+            dto,
+            request,
+          );
 
           expect(professionVersionsService.save).toHaveBeenCalledWith(
             expect.objectContaining({
@@ -183,7 +237,17 @@ describe(QualificationsController, () => {
             version,
           );
 
-          await controller.update(response, 'profession-id', 'version-id', dto);
+          const request = createDefaultMockRequest({
+            user: userFactory.build(),
+          });
+
+          await controller.update(
+            response,
+            'profession-id',
+            'version-id',
+            dto,
+            request,
+          );
 
           expect(professionVersionsService.save).toHaveBeenCalledWith(
             expect.objectContaining({
@@ -224,7 +288,17 @@ describe(QualificationsController, () => {
         professionsService.findWithVersions.mockResolvedValue(profession);
         professionVersionsService.findWithProfession.mockResolvedValue(version);
 
-        await controller.update(response, 'profession-id', 'version-id', dto);
+        const request = createDefaultMockRequest({
+          user: userFactory.build(),
+        });
+
+        await controller.update(
+          response,
+          'profession-id',
+          'version-id',
+          dto,
+          request,
+        );
 
         expect(professionVersionsService.save).toHaveBeenCalledWith(
           expect.objectContaining({
@@ -265,7 +339,17 @@ describe(QualificationsController, () => {
         professionVersionsService.findWithProfession.mockResolvedValue(version);
         (isUK as jest.Mock).mockImplementation(() => false);
 
-        await controller.update(response, 'profession-id', 'version-id', dto);
+        const request = createDefaultMockRequest({
+          user: userFactory.build(),
+        });
+
+        await controller.update(
+          response,
+          'profession-id',
+          'version-id',
+          dto,
+          request,
+        );
 
         expect(response.render).toHaveBeenCalledWith(
           'admin/professions/qualifications',
@@ -285,6 +369,34 @@ describe(QualificationsController, () => {
           }),
         );
       });
+    });
+
+    it('should check the user has permission to update the Profession', async () => {
+      const profession = professionFactory.build();
+
+      professionsService.findWithVersions.mockResolvedValue(profession);
+
+      const request = createDefaultMockRequest({
+        user: userFactory.build(),
+      });
+
+      const dto: QualificationsDto = {
+        routesToObtain: 'General secondary education',
+        moreInformationUrl: 'http://www.example.com/more-info',
+        ukRecognition: 'ukRecognition',
+        ukRecognitionUrl: 'http://example.com/uk',
+        change: true,
+      };
+
+      await controller.update(
+        response,
+        'profession-id',
+        'version-id',
+        dto,
+        request,
+      );
+
+      expect(checkCanViewProfession).toHaveBeenCalledWith(request, profession);
     });
   });
 

--- a/src/professions/admin/qualifications.controller.ts
+++ b/src/professions/admin/qualifications.controller.ts
@@ -5,6 +5,7 @@ import {
   Param,
   Post,
   Query,
+  Req,
   Res,
   UseGuards,
 } from '@nestjs/common';
@@ -25,6 +26,8 @@ import { ProfessionVersionsService } from '../profession-versions.service';
 import { isUK } from '../../helpers/nations.helper';
 import { ProfessionVersion } from '../profession-version.entity';
 import { Profession } from '../profession.entity';
+import { RequestWithAppSession } from '../../common/interfaces/request-with-app-session.interface';
+import { checkCanViewProfession } from '../../users/helpers/check-can-view-profession';
 
 @UseGuards(AuthenticationGuard)
 @Controller('admin/professions')
@@ -47,10 +50,13 @@ export class QualificationsController {
     @Param('professionId') professionId: string,
     @Param('versionId') versionId: string,
     @Query('change') change: boolean,
+    @Req() request: RequestWithAppSession,
   ): Promise<void> {
     const profession = await this.professionsService.findWithVersions(
       professionId,
     );
+
+    checkCanViewProfession(request, profession);
 
     const version = await this.professionVersionsService.findWithProfession(
       versionId,
@@ -77,16 +83,19 @@ export class QualificationsController {
     @Param('professionId') professionId: string,
     @Param('versionId') versionId: string,
     @Body() qualificationsDto,
+    @Req() request: RequestWithAppSession,
   ): Promise<void> {
+    const profession = await this.professionsService.findWithVersions(
+      professionId,
+    );
+
+    checkCanViewProfession(request, profession);
+
     const validator = await Validator.validate(
       QualificationsDto,
       qualificationsDto,
     );
     const submittedValues = validator.obj;
-
-    const profession = await this.professionsService.findWithVersions(
-      professionId,
-    );
 
     const version = await this.professionVersionsService.findWithProfession(
       versionId,

--- a/src/professions/admin/registration.controller.spec.ts
+++ b/src/professions/admin/registration.controller.spec.ts
@@ -9,11 +9,16 @@ import { createMockI18nService } from '../../testutils/create-mock-i18n-service'
 
 import professionFactory from '../../testutils/factories/profession';
 import professionVersionFactory from '../../testutils/factories/profession-version';
+import userFactory from '../../testutils/factories/user';
 
 import { ProfessionVersionsService } from '../profession-versions.service';
 import { ProfessionsService } from '../professions.service';
 
 import { translationOf } from '../../testutils/translation-of';
+import { createDefaultMockRequest } from '../../testutils/factories/create-default-mock-request';
+import { checkCanViewProfession } from '../../users/helpers/check-can-view-profession';
+
+jest.mock('../../users/helpers/check-can-view-profession');
 
 describe(RegistrationController, () => {
   let controller: RegistrationController;
@@ -57,7 +62,17 @@ describe(RegistrationController, () => {
         professionsService.findWithVersions.mockResolvedValue(profession);
         professionVersionsService.findWithProfession.mockResolvedValue(version);
 
-        await controller.edit(response, 'profession-id', 'version-id', 'false');
+        const request = createDefaultMockRequest({
+          user: userFactory.build(),
+        });
+
+        await controller.edit(
+          response,
+          'profession-id',
+          'version-id',
+          'false',
+          request,
+        );
 
         expect(response.render).toHaveBeenCalledWith(
           'admin/professions/registration',
@@ -79,10 +94,20 @@ describe(RegistrationController, () => {
           registrationUrl: 'http://example.com',
         });
 
+        const request = createDefaultMockRequest({
+          user: userFactory.build(),
+        });
+
         professionsService.findWithVersions.mockResolvedValue(profession);
         professionVersionsService.findWithProfession.mockResolvedValue(version);
 
-        await controller.edit(response, 'profession-id', 'version-id', 'false');
+        await controller.edit(
+          response,
+          'profession-id',
+          'version-id',
+          'false',
+          request,
+        );
 
         expect(response.render).toHaveBeenCalledWith(
           'admin/professions/registration',
@@ -93,6 +118,26 @@ describe(RegistrationController, () => {
           }),
         );
       });
+    });
+
+    it('checks the user has permission to view the Profession', async () => {
+      const profession = professionFactory.justCreated('profession-id').build();
+
+      professionsService.findWithVersions.mockResolvedValue(profession);
+
+      const request = createDefaultMockRequest({
+        user: userFactory.build(),
+      });
+
+      await controller.edit(
+        response,
+        'profession-id',
+        'version-id',
+        'false',
+        request,
+      );
+
+      expect(checkCanViewProfession).toHaveBeenCalledWith(request, profession);
     });
   });
 
@@ -115,11 +160,16 @@ describe(RegistrationController, () => {
           registrationUrl: 'http://example.com',
         };
 
+        const request = createDefaultMockRequest({
+          user: userFactory.build(),
+        });
+
         await controller.update(
           response,
           'profession-id',
           'version-id',
           registrationDto,
+          request,
         );
 
         expect(professionVersionsService.save).toHaveBeenCalledWith(
@@ -154,11 +204,16 @@ describe(RegistrationController, () => {
           registrationUrl: 'example.com',
         };
 
+        const request = createDefaultMockRequest({
+          user: userFactory.build(),
+        });
+
         await controller.update(
           response,
           'profession-id',
           'version-id',
           registrationDto,
+          request,
         );
 
         expect(professionVersionsService.save).toHaveBeenCalledWith(
@@ -181,12 +236,16 @@ describe(RegistrationController, () => {
           mandatoryRegistration: undefined,
           registrationUrl: 'not a url',
         };
+        const request = createDefaultMockRequest({
+          user: userFactory.build(),
+        });
 
         await controller.update(
           response,
           'profession-id',
           'version-id',
           registrationDtoWithInvalidURL,
+          request,
         );
 
         expect(professionVersionsService.save).not.toHaveBeenCalled();
@@ -225,11 +284,16 @@ describe(RegistrationController, () => {
             change: true,
           };
 
+          const request = createDefaultMockRequest({
+            user: userFactory.build(),
+          });
+
           await controller.update(
             response,
             'profession-id',
             'version-id',
             registrationDtoWithChangeParam,
+            request,
           );
 
           expect(response.redirect).toHaveBeenCalledWith(
@@ -258,11 +322,16 @@ describe(RegistrationController, () => {
             change: false,
           };
 
+          const request = createDefaultMockRequest({
+            user: userFactory.build(),
+          });
+
           await controller.update(
             response,
             'profession-id',
             'version-id',
             registrationDtoWithFalseChangeParam,
+            request,
           );
 
           expect(response.redirect).toHaveBeenCalledWith(
@@ -270,6 +339,31 @@ describe(RegistrationController, () => {
           );
         });
       });
+    });
+
+    it('checks the user has permission to update the Profession', async () => {
+      const profession = professionFactory.justCreated('profession-id').build();
+
+      professionsService.findWithVersions.mockResolvedValue(profession);
+
+      const request = createDefaultMockRequest({
+        user: userFactory.build(),
+      });
+
+      const registrationDto = {
+        registrationRequirements: 'Something',
+        registrationUrl: 'example.com',
+      };
+
+      await controller.update(
+        response,
+        'profession-id',
+        'version-id',
+        registrationDto,
+        request,
+      );
+
+      expect(checkCanViewProfession).toHaveBeenCalledWith(request, profession);
     });
   });
 

--- a/src/professions/admin/registration.controller.ts
+++ b/src/professions/admin/registration.controller.ts
@@ -5,6 +5,7 @@ import {
   Param,
   Post,
   Query,
+  Req,
   Res,
   UseGuards,
 } from '@nestjs/common';
@@ -33,6 +34,8 @@ import { RegistrationTemplate } from './interfaces/registration.template';
 
 import ViewUtils from './viewUtils';
 import { Profession } from '../profession.entity';
+import { RequestWithAppSession } from '../../common/interfaces/request-with-app-session.interface';
+import { checkCanViewProfession } from '../../users/helpers/check-can-view-profession';
 
 @UseGuards(AuthenticationGuard)
 @Controller('admin/professions')
@@ -55,10 +58,13 @@ export class RegistrationController {
     @Param('professionId') professionId: string,
     @Param('versionId') versionId: string,
     @Query('change') change: string,
+    @Req() req: RequestWithAppSession,
   ): Promise<void> {
     const profession = await this.professionsService.findWithVersions(
       professionId,
     );
+
+    checkCanViewProfession(req, profession);
 
     const version = await this.professionVersionsService.findWithProfession(
       versionId,
@@ -79,7 +85,13 @@ export class RegistrationController {
     @Param('professionId') professionId: string,
     @Param('versionId') versionId: string,
     @Body() registrationDto,
+    @Req() req: RequestWithAppSession,
   ): Promise<void> {
+    const profession = await this.professionsService.findWithVersions(
+      professionId,
+    );
+    checkCanViewProfession(req, profession);
+
     const validator = await Validator.validate(
       RegistrationDto,
       registrationDto,
@@ -88,10 +100,6 @@ export class RegistrationController {
 
     const version = await this.professionVersionsService.findWithProfession(
       versionId,
-    );
-
-    const profession = await this.professionsService.findWithVersions(
-      professionId,
     );
 
     if (!validator.valid()) {

--- a/src/professions/admin/scope.controller.spec.ts
+++ b/src/professions/admin/scope.controller.spec.ts
@@ -12,6 +12,11 @@ import { createMockI18nService } from '../../testutils/create-mock-i18n-service'
 import { translationOf } from '../../testutils/translation-of';
 import { ProfessionVersionsService } from '../profession-versions.service';
 import professionVersionFactory from '../../testutils/factories/profession-version';
+import { createDefaultMockRequest } from '../../testutils/factories/create-default-mock-request';
+import userFactory from '../../testutils/factories/user';
+import { checkCanViewProfession } from '../../users/helpers/check-can-view-profession';
+
+jest.mock('../../users/helpers/check-can-view-profession');
 
 describe('ScopeController', () => {
   let controller: ScopeController;
@@ -75,7 +80,17 @@ describe('ScopeController', () => {
 
         industriesService.all.mockResolvedValue(industries);
 
-        await controller.edit(response, 'profession-id', 'version-id', 'false');
+        const request = createDefaultMockRequest({
+          user: userFactory.build(),
+        });
+
+        await controller.edit(
+          response,
+          'profession-id',
+          'version-id',
+          'false',
+          request,
+        );
 
         expect(response.render).toHaveBeenCalledWith(
           'admin/professions/scope',
@@ -158,7 +173,17 @@ describe('ScopeController', () => {
           }),
         ]);
 
-        await controller.edit(response, 'profession-id', 'version-id', 'false');
+        const request = createDefaultMockRequest({
+          user: userFactory.build(),
+        });
+
+        await controller.edit(
+          response,
+          'profession-id',
+          'version-id',
+          'false',
+          request,
+        );
 
         expect(response.render).toHaveBeenCalledWith(
           'admin/professions/scope',
@@ -226,7 +251,17 @@ describe('ScopeController', () => {
         professionsService.findWithVersions.mockResolvedValue(profession);
         professionVersionsService.findWithProfession.mockResolvedValue(version);
 
-        await controller.edit(response, 'profession-id', 'version-id', 'false');
+        const request = createDefaultMockRequest({
+          user: userFactory.build(),
+        });
+
+        await controller.edit(
+          response,
+          'profession-id',
+          'version-id',
+          'false',
+          request,
+        );
 
         expect(response.render).toHaveBeenCalledWith(
           'admin/professions/scope',
@@ -235,6 +270,29 @@ describe('ScopeController', () => {
           }),
         );
       });
+    });
+
+    it('checks the user has permission to view the profession', async () => {
+      const profession = professionFactory.build();
+
+      const version = professionVersionFactory.build();
+
+      professionsService.findWithVersions.mockResolvedValue(profession);
+      professionVersionsService.findWithProfession.mockResolvedValue(version);
+
+      const request = createDefaultMockRequest({
+        user: userFactory.build(),
+      });
+
+      await controller.edit(
+        response,
+        'profession-id',
+        'version-id',
+        'false',
+        request,
+      );
+
+      expect(checkCanViewProfession).toHaveBeenCalledWith(request, profession);
     });
   });
 
@@ -266,11 +324,16 @@ describe('ScopeController', () => {
 
         industriesService.findByIds.mockResolvedValue([constructionIndustry]);
 
+        const request = createDefaultMockRequest({
+          user: userFactory.build(),
+        });
+
         await controller.update(
           scopeDto,
           response,
           'profession-id',
           'version-id',
+          request,
         );
 
         expect(professionVersionsService.save).toHaveBeenCalledWith(
@@ -305,11 +368,16 @@ describe('ScopeController', () => {
           industries: ['construction-uuid'],
         };
 
+        const request = createDefaultMockRequest({
+          user: userFactory.build(),
+        });
+
         await controller.update(
           scopeDto,
           response,
           'profession-id',
           'version-id',
+          request,
         );
 
         expect(professionVersionsService.save).toHaveBeenCalledWith(
@@ -328,11 +396,16 @@ describe('ScopeController', () => {
           industries: undefined,
         };
 
+        const request = createDefaultMockRequest({
+          user: userFactory.build(),
+        });
+
         await controller.update(
           scopeDtoWithNoAnswers,
           response,
           'profession-id',
           'version-id',
+          request,
         );
 
         expect(response.render).toHaveBeenCalledWith(
@@ -380,11 +453,16 @@ describe('ScopeController', () => {
 
           industriesService.findByIds.mockResolvedValue([industry]);
 
+          const request = createDefaultMockRequest({
+            user: userFactory.build(),
+          });
+
           await controller.update(
             scopeDtoWithChangeParam,
             response,
             'profession-id',
             'version-id',
+            request,
           );
 
           expect(response.redirect).toHaveBeenCalledWith(
@@ -418,11 +496,16 @@ describe('ScopeController', () => {
 
           industriesService.findByIds.mockResolvedValue([industry]);
 
+          const request = createDefaultMockRequest({
+            user: userFactory.build(),
+          });
+
           await controller.update(
             scopeDtoWithoutChangeParam,
             response,
             'profession-id',
             'version-id',
+            request,
           );
 
           expect(response.redirect).toHaveBeenCalledWith(
@@ -430,6 +513,35 @@ describe('ScopeController', () => {
           );
         });
       });
+    });
+
+    it('checks the user has permission to update the profession', async () => {
+      const profession = professionFactory.build();
+
+      const version = professionVersionFactory.build();
+
+      professionsService.findWithVersions.mockResolvedValue(profession);
+      professionVersionsService.findWithProfession.mockResolvedValue(version);
+
+      const request = createDefaultMockRequest({
+        user: userFactory.build(),
+      });
+
+      const scopeDto = {
+        coversUK: '0',
+        nations: ['GB-ENG'],
+        industries: ['construction-uuid'],
+      };
+
+      await controller.update(
+        scopeDto,
+        response,
+        'profession-id',
+        'version-id',
+        request,
+      );
+
+      expect(checkCanViewProfession).toHaveBeenCalledWith(request, profession);
     });
   });
 

--- a/src/professions/admin/scope.controller.ts
+++ b/src/professions/admin/scope.controller.ts
@@ -5,6 +5,7 @@ import {
   Param,
   Post,
   Query,
+  Req,
   Res,
   UseGuards,
 } from '@nestjs/common';
@@ -30,6 +31,8 @@ import { ProfessionVersion } from '../profession-version.entity';
 import { allNations, isUK } from '../../helpers/nations.helper';
 import { ScopeDto } from './dto/scope.dto';
 import { Profession } from '../profession.entity';
+import { checkCanViewProfession } from '../../users/helpers/check-can-view-profession';
+import { RequestWithAppSession } from '../../common/interfaces/request-with-app-session.interface';
 
 @UseGuards(AuthenticationGuard)
 @Controller('admin/professions')
@@ -53,11 +56,14 @@ export class ScopeController {
     @Param('professionId') professionId: string,
     @Param('versionId') versionId: string,
     @Query('change') change: string,
+    @Req() req: RequestWithAppSession,
     errors: object | undefined = undefined,
   ): Promise<void> {
     const profession = await this.professionsService.findWithVersions(
       professionId,
     );
+
+    checkCanViewProfession(req, profession);
 
     const version = await this.professionVersionsService.findWithProfession(
       versionId,
@@ -90,6 +96,7 @@ export class ScopeController {
     @Res() res: Response,
     @Param('professionId') professionId: string,
     @Param('versionId') versionId: string,
+    @Req() req: RequestWithAppSession,
   ): Promise<void> {
     const validator = await Validator.validate(ScopeDto, scopeDto);
     const submittedValues = validator.obj;
@@ -99,6 +106,8 @@ export class ScopeController {
     const profession = await this.professionsService.findWithVersions(
       professionId,
     );
+
+    checkCanViewProfession(req, profession);
 
     const version = await this.professionVersionsService.findWithProfession(
       versionId,

--- a/src/users/helpers/check-can-view-profession.spec.ts
+++ b/src/users/helpers/check-can-view-profession.spec.ts
@@ -1,0 +1,24 @@
+import { createDefaultMockRequest } from '../../testutils/factories/create-default-mock-request';
+import organisationFactory from '../../testutils/factories/organisation';
+import professionFactory from '../../testutils/factories/profession';
+import { checkCanViewOrganisation } from './check-can-view-organisation';
+import { checkCanViewProfession } from './check-can-view-profession';
+
+jest.mock('./check-can-view-organisation');
+
+describe('checkCanViewProfession', () => {
+  it('passes in a Profession with an organisation to call CheckCanViewOrganisation', () => {
+    const organisation = organisationFactory.build();
+    const profession = professionFactory.build({
+      organisation: organisation,
+    });
+
+    const request = createDefaultMockRequest({ profession: profession });
+    checkCanViewProfession(request, profession);
+
+    expect(checkCanViewOrganisation).toHaveBeenCalledWith(
+      request,
+      organisation,
+    );
+  });
+});

--- a/src/users/helpers/check-can-view-profession.ts
+++ b/src/users/helpers/check-can-view-profession.ts
@@ -1,0 +1,10 @@
+import { RequestWithAppSession } from '../../common/interfaces/request-with-app-session.interface';
+import { Profession } from '../../professions/profession.entity';
+import { checkCanViewOrganisation } from './check-can-view-organisation';
+
+export function checkCanViewProfession(
+  request: RequestWithAppSession,
+  profession: Profession,
+) {
+  checkCanViewOrganisation(request, profession.organisation);
+}


### PR DESCRIPTION
# Changes in this PR

Ensures users can't view other Profession admin pages or edit Professions from another Organisation unless they're central admins. They could only do this if they had the UUID of the Profession and the version, so it was very unlikely that they'd have been able to do this anyway.
