### PR TITLE
(2151) Replace per page validation with pre-publish validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Display number of results above filters on mobile
 - Hide filters on mobile once users have searched
 - Only allow users to edit a Profession if they are a central user, or in that Profession's primary Organisation
+- Allow a central user to create a draft Profession with only a name and an Organisation
+- Validate that all necessary fields are completed before a Profession is published
 
 ## [release-009] - 2022-03-11
 

--- a/cypress/integration/admin/professions/edit.spec.ts
+++ b/cypress/integration/admin/professions/edit.spec.ts
@@ -392,7 +392,7 @@ describe('Editing an existing profession', () => {
           },
         );
 
-        cy.checkAccessibility();
+        cy.checkAccessibility({ 'color-contrast': { enabled: false } });
 
         cy.checkSummaryListRowValue(
           'professions.form.label.qualifications.routesToObtain',
@@ -407,7 +407,7 @@ describe('Editing an existing profession', () => {
           'professions.form.label.qualifications.routesToObtain',
         );
 
-        cy.checkAccessibility();
+        cy.checkAccessibility({ 'color-contrast': { enabled: false } });
 
         cy.get('textarea[name="routesToObtain"]').type(
           'General secondary education',
@@ -423,7 +423,7 @@ describe('Editing an existing profession', () => {
           cy.get('button').contains(buttonText).click();
         });
 
-        cy.checkAccessibility();
+        cy.checkAccessibility({ 'color-contrast': { enabled: false } });
 
         cy.checkSummaryListRowValue(
           'professions.form.label.qualifications.routesToObtain',

--- a/cypress/integration/admin/professions/edit.spec.ts
+++ b/cypress/integration/admin/professions/edit.spec.ts
@@ -386,12 +386,6 @@ describe('Editing an existing profession', () => {
 
         cy.checkAccessibility();
 
-        cy.translate('professions.form.headings.qualifications').then(
-          (qualifications) => {
-            cy.get('body').should('not.contain', qualifications);
-          },
-        );
-
         cy.translate('professions.admin.button.edit.draft').then(
           (buttonText) => {
             cy.contains(buttonText).click();

--- a/cypress/integration/admin/professions/edit.spec.ts
+++ b/cypress/integration/admin/professions/edit.spec.ts
@@ -95,10 +95,7 @@ describe('Editing an existing profession', () => {
         cy.get('dt').contains(label).siblings().should('not.contain', 'Change');
       });
 
-      cy.clickSummaryListRowAction(
-        'professions.form.label.scope.nations',
-        'Change',
-      );
+      cy.clickSummaryListRowChangeLink('professions.form.label.scope.nations');
 
       // Conditional radio buttons add an additional `aria-expanded` field,
       // so ignore that rule on this page
@@ -128,9 +125,8 @@ describe('Editing an existing profession', () => {
         });
       });
 
-      cy.clickSummaryListRowAction(
+      cy.clickSummaryListRowChangeLink(
         'professions.form.label.regulatedActivities.regulationSummary',
-        'Change',
       );
       cy.checkAccessibility();
       cy.translate('professions.form.captions.edit', {
@@ -158,9 +154,8 @@ describe('Editing an existing profession', () => {
         },
       );
 
-      cy.clickSummaryListRowAction(
+      cy.clickSummaryListRowChangeLink(
         'professions.form.label.qualifications.routesToObtain',
-        'Change',
       );
 
       cy.checkAccessibility();
@@ -180,9 +175,8 @@ describe('Editing an existing profession', () => {
         'Updated routes to obtain qualification',
       );
 
-      cy.clickSummaryListRowAction(
+      cy.clickSummaryListRowChangeLink(
         'professions.form.label.legislation.nationalLegislation',
-        'Change',
       );
       cy.checkAccessibility();
       cy.translate('professions.form.captions.edit', {
@@ -202,9 +196,8 @@ describe('Editing an existing profession', () => {
         1,
       );
 
-      cy.clickSummaryListRowAction(
+      cy.clickSummaryListRowChangeLink(
         'professions.form.label.legislation.nationalLegislation',
-        'Change',
       );
       cy.checkAccessibility();
       cy.translate('professions.form.captions.edit', {
@@ -280,10 +273,7 @@ describe('Editing an existing profession', () => {
         cy.contains(buttonText).click();
       });
 
-      cy.clickSummaryListRowAction(
-        'professions.form.label.scope.nations',
-        'Change',
-      );
+      cy.clickSummaryListRowChangeLink('professions.form.label.scope.nations');
 
       cy.translate('app.unitedKingdom').then((uk) => {
         cy.get('label').contains(uk).click();
@@ -299,9 +289,8 @@ describe('Editing an existing profession', () => {
         },
       );
 
-      cy.clickSummaryListRowAction(
+      cy.clickSummaryListRowChangeLink(
         'professions.form.label.qualifications.routesToObtain',
-        'Change',
       );
 
       cy.translate('professions.form.label.qualifications.ukRecognition').then(
@@ -314,10 +303,7 @@ describe('Editing an existing profession', () => {
         cy.get('button').contains(buttonText).click();
       });
 
-      cy.clickSummaryListRowAction(
-        'professions.form.label.scope.nations',
-        'Change',
-      );
+      cy.clickSummaryListRowChangeLink('professions.form.label.scope.nations');
 
       cy.translate('professions.form.label.scope.certainNations').then(
         (certainNations) => {
@@ -339,9 +325,8 @@ describe('Editing an existing profession', () => {
         },
       );
 
-      cy.clickSummaryListRowAction(
+      cy.clickSummaryListRowChangeLink(
         'professions.form.label.qualifications.routesToObtain',
-        'Change',
       );
 
       cy.translate('professions.form.label.qualifications.ukRecognition').then(
@@ -365,10 +350,7 @@ describe('Editing an existing profession', () => {
         cy.contains(buttonText).click();
       });
 
-      cy.clickSummaryListRowAction(
-        'professions.form.label.scope.nations',
-        'Change',
-      );
+      cy.clickSummaryListRowChangeLink('professions.form.label.scope.nations');
 
       cy.translate('app.unitedKingdom').then((uk) => {
         cy.get('label').contains(uk).click();
@@ -427,9 +409,8 @@ describe('Editing an existing profession', () => {
           '',
         );
 
-        cy.clickSummaryListRowAction(
+        cy.clickSummaryListRowChangeLink(
           'professions.form.label.qualifications.routesToObtain',
-          'Change',
         );
 
         cy.checkAccessibility();
@@ -502,9 +483,8 @@ describe('Editing an existing profession', () => {
 
         cy.checkAccessibility();
 
-        cy.clickSummaryListRowAction(
+        cy.clickSummaryListRowChangeLink(
           'professions.form.label.legislation.nationalLegislation',
-          'Change',
         );
         cy.checkAccessibility();
         cy.translate('professions.form.captions.edit', {
@@ -560,9 +540,8 @@ describe('Editing an existing profession', () => {
 
       cy.checkAccessibility();
 
-      cy.clickSummaryListRowAction(
+      cy.clickSummaryListRowChangeLink(
         'professions.form.label.topLevelInformation.name',
-        'Change',
       );
       cy.checkAccessibility();
       cy.translate('professions.form.captions.edit', {
@@ -580,9 +559,8 @@ describe('Editing an existing profession', () => {
         'Updated name',
       );
 
-      cy.clickSummaryListRowAction(
+      cy.clickSummaryListRowChangeLink(
         'professions.form.label.topLevelInformation.regulatedAuthority',
-        'Change',
       );
       cy.checkAccessibility();
       cy.translate('professions.form.captions.edit', {

--- a/cypress/integration/admin/professions/edit.spec.ts
+++ b/cypress/integration/admin/professions/edit.spec.ts
@@ -384,7 +384,7 @@ describe('Editing an existing profession', () => {
             cy.contains('View details').click();
           });
 
-        cy.checkAccessibility();
+        cy.checkAccessibility({ 'color-contrast': { enabled: false } });
 
         cy.translate('professions.admin.button.edit.draft').then(
           (buttonText) => {
@@ -448,7 +448,7 @@ describe('Editing an existing profession', () => {
           },
         );
 
-        cy.checkAccessibility();
+        cy.checkAccessibility({ 'color-contrast': { enabled: false } });
 
         cy.checkSummaryListRowValue(
           'professions.show.qualification.moreInformationUrl',
@@ -467,7 +467,7 @@ describe('Editing an existing profession', () => {
             cy.contains('View details').click();
           });
 
-        cy.checkAccessibility();
+        cy.checkAccessibility({ 'color-contrast': { enabled: false } });
 
         cy.translate('professions.admin.button.edit.draft').then(
           (buttonText) => {

--- a/cypress/integration/admin/professions/new.spec.ts
+++ b/cypress/integration/admin/professions/new.spec.ts
@@ -59,6 +59,14 @@ describe('Adding a new profession', () => {
         cy.get('button').contains(buttonText).click();
       });
 
+      cy.checkAccessibility({ 'color-contrast': { enabled: false } });
+      cy.checkPublishBlocked([
+        'scope',
+        'regulatedActivities',
+        'qualifications',
+        'legislation',
+      ]);
+      cy.clickSummaryListRowChangeLink('professions.form.label.scope.nations');
       // Conditional radio buttons add an additional `aria-expanded` field,
       // so ignore that rule on this page
       cy.checkAccessibility({ 'aria-allowed-attr': { enabled: false } });
@@ -83,6 +91,15 @@ describe('Adding a new profession', () => {
         cy.get('button').contains(buttonText).click();
       });
 
+      cy.checkAccessibility({ 'color-contrast': { enabled: false } });
+      cy.checkPublishBlocked([
+        'regulatedActivities',
+        'qualifications',
+        'legislation',
+      ]);
+      cy.clickSummaryListRowChangeLink(
+        'professions.form.label.registration.registrationRequirements',
+      );
       cy.checkAccessibility();
       cy.translate('professions.form.captions.addWithName', {
         professionName: 'Example Profession',
@@ -110,8 +127,16 @@ describe('Adding a new profession', () => {
         cy.get('button').contains(buttonText).click();
       });
 
+      cy.checkAccessibility({ 'color-contrast': { enabled: false } });
+      cy.checkPublishBlocked([
+        'regulatedActivities',
+        'qualifications',
+        'legislation',
+      ]);
+      cy.clickSummaryListRowChangeLink(
+        'professions.form.label.regulatedActivities.regulationType',
+      );
       cy.checkAccessibility();
-
       cy.translate('professions.form.headings.regulatedActivities').then(
         (heading) => {
           cy.get('body').should('contain', heading);
@@ -138,6 +163,11 @@ describe('Adding a new profession', () => {
         cy.get('button').contains(buttonText).click();
       });
 
+      cy.checkAccessibility({ 'color-contrast': { enabled: false } });
+      cy.checkPublishBlocked(['qualifications', 'legislation']);
+      cy.clickSummaryListRowChangeLink(
+        'professions.form.label.qualifications.routesToObtain',
+      );
       cy.checkAccessibility();
       cy.translate('professions.form.headings.qualifications').then(
         (heading) => {
@@ -163,6 +193,11 @@ describe('Adding a new profession', () => {
         cy.get('button').contains(buttonText).click();
       });
 
+      cy.checkAccessibility({ 'color-contrast': { enabled: false } });
+      cy.checkPublishBlocked(['legislation']);
+      cy.clickSummaryListRowChangeLink(
+        'professions.form.label.legislation.nationalLegislation',
+      );
       cy.checkAccessibility();
       cy.translate('professions.form.headings.legislation').then((heading) => {
         cy.get('body').should('contain', heading);
@@ -182,6 +217,7 @@ describe('Adding a new profession', () => {
       });
 
       cy.checkAccessibility();
+      cy.checkPublishNotBlocked();
       cy.translate('professions.form.headings.checkAnswers').then((heading) => {
         cy.get('body').should('contain', heading);
       });

--- a/cypress/integration/admin/professions/publish.spec.ts
+++ b/cypress/integration/admin/professions/publish.spec.ts
@@ -113,7 +113,7 @@ describe('Publishing professions', () => {
         });
     });
 
-    it('Allows me to publish a draft profession from the check your answers page', () => {
+    it('Allows me to publish a draft profession from the Check Your Answers page', () => {
       cy.get('a').contains('Regulated professions').click();
       cy.checkAccessibility();
 
@@ -128,30 +128,41 @@ describe('Publishing professions', () => {
       });
 
       cy.get('[data-cy=changed-by-text]').should('not.exist');
+      cy.checkPublishBlocked(['regulatedActivities', 'qualifications']);
 
       cy.translate('professions.admin.button.edit.draft').then((buttonText) => {
         cy.contains(buttonText).click();
       });
 
       cy.clickSummaryListRowChangeLink(
-        'professions.form.label.legislation.nationalLegislation',
+        'professions.form.label.qualifications.routesToObtain',
       );
       cy.checkAccessibility();
-
-      cy.get('textarea[name="nationalLegislation"]').type(
-        'National legislation',
-      );
-
+      cy.get('textarea[name="routesToObtain"]').type('Routes to obtain');
       cy.translate('app.continue').then((buttonText) => {
         cy.get('button').contains(buttonText).click();
       });
-      cy.checkAccessibility();
 
-      cy.checkIndexedSummaryListRowValue(
-        'professions.form.label.legislation.nationalLegislation',
-        'National legislation',
-        1,
+      cy.checkAccessibility({ 'color-contrast': { enabled: false } });
+      cy.clickSummaryListRowChangeLink(
+        'professions.form.label.regulatedActivities.reservedActivities',
       );
+      cy.checkAccessibility();
+      cy.get('textarea[name="reservedActivities"]').type('Reserved activities');
+      cy.translate('app.continue').then((buttonText) => {
+        cy.get('button').contains(buttonText).click();
+      });
+
+      cy.checkSummaryListRowValue(
+        'professions.form.label.qualifications.routesToObtain',
+        'Routes to obtain',
+      );
+      cy.checkSummaryListRowValue(
+        'professions.form.label.regulatedActivities.reservedActivities',
+        'Reserved activities',
+      );
+
+      cy.checkPublishNotBlocked();
 
       cy.translate('professions.form.button.publish').then((buttonText) => {
         cy.get('a').contains(buttonText).click();
@@ -215,7 +226,7 @@ describe('Publishing professions', () => {
       cy.visitAndCheckAccessibility('/admin/professions');
 
       cy.get('tr')
-        .contains('Gas Safe Engineer')
+        .contains('Orthodontic Therapist')
         .then(($header) => {
           const $row = $header.parent();
 
@@ -225,7 +236,7 @@ describe('Publishing professions', () => {
         });
     });
 
-    it('Allows me to publish a draft profession with the bare minimum fields, without breaking the view', () => {
+    it('Does not allows me to publish a draft profession with missing fields from the profession page', () => {
       cy.get('a').contains('Regulated professions').click();
       cy.checkAccessibility();
 
@@ -235,68 +246,42 @@ describe('Publishing professions', () => {
           cy.get('a').contains('View details').click();
         });
 
+      cy.checkAccessibility({ 'color-contrast': { enabled: false } });
       cy.translate('app.status.draft').then((status) => {
         cy.get('h2[data-status]').should('contain', status);
       });
 
-      cy.translate('professions.form.button.publish').then((publishButton) => {
-        cy.get('a').contains(publishButton).click();
-      });
+      cy.checkPublishBlocked([
+        'scope',
+        'regulatedActivities',
+        'qualifications',
+        'legislation',
+      ]);
+    });
 
+    it('Does not allows me to publish a draft profession with missing fields from the Check Your Answers page', () => {
+      cy.get('a').contains('Regulated professions').click();
       cy.checkAccessibility();
 
-      cy.translate('professions.form.button.publish').then((buttonText) => {
-        cy.get('button').contains(buttonText).click();
-      });
-
-      cy.checkAccessibility();
-
-      cy.translate('professions.admin.publish.confirmation.heading').then(
-        (confirmation) => {
-          cy.get('html').should('contain', confirmation);
-        },
-      );
-
-      cy.translate('professions.admin.button.edit.live').then((buttonText) => {
-        cy.get('html').should('contain', buttonText);
-      });
-
-      cy.translate('professions.admin.changed.by').then((changedByText) => {
-        cy.get('[data-cy=changed-by-text]').should('contain', changedByText);
-      });
-      cy.get('[data-cy=changed-by-user-name]').should('contain', 'Editor');
-      cy.get('[data-cy=changed-by-user-email]').should(
-        'contain',
-        'beis-rpr+editor@dxw.com',
-      );
-      cy.get('[data-cy=last-modified]').should(
-        'contain',
-        format(new Date(), 'd MMM yyyy'),
-      );
-
-      cy.get('[data-cy=currently-published-version-text]').within(() => {
-        cy.translate('professions.admin.publicFacingLink.label').then(
-          (publicFacingLinkLabel) => {
-            cy.get('a').should('contain', publicFacingLinkLabel);
-          },
-        );
-
-        cy.get('a').click();
-      });
-      cy.get('body').should('contain', 'Draft Profession');
-      cy.go('back');
-
-      cy.visitAndCheckAccessibility('/admin/professions');
-
-      cy.get('tr')
-        .contains('Draft Profession')
-        .then(($header) => {
-          const $row = $header.parent();
-
-          cy.translate('app.status.live').then((status) => {
-            cy.wrap($row).should('contain', status);
-          });
+      cy.contains('Draft Profession')
+        .parent('tr')
+        .within(() => {
+          cy.get('a').contains('View details').click();
         });
+
+      cy.checkAccessibility({ 'color-contrast': { enabled: false } });
+      cy.translate('app.status.draft').then((status) => {
+        cy.get('h2[data-status]').should('contain', status);
+      });
+
+      cy.translate('professions.admin.button.edit.draft').then((buttonText) => {
+        cy.contains(buttonText).click();
+      });
+
+      cy.checkPublishBlocked(
+        ['scope', 'regulatedActivities', 'qualifications', 'legislation'],
+        false,
+      );
     });
   });
 

--- a/cypress/integration/admin/professions/publish.spec.ts
+++ b/cypress/integration/admin/professions/publish.spec.ts
@@ -23,6 +23,7 @@ describe('Publishing professions', () => {
 
       cy.get('[data-cy=changed-by-text]').should('not.exist');
       cy.get('[data-cy=currently-published-version-text]').should('not.exist');
+      cy.checkPublishNotBlocked();
 
       cy.translate('professions.form.button.publish').then((publishButton) => {
         cy.get('a').contains(publishButton).click();

--- a/cypress/integration/admin/professions/publish.spec.ts
+++ b/cypress/integration/admin/professions/publish.spec.ts
@@ -292,7 +292,7 @@ describe('Publishing professions', () => {
       cy.visitAndCheckAccessibility('/admin');
     });
 
-    it('I can create and publish a new profession from the Check your answers page', () => {
+    it('I can create and publish a new profession from the Check Your Answers page', () => {
       cy.visitAndCheckAccessibility('/admin/professions');
 
       cy.translate('professions.admin.addButtonLabel').then((buttonText) => {
@@ -323,6 +323,14 @@ describe('Publishing professions', () => {
         cy.get('button').contains(buttonText).click();
       });
 
+      cy.checkAccessibility({ 'color-contrast': { enabled: false } });
+      cy.checkPublishBlocked([
+        'scope',
+        'regulatedActivities',
+        'qualifications',
+        'legislation',
+      ]);
+      cy.clickSummaryListRowChangeLink('professions.form.label.scope.nations');
       // Conditional radio buttons add an additional `aria-expanded` field,
       // so ignore that rule on this page
       cy.checkAccessibility({ 'aria-allowed-attr': { enabled: false } });
@@ -347,6 +355,15 @@ describe('Publishing professions', () => {
         cy.get('button').contains(buttonText).click();
       });
 
+      cy.checkAccessibility({ 'color-contrast': { enabled: false } });
+      cy.checkPublishBlocked([
+        'regulatedActivities',
+        'qualifications',
+        'legislation',
+      ]);
+      cy.clickSummaryListRowChangeLink(
+        'professions.form.label.registration.registrationRequirements',
+      );
       cy.checkAccessibility();
       cy.translate('professions.form.captions.addWithName', {
         professionName: 'Example Profession',
@@ -363,8 +380,16 @@ describe('Publishing professions', () => {
         cy.get('button').contains(buttonText).click();
       });
 
+      cy.checkAccessibility({ 'color-contrast': { enabled: false } });
+      cy.checkPublishBlocked([
+        'regulatedActivities',
+        'qualifications',
+        'legislation',
+      ]);
+      cy.clickSummaryListRowChangeLink(
+        'professions.form.label.regulatedActivities.regulationType',
+      );
       cy.checkAccessibility();
-
       cy.translate('professions.form.headings.regulatedActivities').then(
         (heading) => {
           cy.get('body').should('contain', heading);
@@ -391,6 +416,11 @@ describe('Publishing professions', () => {
         cy.get('button').contains(buttonText).click();
       });
 
+      cy.checkAccessibility({ 'color-contrast': { enabled: false } });
+      cy.checkPublishBlocked(['qualifications', 'legislation']);
+      cy.clickSummaryListRowChangeLink(
+        'professions.form.label.qualifications.routesToObtain',
+      );
       cy.checkAccessibility();
       cy.translate('professions.form.headings.qualifications').then(
         (heading) => {
@@ -416,6 +446,11 @@ describe('Publishing professions', () => {
         cy.get('button').contains(buttonText).click();
       });
 
+      cy.checkAccessibility({ 'color-contrast': { enabled: false } });
+      cy.checkPublishBlocked(['legislation']);
+      cy.clickSummaryListRowChangeLink(
+        'professions.form.label.legislation.nationalLegislation',
+      );
       cy.checkAccessibility();
       cy.translate('professions.form.headings.legislation').then((heading) => {
         cy.get('body').should('contain', heading);
@@ -435,7 +470,7 @@ describe('Publishing professions', () => {
       });
 
       cy.checkAccessibility();
-
+      cy.checkPublishNotBlocked();
       cy.translate('professions.form.captions.addWithName', {
         professionName: 'Example Profession',
       }).then((addCaption) => {

--- a/cypress/integration/admin/professions/publish.spec.ts
+++ b/cypress/integration/admin/professions/publish.spec.ts
@@ -133,9 +133,8 @@ describe('Publishing professions', () => {
         cy.contains(buttonText).click();
       });
 
-      cy.clickSummaryListRowAction(
+      cy.clickSummaryListRowChangeLink(
         'professions.form.label.legislation.nationalLegislation',
-        'Change',
       );
       cy.checkAccessibility();
 

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -241,6 +241,57 @@ Cypress.Commands.add(
   },
 );
 
+Cypress.Commands.add(
+  'checkPublishBlocked',
+  (missingSections: string[], shouldHaveButton = true) => {
+    return cy
+      .translate('professions.admin.publish.blocked.heading')
+      .then((heading) => {
+        cy.get('h2')
+          .contains(heading)
+          .parent()
+          .within(() => {
+            cy.get('li').should('have.length', missingSections.length);
+            missingSections.forEach((missingSection) => {
+              cy.translate(`professions.form.headings.${missingSection}`).then(
+                (section) => {
+                  cy.translate(`professions.admin.publish.blocked.missing`, {
+                    section,
+                  }).then((sectionText) => {
+                    cy.get('li').should('contain', sectionText);
+                  });
+                },
+              );
+            });
+          });
+
+        cy.translate('professions.form.button.publish').then((publishLabel) => {
+          if (shouldHaveButton) {
+            cy.get('a')
+              .contains(publishLabel)
+              .should('have.class', 'govuk-button--disabled');
+          } else {
+            cy.root().should('not.contain', publishLabel);
+          }
+        });
+      });
+  },
+);
+
+Cypress.Commands.add('checkPublishNotBlocked', () => {
+  return cy
+    .translate('professions.admin.publish.blocked.heading')
+    .then((heading) => {
+      cy.get('body').should('not.contain', heading);
+
+      cy.translate('professions.form.button.publish').then((publishLabel) => {
+        cy.get('a')
+          .contains(publishLabel)
+          .should('not.have.class', 'govuk-button--disabled');
+      });
+    });
+});
+
 Cypress.Commands.add('visitAndCheckAccessibility', (url: string) => {
   cy.visit(url);
   cy.checkAccessibility();

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -188,21 +188,20 @@ Cypress.Commands.add(
   },
 );
 
-Cypress.Commands.add(
-  'clickSummaryListRowAction',
-  (key: string, action: string) => {
-    return cy.translate(key).then((label) => {
+Cypress.Commands.add('clickSummaryListRowChangeLink', (key: string) => {
+  return cy.translate(key).then((label) => {
+    cy.translate('app.change').then((changeLabel) => {
       cy.get('.govuk-summary-list__key')
         .contains(label)
         .siblings('.govuk-summary-list__actions')
         .then(($summaryListValue) => {
           cy.wrap($summaryListValue).within(() => {
-            cy.contains(action).click();
+            cy.contains(changeLabel).click();
           });
         });
     });
-  },
-);
+  });
+});
 
 Cypress.Commands.add(
   'checkCorrectNumberOfProfessionsAreShown',

--- a/cypress/support/index.ts
+++ b/cypress/support/index.ts
@@ -57,7 +57,7 @@ declare global {
         key: string,
         listItems: string[],
       ): Chainable<string>;
-      clickSummaryListRowAction(key: string, action: string): Chainable<string>;
+      clickSummaryListRowChangeLink(key: string): Chainable<string>;
       checkCorrectNumberOfProfessionsAreShown(
         statuses: ('live' | 'archived' | 'draft')[],
       ): Chainable<string>;

--- a/cypress/support/index.ts
+++ b/cypress/support/index.ts
@@ -64,6 +64,11 @@ declare global {
       checkCorrectNumberOfOrganisationsAreShown(
         statuses: ('live' | 'archived' | 'draft')[],
       ): Chainable<string>;
+      checkPublishBlocked(
+        missingSections: string[],
+        shouldHaveButton?: boolean,
+      ): Chainable<string>;
+      checkPublishNotBlocked(): Chainable<string>;
       visitAndCheckAccessibility(url: string): void;
       checkAccessibility(rules?: AxeRules): void;
     }

--- a/seeds/development/professions.json
+++ b/seeds/development/professions.json
@@ -104,6 +104,7 @@
         "occupationLocations": ["GB-ENG", "GB-SCT", "GB-WLS", "GB-NIR"],
         "industries": ["industries.education"],
         "description": "A description of the profession",
+        "regulationType": "accreditation",
         "reservedActivities": "Some reserved activities",
         "legislations": [
           "The Education (School Teachers' Qualifications) (England) Regulations 2003/1662 (as amended)"

--- a/seeds/test/professions.json
+++ b/seeds/test/professions.json
@@ -104,6 +104,7 @@
         "occupationLocations": ["GB-ENG", "GB-SCT", "GB-WLS", "GB-NIR"],
         "industries": ["industries.education"],
         "description": "A description of the profession",
+        "regulationType": "accreditation",
         "reservedActivities": "Some reserved activities",
         "legislations": [
           "The Education (School Teachers' Qualifications) (England) Regulations 2003/1662 (as amended)"

--- a/src/i18n/en/professions.json
+++ b/src/i18n/en/professions.json
@@ -275,6 +275,10 @@
         "body": "The new profession <strong>{name}</strong> has been published.",
         "next": "What happens next?",
         "backToDashboard": "Back to the dashboard"
+      },
+      "blocked": {
+        "heading": "This page is not ready to publish. Before you can publish, check:",
+        "missing": "{section} is complete"
       }
     },
     "status": {

--- a/src/professions/admin/check-your-answers.controller.ts
+++ b/src/professions/admin/check-your-answers.controller.ts
@@ -21,10 +21,10 @@ import { UserPermission } from '../../users/user-permission';
 import ViewUtils from './viewUtils';
 import { BackLink } from '../../common/decorators/back-link.decorator';
 import { ProfessionVersionsService } from '../profession-versions.service';
-import { isConfirmed } from '../../helpers/is-confirmed';
 import { isUK } from '../../helpers/nations.helper';
 import { RequestWithAppSession } from '../../common/interfaces/request-with-app-session.interface';
 import { checkCanViewProfession } from '../../users/helpers/check-can-view-profession';
+import { getPublicationBlockers } from '../helpers/get-publication-blockers.helper';
 
 @UseGuards(AuthenticationGuard)
 @Controller('admin/professions')
@@ -99,11 +99,11 @@ export class CheckYourAnswersController {
       regulationUrl: version.regulationUrl,
       qualification,
       legislations: version.legislations,
-      confirmed: isConfirmed(draftProfession),
       captionText: await ViewUtils.captionText(
         this.i18nService,
         draftProfession,
       ),
+      publicationBlockers: getPublicationBlockers(version),
       isUK: version.occupationLocations
         ? isUK(version.occupationLocations)
         : false,

--- a/src/professions/admin/dto/legislation.dto.ts
+++ b/src/professions/admin/dto/legislation.dto.ts
@@ -1,6 +1,5 @@
 import { Transform } from 'class-transformer';
 import { IsNotEmpty, IsUrl, ValidateIf } from 'class-validator';
-import { parseBoolean } from '../../../helpers/parse-boolean.helper';
 import {
   preprocessUrl,
   urlOptions,
@@ -32,7 +31,4 @@ export default class LegislationDto {
   @Transform(({ value }) => preprocessUrl(value))
   @ValidateIf((e) => e.secondLink)
   secondLink?: string;
-
-  @Transform(({ value }) => parseBoolean(value))
-  change: boolean;
 }

--- a/src/professions/admin/dto/legislation.dto.ts
+++ b/src/professions/admin/dto/legislation.dto.ts
@@ -30,7 +30,7 @@ export default class LegislationDto {
     message: 'professions.form.errors.legislation.secondLink.invalid',
   })
   @Transform(({ value }) => preprocessUrl(value))
-  @ValidateIf((e) => e.secondLink || e.secondNationalLegislation)
+  @ValidateIf((e) => e.secondLink)
   secondLink?: string;
 
   @Transform(({ value }) => parseBoolean(value))

--- a/src/professions/admin/dto/qualifications.dto.ts
+++ b/src/professions/admin/dto/qualifications.dto.ts
@@ -1,6 +1,5 @@
 import { Transform } from 'class-transformer';
 import { IsNotEmpty, ValidateIf, IsUrl } from 'class-validator';
-import { parseBoolean } from '../../../helpers/parse-boolean.helper';
 import {
   preprocessUrl,
   urlOptions,
@@ -27,7 +26,4 @@ export class QualificationsDto {
   @Transform(({ value }) => preprocessUrl(value))
   @ValidateIf((e) => e.ukRecognitionUrl)
   ukRecognitionUrl: string;
-
-  @Transform(({ value }) => parseBoolean(value))
-  change: boolean;
 }

--- a/src/professions/admin/dto/registration.dto.ts
+++ b/src/professions/admin/dto/registration.dto.ts
@@ -1,6 +1,5 @@
 import { Transform } from 'class-transformer';
 import { IsUrl, ValidateIf } from 'class-validator';
-import { parseBoolean } from '../../../helpers/parse-boolean.helper';
 import {
   preprocessUrl,
   urlOptions,
@@ -15,7 +14,4 @@ export class RegistrationDto {
   @Transform(({ value }) => preprocessUrl(value))
   @ValidateIf((e) => e.registrationUrl)
   registrationUrl: string;
-
-  @Transform(({ value }) => parseBoolean(value))
-  change: boolean;
 }

--- a/src/professions/admin/dto/regulated-activities.dto.ts
+++ b/src/professions/admin/dto/regulated-activities.dto.ts
@@ -1,6 +1,5 @@
 import { Transform } from 'class-transformer';
 import { IsNotEmpty, IsUrl, ValidateIf } from 'class-validator';
-import { parseBoolean } from '../../../helpers/parse-boolean.helper';
 import {
   preprocessUrl,
   urlOptions,
@@ -25,7 +24,4 @@ export class RegulatedActivitiesDto {
   @Transform(({ value }) => preprocessUrl(value))
   @ValidateIf((e) => e.regulationUrl)
   regulationUrl: string;
-
-  @Transform(({ value }) => parseBoolean(value))
-  change: boolean;
 }

--- a/src/professions/admin/dto/scope.dto.ts
+++ b/src/professions/admin/dto/scope.dto.ts
@@ -1,6 +1,4 @@
-import { Transform } from 'class-transformer';
 import { IsNotEmpty, ValidateIf, IsIn } from 'class-validator';
-import { parseBoolean } from '../../../helpers/parse-boolean.helper';
 
 export class ScopeDto {
   @IsIn(['1', '0'], { message: 'professions.form.errors.nations.empty' })
@@ -12,7 +10,4 @@ export class ScopeDto {
 
   @IsNotEmpty({ message: 'professions.form.errors.industries.empty' })
   industries: string[];
-
-  @Transform(({ value }) => parseBoolean(value))
-  change: boolean;
 }

--- a/src/professions/admin/interfaces/check-your-answers.template.ts
+++ b/src/professions/admin/interfaces/check-your-answers.template.ts
@@ -1,5 +1,6 @@
 import { Legislation } from '../../../legislations/legislation.entity';
 import QualificationPresenter from '../../../qualifications/presenters/qualification.presenter';
+import { PublicationBlocker } from '../../helpers/get-publication-blockers.helper';
 import { RegulationType } from '../../profession-version.entity';
 
 export interface CheckYourAnswersTemplate {
@@ -21,6 +22,6 @@ export interface CheckYourAnswersTemplate {
   legislations: Legislation[];
   captionText: string;
   isUK: boolean;
-  confirmed: boolean;
+  publicationBlockers: PublicationBlocker[];
   edit: boolean;
 }

--- a/src/professions/admin/interfaces/legislation.template.ts
+++ b/src/professions/admin/interfaces/legislation.template.ts
@@ -4,6 +4,5 @@ export interface LegislationTemplate {
   legislation: Legislation | null;
   secondLegislation: Legislation | null;
   captionText: string;
-  change: boolean;
   errors?: object;
 }

--- a/src/professions/admin/interfaces/qualifications.template.ts
+++ b/src/professions/admin/interfaces/qualifications.template.ts
@@ -5,6 +5,5 @@ export interface QualificationsTemplate {
   ukRecognitionUrl: string;
   captionText: string;
   isUK: boolean;
-  change: boolean;
   errors: object | undefined;
 }

--- a/src/professions/admin/interfaces/registration.template.ts
+++ b/src/professions/admin/interfaces/registration.template.ts
@@ -1,5 +1,4 @@
 export interface RegistrationTemplate {
-  change: boolean;
   captionText: string;
   errors: object | undefined;
 }

--- a/src/professions/admin/interfaces/regulated-activities.template.ts
+++ b/src/professions/admin/interfaces/regulated-activities.template.ts
@@ -7,6 +7,5 @@ export interface RegulatedActivitiesTemplate {
   protectedTitles: string;
   regulationUrl: string;
   captionText: string;
-  change: boolean;
   errors: object | undefined;
 }

--- a/src/professions/admin/interfaces/scope.template.ts
+++ b/src/professions/admin/interfaces/scope.template.ts
@@ -6,6 +6,5 @@ export interface ScopeTemplate {
   industriesCheckboxItems: CheckboxItems[];
   nationsCheckboxArgs: CheckboxArgs;
   captionText: string;
-  change: boolean;
   errors: object | undefined;
 }

--- a/src/professions/admin/interfaces/show-template.interface.ts
+++ b/src/professions/admin/interfaces/show-template.interface.ts
@@ -1,5 +1,7 @@
+import { PublicationBlocker } from '../../helpers/get-publication-blockers.helper';
 import { ShowTemplate as PublicShowTemplate } from '../../interfaces/show-template.interface';
 
 export interface ShowTemplate extends PublicShowTemplate {
   hasLiveVersion: boolean;
+  publicationBlockers: PublicationBlocker[];
 }

--- a/src/professions/admin/legislation.controller.spec.ts
+++ b/src/professions/admin/legislation.controller.spec.ts
@@ -69,13 +69,7 @@ describe(LegislationController, () => {
           user: userFactory.build(),
         });
 
-        await controller.edit(
-          response,
-          'profession-id',
-          'version-id',
-          'false',
-          request,
-        );
+        await controller.edit(response, 'profession-id', 'version-id', request);
 
         expect(response.render).toHaveBeenCalledWith(
           'admin/professions/legislation',
@@ -97,13 +91,7 @@ describe(LegislationController, () => {
           user: userFactory.build(),
         });
 
-        await controller.edit(
-          response,
-          'profession-id',
-          'version-id',
-          'false',
-          request,
-        );
+        await controller.edit(response, 'profession-id', 'version-id', request);
 
         expect(checkCanViewProfession).toHaveBeenCalledWith(
           request,
@@ -140,13 +128,7 @@ describe(LegislationController, () => {
           user: userFactory.build(),
         });
 
-        await controller.edit(
-          response,
-          'profession-id',
-          'version-id',
-          'false',
-          request,
-        );
+        await controller.edit(response, 'profession-id', 'version-id', request);
 
         expect(response.render).toHaveBeenCalledWith(
           'admin/professions/legislation',
@@ -172,7 +154,6 @@ describe(LegislationController, () => {
         const dto: LegislationDto = {
           link: 'www.legal-legislation.com',
           nationalLegislation: 'Legal Services Act 2008',
-          change: false,
         };
 
         professionsService.findWithVersions.mockResolvedValue(profession);
@@ -221,7 +202,6 @@ describe(LegislationController, () => {
           nationalLegislation: 'Legal Services Act 2008',
           secondLink: 'http://www.another-legal-legislation.com',
           secondNationalLegislation: 'Another Legal Services Act 2008',
-          change: false,
         };
 
         professionsService.findWithVersions.mockResolvedValue(profession);
@@ -274,7 +254,6 @@ describe(LegislationController, () => {
           nationalLegislation: 'Legal Services Act 2008',
           secondLink: 'www.another-legal-legislation.com   ',
           secondNationalLegislation: 'Another Legal Services Act 2008',
-          change: false,
         };
 
         professionsService.findWithVersions.mockResolvedValue(profession);
@@ -326,7 +305,6 @@ describe(LegislationController, () => {
           const dto: LegislationDto = {
             link: undefined,
             nationalLegislation: undefined,
-            change: false,
           };
 
           professionsService.findWithVersions.mockResolvedValue(profession);
@@ -372,7 +350,6 @@ describe(LegislationController, () => {
           const dto: LegislationDto = {
             link: 'bad link',
             nationalLegislation: 'national legislation value',
-            change: false,
           };
 
           professionsService.findWithVersions.mockResolvedValue(profession);
@@ -422,7 +399,6 @@ describe(LegislationController, () => {
       const dto: LegislationDto = {
         link: 'www.legal-legislation.com',
         nationalLegislation: 'Legal Services Act 2008',
-        change: false,
       };
 
       await controller.update(

--- a/src/professions/admin/legislation.controller.ts
+++ b/src/professions/admin/legislation.controller.ts
@@ -4,12 +4,11 @@ import {
   Get,
   Param,
   Post,
-  Query,
   Req,
   Res,
   UseGuards,
 } from '@nestjs/common';
-import { Response, Request } from 'express';
+import { Response } from 'express';
 import { AuthenticationGuard } from '../../common/authentication.guard';
 import { Permissions } from '../../common/permissions.decorator';
 import { Validator } from '../../helpers/validator';
@@ -38,16 +37,13 @@ export class LegislationController {
 
   @Get('/:professionId/versions/:versionId/legislation/edit')
   @Permissions(UserPermission.CreateProfession, UserPermission.EditProfession)
-  @BackLink((request: Request) =>
-    request.query.change === 'true'
-      ? '/admin/professions/:professionId/versions/:versionId/check-your-answers'
-      : '/admin/professions/:professionId/versions/:versionId/qualifications/edit',
+  @BackLink(
+    '/admin/professions/:professionId/versions/:versionId/check-your-answers',
   )
   async edit(
     @Res() res: Response,
     @Param('professionId') professionId: string,
     @Param('versionId') versionId: string,
-    @Query('change') change: string,
     @Req() request: RequestWithAppSession,
   ): Promise<void> {
     const profession = await this.professionsService.findWithVersions(
@@ -65,16 +61,13 @@ export class LegislationController {
       version.legislations[0],
       version.legislations[1],
       profession,
-      change === 'true',
     );
   }
 
   @Post('/:professionId/versions/:versionId/legislation')
   @Permissions(UserPermission.CreateProfession, UserPermission.EditProfession)
-  @BackLink((request: Request) =>
-    request.body.change === 'true'
-      ? '/admin/professions/:professionId/versions/:versionId/check-your-answers'
-      : '/admin/professions/:professionId/versions/:versionId/qualifications/edit',
+  @BackLink(
+    '/admin/professions/:professionId/versions/:versionId/check-your-answers',
   )
   async update(
     @Res() res: Response,
@@ -120,7 +113,6 @@ export class LegislationController {
         updatedLegislation,
         updatedSecondLegislation,
         profession,
-        submittedValues.change,
         errors,
       );
     }
@@ -145,14 +137,12 @@ export class LegislationController {
     legislation: Legislation,
     secondLegislation: Legislation,
     profession: Profession,
-    change: boolean,
     errors: object | undefined = undefined,
   ): Promise<void> {
     const templateArgs: LegislationTemplate = {
       legislation,
       secondLegislation,
       captionText: await ViewUtils.captionText(this.i18nService, profession),
-      change,
       errors,
     };
 

--- a/src/professions/admin/profession-publication.controller.ts
+++ b/src/professions/admin/profession-publication.controller.ts
@@ -1,4 +1,13 @@
-import { Controller, Get, Param, Put, Render, Req, Res } from '@nestjs/common';
+import {
+  BadRequestException,
+  Controller,
+  Get,
+  Param,
+  Put,
+  Render,
+  Req,
+  Res,
+} from '@nestjs/common';
 import { Request, Response } from 'express';
 import { I18nService } from 'nestjs-i18n';
 import { BackLink } from '../../common/decorators/back-link.decorator';
@@ -10,6 +19,7 @@ import { isConfirmed } from '../../helpers/is-confirmed';
 import { checkCanViewProfession } from '../../users/helpers/check-can-view-profession';
 import { getActingUser } from '../../users/helpers/get-acting-user.helper';
 import { UserPermission } from '../../users/user-permission';
+import { getPublicationBlockers } from '../helpers/get-publication-blockers.helper';
 import { ProfessionVersionsService } from '../profession-versions.service';
 import { Profession } from '../profession.entity';
 import { ProfessionsService } from '../professions.service';
@@ -63,6 +73,10 @@ export class ProfessionPublicationController {
       professionId,
       versionId,
     );
+
+    if (getPublicationBlockers(version).length) {
+      throw new BadRequestException();
+    }
 
     const newVersion = await this.professionVersionsService.create(
       version,

--- a/src/professions/admin/profession-versions.controller.spec.ts
+++ b/src/professions/admin/profession-versions.controller.spec.ts
@@ -20,6 +20,7 @@ import { createDefaultMockRequest } from '../../testutils/factories/create-defau
 import organisationFactory from '../../testutils/factories/organisation';
 import * as getOrganisationsFromProfessionModule from '../helpers/get-organisations-from-profession.helper';
 import { checkCanViewProfession } from '../../users/helpers/check-can-view-profession';
+import * as getPublicationBlockersModule from '../helpers/get-publication-blockers.helper';
 
 jest.mock('../../organisations/organisation.entity');
 jest.mock('../presenters/profession.presenter');
@@ -175,6 +176,9 @@ describe('ProfessionVersionsController', () => {
             getOrganisationsFromProfessionModule,
             'getOrganisationsFromProfession',
           );
+          const getPublicationBlockersSpy = jest
+            .spyOn(getPublicationBlockersModule, 'getPublicationBlockers')
+            .mockReturnValue([]);
 
           const request = createDefaultMockRequest({
             user: userFactory.build(),
@@ -197,6 +201,7 @@ describe('ProfessionVersionsController', () => {
             nations: ['Translation of `nations.england`'],
             industries: ['Translation of `industries.example`'],
             organisations: [profession.organisation],
+            publicationBlockers: [],
           });
 
           expect(
@@ -208,6 +213,7 @@ describe('ProfessionVersionsController', () => {
           expect(getOrganisationsFromProfessionSpy).toHaveBeenCalledWith(
             professionWithVersion,
           );
+          expect(getPublicationBlockersSpy).toHaveBeenCalledWith(version);
         });
       });
 
@@ -243,6 +249,9 @@ describe('ProfessionVersionsController', () => {
             getOrganisationsFromProfessionModule,
             'getOrganisationsFromProfession',
           );
+          const getPublicationBlockersSpy = jest
+            .spyOn(getPublicationBlockersModule, 'getPublicationBlockers')
+            .mockReturnValue([]);
 
           const request = createDefaultMockRequest({
             user: userFactory.build(),
@@ -268,6 +277,7 @@ describe('ProfessionVersionsController', () => {
               profession.organisation,
               profession.additionalOrganisation,
             ],
+            publicationBlockers: [],
           });
 
           expect(
@@ -279,6 +289,7 @@ describe('ProfessionVersionsController', () => {
           expect(getOrganisationsFromProfessionSpy).toHaveBeenCalledWith(
             professionWithVersion,
           );
+          expect(getPublicationBlockersSpy).toHaveBeenCalledWith(version);
         });
       });
     });
@@ -309,6 +320,14 @@ describe('ProfessionVersionsController', () => {
         (Organisation.withLatestVersion as jest.Mock).mockImplementation(
           (organisation) => organisation,
         );
+        const getPublicationBlockersSpy = jest
+          .spyOn(getPublicationBlockersModule, 'getPublicationBlockers')
+          .mockReturnValue([
+            {
+              type: 'incomplete-section',
+              section: 'qualifications',
+            },
+          ]);
 
         const request = createDefaultMockRequest({ user: userFactory.build() });
 
@@ -329,7 +348,15 @@ describe('ProfessionVersionsController', () => {
           nations: [translationOf('nations.england')],
           industries: [translationOf('industries.example')],
           organisations: [profession.organisation],
+          publicationBlockers: [
+            {
+              type: 'incomplete-section',
+              section: 'qualifications',
+            },
+          ],
         });
+
+        expect(getPublicationBlockersSpy).toHaveBeenCalledWith(version);
       });
     });
 
@@ -368,6 +395,19 @@ describe('ProfessionVersionsController', () => {
 
         const request = createDefaultMockRequest({ user: userFactory.build() });
 
+        const getPublicationBlockersSpy = jest
+          .spyOn(getPublicationBlockersModule, 'getPublicationBlockers')
+          .mockReturnValue([
+            {
+              type: 'incomplete-section',
+              section: 'qualifications',
+            },
+            {
+              type: 'incomplete-section',
+              section: 'legislation',
+            },
+          ]);
+
         const result = await controller.show(
           'profession-id',
           'version-id',
@@ -385,6 +425,16 @@ describe('ProfessionVersionsController', () => {
           nations: [],
           industries: [],
           organisations: [profession.organisation],
+          publicationBlockers: [
+            {
+              type: 'incomplete-section',
+              section: 'qualifications',
+            },
+            {
+              type: 'incomplete-section',
+              section: 'legislation',
+            },
+          ],
         });
 
         expect(
@@ -393,6 +443,7 @@ describe('ProfessionVersionsController', () => {
         expect(professionVersionsService.hasLiveVersion).toHaveBeenCalledWith(
           professionWithVersion,
         );
+        expect(getPublicationBlockersSpy).toHaveBeenCalledWith(version);
       });
     });
   });

--- a/src/professions/admin/profession-versions.controller.ts
+++ b/src/professions/admin/profession-versions.controller.ts
@@ -27,6 +27,7 @@ import { getOrganisationsFromProfession } from '../helpers/get-organisations-fro
 import { ShowTemplate } from './interfaces/show-template.interface';
 import { isUK } from '../../helpers/nations.helper';
 import { checkCanViewProfession } from '../../users/helpers/check-can-view-profession';
+import { getPublicationBlockers } from '../helpers/get-publication-blockers.helper';
 
 @UseGuards(AuthenticationGuard)
 @Controller('/admin/professions')
@@ -104,6 +105,7 @@ export class ProfessionVersionsController {
       nations,
       industries,
       organisations,
+      publicationBlockers: getPublicationBlockers(version),
     };
   }
 

--- a/src/professions/admin/qualifications.controller.spec.ts
+++ b/src/professions/admin/qualifications.controller.spec.ts
@@ -71,13 +71,7 @@ describe(QualificationsController, () => {
           user: userFactory.build(),
         });
 
-        await controller.edit(
-          response,
-          'profession-id',
-          'version-id',
-          false,
-          request,
-        );
+        await controller.edit(response, 'profession-id', 'version-id', request);
 
         expect(response.render).toHaveBeenCalledWith(
           'admin/professions/qualifications',
@@ -117,13 +111,7 @@ describe(QualificationsController, () => {
           user: userFactory.build(),
         });
 
-        await controller.edit(
-          response,
-          'profession-id',
-          'version-id',
-          false,
-          request,
-        );
+        await controller.edit(response, 'profession-id', 'version-id', request);
 
         expect(response.render).toHaveBeenCalledWith(
           'admin/professions/qualifications',
@@ -148,13 +136,7 @@ describe(QualificationsController, () => {
         user: userFactory.build(),
       });
 
-      await controller.edit(
-        response,
-        'profession-id',
-        'version-id',
-        false,
-        request,
-      );
+      await controller.edit(response, 'profession-id', 'version-id', request);
 
       expect(checkCanViewProfession).toHaveBeenCalledWith(request, profession);
     });
@@ -162,108 +144,51 @@ describe(QualificationsController, () => {
 
   describe('update', () => {
     describe('when all required parameters are entered', () => {
-      describe('when the "Change" query param is false', () => {
-        it('creates a new Qualification on the Profession and redirects to the next page in the journey', async () => {
-          const profession = professionFactory.build({ id: 'profession-id' });
+      it('creates a new Qualification on the Profession and redirects to the next page in the journey', async () => {
+        const profession = professionFactory.build({ id: 'profession-id' });
 
-          const version = professionVersionFactory.build({
-            id: 'version-id',
-            profession: profession,
-            qualification: qualificationFactory.build(),
-          });
-
-          const dto: QualificationsDto = {
-            routesToObtain: 'General secondary education',
-            moreInformationUrl: 'http://www.example.com/more-info',
-            ukRecognition: 'ukRecognition',
-            ukRecognitionUrl: 'http://example.com/uk',
-            change: false,
-          };
-
-          professionsService.findWithVersions.mockResolvedValue(profession);
-          professionVersionsService.findWithProfession.mockResolvedValue(
-            version,
-          );
-
-          const request = createDefaultMockRequest({
-            user: userFactory.build(),
-          });
-
-          await controller.update(
-            response,
-            'profession-id',
-            'version-id',
-            dto,
-            request,
-          );
-
-          expect(professionVersionsService.save).toHaveBeenCalledWith(
-            expect.objectContaining({
-              qualification: expect.objectContaining({
-                routesToObtain: 'General secondary education',
-                url: 'http://www.example.com/more-info',
-                ukRecognition: 'ukRecognition',
-                ukRecognitionUrl: 'http://example.com/uk',
-              }),
-            }),
-          );
-
-          expect(response.redirect).toHaveBeenCalledWith(
-            '/admin/professions/profession-id/versions/version-id/legislation/edit',
-          );
+        const version = professionVersionFactory.build({
+          id: 'version-id',
+          profession: profession,
+          qualification: qualificationFactory.build(),
         });
-      });
 
-      describe('when the "Change" query param is true', () => {
-        it('creates a new Qualification on the Profession and redirects to "Check your answers"', async () => {
-          const profession = professionFactory.build({ id: 'profession-id' });
+        const dto: QualificationsDto = {
+          routesToObtain: 'General secondary education',
+          moreInformationUrl: 'http://www.example.com/more-info',
+          ukRecognition: 'ukRecognition',
+          ukRecognitionUrl: 'http://example.com/uk',
+        };
 
-          const version = professionVersionFactory.build({
-            id: 'version-id',
-            profession: profession,
-            qualification: qualificationFactory.build(),
-          });
+        professionsService.findWithVersions.mockResolvedValue(profession);
+        professionVersionsService.findWithProfession.mockResolvedValue(version);
 
-          const dto: QualificationsDto = {
-            routesToObtain: 'General secondary education',
-            moreInformationUrl: 'http://www.example.com/more-info',
-            ukRecognition: 'ukRecognition',
-            ukRecognitionUrl: 'http://example.com/uk',
-            change: true,
-          };
-
-          professionsService.findWithVersions.mockResolvedValue(profession);
-          professionVersionsService.findWithProfession.mockResolvedValue(
-            version,
-          );
-
-          const request = createDefaultMockRequest({
-            user: userFactory.build(),
-          });
-
-          await controller.update(
-            response,
-            'profession-id',
-            'version-id',
-            dto,
-            request,
-          );
-
-          expect(professionVersionsService.save).toHaveBeenCalledWith(
-            expect.objectContaining({
-              qualification: expect.objectContaining({
-                routesToObtain: 'General secondary education',
-                url: 'http://www.example.com/more-info',
-                ukRecognition: 'ukRecognition',
-                ukRecognitionUrl: 'http://example.com/uk',
-              }),
-            }),
-          );
-
-          expect(response.redirect).toHaveBeenCalledWith(
-            '/admin/professions/profession-id/versions/version-id/check-your-answers',
-          );
+        const request = createDefaultMockRequest({
+          user: userFactory.build(),
         });
+
+        await controller.update(
+          response,
+          'profession-id',
+          'version-id',
+          dto,
+          request,
+        );
+
+        expect(professionVersionsService.save).toHaveBeenCalledWith(
+          expect.objectContaining({
+            qualification: expect.objectContaining({
+              routesToObtain: 'General secondary education',
+              url: 'http://www.example.com/more-info',
+              ukRecognition: 'ukRecognition',
+              ukRecognitionUrl: 'http://example.com/uk',
+            }),
+          }),
+        );
+
+        expect(response.redirect).toHaveBeenCalledWith(
+          '/admin/professions/profession-id/versions/version-id/check-your-answers',
+        );
       });
     });
 
@@ -282,7 +207,6 @@ describe(QualificationsController, () => {
           moreInformationUrl: 'www.example.com/more-info ',
           ukRecognition: 'ukRecognition',
           ukRecognitionUrl: 'example.com/uk',
-          change: true,
         };
 
         professionsService.findWithVersions.mockResolvedValue(profession);
@@ -330,7 +254,6 @@ describe(QualificationsController, () => {
         const dto: QualificationsDto = {
           routesToObtain: '',
           moreInformationUrl: 'not a url',
-          change: false,
           ukRecognition: '',
           ukRecognitionUrl: 'not a url',
         };
@@ -385,7 +308,6 @@ describe(QualificationsController, () => {
         moreInformationUrl: 'http://www.example.com/more-info',
         ukRecognition: 'ukRecognition',
         ukRecognitionUrl: 'http://example.com/uk',
-        change: true,
       };
 
       await controller.update(

--- a/src/professions/admin/registration.controller.spec.ts
+++ b/src/professions/admin/registration.controller.spec.ts
@@ -66,13 +66,7 @@ describe(RegistrationController, () => {
           user: userFactory.build(),
         });
 
-        await controller.edit(
-          response,
-          'profession-id',
-          'version-id',
-          'false',
-          request,
-        );
+        await controller.edit(response, 'profession-id', 'version-id', request);
 
         expect(response.render).toHaveBeenCalledWith(
           'admin/professions/registration',
@@ -101,13 +95,7 @@ describe(RegistrationController, () => {
         professionsService.findWithVersions.mockResolvedValue(profession);
         professionVersionsService.findWithProfession.mockResolvedValue(version);
 
-        await controller.edit(
-          response,
-          'profession-id',
-          'version-id',
-          'false',
-          request,
-        );
+        await controller.edit(response, 'profession-id', 'version-id', request);
 
         expect(response.render).toHaveBeenCalledWith(
           'admin/professions/registration',
@@ -129,13 +117,7 @@ describe(RegistrationController, () => {
         user: userFactory.build(),
       });
 
-      await controller.edit(
-        response,
-        'profession-id',
-        'version-id',
-        'false',
-        request,
-      );
+      await controller.edit(response, 'profession-id', 'version-id', request);
 
       expect(checkCanViewProfession).toHaveBeenCalledWith(request, profession);
     });
@@ -181,7 +163,7 @@ describe(RegistrationController, () => {
         );
 
         expect(response.redirect).toHaveBeenCalledWith(
-          '/admin/professions/profession-id/versions/version-id/regulated-activities/edit',
+          '/admin/professions/profession-id/versions/version-id/check-your-answers',
         );
       });
     });
@@ -225,7 +207,7 @@ describe(RegistrationController, () => {
         );
 
         expect(response.redirect).toHaveBeenCalledWith(
-          '/admin/professions/profession-id/versions/version-id/regulated-activities/edit',
+          '/admin/professions/profession-id/versions/version-id/check-your-answers',
         );
       });
     });
@@ -260,84 +242,6 @@ describe(RegistrationController, () => {
             },
           }),
         );
-      });
-    });
-
-    describe('the "change" query param', () => {
-      describe('when set to true', () => {
-        it('redirects to check your answers on submit', async () => {
-          const profession = professionFactory.build({
-            id: 'profession-id',
-          });
-          const version = professionVersionFactory.build({
-            id: 'version-id',
-            profession: profession,
-          });
-
-          professionsService.findWithVersions.mockResolvedValue(profession);
-          professionVersionsService.findWithProfession.mockResolvedValue(
-            version,
-          );
-
-          const registrationDtoWithChangeParam = {
-            registrationUrl: '',
-            change: true,
-          };
-
-          const request = createDefaultMockRequest({
-            user: userFactory.build(),
-          });
-
-          await controller.update(
-            response,
-            'profession-id',
-            'version-id',
-            registrationDtoWithChangeParam,
-            request,
-          );
-
-          expect(response.redirect).toHaveBeenCalledWith(
-            '/admin/professions/profession-id/versions/version-id/check-your-answers',
-          );
-        });
-      });
-
-      describe('when false or missing', () => {
-        it('continues to the next step in the journey', async () => {
-          const profession = professionFactory.build({
-            id: 'profession-id',
-          });
-          const version = professionVersionFactory.build({
-            id: 'version-id',
-            profession: profession,
-          });
-
-          professionsService.findWithVersions.mockResolvedValue(profession);
-          professionVersionsService.findWithProfession.mockResolvedValue(
-            version,
-          );
-
-          const registrationDtoWithFalseChangeParam = {
-            registrationUrl: '',
-            change: false,
-          };
-
-          const request = createDefaultMockRequest({
-            user: userFactory.build(),
-          });
-
-          await controller.update(
-            response,
-            'profession-id',
-            'version-id',
-            registrationDtoWithFalseChangeParam,
-            request,
-          );
-
-          expect(response.redirect).toHaveBeenCalledWith(
-            '/admin/professions/profession-id/versions/version-id/regulated-activities/edit',
-          );
-        });
       });
     });
 

--- a/src/professions/admin/regulated-activities.controller.spec.ts
+++ b/src/professions/admin/regulated-activities.controller.spec.ts
@@ -87,13 +87,7 @@ describe(RegulatedActivitiesController, () => {
         user: userFactory.build(),
       });
 
-      await controller.edit(
-        response,
-        'profession-id',
-        'version-id',
-        'false',
-        request,
-      );
+      await controller.edit(response, 'profession-id', 'version-id', request);
 
       expect(response.render).toHaveBeenCalledWith(
         'admin/professions/regulated-activities',
@@ -119,13 +113,7 @@ describe(RegulatedActivitiesController, () => {
         user: userFactory.build(),
       });
 
-      await controller.edit(
-        response,
-        'profession-id',
-        'version-id',
-        'false',
-        request,
-      );
+      await controller.edit(response, 'profession-id', 'version-id', request);
 
       expect(checkCanViewProfession).toHaveBeenCalledWith(request, profession);
     });
@@ -156,7 +144,6 @@ describe(RegulatedActivitiesController, () => {
             reservedActivities: 'Example reserved activities',
             protectedTitles: 'Example protected titles',
             regulationUrl: 'https://example.com/regulation',
-            change: false,
           };
 
           const request = createDefaultMockRequest({
@@ -183,7 +170,7 @@ describe(RegulatedActivitiesController, () => {
           );
 
           expect(response.redirect).toHaveBeenCalledWith(
-            '/admin/professions/profession-id/versions/version-id/qualifications/edit',
+            '/admin/professions/profession-id/versions/version-id/check-your-answers',
           );
         });
       });
@@ -211,7 +198,6 @@ describe(RegulatedActivitiesController, () => {
             reservedActivities: 'Example reserved activities',
             protectedTitles: 'Example protected titles',
             regulationUrl: ' example.com/regulation',
-            change: false,
           };
 
           const request = createDefaultMockRequest({
@@ -234,61 +220,6 @@ describe(RegulatedActivitiesController, () => {
               reservedActivities: 'Example reserved activities',
               protectedTitles: 'Example protected titles',
               regulationUrl: 'http://example.com/regulation',
-            }),
-          );
-
-          expect(response.redirect).toHaveBeenCalledWith(
-            '/admin/professions/profession-id/versions/version-id/qualifications/edit',
-          );
-        });
-      });
-
-      describe('when the "Change" query param is true', () => {
-        it('updates the Profession and redirects to the Check your answers page', async () => {
-          const profession = professionFactory.build({ id: 'profession-id' });
-          const version = professionVersionFactory.build({
-            id: 'version-id',
-            profession: profession,
-            description: 'Example regulation summary',
-            regulationType: RegulationType.Licensing,
-            reservedActivities: 'Example reserved activities',
-            protectedTitles: 'Example protected titles',
-            regulationUrl: 'https://example.com/regulation',
-          });
-
-          professionsService.findWithVersions.mockResolvedValue(profession);
-          professionVersionsService.findWithProfession.mockResolvedValue(
-            version,
-          );
-
-          const regulatedActivitiesDto: RegulatedActivitiesDto = {
-            regulationSummary: 'Example regulation summary',
-            regulationType: RegulationType.Licensing,
-            reservedActivities: 'Example reserved activities',
-            protectedTitles: 'Example protected titles',
-            regulationUrl: 'https://example.com/regulation',
-            change: true,
-          };
-
-          const request = createDefaultMockRequest({
-            user: userFactory.build(),
-          });
-
-          await controller.update(
-            response,
-            'profession-id',
-            'version-id',
-            regulatedActivitiesDto,
-            request,
-          );
-
-          expect(professionVersionsService.save).toHaveBeenCalledWith(
-            expect.objectContaining({
-              id: 'version-id',
-              description: 'Example regulation summary',
-              reservedActivities: 'Example reserved activities',
-              protectedTitles: 'Example protected titles',
-              regulationUrl: 'https://example.com/regulation',
             }),
           );
 
@@ -322,7 +253,6 @@ describe(RegulatedActivitiesController, () => {
           reservedActivities: undefined,
           protectedTitles: undefined,
           regulationUrl: undefined,
-          change: false,
         };
 
         const request = createDefaultMockRequest({ user: userFactory.build() });
@@ -367,7 +297,6 @@ describe(RegulatedActivitiesController, () => {
         reservedActivities: 'Example reserved activities',
         protectedTitles: 'Example protected titles',
         regulationUrl: 'https://example.com/regulation',
-        change: false,
       };
 
       const request = createDefaultMockRequest({

--- a/src/professions/admin/regulated-activities.controller.ts
+++ b/src/professions/admin/regulated-activities.controller.ts
@@ -5,11 +5,10 @@ import {
   Param,
   Post,
   Body,
-  Query,
   UseGuards,
   Req,
 } from '@nestjs/common';
-import { Response, Request } from 'express';
+import { Response } from 'express';
 import { AuthenticationGuard } from '../../common/authentication.guard';
 import { Validator } from '../../helpers/validator';
 import { ValidationFailedError } from '../../common/validation/validation-failed.error';
@@ -43,16 +42,13 @@ export class RegulatedActivitiesController {
 
   @Get('/:professionId/versions/:versionId/regulated-activities/edit')
   @Permissions(UserPermission.CreateProfession, UserPermission.EditProfession)
-  @BackLink((request: Request) =>
-    request.query.change === 'true'
-      ? '/admin/professions/:professionId/versions/:versionId/check-your-answers'
-      : '/admin/professions/:professionId/versions/:versionId/registration/edit',
+  @BackLink(
+    '/admin/professions/:professionId/versions/:versionId/check-your-answers',
   )
   async edit(
     @Res() res: Response,
     @Param('professionId') professionId: string,
     @Param('versionId') versionId: string,
-    @Query('change') change: string,
     @Req() req: RequestWithAppSession,
   ): Promise<void> {
     const profession = await this.professionsService.findWithVersions(
@@ -73,16 +69,13 @@ export class RegulatedActivitiesController {
       version.protectedTitles,
       version.regulationUrl,
       profession,
-      change === 'true',
     );
   }
 
   @Post('/:professionId/versions/:versionId/regulated-activities')
   @Permissions(UserPermission.CreateProfession, UserPermission.EditProfession)
-  @BackLink((request: Request) =>
-    request.body.change === 'true'
-      ? '/admin/professions/:professionId/versions/:versionId/check-your-answers'
-      : '/admin/professions/:professionId/versions/:versionId/registration/edit',
+  @BackLink(
+    '/admin/professions/:professionId/versions/:versionId/check-your-answers',
   )
   async update(
     @Res() res: Response,
@@ -118,7 +111,6 @@ export class RegulatedActivitiesController {
         submittedValues.protectedTitles,
         submittedValues.regulationUrl,
         profession,
-        submittedValues.change,
         errors,
       );
     }
@@ -136,14 +128,8 @@ export class RegulatedActivitiesController {
 
     await this.professionVersionsService.save(updatedVersion);
 
-    if (submittedValues.change) {
-      return res.redirect(
-        `/admin/professions/${professionId}/versions/${versionId}/check-your-answers`,
-      );
-    }
-
     return res.redirect(
-      `/admin/professions/${professionId}/versions/${versionId}/qualifications/edit`,
+      `/admin/professions/${professionId}/versions/${versionId}/check-your-answers`,
     );
   }
 
@@ -155,7 +141,6 @@ export class RegulatedActivitiesController {
     protectedTitles: string | null,
     regulationUrl: string | null,
     profession: Profession,
-    change: boolean,
     errors: object | undefined = undefined,
   ): Promise<void> {
     const regulationTypePresenter = new RegulationTypeRadioButtonsPresenter(
@@ -173,7 +158,6 @@ export class RegulatedActivitiesController {
       protectedTitles,
       regulationUrl,
       captionText: await ViewUtils.captionText(this.i18nService, profession),
-      change,
       errors,
     };
 

--- a/src/professions/admin/scope.controller.spec.ts
+++ b/src/professions/admin/scope.controller.spec.ts
@@ -84,13 +84,7 @@ describe('ScopeController', () => {
           user: userFactory.build(),
         });
 
-        await controller.edit(
-          response,
-          'profession-id',
-          'version-id',
-          'false',
-          request,
-        );
+        await controller.edit(response, 'profession-id', 'version-id', request);
 
         expect(response.render).toHaveBeenCalledWith(
           'admin/professions/scope',
@@ -177,13 +171,7 @@ describe('ScopeController', () => {
           user: userFactory.build(),
         });
 
-        await controller.edit(
-          response,
-          'profession-id',
-          'version-id',
-          'false',
-          request,
-        );
+        await controller.edit(response, 'profession-id', 'version-id', request);
 
         expect(response.render).toHaveBeenCalledWith(
           'admin/professions/scope',
@@ -255,13 +243,7 @@ describe('ScopeController', () => {
           user: userFactory.build(),
         });
 
-        await controller.edit(
-          response,
-          'profession-id',
-          'version-id',
-          'false',
-          request,
-        );
+        await controller.edit(response, 'profession-id', 'version-id', request);
 
         expect(response.render).toHaveBeenCalledWith(
           'admin/professions/scope',
@@ -284,13 +266,7 @@ describe('ScopeController', () => {
         user: userFactory.build(),
       });
 
-      await controller.edit(
-        response,
-        'profession-id',
-        'version-id',
-        'false',
-        request,
-      );
+      await controller.edit(response, 'profession-id', 'version-id', request);
 
       expect(checkCanViewProfession).toHaveBeenCalledWith(request, profession);
     });
@@ -346,7 +322,7 @@ describe('ScopeController', () => {
         );
 
         expect(response.redirect).toHaveBeenCalledWith(
-          '/admin/professions/profession-id/versions/version-id/registration/edit',
+          '/admin/professions/profession-id/versions/version-id/check-your-answers',
         );
       });
 
@@ -423,95 +399,6 @@ describe('ScopeController', () => {
         );
 
         expect(industriesService.all).toHaveBeenCalled();
-      });
-    });
-
-    describe('the "change" query param', () => {
-      describe('when set to true', () => {
-        it('redirects to check your answers on submit', async () => {
-          const profession = professionFactory.build({
-            id: 'profession-id',
-          });
-
-          const version = professionVersionFactory.build({
-            profession: profession,
-          });
-
-          const industry = industryFactory.build({ id: 'construction-uuid' });
-
-          professionsService.findWithVersions.mockResolvedValue(profession);
-          professionVersionsService.findWithProfession.mockResolvedValue(
-            version,
-          );
-
-          const scopeDtoWithChangeParam = {
-            coversUK: '0',
-            nations: ['GB-ENG'],
-            industries: ['construction-uuid'],
-            change: true,
-          };
-
-          industriesService.findByIds.mockResolvedValue([industry]);
-
-          const request = createDefaultMockRequest({
-            user: userFactory.build(),
-          });
-
-          await controller.update(
-            scopeDtoWithChangeParam,
-            response,
-            'profession-id',
-            'version-id',
-            request,
-          );
-
-          expect(response.redirect).toHaveBeenCalledWith(
-            '/admin/professions/profession-id/versions/version-id/check-your-answers',
-          );
-        });
-      });
-
-      describe('when set to false', () => {
-        it('continues to the next step in the journey', async () => {
-          const profession = professionFactory.build({
-            id: 'profession-id',
-          });
-
-          const version = professionVersionFactory.build({
-            profession: profession,
-          });
-
-          professionsService.findWithVersions.mockResolvedValue(profession);
-          professionVersionsService.findWithProfession.mockResolvedValue(
-            version,
-          );
-
-          const industry = industryFactory.build({ id: 'construction-uuid' });
-
-          const scopeDtoWithoutChangeParam = {
-            nations: ['GB-ENG'],
-            coversUK: '0',
-            industries: ['construction-uuid'],
-          };
-
-          industriesService.findByIds.mockResolvedValue([industry]);
-
-          const request = createDefaultMockRequest({
-            user: userFactory.build(),
-          });
-
-          await controller.update(
-            scopeDtoWithoutChangeParam,
-            response,
-            'profession-id',
-            'version-id',
-            request,
-          );
-
-          expect(response.redirect).toHaveBeenCalledWith(
-            '/admin/professions/profession-id/versions/version-id/registration/edit',
-          );
-        });
       });
     });
 

--- a/src/professions/admin/scope.controller.ts
+++ b/src/professions/admin/scope.controller.ts
@@ -4,12 +4,11 @@ import {
   Get,
   Param,
   Post,
-  Query,
   Req,
   Res,
   UseGuards,
 } from '@nestjs/common';
-import { Response, Request } from 'express';
+import { Response } from 'express';
 import { IndustriesCheckboxPresenter } from '../../industries/industries-checkbox.presenter';
 import { NationsCheckboxPresenter } from '../../nations/nations-checkbox.presenter';
 import { Validator } from '../../helpers/validator';
@@ -46,16 +45,13 @@ export class ScopeController {
 
   @Get('/:professionId/versions/:versionId/scope/edit')
   @Permissions(UserPermission.CreateProfession, UserPermission.EditProfession)
-  @BackLink((request: Request) =>
-    request.query.change === 'true'
-      ? '/admin/professions/:professionId/versions/:versionId/check-your-answers'
-      : '/admin/professions/:professionId/versions/:versionId/top-level-information/edit',
+  @BackLink(
+    '/admin/professions/:professionId/versions/:versionId/check-your-answers',
   )
   async edit(
     @Res() res: Response,
     @Param('professionId') professionId: string,
     @Param('versionId') versionId: string,
-    @Query('change') change: string,
     @Req() req: RequestWithAppSession,
     errors: object | undefined = undefined,
   ): Promise<void> {
@@ -79,17 +75,14 @@ export class ScopeController {
       version.industries || [],
       version.occupationLocations || [],
       profession,
-      change === 'true',
       errors,
     );
   }
 
   @Post('/:professionId/versions/:versionId/scope')
   @Permissions(UserPermission.CreateProfession, UserPermission.EditProfession)
-  @BackLink((request: Request) =>
-    request.body.change === 'true'
-      ? '/admin/professions/:professionId/versions/:versionId/check-your-answers'
-      : '/admin/professions/:professionId/versions/:versionId/top-level-information/edit',
+  @BackLink(
+    '/admin/professions/:professionId/versions/:versionId/check-your-answers',
   )
   async update(
     @Body() scopeDto, // unfortunately we can't type this here without a validation error being thrown outside of this
@@ -125,7 +118,6 @@ export class ScopeController {
         submittedIndustries,
         submittedValues.nations || [],
         profession,
-        submittedValues.change,
         errors,
       );
     }
@@ -144,14 +136,8 @@ export class ScopeController {
 
     await this.professionVersionsService.save(updatedVersion);
 
-    if (submittedValues.change) {
-      return res.redirect(
-        `/admin/professions/${professionId}/versions/${versionId}/check-your-answers`,
-      );
-    }
-
     return res.redirect(
-      `/admin/professions/${professionId}/versions/${versionId}/registration/edit`,
+      `/admin/professions/${professionId}/versions/${versionId}/check-your-answers`,
     );
   }
 
@@ -161,7 +147,6 @@ export class ScopeController {
     selectedIndustries: Industry[],
     selectedNations: string[],
     profession: Profession,
-    change: boolean,
     errors: object | undefined = undefined,
   ): Promise<void> {
     const industries = await this.industriesService.all();
@@ -189,7 +174,6 @@ export class ScopeController {
       industriesCheckboxItems,
       nationsCheckboxArgs,
       captionText: await ViewUtils.captionText(this.i18nService, profession),
-      change,
       errors,
     };
 

--- a/src/professions/admin/top-level-information.controller.spec.ts
+++ b/src/professions/admin/top-level-information.controller.spec.ts
@@ -214,7 +214,7 @@ describe('TopLevelInformationController', () => {
         );
 
         expect(response.redirect).toHaveBeenCalledWith(
-          '/admin/professions/profession-id/versions/version-id/scope/edit',
+          '/admin/professions/profession-id/versions/version-id/check-your-answers',
         );
       });
     });
@@ -253,74 +253,6 @@ describe('TopLevelInformationController', () => {
         );
 
         expect(professionsService.save).not.toHaveBeenCalled();
-      });
-    });
-
-    describe('the "change" query param', () => {
-      describe('when set to true', () => {
-        it('redirects to check your answers on submit', async () => {
-          const profession = professionFactory.build({
-            id: 'profession-id',
-          });
-
-          professionsService.findWithVersions.mockResolvedValue(profession);
-
-          const topLevelDetailsDtoWithChangeParam = {
-            name: 'A new profession',
-            regulatoryBody: 'example-org-id',
-            change: true,
-          };
-
-          const organisation = organisationFactory.build();
-          organisationsService.find.mockResolvedValue(organisation);
-
-          const request = createDefaultMockRequest({
-            user: userFactory.build(),
-          });
-
-          await controller.update(
-            topLevelDetailsDtoWithChangeParam,
-            response,
-            'profession-id',
-            'version-id',
-            request,
-          );
-
-          expect(response.redirect).toHaveBeenCalledWith(
-            '/admin/professions/profession-id/versions/version-id/check-your-answers',
-          );
-        });
-      });
-
-      describe('when set to false', () => {
-        it('continues to the next step in the journey', async () => {
-          const profession = professionFactory.build({
-            id: 'profession-id',
-          });
-
-          professionsService.findWithVersions.mockResolvedValue(profession);
-
-          const topLevelDetailsDtoWithoutChangeParam = {
-            name: 'A new profession',
-            regulatoryBody: 'example-org-id',
-          };
-
-          const request = createDefaultMockRequest({
-            user: userFactory.build(),
-          });
-
-          await controller.update(
-            topLevelDetailsDtoWithoutChangeParam,
-            response,
-            'profession-id',
-            'version-id',
-            request,
-          );
-
-          expect(response.redirect).toHaveBeenCalledWith(
-            '/admin/professions/profession-id/versions/version-id/scope/edit',
-          );
-        });
       });
     });
 

--- a/src/professions/admin/top-level-information.controller.ts
+++ b/src/professions/admin/top-level-information.controller.ts
@@ -133,14 +133,8 @@ export class TopLevelInformationController {
 
     await this.professionsService.save(updatedProfession);
 
-    if (submittedValues.change) {
-      return res.redirect(
-        `/admin/professions/${professionId}/versions/${versionId}/check-your-answers`,
-      );
-    }
-
     return res.redirect(
-      `/admin/professions/${professionId}/versions/${versionId}/scope/edit`,
+      `/admin/professions/${professionId}/versions/${versionId}/check-your-answers`,
     );
   }
 

--- a/src/professions/helpers/get-publication-blockers.helper.spec.ts
+++ b/src/professions/helpers/get-publication-blockers.helper.spec.ts
@@ -1,0 +1,178 @@
+import { Legislation } from '../../legislations/legislation.entity';
+import professionVersionFactory from '../../testutils/factories/profession-version';
+import {
+  getPublicationBlockers,
+  PublicationBlocker,
+} from './get-publication-blockers.helper';
+
+describe('getPublicationBlockers', () => {
+  describe('when given a just created ProfessionVersion', () => {
+    it('returns all publish blockers', () => {
+      const version = professionVersionFactory
+        .justCreated('version-id')
+        .build();
+
+      expect(getPublicationBlockers(version)).toEqual([
+        {
+          type: 'incomplete-section',
+          section: 'scope',
+        },
+        {
+          type: 'incomplete-section',
+          section: 'regulatedActivities',
+        },
+        {
+          type: 'incomplete-section',
+          section: 'qualifications',
+        },
+        {
+          type: 'incomplete-section',
+          section: 'legislation',
+        },
+      ] as PublicationBlocker[]);
+    });
+  });
+
+  describe('when given a complete ProfessionVersion', () => {
+    it('returns an empty array', () => {
+      const version = professionVersionFactory.build();
+
+      expect(getPublicationBlockers(version)).toEqual([]);
+    });
+  });
+
+  describe('when given a ProfessionVersion with empty industries', () => {
+    it('returns the "scope" publish blocked', () => {
+      const version = professionVersionFactory.build({
+        industries: [],
+      });
+
+      expect(getPublicationBlockers(version)).toEqual([
+        {
+          type: 'incomplete-section',
+          section: 'scope',
+        },
+      ] as PublicationBlocker[]);
+    });
+  });
+
+  describe('when given a ProfessionVersion with empty nations', () => {
+    it('returns the "scope" publish blocked', () => {
+      const version = professionVersionFactory.build({
+        occupationLocations: [],
+      });
+
+      expect(getPublicationBlockers(version)).toEqual([
+        {
+          type: 'incomplete-section',
+          section: 'scope',
+        },
+      ] as PublicationBlocker[]);
+    });
+  });
+
+  describe('when given a ProfessionVersion with an empty regulations summary', () => {
+    it('returns the "regulatedActivities" publish blocked', () => {
+      const version = professionVersionFactory.build({
+        description: '',
+      });
+
+      expect(getPublicationBlockers(version)).toEqual([
+        {
+          type: 'incomplete-section',
+          section: 'regulatedActivities',
+        },
+      ] as PublicationBlocker[]);
+    });
+  });
+
+  describe('when given a ProfessionVersion with an undefined regulation type', () => {
+    it('returns the "regulatedActivities" publish blocked', () => {
+      const version = professionVersionFactory.build({
+        regulationType: undefined,
+      });
+
+      expect(getPublicationBlockers(version)).toEqual([
+        {
+          type: 'incomplete-section',
+          section: 'regulatedActivities',
+        },
+      ] as PublicationBlocker[]);
+    });
+  });
+
+  describe('when given a ProfessionVersion with an empty reserved activities', () => {
+    it('returns the "regulatedActivities" publish blocked', () => {
+      const version = professionVersionFactory.build({
+        reservedActivities: '',
+      });
+
+      expect(getPublicationBlockers(version)).toEqual([
+        {
+          type: 'incomplete-section',
+          section: 'regulatedActivities',
+        },
+      ] as PublicationBlocker[]);
+    });
+  });
+
+  describe('when given a ProfessionVersion with an undefined qualification', () => {
+    it('returns the "qualifications" publish blocked', () => {
+      const version = professionVersionFactory.build({
+        qualification: undefined,
+      });
+
+      expect(getPublicationBlockers(version)).toEqual([
+        {
+          type: 'incomplete-section',
+          section: 'qualifications',
+        },
+      ] as PublicationBlocker[]);
+    });
+  });
+
+  describe('when given a ProfessionVersion with an empty qualification route', () => {
+    it('returns the "qualifications" publish blocked', () => {
+      const version = professionVersionFactory.build({
+        qualification: { routesToObtain: '' },
+      });
+
+      expect(getPublicationBlockers(version)).toEqual([
+        {
+          type: 'incomplete-section',
+          section: 'qualifications',
+        },
+      ] as PublicationBlocker[]);
+    });
+  });
+
+  describe('when given a ProfessionVersion with an undefined legislations', () => {
+    it('returns the "legislation" publish blocked', () => {
+      const version = professionVersionFactory.build({
+        legislations: undefined,
+      });
+
+      expect(getPublicationBlockers(version)).toEqual([
+        {
+          type: 'incomplete-section',
+          section: 'legislation',
+        },
+      ] as PublicationBlocker[]);
+    });
+  });
+
+  describe('when given a ProfessionVersion with an empty legislation name', () => {
+    it('returns the "legislation" publish blocked', () => {
+      const version = professionVersionFactory.build({
+        legislations: [new Legislation()],
+      });
+
+      expect(getPublicationBlockers(version)).toEqual([
+        {
+          type: 'incomplete-section',
+          section: 'legislation',
+        },
+      ] as PublicationBlocker[]);
+    });
+  });
+});

--- a/src/professions/helpers/get-publication-blockers.helper.ts
+++ b/src/professions/helpers/get-publication-blockers.helper.ts
@@ -1,0 +1,48 @@
+import { ProfessionVersion } from '../profession-version.entity';
+
+type Section =
+  | 'scope'
+  | 'regulatedActivities'
+  | 'qualifications'
+  | 'legislation';
+
+interface IncompleteSectionPublicationBlocker {
+  type: 'incomplete-section';
+  section: Section;
+}
+
+export type PublicationBlocker = IncompleteSectionPublicationBlocker;
+
+export function getPublicationBlockers(
+  profession: ProfessionVersion,
+): PublicationBlocker[] {
+  const blockers: PublicationBlocker[] = [];
+
+  if (
+    !profession.industries?.length ||
+    !profession.occupationLocations?.length
+  ) {
+    blockers.push({ type: 'incomplete-section', section: 'scope' });
+  }
+
+  if (
+    !profession.description ||
+    !profession.regulationType ||
+    !profession.reservedActivities
+  ) {
+    blockers.push({
+      type: 'incomplete-section',
+      section: 'regulatedActivities',
+    });
+  }
+
+  if (!profession.qualification?.routesToObtain) {
+    blockers.push({ type: 'incomplete-section', section: 'qualifications' });
+  }
+
+  if (!profession.legislations?.[0]?.name) {
+    blockers.push({ type: 'incomplete-section', section: 'legislation' });
+  }
+
+  return blockers;
+}

--- a/views/admin/professions/check-your-answers.njk
+++ b/views/admin/professions/check-your-answers.njk
@@ -111,7 +111,7 @@
                 actions: {
                   items: [
                     {
-                      href: "/admin/professions/" + professionId + "/versions/" + versionId + "/scope/edit?change=true",
+                      href: "/admin/professions/" + professionId + "/versions/" + versionId + "/scope/edit",
                       text: ("app.change" | t),
                       visuallyHiddenText: ("professions.form.label.scope.nation" | t)
                     }
@@ -128,7 +128,7 @@
                 actions: {
                   items: [
                     {
-                      href: "/admin/professions/" + professionId + "/versions/" + versionId + "/scope/edit?change=true",
+                      href: "/admin/professions/" + professionId + "/versions/" + versionId + "/scope/edit",
                       text: ("app.change" | t),
                       visuallyHiddenText: ("professions.form.label.scop.industry" | t)
                     }
@@ -154,7 +154,7 @@
                 actions: {
                   items: [
                     {
-                      href: "/admin/professions/" + professionId + "/versions/" + versionId + "/regulated-activities/edit?change=true",
+                      href: "/admin/professions/" + professionId + "/versions/" + versionId + "/regulated-activities/edit",
                       text: ("app.change" | t),
                       visuallyHiddenText: ("professions.form.label.regulatedActivities.regulationSummary" | t)
                     }
@@ -171,7 +171,7 @@
                 actions: {
                   items: [
                     {
-                      href: "/admin/professions/" + professionId + "/versions/" + versionId + "/regulated-activities/edit?change=true",
+                      href: "/admin/professions/" + professionId + "/versions/" + versionId + "/regulated-activities/edit",
                       text: ("app.change" | t),
                       visuallyHiddenText: ("professions.form.label.regulatedActivities.regulationType" | t)
                     }
@@ -188,7 +188,7 @@
                 actions: {
                   items: [
                     {
-                      href: "/admin/professions/" + professionId + "/versions/" + versionId + "/regulated-activities/edit?change=true",
+                      href: "/admin/professions/" + professionId + "/versions/" + versionId + "/regulated-activities/edit",
                       text: ("app.change" | t),
                       visuallyHiddenText: ("professions.form.label.regulatedActivities.reservedActivities" | t)
                     }
@@ -205,7 +205,7 @@
                 actions: {
                   items: [
                     {
-                      href: "/admin/professions/" + professionId + "/versions/" + versionId + "/regulated-activities/edit?change=true",
+                      href: "/admin/professions/" + professionId + "/versions/" + versionId + "/regulated-activities/edit",
                       text: ("app.change" | t),
                       visuallyHiddenText: ("professions.form.label.regulatedActivities.protectedTitles" | t)
                     }
@@ -222,7 +222,7 @@
                 actions: {
                   items: [
                     {
-                      href: "/admin/professions/" + professionId + "/versions/" + versionId + "/regulated-activities/edit?change=true",
+                      href: "/admin/professions/" + professionId + "/versions/" + versionId + "/regulated-activities/edit",
                       text: ("app.change" | t),
                       visuallyHiddenText: ("professions.form.label.regulatedActivities.regulationUrl" | t)
                     }
@@ -249,7 +249,7 @@
                 actions: {
                   items: [
                     {
-                      href: "/admin/professions/" + professionId + "/versions/" + versionId + "/qualifications/edit?change=true",
+                      href: "/admin/professions/" + professionId + "/versions/" + versionId + "/qualifications/edit",
                       text: ("app.change" | t),
                       visuallyHiddenText: ("professions.form.label.qualifications.routesToObtain" | t)
                     }
@@ -266,7 +266,7 @@
                 actions: {
                   items: [
                     {
-                      href: "/admin/professions/" + professionId + "/versions/" + versionId + "/qualifications/edit?change=true",
+                      href: "/admin/professions/" + professionId + "/versions/" + versionId + "/qualifications/edit",
                       text: ("app.change" | t),
                       visuallyHiddenText: ("professions.form.label.qualifications.moreInformationUrl" | t)
                     }
@@ -283,7 +283,7 @@
                 actions: {
                   items: [
                     {
-                      href: "/admin/professions/" + professionId + "/versions/" + versionId + "/qualifications/edit?change=true",
+                      href: "/admin/professions/" + professionId + "/versions/" + versionId + "/qualifications/edit",
                       text: ("app.change" | t),
                       visuallyHiddenText: ("professions.form.label.qualifications.ukRecognition" | t)
                     }
@@ -300,7 +300,7 @@
                 actions: {
                   items: [
                     {
-                      href: "/admin/professions/" + professionId + "/versions/" + versionId + "/qualifications/edit?change=true",
+                      href: "/admin/professions/" + professionId + "/versions/" + versionId + "/qualifications/edit",
                       text: ("app.change" | t),
                       visuallyHiddenText: ("professions.form.label.qualifications.ukRecognitionUrl" | t)
                     }
@@ -327,7 +327,7 @@
                 actions: {
                   items: [
                     {
-                      href: "/admin/professions/" + professionId + "/versions/" + versionId + "/registration/edit?change=true",
+                      href: "/admin/professions/" + professionId + "/versions/" + versionId + "/registration/edit",
                       text: ("app.change" | t),
                       visuallyHiddenText: ("professions.form.label.registration.registrationRequirements" | t)
                     }
@@ -344,7 +344,7 @@
                 actions: {
                   items: [
                     {
-                      href: "/admin/professions/" + professionId + "/versions/" + versionId + "/registration/edit?change=true",
+                      href: "/admin/professions/" + professionId + "/versions/" + versionId + "/registration/edit",
                       text: ("app.change" | t),
                       visuallyHiddenText: ("professions.form.label.registration.registrationUrl" | t)
                     }
@@ -371,7 +371,7 @@
                   actions: {
                     items: [
                       {
-                        href: "/admin/professions/" + professionId + "/versions/" + versionId + "/legislation/edit?change=true",
+                        href: "/admin/professions/" + professionId + "/versions/" + versionId + "/legislation/edit",
                         text: ("app.change" | t),
                         visuallyHiddenText: ("professions.form.label.legislation.nationalLegislation" | t) + " " + loop.index
                       }
@@ -388,7 +388,7 @@
                   actions: {
                     items: [
                       {
-                        href: "/admin/professions/" + professionId + "/versions/" + versionId + "/legislation/edit?change=true",
+                        href: "/admin/professions/" + professionId + "/versions/" + versionId + "/legislation/edit",
                         text: ("app.change" | t),
                         visuallyHiddenText: ("professions.form.label.legislation.nationalLegislation" | t) + " " + loop.index
                       }

--- a/views/admin/professions/check-your-answers.njk
+++ b/views/admin/professions/check-your-answers.njk
@@ -399,36 +399,10 @@
             })
           }}
         {% endfor %}
-
-        {% if not edit and not confirmed %}
-          <div class="govuk-button-group rpr-internal__buttons-container">
-            <form method="post" action="confirmation">
-              {{
-                govukButton({
-                  id: "submit-button",
-                  classes: "govuk-button--secondary",
-                  type: "Submit",
-                  preventDoubleClick: true,
-                  text: ("professions.form.button.saveAsDraft" | t)
-                })
-              }}
-            </form>
-            {% if 'publishProfession' in permissions %}
-              {{
-                govukButton({
-                  text: ('professions.form.button.publish' | t),
-                  classes: "govuk-button",
-                  id: "publish-button",
-                  href: "/admin/professions/" + professionId + "/versions/" + versionId + "/publish?fromEdit=true"
-                })
-              }}
-            {% endif %}
-          </div>
-        {% endif %}
     </div>
 
     <div class="govuk-grid-column-one-third">
-      {% if not edit and confirmed %}
+      {% if not edit %}
         <aside class="app-related-items rpr-internal__details-page-sidebar" role="complementary">
           <ul class="govuk-list">
             <li>
@@ -449,9 +423,9 @@
                 {{
                   govukButton({
                     text: ('professions.form.button.publish' | t),
-                    classes: "govuk-button",
                     id: "publish-button",
-                    href: "/admin/professions/" + professionId + "/versions/" + versionId + "/publish?fromEdit=true"
+                    href: "/admin/professions/" + professionId + "/versions/" + versionId + "/publish?fromEdit=true",
+                    disabled: publicationBlockers.length
                   })
                 }}
               </li>
@@ -459,6 +433,7 @@
           </ul>
         </aside>
       {% endif %}
+      {% include '../../shared/_publication-blockers.njk' %}
     </div>
   </div>
 

--- a/views/admin/professions/legislation.njk
+++ b/views/admin/professions/legislation.njk
@@ -16,8 +16,6 @@
       <h1 class="govuk-heading-l">{{ ("professions.form.headings.legislation" | t) }}</h1>
 
       <form method="post" action="./">
-        <input type="hidden" name="change" value="{{ change }}" />
-
         {{
           govukTextarea({
             label: {

--- a/views/admin/professions/qualifications.njk
+++ b/views/admin/professions/qualifications.njk
@@ -18,7 +18,6 @@
       <h1 class="govuk-heading-l">{{ heading }}</h1>
 
       <form method="post" action="./">
-        <input type="hidden" name="change" value="{{ change }}" />
         {{
           govukTextarea({
             label: {

--- a/views/admin/professions/registration.njk
+++ b/views/admin/professions/registration.njk
@@ -17,8 +17,6 @@
       <h1 class="govuk-heading-l">{{ heading }}</h1>
 
       <form method="post" action="./">
-        <input type="hidden" name="change" value="{{ change }}" />
-
         {{
           govukInput({
             id: "registrationRequirements",

--- a/views/admin/professions/regulated-activities.njk
+++ b/views/admin/professions/regulated-activities.njk
@@ -19,8 +19,6 @@
       <h1 class="govuk-heading-l">{{ heading }}</h1>
 
       <form method="post" action="./">
-        <input type="hidden" name="change" value="{{ change }}" />
-
         {{
           govukTextarea({
             label: {

--- a/views/admin/professions/scope.njk
+++ b/views/admin/professions/scope.njk
@@ -19,8 +19,6 @@
     <h1 class="govuk-heading-l">{{ heading }}</h1>
 
     <form method="post" action="./">
-      <input type="hidden" name="change" value="{{ change }}" />
-
       {% set nationHtml %}
         {{
           govukCheckboxes(nationsCheckboxArgs)

--- a/views/admin/professions/show.njk
+++ b/views/admin/professions/show.njk
@@ -62,9 +62,9 @@
                   {{
                     govukButton({
                       text: ('professions.form.button.publish' | t),
-                      classes: "govuk-button",
                       attributes: { "data-cy": "publish-button" },
-                      href: "/admin/professions/" + profession.id + "/versions/" + profession.versionId + "/publish"
+                      href: "/admin/professions/" + profession.id + "/versions/" + profession.versionId + "/publish",
+                      disabled: publicationBlockers.length
                     })
                   }}
                 </li>
@@ -82,6 +82,7 @@
               {% endif %}
             </ul>
           </nav>
+          {% include '../../shared/_publication-blockers.njk' %}
         {% endif %}
       </aside>
     </div>

--- a/views/shared/_publication-blockers.njk
+++ b/views/shared/_publication-blockers.njk
@@ -1,0 +1,14 @@
+{% if publicationBlockers.length %}
+<div>
+  <h2 class="govuk-heading-s">{{ "professions.admin.publish.blocked.heading" | t }}</h2>
+    <ul class="govuk-list govuk-list--bullet">
+      {%for blocker in publicationBlockers %}
+        {% if blocker.type === "incomplete-section" %}
+          {% set sectionName = (("professions.form.headings." + blocker.section) | t) %}
+          <li class="govuk-body-s">{{ "professions.admin.publish.blocked.missing" | t({section: sectionName}) }}</li>
+        {% endif %}
+      {% endfor %}
+    </ul>
+  </b>
+</div>
+{% endif %}


### PR DESCRIPTION
# Changes in this PR
* Change Profession creation flow so that the user is taken to Check Your Answers after completing the top-level information
* Enforce that a Profession cannot be published until required sections are completed

## Screenshots of UI changes

### Before
![localhost_3000_admin_professions_61997465-2d80-4d30-b059-960d05978337_versions_70a7ce54-3fa3-486e-9325-15a5c38b43b9 (2)](https://user-images.githubusercontent.com/94137563/158859971-791c5866-239c-4aaf-85bc-babf0867a49d.png)
![localhost_3000_admin_professions_61997465-2d80-4d30-b059-960d05978337_versions_cc3d6159-5133-4bec-a9c2-af3445586a05_check-your-answers](https://user-images.githubusercontent.com/94137563/158859992-e4e8beec-139c-47fd-8676-20fea57ab4e5.png)

### After
![localhost_3000_admin_professions_61997465-2d80-4d30-b059-960d05978337_versions_70a7ce54-3fa3-486e-9325-15a5c38b43b9 (1)](https://user-images.githubusercontent.com/94137563/158859943-486d1a23-bd2b-45f8-9321-146033f66ff4.png)
![localhost_3000_admin_professions_61997465-2d80-4d30-b059-960d05978337_versions_d2282cc4-3f0a-47cb-8604-98b9facd7be3_check-your-answers](https://user-images.githubusercontent.com/94137563/158859961-29bf2372-212f-4abf-a8b5-cad960d4d857.png)

