### PR TITLE
(2192) Search organisations by alternate name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - Use Opensearch for searching Organisations
+- Backlink on public show pages takes the user back to the search results
 
 ## [release-010] - 2022-03-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [unreleased]
+
+### Changed
+
+- Use Opensearch for searching Organisations
+
 ## [release-010] - 2022-03-22
 
 ### Added

--- a/cypress/integration/organisations/search/search.spec.ts
+++ b/cypress/integration/organisations/search/search.spec.ts
@@ -59,9 +59,13 @@ describe('Searching an organisation', () => {
       const scottishProfessions = professions.filter((profession) =>
         profession.versions.some(
           (version) =>
-            version.status === 'live' &&
+            version.occupationLocations &&
             version.occupationLocations.includes('GB-SCT'),
         ),
+      );
+
+      const organisations = scottishProfessions.map(
+        (profession) => profession.organisation,
       );
 
       cy.get('input[name="nations[]"][value="GB-SCT"]').check();
@@ -71,8 +75,11 @@ describe('Searching an organisation', () => {
 
       cy.get('input[name="nations[]"][value="GB-SCT"]').should('be.checked');
 
-      cy.get('body').should('contain', 'Law Society of England and Wales');
-      checkResultLength(scottishProfessions.length);
+      checkResultLength(organisations.length);
+
+      for (const organisation of organisations) {
+        cy.get('body').should('contain', organisation);
+      }
     });
   });
 

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "seed:test": "NODE_ENV=test node dist/seeder",
     "seed:production": "NODE_ENV=production node dist/seeder",
     "seed:test:refresh": "npm run build && NODE_ENV=test node dist/seeder --refresh",
-    "opensearch:test:purge": "curl -X DELETE 'http://admin:admin@localhost:9200/professions_test' &> /dev/null",
+    "opensearch:test:purge": "curl -X DELETE 'http://admin:admin@localhost:9200/professions_test' &> /dev/null && curl -X DELETE 'http://admin:admin@localhost:9200/organisations_test' &> /dev/null",
     "opensearch:reseed:professions": "ts-node ./src/console.ts opensearch:reseed:professions",
     "heroku:set-callback-urls": "ts-node util/set-callback-urls.ts",
     "bull:repl": "bull-repl"

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "seed:test:refresh": "npm run build && NODE_ENV=test node dist/seeder --refresh",
     "opensearch:test:purge": "curl -X DELETE 'http://admin:admin@localhost:9200/professions_test' &> /dev/null && curl -X DELETE 'http://admin:admin@localhost:9200/organisations_test' &> /dev/null",
     "opensearch:reseed:professions": "ts-node ./src/console.ts opensearch:reseed:professions",
+    "opensearch:reseed:organisations": "ts-node ./src/console.ts opensearch:reseed:organisations",
     "heroku:set-callback-urls": "ts-node util/set-callback-urls.ts",
     "bull:repl": "bull-repl"
   },

--- a/seeds/test/organisations.json
+++ b/seeds/test/organisations.json
@@ -4,7 +4,7 @@
     "slug": "department-for-education",
     "versions": [
       {
-        "alternateName": "",
+        "alternateName": "DFE",
         "address": "123 Example Street\nLondon\nEC1 1AB",
         "url": "https://www.gov.uk/guidance/early-years-qualifications-finder#overseas-qualifications",
         "email": "dfe@example.com",
@@ -14,7 +14,7 @@
         "created_at": "2022-01-01"
       },
       {
-        "alternateName": "DFE",
+        "alternateName": "",
         "address": "345 Example Street\nLondon\nEC1 1AB",
         "url": "https://www.gov.uk/guidance/early-years-qualifications-finder#overseas-qualifications",
         "email": "old@example.com",

--- a/src/console.ts
+++ b/src/console.ts
@@ -2,8 +2,12 @@ process.env['ENTITIES'] = __dirname + '/**/*.entity.ts';
 
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
+
 import { ProfessionVersionsService } from './professions/profession-versions.service';
 import { ProfessionsSearchService } from './professions/professions-search.service';
+
+import { OrganisationVersionsService } from './organisations/organisation-versions.service';
+import { OrganisationsSearchService } from './organisations/organisations-search.service';
 
 async function bootstrap() {
   const application = await NestFactory.createApplicationContext(AppModule);
@@ -27,6 +31,25 @@ async function bootstrap() {
 
       for (const profession of professions) {
         professionsSearchService.index(profession);
+      }
+
+      break;
+    case 'opensearch:reseed:organisations':
+      console.log('Reseeding organisations...');
+
+      const organisationVersionsService = application.get(
+        OrganisationVersionsService,
+      );
+      const organisationsSearchService = application.get(
+        OrganisationsSearchService,
+      );
+
+      await organisationsSearchService.deleteAll();
+
+      const orgs = await organisationVersionsService.all();
+
+      for (const org of orgs) {
+        organisationsSearchService.index(org);
       }
 
       break;

--- a/src/organisations/admin/organisations.controller.spec.ts
+++ b/src/organisations/admin/organisations.controller.spec.ts
@@ -433,10 +433,13 @@ describe('OrganisationsController', () => {
           };
 
           const organisation = organisationFactory.build({ slug: '' });
-          const version = organisationVersionFactory.build({});
+          const version = organisationVersionFactory.build({
+            organisation: organisation,
+          });
 
-          organisationsService.find.mockResolvedValue(organisation);
-          organisationVersionsService.find.mockResolvedValue(version);
+          organisationVersionsService.findByIdWithOrganisation.mockResolvedValue(
+            version,
+          );
 
           const newOrganisation = {
             ...organisation,
@@ -468,7 +471,7 @@ describe('OrganisationsController', () => {
           );
 
           const updatedOrganisation = Organisation.withVersion(
-            organisation,
+            newOrganisation,
             newVersion,
             true,
           );
@@ -514,14 +517,17 @@ describe('OrganisationsController', () => {
             name: 'My awesome organisation',
             slug: 'my-awesome-organisation',
           });
-          const version = organisationVersionFactory.build({});
+          const version = organisationVersionFactory.build({
+            organisation: organisation,
+          });
           const response = createMock<Response>();
           const request = createDefaultMockRequest({
             user: userFactory.build(),
           });
 
-          organisationsService.find.mockResolvedValue(organisation);
-          organisationVersionsService.find.mockResolvedValue(version);
+          organisationVersionsService.findByIdWithOrganisation.mockResolvedValue(
+            version,
+          );
 
           const newVersion = {
             ...version,
@@ -557,7 +563,9 @@ describe('OrganisationsController', () => {
       describe('when the slug is not set', () => {
         beforeEach(async () => {
           organisation = organisationFactory.build({ slug: '' });
-          version = organisationVersionFactory.build();
+          version = organisationVersionFactory.build({
+            organisation: organisation,
+          });
           response = createMock<Response>();
           request = createDefaultMockRequest({
             user: userFactory.build(),
@@ -567,8 +575,9 @@ describe('OrganisationsController', () => {
             confirm: true,
           });
 
-          organisationsService.find.mockResolvedValue(organisation);
-          organisationVersionsService.find.mockResolvedValue(version);
+          organisationVersionsService.findByIdWithOrganisation.mockResolvedValue(
+            version,
+          );
 
           flashMock = flashMessage as jest.Mock;
           flashMock.mockImplementation(() => 'STUB_FLASH_MESSAGE');
@@ -583,17 +592,17 @@ describe('OrganisationsController', () => {
         });
 
         it('should set the slug and confirm the version', async () => {
-          expect(organisationsService.find).toHaveBeenCalledWith('some-uuid');
-          expect(organisationVersionsService.find).toHaveBeenCalledWith(
-            'some-other-uuid',
-          );
+          expect(
+            organisationVersionsService.findByIdWithOrganisation,
+          ).toHaveBeenCalledWith('some-uuid', 'some-other-uuid');
 
           expect(organisationsService.setSlug).toHaveBeenCalledWith(
             organisation,
           );
-          expect(organisationVersionsService.confirm).toHaveBeenCalledWith(
-            version,
-          );
+          expect(organisationVersionsService.confirm).toHaveBeenCalledWith({
+            ...version,
+            organisation: organisation,
+          });
         });
 
         it('should set a flash message and redirect', () => {
@@ -618,7 +627,9 @@ describe('OrganisationsController', () => {
       describe('when the slug is set', () => {
         beforeEach(async () => {
           organisation = organisationFactory.build({ slug: 'some-slug' });
-          version = organisationVersionFactory.build();
+          version = organisationVersionFactory.build({
+            organisation: organisation,
+          });
           response = createMock<Response>();
           request = createDefaultMockRequest({
             user: userFactory.build(),
@@ -628,8 +639,9 @@ describe('OrganisationsController', () => {
             confirm: true,
           });
 
-          organisationsService.find.mockResolvedValue(organisation);
-          organisationVersionsService.find.mockResolvedValue(version);
+          organisationVersionsService.findByIdWithOrganisation.mockResolvedValue(
+            version,
+          );
 
           (escape as jest.Mock).mockImplementation();
 
@@ -649,9 +661,10 @@ describe('OrganisationsController', () => {
           expect(organisationsService.setSlug).not.toHaveBeenCalledWith(
             organisation,
           );
-          expect(organisationVersionsService.confirm).toHaveBeenCalledWith(
-            version,
-          );
+          expect(organisationVersionsService.confirm).toHaveBeenCalledWith({
+            ...version,
+            organisation: organisation,
+          });
         });
 
         it('should set a flash message and redirect', () => {
@@ -687,14 +700,17 @@ describe('OrganisationsController', () => {
     };
 
     const organisation = organisationFactory.build();
-    const version = organisationVersionFactory.build({});
+    const version = organisationVersionFactory.build({
+      organisation: organisation,
+    });
     const response = createMock<Response>();
     const request = createDefaultMockRequest({
       user: userFactory.build(),
     });
 
-    organisationsService.find.mockResolvedValue(organisation);
-    organisationVersionsService.find.mockResolvedValue(version);
+    organisationVersionsService.findByIdWithOrganisation.mockResolvedValue(
+      version,
+    );
 
     await controller.update(
       organisation.id,

--- a/src/organisations/admin/organisations.controller.spec.ts
+++ b/src/organisations/admin/organisations.controller.spec.ts
@@ -133,11 +133,8 @@ describe('OrganisationsController', () => {
           expect(await controller.index(request)).toEqual(templateParams);
 
           expect(
-            organisationVersionsService.allWithLatestVersion,
-          ).toHaveBeenCalled();
-
-          expect(OrganisationsFilterHelper).toBeCalledWith(organisations);
-          expect(OrganisationsFilterHelper.prototype.filter).toBeCalledWith({
+            organisationVersionsService.searchWithLatestVersion,
+          ).toHaveBeenCalledWith({
             keywords: '',
             nations: [],
             industries: [],
@@ -215,11 +212,8 @@ describe('OrganisationsController', () => {
           ).toEqual(templateParams);
 
           expect(
-            organisationVersionsService.allWithLatestVersion,
-          ).toHaveBeenCalled();
-
-          expect(OrganisationsFilterHelper).toBeCalledWith(organisations);
-          expect(OrganisationsFilterHelper.prototype.filter).toBeCalledWith({
+            organisationVersionsService.searchWithLatestVersion,
+          ).toHaveBeenCalledWith({
             keywords: 'example keywords',
             nations: [nations[2]],
             industries: [industries[1]],
@@ -296,11 +290,8 @@ describe('OrganisationsController', () => {
         expect(await controller.index(request)).toEqual(templateParams);
 
         expect(
-          organisationVersionsService.allWithLatestVersion,
-        ).toHaveBeenCalled();
-
-        expect(OrganisationsFilterHelper).toBeCalledWith(organisations);
-        expect(OrganisationsFilterHelper.prototype.filter).toBeCalledWith({
+          organisationVersionsService.searchWithLatestVersion,
+        ).toHaveBeenCalledWith({
           keywords: '',
           nations: [],
           organisations: [userOrganisation],

--- a/src/organisations/admin/organisations.controller.ts
+++ b/src/organisations/admin/organisations.controller.ts
@@ -35,7 +35,6 @@ import { IndexTemplate } from './interfaces/index-template.interface';
 
 import { OrganisationDto } from './dto/organisation.dto';
 import { FilterDto } from './dto/filter.dto';
-import { OrganisationsFilterHelper } from '../helpers/organisations-filter.helper';
 import { IndustriesService } from '../../industries/industries.service';
 import { createFilterInput } from '../../helpers/create-filter-input.helper';
 
@@ -80,8 +79,6 @@ export class OrganisationsController {
       : 'single-organisation';
 
     const allNations = Nation.all();
-    const allOrganisations =
-      await this.organisationVersionsService.allWithLatestVersion();
     const allIndustries = await this.industriesService.all();
 
     const filter = query || new FilterDto();
@@ -96,9 +93,10 @@ export class OrganisationsController {
       filterInput.organisations = [actingUser.organisation];
     }
 
-    const filteredOrganisations = new OrganisationsFilterHelper(
-      allOrganisations,
-    ).filter(filterInput);
+    const filteredOrganisations =
+      await this.organisationVersionsService.searchWithLatestVersion(
+        filterInput,
+      );
 
     const userOrganisation = showAllOrgs
       ? await this.i18nService.translate('app.beis')

--- a/src/organisations/organisation-versions.service.spec.ts
+++ b/src/organisations/organisation-versions.service.spec.ts
@@ -98,6 +98,43 @@ describe('OrganisationVersionsService', () => {
     });
   });
 
+  describe('all', () => {
+    it('returns all OrganisationVersion', async () => {
+      const organisationVersions = organisationVersionFactory.buildList(5);
+      const queryBuilder = createMock<SelectQueryBuilder<OrganisationVersion>>({
+        leftJoinAndSelect: () => queryBuilder,
+        where: () => queryBuilder,
+        getMany: async () => organisationVersions,
+      });
+
+      jest
+        .spyOn(repo, 'createQueryBuilder')
+        .mockImplementation(() => queryBuilder);
+
+      const result = await service.all();
+
+      expect(result).toEqual(organisationVersions);
+
+      expect(queryBuilder).toHaveJoined([
+        'organisationVersion.organisation',
+        'organisationVersion.user',
+        'organisation.professions',
+      ]);
+
+      expect(queryBuilder.leftJoinAndSelect).toHaveBeenCalledWith(
+        'professions.versions',
+        'professionVersions',
+      );
+
+      expect(queryBuilder.leftJoinAndSelect).toHaveBeenCalledWith(
+        'professionVersions.industries',
+        'industries',
+      );
+
+      expect(queryBuilder.getMany).toHaveBeenCalled();
+    });
+  });
+
   describe('findByIdWithOrganisation', () => {
     it('returns an Organisation with a version, fetching its draft and live professions', async () => {
       const organisationVersion = organisationVersionFactory.build();

--- a/src/organisations/organisation-versions.service.spec.ts
+++ b/src/organisations/organisation-versions.service.spec.ts
@@ -545,6 +545,11 @@ describe('OrganisationVersionsService', () => {
         status: OrganisationVersionStatus.Live,
       });
 
+      expect(organisationsSearchService.index).toBeCalledWith({
+        ...version,
+        status: OrganisationVersionStatus.Live,
+      });
+
       expect(queryRunner.commitTransaction).toHaveBeenCalled();
       expect(queryRunner.release).toHaveBeenCalled();
     });

--- a/src/organisations/organisation-versions.service.ts
+++ b/src/organisations/organisation-versions.service.ts
@@ -331,6 +331,23 @@ export class OrganisationVersionsService {
       });
     }
 
+    if (filter.organisations?.length) {
+      const organisations = filter.organisations.map((o) => o.id);
+
+      query = query.andWhere('organisation.id IN(:...organisations)', {
+        organisations: organisations,
+      });
+    }
+
+    if (filter.regulationTypes?.length) {
+      query = query.andWhere(
+        'professionVersions.regulationType IN(:...regulationTypes)',
+        {
+          regulationTypes: filter.regulationTypes,
+        },
+      );
+    }
+
     const versions = await query.getMany();
 
     return versions.map((version) =>

--- a/src/organisations/organisation-versions.service.ts
+++ b/src/organisations/organisation-versions.service.ts
@@ -30,6 +30,10 @@ export class OrganisationVersionsService {
     return this.repository.findOne(id);
   }
 
+  async all(): Promise<OrganisationVersion[]> {
+    return await this.versionsWithJoins().getMany();
+  }
+
   async create(
     previousVersion: OrganisationVersion,
     user: User,

--- a/src/organisations/organisation-versions.service.ts
+++ b/src/organisations/organisation-versions.service.ts
@@ -195,6 +195,8 @@ export class OrganisationVersionsService {
       await queryRunner.release();
     }
 
+    await this.organisationsSearchService.index(version);
+
     return version;
   }
 

--- a/src/organisations/organisation-versions.service.ts
+++ b/src/organisations/organisation-versions.service.ts
@@ -6,6 +6,7 @@ import {
   OrganisationVersionStatus,
 } from './organisation-version.entity';
 import { Organisation } from './organisation.entity';
+import { OrganisationsSearchService } from './organisations-search.service';
 import { User } from '../users/user.entity';
 import { ProfessionVersionStatus } from '../professions/profession-version.entity';
 
@@ -16,6 +17,7 @@ export class OrganisationVersionsService {
     @InjectRepository(OrganisationVersion)
     private repository: Repository<OrganisationVersion>,
     private professionVersionsService: ProfessionVersionsService,
+    private organisationsSearchService: OrganisationsSearchService,
     private connection: Connection,
   ) {}
 
@@ -159,6 +161,8 @@ export class OrganisationVersionsService {
 
   async confirm(version: OrganisationVersion): Promise<OrganisationVersion> {
     version.status = OrganisationVersionStatus.Draft;
+
+    await this.organisationsSearchService.index(version);
 
     return this.repository.save(version);
   }

--- a/src/organisations/organisations-search.service.spec.ts
+++ b/src/organisations/organisations-search.service.spec.ts
@@ -1,0 +1,139 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { createMock, DeepMocked } from '@golevelup/ts-jest';
+import { OpensearchClient } from 'nestjs-opensearch';
+
+import { OrganisationsSearchService } from './organisations-search.service';
+import organisationVersionFactory from '../testutils/factories/organisation-version';
+
+describe('OrganisationsSearchService', () => {
+  let service: OrganisationsSearchService;
+  let opensearchClient: DeepMocked<OpensearchClient>;
+
+  beforeEach(async () => {
+    opensearchClient = createMock<OpensearchClient>({
+      indices: {
+        delete: jest.fn(),
+      },
+    });
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        OrganisationsSearchService,
+        {
+          provide: OpensearchClient,
+          useValue: opensearchClient,
+        },
+      ],
+    }).compile();
+
+    service = module.get<OrganisationsSearchService>(
+      OrganisationsSearchService,
+    );
+  });
+
+  describe('indexName', () => {
+    it('appends the environment name to the index', () => {
+      expect(service.indexName).toEqual('organisations_test');
+    });
+  });
+
+  describe('index', () => {
+    it('indexes the entity', async () => {
+      const organisationVersion = organisationVersionFactory.build();
+
+      service.index(organisationVersion);
+
+      expect(opensearchClient.index).toHaveBeenCalledWith({
+        id: organisationVersion.id,
+        index: service.indexName,
+        body: {
+          name: organisationVersion.organisation.name,
+          alternateName: organisationVersion.alternateName,
+        },
+      });
+    });
+  });
+
+  describe('delete', () => {
+    it('deletes the entity', async () => {
+      const organisationVersion = organisationVersionFactory.build();
+
+      service.delete(organisationVersion);
+
+      expect(opensearchClient.delete).toHaveBeenCalledWith({
+        index: service.indexName,
+        id: organisationVersion.id,
+      });
+    });
+  });
+
+  describe('bulkDelete', () => {
+    it('deletes all entities with given ids', async () => {
+      const organisationVersion1 = organisationVersionFactory.build({
+        id: 'some-uuid',
+      });
+      const organisationVersion2 = organisationVersionFactory.build({
+        id: 'some-other-uuid',
+      });
+
+      service.bulkDelete([organisationVersion1, organisationVersion2]);
+
+      expect(opensearchClient.deleteByQuery).toHaveBeenCalledWith({
+        index: service.indexName,
+        body: {
+          query: {
+            ids: {
+              values: ['some-uuid', 'some-other-uuid'],
+            },
+          },
+        },
+      });
+    });
+  });
+
+  describe('search', () => {
+    it('runs a search query', async () => {
+      (opensearchClient.search as jest.Mock).mockReturnValue({
+        body: {
+          hits: {
+            hits: [
+              {
+                _id: '123',
+              },
+              {
+                _id: '456',
+              },
+            ],
+          },
+        },
+      });
+
+      const result = await service.search('something');
+
+      expect(result).toEqual(['123', '456']);
+
+      expect(opensearchClient.search).toHaveBeenCalledWith({
+        index: service.indexName,
+        body: {
+          query: {
+            multi_match: {
+              query: 'something',
+              fields: ['name', 'alternateName'],
+            },
+          },
+        },
+      });
+    });
+  });
+
+  describe('deleteAll', () => {
+    it('deletes all documents in an index', async () => {
+      await service.deleteAll();
+
+      expect(opensearchClient.indices.delete).toHaveBeenCalledWith({
+        index: service.indexName,
+        ignore_unavailable: true,
+      });
+    });
+  });
+});

--- a/src/organisations/organisations-search.service.ts
+++ b/src/organisations/organisations-search.service.ts
@@ -1,0 +1,72 @@
+import { OpensearchClient } from 'nestjs-opensearch';
+import { Injectable } from '@nestjs/common';
+import {
+  SearchResponse,
+  SearchHit,
+} from '@opensearch-project/opensearch/api/types';
+import { OrganisationVersion } from './organisation-version.entity';
+
+@Injectable()
+export class OrganisationsSearchService {
+  readonly indexName: string = `organisations_${process.env['NODE_ENV']}`;
+
+  public constructor(private readonly client: OpensearchClient) {}
+
+  public async index(organisationVersion: OrganisationVersion): Promise<any> {
+    await this.client.index({
+      id: organisationVersion.id,
+      index: this.indexName,
+      body: {
+        name: organisationVersion.organisation.name,
+        alternateName: organisationVersion.alternateName,
+      },
+    });
+  }
+
+  public async delete(organisationVersion: OrganisationVersion): Promise<any> {
+    await this.client.delete({
+      index: this.indexName,
+      id: organisationVersion.id,
+    });
+  }
+
+  public async bulkDelete(versions: OrganisationVersion[]): Promise<any> {
+    const ids = versions.map((version) => version.id);
+
+    await this.client.deleteByQuery({
+      index: this.indexName,
+      body: {
+        query: {
+          ids: {
+            values: ids,
+          },
+        },
+      },
+    });
+  }
+
+  public async deleteAll(): Promise<any> {
+    await this.client.indices.delete({
+      index: this.indexName,
+      ignore_unavailable: true,
+    });
+  }
+
+  public async search(query: string): Promise<string[]> {
+    const response = await this.client.search<SearchResponse>({
+      index: this.indexName,
+      body: {
+        query: {
+          multi_match: {
+            query: query,
+            fields: ['name', 'alternateName'],
+          },
+        },
+      },
+    });
+
+    const hits = response.body.hits.hits;
+
+    return hits.map((hit: SearchHit) => hit._id);
+  }
+}

--- a/src/organisations/organisations.module.ts
+++ b/src/organisations/organisations.module.ts
@@ -7,6 +7,7 @@ import { ProfessionVersion } from '../professions/profession-version.entity';
 import { OrganisationVersion } from './organisation-version.entity';
 import { OrganisationsService } from './organisations.service';
 import { OrganisationVersionsService } from './organisation-versions.service';
+import { OrganisationsSearchService } from './organisations-search.service';
 import { OrganisationsController as AdminOrganisationsController } from './admin/organisations.controller';
 import { OrganisationVersionsController as AdminOrganisationVersionsController } from './admin/organisation-versions.controller';
 
@@ -25,6 +26,7 @@ import { SearchModule } from '../search/search.module';
     OrganisationVersionsService,
     ProfessionVersionsService,
     ProfessionsSearchService,
+    OrganisationsSearchService,
   ],
   controllers: [
     AdminOrganisationsController,

--- a/src/organisations/organisations.seeder.ts
+++ b/src/organisations/organisations.seeder.ts
@@ -5,6 +5,7 @@ import { Seeder } from 'nestjs-seeder';
 import { InjectRepository } from '@nestjs/typeorm';
 
 import { Organisation } from '../organisations/organisation.entity';
+import { OrganisationsSearchService } from '../organisations/organisations-search.service';
 import {
   OrganisationVersion,
   OrganisationVersionStatus,
@@ -38,6 +39,7 @@ export class OrganisationsSeeder implements Seeder {
     private readonly organisationsRepository: Repository<Organisation>,
     @InjectRepository(OrganisationVersion)
     private readonly organisationVersionsRepository: Repository<OrganisationVersion>,
+    private readonly searchService: OrganisationsSearchService,
   ) {}
 
   async seed(): Promise<any> {
@@ -94,7 +96,13 @@ export class OrganisationsSeeder implements Seeder {
       }),
     );
 
-    await this.organisationVersionsRepository.save(versions.flat());
+    const flattenedVersions = versions.flat();
+
+    await this.organisationVersionsRepository.save(flattenedVersions);
+
+    for (const version of flattenedVersions) {
+      await this.searchService.index(version);
+    }
   }
 
   async drop(): Promise<any> {

--- a/src/organisations/search/search.controller.spec.ts
+++ b/src/organisations/search/search.controller.spec.ts
@@ -57,7 +57,7 @@ describe('SearchController', () => {
 
   beforeEach(async () => {
     organisationVersionsService = createMock<OrganisationVersionsService>();
-    organisationVersionsService.allLive.mockResolvedValue([
+    organisationVersionsService.searchLive.mockResolvedValue([
       organisation1,
       organisation2,
     ]);
@@ -116,7 +116,7 @@ describe('SearchController', () => {
         expect(result).toEqual(expected);
       });
 
-      it('should request organisations populated with professions from `OrganisationVersionsService`', async () => {
+      it('should make a search request from `OrganisationVersionsService`', async () => {
         await controller.index(
           {
             keywords: '',
@@ -126,7 +126,11 @@ describe('SearchController', () => {
           request,
         );
 
-        expect(organisationVersionsService.allLive).toHaveBeenCalled();
+        expect(organisationVersionsService.searchLive).toHaveBeenCalledWith({
+          keywords: '',
+          industries: [],
+          nations: [],
+        });
       });
     });
 
@@ -148,111 +152,17 @@ describe('SearchController', () => {
         },
         Nation.all(),
         industries,
-        [],
-        i18nService,
-      ).present();
-
-      expect(result).toEqual(expected);
-    });
-
-    it('should return filtered organisations when searching by nation', async () => {
-      const result = await controller.index(
-        {
-          keywords: '',
-          industries: [],
-          nations: ['GB-SCT'],
-        },
-        request,
-      );
-
-      const expected = await new SearchPresenter(
-        {
-          keywords: '',
-          industries: [],
-          nations: [Nation.find('GB-SCT')],
-        },
-        Nation.all(),
-        industries,
-        [organisation1],
-        i18nService,
-      ).present();
-
-      expect(result).toEqual(expected);
-    });
-
-    it('should return filtered organisations when searching by industry', async () => {
-      const result = await controller.index(
-        {
-          keywords: '',
-          industries: [industry2.id],
-          nations: [],
-        },
-        request,
-      );
-
-      const expected = await new SearchPresenter(
-        {
-          keywords: '',
-          industries: [industry2],
-          nations: [],
-        },
-        Nation.all(),
-        industries,
-        [organisation2],
-        i18nService,
-      ).present();
-
-      expect(result).toEqual(expected);
-    });
-
-    it('should return filtered organisations when searching by keyword', async () => {
-      const result = await controller.index(
-        {
-          keywords: 'Medical',
-          industries: [],
-          nations: [],
-        },
-        request,
-      );
-
-      const expected = await new SearchPresenter(
-        {
-          keywords: 'Medical',
-          industries: [],
-          nations: [],
-        },
-        Nation.all(),
-        industries,
-        [organisation1],
-        i18nService,
-      ).present();
-
-      expect(result).toEqual(expected);
-    });
-
-    it('should return unfiltered organisations when no search parameters are specified', async () => {
-      const result = await controller.index(
-        {
-          keywords: '',
-          industries: [],
-          nations: [],
-        },
-        request,
-      );
-
-      const expected = await new SearchPresenter(
-        {
-          keywords: '',
-          industries: [],
-          nations: [],
-        },
-        Nation.all(),
-        industries,
         [organisation1, organisation2],
         i18nService,
       ).present();
 
       expect(result).toEqual(expected);
+
+      expect(organisationVersionsService.searchLive).toHaveBeenCalledWith({
+        keywords: 'example search',
+        industries: [industry1, industry2],
+        nations: [Nation.find('GB-NIR')],
+      });
     });
 
     it('should set the searchResultUrl', async () => {

--- a/src/organisations/search/search.controller.ts
+++ b/src/organisations/search/search.controller.ts
@@ -3,7 +3,6 @@ import { I18nService } from 'nestjs-i18n';
 import { Request } from 'express';
 import { IndustriesService } from '../../industries/industries.service';
 import { Nation } from '../../nations/nation';
-import { OrganisationsFilterHelper } from '../helpers/organisations-filter.helper';
 import { OrganisationVersionsService } from '../organisation-versions.service';
 
 import { FilterDto } from './dto/filter.dto';
@@ -33,17 +32,14 @@ export class SearchController {
     const allNations = Nation.all();
     const allIndustries = await this.industriesService.all();
 
-    const allOrganisations = await this.organisationVersionsService.allLive();
-
     const filterInput = createFilterInput({
       ...filter,
       allNations,
       allIndustries,
     });
 
-    const filteredOrganisations = new OrganisationsFilterHelper(
-      allOrganisations,
-    ).filter(filterInput);
+    const filteredOrganisations =
+      await this.organisationVersionsService.searchLive(filterInput);
 
     return new SearchPresenter(
       filterInput,

--- a/src/professions/professions.module.ts
+++ b/src/professions/professions.module.ts
@@ -25,6 +25,7 @@ import { ProfessionArchiveController } from './admin/profession-archive.controll
 import { OrganisationVersionsService } from '../organisations/organisation-versions.service';
 import { OrganisationVersion } from '../organisations/organisation-version.entity';
 import { ProfessionsSearchService } from './professions-search.service';
+import { OrganisationsSearchService } from '../organisations/organisations-search.service';
 import { SearchModule } from '../search/search.module';
 @Module({
   imports: [
@@ -41,6 +42,7 @@ import { SearchModule } from '../search/search.module';
     OrganisationsService,
     OrganisationVersionsService,
     ProfessionsSearchService,
+    OrganisationsSearchService,
     ProfessionVersionsService,
   ],
   controllers: [

--- a/src/seeder.ts
+++ b/src/seeder.ts
@@ -22,6 +22,8 @@ import { OrganisationVersion } from './organisations/organisation-version.entity
 import { ProfessionVersion } from './professions/profession-version.entity';
 
 import { ProfessionsSearchService } from './professions/professions-search.service';
+import { OrganisationsSearchService } from './organisations/organisations-search.service';
+
 import { SearchModule } from './search/search.module';
 
 seeder({
@@ -48,7 +50,7 @@ seeder({
     ]),
     SearchModule.register(),
   ],
-  providers: [ProfessionsSearchService],
+  providers: [ProfessionsSearchService, OrganisationsSearchService],
 }).run([
   IndustriesSeeder,
   QualificationsSeeder,


### PR DESCRIPTION
This moves the organisation search over to Opensearch and also allows us to search by the organisation's alternate name. Unlike professions, I've also moved the backend search over to Opensearch, which I think we should do with professions too. Once this has been done, there's a bunch of filtering code we can delete.

Hope this isn't too much of a monster to review. If it is, please shout and I can break it down into smaller chunks.