### PR TITLE
"Clear all filters" button & public search mobile improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Improve constraints around editing users
 - Improve constraints around editing organisations
 - Improve constraints around editing professions
+- Display number of results above filters on mobile
+- Hide filters on mobile once users have searched
 - Only allow users to edit a Profession if they are a central user, or in that Profession's primary Organisation
 
 ## [release-009] - 2022-03-11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Allow central users to filter Profession and Organisation listings by regulation type
 - Search profession keywords using Opensearch
 - Add a script to reindex professions in Opensearch
+- Add button for clearing all filters on public and internal pages
 
 ### Changed
 

--- a/assets/javascripts/application.js
+++ b/assets/javascripts/application.js
@@ -5,3 +5,12 @@ const { enableAutoPageviews } = Plausible();
 
 initAll();
 enableAutoPageviews();
+
+const detailsHeaderElements = document.getElementsByClassName(
+  'rpr-listing__filters-container rpr-listing__filters--searched',
+);
+const detailsHeader = detailsHeaderElements[0];
+
+if (window.screen.width < 480 && detailsHeader) {
+  detailsHeader.removeAttribute('open');
+}

--- a/assets/stylesheets/application.scss
+++ b/assets/stylesheets/application.scss
@@ -62,6 +62,20 @@ $small-screen: 768px;
   &__ra-summary-list dd {
     padding: 2px 0;
   }
+
+  &__results-found--mobile {
+    display: none;
+    @media screen and (max-width: $small-screen) {
+      display: block;
+    }
+  }
+
+  &__results-found--desktop {
+    display: block;
+    @media screen and (max-width: $small-screen) {
+      display: none;
+    }
+  }
 }
 
 .rpr-internal {

--- a/assets/stylesheets/application.scss
+++ b/assets/stylesheets/application.scss
@@ -42,6 +42,18 @@ $small-screen: 768px;
     overflow-y: auto;
   }
 
+  &__filters-details-summary {
+    display: none;
+    @media screen and (max-width: $small-screen) {
+      display: block;
+    }
+  }
+
+  &__filters-details-text {
+    border: 0;
+    padding-left: 0;
+  }
+
   &__search-criteria-container {
     margin-bottom: 5px;
   }

--- a/assets/stylesheets/application.scss
+++ b/assets/stylesheets/application.scss
@@ -140,7 +140,7 @@ $small-screen: 768px;
       color: govuk-colour('white');
     }
 
-    &__fitlers-details-summary {
+    &__filters-details-summary {
       display: block;
     }
   }

--- a/cypress/integration/admin/organisations/index.spec.ts
+++ b/cypress/integration/admin/organisations/index.spec.ts
@@ -184,6 +184,81 @@ describe('Listing organisations', () => {
         );
       });
     });
+
+    it('I can clear all filters', () => {
+      expandFilters();
+
+      cy.get('input[name="keywords"]').type('Medical');
+
+      cy.translate('industries.law').then((lawText) => {
+        cy.get('label')
+          .contains(lawText)
+          .parent()
+          .within(() => {
+            cy.get('input[name="industries[]"]').check();
+          });
+
+        cy.translate('professions.regulationTypes.licensing.name').then(
+          (nameLabel) => {
+            cy.get('label').contains(nameLabel).parent().find('input').check();
+          },
+        );
+
+        cy.translate('nations.wales').then((wales) => {
+          cy.get('label')
+            .contains(wales)
+            .parent()
+            .within(() => {
+              cy.get('input[name="nations[]"]').check();
+            });
+        });
+
+        clickFilterButtonAndCheckAccessibility();
+        expandFilters();
+
+        cy.translate('app.filters.clearAllButton').then((clearAllButton) => {
+          cy.get('a').contains(clearAllButton).click();
+        });
+        cy.checkAccessibility();
+        expandFilters();
+
+        cy.get('input[name="keywords"]').should('not.have.value', 'Medical');
+
+        cy.translate('nations.wales').then((wales) => {
+          cy.get('label')
+            .contains(wales)
+            .parent()
+            .within(() => {
+              cy.get('input[name="nations[]"]').should('not.be.checked');
+            });
+        });
+
+        cy.translate('industries.law').then((lawText) => {
+          cy.get('label')
+            .contains(lawText)
+            .parent()
+            .within(() => {
+              cy.get('input[name="industries[]"]').should('not.be.checked');
+            });
+        });
+
+        cy.translate('professions.regulationTypes.licensing.name').then(
+          (nameLabel) => {
+            cy.get('label')
+              .contains(nameLabel)
+              .parent()
+              .find('input')
+              .should('not.be.checked');
+          },
+        );
+
+        cy.checkCorrectNumberOfOrganisationsAreShown([
+          'live',
+          'draft',
+          'archived',
+        ]);
+      });
+    });
   });
 
   context('When I am logged in as an organisation admin', () => {
@@ -204,7 +279,7 @@ describe('Listing organisations', () => {
   });
 
   function clickFilterButtonAndCheckAccessibility(): void {
-    cy.translate('organisations.admin.filter.button').then((buttonLabel) => {
+    cy.translate('app.filters.filterButton').then((buttonLabel) => {
       cy.get('button').contains(buttonLabel).click();
     });
 

--- a/cypress/integration/admin/organisations/index.spec.ts
+++ b/cypress/integration/admin/organisations/index.spec.ts
@@ -13,7 +13,11 @@ describe('Listing organisations', () => {
     it('Lists all the organisations', () => {
       cy.readFile('./seeds/test/professions.json').then((professions) => {
         cy.readFile('./seeds/test/organisations.json').then((organisations) => {
-          let confirmedCount = 0;
+          cy.checkCorrectNumberOfOrganisationsAreShown([
+            'draft',
+            'live',
+            'archived',
+          ]);
 
           organisations.forEach((organisation) => {
             const latestVersion =
@@ -22,8 +26,6 @@ describe('Listing organisations', () => {
             if (latestVersion.status === 'unconfirmed') {
               cy.get('tr').should('not.contain', organisation.name);
             } else {
-              confirmedCount++;
-
               cy.get('tr')
                 .contains(organisation.name)
                 .then(($header) => {
@@ -59,12 +61,6 @@ describe('Listing organisations', () => {
                   });
                 });
             }
-          });
-
-          cy.translate('organisations.search.foundPlural', {
-            count: confirmedCount,
-          }).then((foundText) => {
-            cy.get('body').should('contain', foundText);
           });
         });
       });

--- a/cypress/integration/admin/professions/index.spec.ts
+++ b/cypress/integration/admin/professions/index.spec.ts
@@ -190,6 +190,71 @@ describe('Listing professions', () => {
         'Secondary School Teacher in State maintained schools (England)',
       );
     });
+
+    it('I can clear all filters and view the original search results', () => {
+      expandFilters();
+
+      cy.get('input[name="keywords"]').type('Attorney');
+
+      cy.get('input[name="nations[]"][value="GB-WLS"]').check();
+
+      cy.get('label')
+        .contains('Law Society of England and Wales')
+        .parent()
+        .find('input')
+        .check();
+
+      cy.translate('industries.education').then((nameLabel) => {
+        cy.get('label').contains(nameLabel).parent().find('input').check();
+      });
+
+      cy.translate('professions.regulationTypes.certification.name').then(
+        (nameLabel) => {
+          cy.get('label').contains(nameLabel).parent().find('input').check();
+        },
+      );
+
+      clickFilterButtonAndCheckAccessibility();
+
+      expandFilters();
+
+      cy.translate('app.filters.clearAllButton').then((clearAllButton) => {
+        cy.get('a').contains(clearAllButton).click();
+      });
+      cy.checkAccessibility();
+
+      cy.get('input[name="keywords"]').should('not.have.value', 'Attorney');
+
+      cy.get('input[name="nations[]"][value="GB-WLS"]').should(
+        'not.be.checked',
+      );
+
+      cy.get('label')
+        .contains('Law Society of England and Wales')
+        .parent()
+        .find('input')
+        .should('not.be.checked');
+
+      cy.translate('industries.education').then((nameLabel) => {
+        cy.get('label')
+          .contains(nameLabel)
+          .parent()
+          .find('input')
+          .should('not.be.checked');
+      });
+
+      cy.translate('professions.regulationTypes.certification.name').then(
+        (nameLabel) => {
+          cy.get('label')
+            .contains(nameLabel)
+            .parent()
+            .find('input')
+            .should('not.be.checked');
+        },
+      );
+
+      cy.checkCorrectNumberOfProfessionsAreShown(['draft', 'live', 'archived']);
+    });
   });
 
   context('When I am logged in as organisation editor', () => {
@@ -247,7 +312,7 @@ describe('Listing professions', () => {
   });
 
   function clickFilterButtonAndCheckAccessibility(): void {
-    cy.translate('professions.admin.filter.button').then((buttonLabel) => {
+    cy.translate('app.filters.filterButton').then((buttonLabel) => {
       cy.get('button').contains(buttonLabel).click();
     });
 

--- a/cypress/integration/admin/professions/index.spec.ts
+++ b/cypress/integration/admin/professions/index.spec.ts
@@ -6,48 +6,36 @@ describe('Listing professions', () => {
     });
 
     it('I can view an unfiltered list of draft, live and archived Professions', () => {
-      cy.readFile('./seeds/test/professions.json').then((professions) => {
-        const professionsToShow = professions.filter((profession) =>
-          profession.versions.some((version) =>
-            ['live', 'draft', 'archived'].includes(version.status),
-          ),
-        );
+      cy.checkCorrectNumberOfProfessionsAreShown(['draft', 'live', 'archived']);
 
-        cy.translate('professions.search.foundPlural', {
-          count: professionsToShow.length,
-        }).then((foundText) => {
-          cy.get('body').should('contain', foundText);
-        });
+      cy.translate('professions.admin.tableHeading.changedBy').then(
+        (changedBy) => {
+          cy.get('tr').eq(0).should('not.contain', changedBy);
+        },
+      );
 
-        cy.translate('professions.admin.tableHeading.changedBy').then(
-          (changedBy) => {
-            cy.get('tr').eq(0).should('not.contain', changedBy);
-          },
-        );
-
-        cy.translate('app.status.live').then((liveText) => {
-          cy.translate('app.status.draft').then((draftText) => {
-            cy.get('tr')
-              .contains('Registered Trademark Attorney')
-              .then(($header) => {
-                const $row = $header.parent();
-                cy.wrap($row).contains(liveText);
-              });
-            cy.get('tr')
-              .contains(
-                'Secondary School Teacher in State maintained schools (England)',
-              )
-              .then(($header) => {
-                const $row = $header.parent();
-                cy.wrap($row).contains(liveText);
-              });
-            cy.get('tr')
-              .contains('Gas Safe Engineer')
-              .then(($header) => {
-                const $row = $header.parent();
-                cy.wrap($row).contains(draftText);
-              });
-          });
+      cy.translate('app.status.live').then((liveText) => {
+        cy.translate('app.status.draft').then((draftText) => {
+          cy.get('tr')
+            .contains('Registered Trademark Attorney')
+            .then(($header) => {
+              const $row = $header.parent();
+              cy.wrap($row).contains(liveText);
+            });
+          cy.get('tr')
+            .contains(
+              'Secondary School Teacher in State maintained schools (England)',
+            )
+            .then(($header) => {
+              const $row = $header.parent();
+              cy.wrap($row).contains(liveText);
+            });
+          cy.get('tr')
+            .contains('Gas Safe Engineer')
+            .then(($header) => {
+              const $row = $header.parent();
+              cy.wrap($row).contains(draftText);
+            });
         });
       });
     });

--- a/cypress/integration/organisations/search/search.spec.ts
+++ b/cypress/integration/organisations/search/search.spec.ts
@@ -133,6 +133,58 @@ describe('Searching an organisation', () => {
         );
     });
   });
+
+  it('I can clear all filters', () => {
+    cy.get('input[name="keywords"]').type('Medical');
+
+    cy.translate('industries.law').then((lawText) => {
+      cy.get('label')
+        .contains(lawText)
+        .parent()
+        .within(() => {
+          cy.get('input[name="industries[]"]').check();
+        });
+
+      cy.translate('nations.wales').then((wales) => {
+        cy.get('label')
+          .contains(wales)
+          .parent()
+          .within(() => {
+            cy.get('input[name="nations[]"]').check();
+          });
+      });
+
+      cy.get('button').click();
+
+      cy.translate('app.filters.clearAllButton').then((clearAllButton) => {
+        cy.get('a').contains(clearAllButton).click();
+      });
+
+      cy.checkAccessibility();
+
+      cy.get('input[name="keywords"]').should('not.have.value', 'Medical');
+
+      cy.translate('nations.wales').then((wales) => {
+        cy.get('label')
+          .contains(wales)
+          .parent()
+          .within(() => {
+            cy.get('input[name="nations[]"]').should('not.be.checked');
+          });
+      });
+
+      cy.translate('industries.law').then((lawText) => {
+        cy.get('label')
+          .contains(lawText)
+          .parent()
+          .within(() => {
+            cy.get('input[name="industries[]"]').should('not.be.checked');
+          });
+      });
+
+      cy.checkCorrectNumberOfOrganisationsAreShown(['live']);
+    });
+  });
 });
 
 function checkResultLength(expectedLength: number): void {

--- a/cypress/integration/organisations/search/search.spec.ts
+++ b/cypress/integration/organisations/search/search.spec.ts
@@ -11,29 +11,19 @@ describe('Searching an organisation', () => {
   });
 
   it('I can view an unfiltered list of organisations', () => {
+    cy.checkCorrectNumberOfOrganisationsAreShown(['live']);
     cy.readFile('./seeds/test/organisations.json').then((organisations) => {
-      let liveCount = 0;
-
       organisations.forEach((organisation) => {
         const live = organisation.versions.some(
           (version) => version.status === 'live',
         );
 
         if (live) {
-          liveCount++;
           cy.get('body').should('contain', organisation.name);
         } else {
           cy.get('body').should('not.contain', organisation.name);
         }
       });
-
-      cy.translate('organisations.search.foundPlural', {
-        count: liveCount,
-      }).then((foundText) => {
-        cy.get('body').should('contain.text', foundText);
-      });
-
-      checkResultLength(liveCount);
     });
   });
 

--- a/cypress/integration/professions/search/search.spec.ts
+++ b/cypress/integration/professions/search/search.spec.ts
@@ -11,25 +11,13 @@ describe('Searching a profession', () => {
   });
 
   it('I can view an unfiltered list of live professions', () => {
-    cy.readFile('./seeds/test/professions.json').then((professions) => {
-      const professionsToShow = professions.filter((profession) =>
-        profession.versions.some((version) =>
-          ['live'].includes(version.status),
-        ),
-      );
-
-      cy.translate('professions.search.foundPlural', {
-        count: professionsToShow.length,
-      }).then((foundText) => {
-        cy.get('body').should('contain.text', foundText);
-      });
-      cy.get('body').should('contain', 'Registered Trademark Attorney');
-      cy.get('body').should(
-        'contain',
-        'Secondary School Teacher in State maintained schools (England)',
-      );
-      cy.get('body').should('not.contain', 'Gas Safe Engineer');
-    });
+    cy.checkCorrectNumberOfProfessionsAreShown(['live']);
+    cy.get('body').should('contain', 'Registered Trademark Attorney');
+    cy.get('body').should(
+      'contain',
+      'Secondary School Teacher in State maintained schools (England)',
+    );
+    cy.get('body').should('not.contain', 'Gas Safe Engineer');
   });
 
   it('Professions are sorted alphabetically', () => {

--- a/cypress/integration/professions/search/search.spec.ts
+++ b/cypress/integration/professions/search/search.spec.ts
@@ -138,4 +138,36 @@ describe('Searching a profession', () => {
         );
     });
   });
+
+  it('I can clear all filters', () => {
+    cy.get('input[name="nations[]"][value="GB-WLS"]').check();
+
+    cy.translate('industries.education').then((nameLabel) => {
+      cy.get('label').contains(nameLabel).parent().find('input').check();
+    });
+
+    cy.get('input[name="keywords"]').type('Attorney');
+
+    cy.get('button').click();
+    cy.checkAccessibility();
+
+    cy.translate('app.filters.clearAllButton').then((clearAllButton) => {
+      cy.get('a').contains(clearAllButton).click();
+    });
+    cy.checkAccessibility();
+
+    cy.get('input[name="keywords"]').should('not.have.value', 'Attorney');
+
+    cy.get('input[name="nations[]"][value="GB-WLS"]').should('not.be.checked');
+
+    cy.translate('industries.education').then((nameLabel) => {
+      cy.get('label')
+        .contains(nameLabel)
+        .parent()
+        .find('input')
+        .should('not.be.checked');
+    });
+
+    cy.checkCorrectNumberOfProfessionsAreShown(['live']);
+  });
 });

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -223,6 +223,25 @@ Cypress.Commands.add(
   },
 );
 
+Cypress.Commands.add(
+  'checkCorrectNumberOfOrganisationsAreShown',
+  (statuses: ('live' | 'archived' | 'draft')[]) => {
+    cy.readFile('./seeds/test/organisations.json').then((organisations) => {
+      const organisationsToShow = organisations.filter((organisation) =>
+        organisation.versions.some((version) =>
+          statuses.includes(version.status),
+        ),
+      );
+
+      cy.translate('organisations.search.foundPlural', {
+        count: organisationsToShow.length,
+      }).then((foundText) => {
+        cy.get('body').should('contain', foundText);
+      });
+    });
+  },
+);
+
 Cypress.Commands.add('visitAndCheckAccessibility', (url: string) => {
   cy.visit(url);
   cy.checkAccessibility();

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -204,6 +204,25 @@ Cypress.Commands.add(
   },
 );
 
+Cypress.Commands.add(
+  'checkCorrectNumberOfProfessionsAreShown',
+  (statuses: ('live' | 'archived' | 'draft')[]) => {
+    cy.readFile('./seeds/test/professions.json').then((professions) => {
+      const professionsToShow = professions.filter((profession) =>
+        profession.versions.some((version) =>
+          statuses.includes(version.status),
+        ),
+      );
+
+      cy.translate('professions.search.foundPlural', {
+        count: professionsToShow.length,
+      }).then((foundText) => {
+        cy.get('body').should('contain', foundText);
+      });
+    });
+  },
+);
+
 Cypress.Commands.add('visitAndCheckAccessibility', (url: string) => {
   cy.visit(url);
   cy.checkAccessibility();

--- a/cypress/support/index.ts
+++ b/cypress/support/index.ts
@@ -61,6 +61,9 @@ declare global {
       checkCorrectNumberOfProfessionsAreShown(
         statuses: ('live' | 'archived' | 'draft')[],
       ): Chainable<string>;
+      checkCorrectNumberOfOrganisationsAreShown(
+        statuses: ('live' | 'archived' | 'draft')[],
+      ): Chainable<string>;
       visitAndCheckAccessibility(url: string): void;
       checkAccessibility(rules?: AxeRules): void;
     }

--- a/cypress/support/index.ts
+++ b/cypress/support/index.ts
@@ -58,6 +58,9 @@ declare global {
         listItems: string[],
       ): Chainable<string>;
       clickSummaryListRowAction(key: string, action: string): Chainable<string>;
+      checkCorrectNumberOfProfessionsAreShown(
+        statuses: ('live' | 'archived' | 'draft')[],
+      ): Chainable<string>;
       visitAndCheckAccessibility(url: string): void;
       checkAccessibility(rules?: AxeRules): void;
     }

--- a/src/i18n/en/app.json
+++ b/src/i18n/en/app.json
@@ -90,5 +90,9 @@
     "live": "Published",
     "draft": "Draft",
     "archived": "Archived"
+  },
+  "filters": {
+    "filterButton": "Filter results",
+    "clearAllButton": "Clear all filters"
   }
 }

--- a/src/i18n/en/organisations.json
+++ b/src/i18n/en/organisations.json
@@ -26,8 +26,7 @@
       "regulationTypes": {
         "label": "Regulation types",
         "hint": "Select all that apply."
-      },
-      "button": "Filter results"
+      }
     },
     "edit": {
       "heading": "Amending a regulatory authority - {organisationName}",

--- a/src/i18n/en/professions.json
+++ b/src/i18n/en/professions.json
@@ -245,8 +245,7 @@
       "regulationTypes": {
         "label": "Regulation types",
         "hint": "Select all that apply."
-      },
-      "button": "Filter results"
+      }
     },
     "tableHeading": {
       "profession": "Profession",

--- a/src/organisations/search/interfaces/index-template.interface.ts
+++ b/src/organisations/search/interfaces/index-template.interface.ts
@@ -13,4 +13,6 @@ export interface IndexTemplate {
   nationsCheckboxItems: CheckboxItems[];
 
   industriesCheckboxItems: CheckboxItems[];
+
+  hasSelectedFilters: boolean;
 }

--- a/src/organisations/search/search.presenter.spec.ts
+++ b/src/organisations/search/search.presenter.spec.ts
@@ -10,6 +10,9 @@ import { IndexTemplate } from './interfaces/index-template.interface';
 import { OrganisationSearchResultPresenter } from './organisation-search-result.presenter';
 import organisationFactory from '../../testutils/factories/organisation';
 import industryFactory from '../../testutils/factories/industry';
+import { hasSelectedFilters } from '../../search/helpers/has-selected-filters.helper';
+
+jest.mock('../../search/helpers/has-selected-filters.helper');
 
 const organisation1 = organisationFactory.build({
   name: 'Example Organisation 1',
@@ -62,6 +65,7 @@ describe('SearchPresenter', () => {
         i18nService,
       );
 
+      (hasSelectedFilters as jest.Mock).mockReturnValue(true);
       const result = await presenter.present();
 
       const industriesCheckboxItems = await new IndustriesCheckboxPresenter(
@@ -89,7 +93,10 @@ describe('SearchPresenter', () => {
           await new OrganisationSearchResultPresenter(organisation2).present(),
           await new OrganisationSearchResultPresenter(organisation3).present(),
         ],
+        hasSelectedFilters: true,
       };
+
+      expect(hasSelectedFilters).toHaveBeenCalledWith(filterInput);
 
       expect(result).toEqual(expected);
     });

--- a/src/organisations/search/search.presenter.ts
+++ b/src/organisations/search/search.presenter.ts
@@ -7,6 +7,7 @@ import { FilterInput } from '../../common/interfaces/filter-input.interface';
 import { IndexTemplate } from './interfaces/index-template.interface';
 import { OrganisationSearchResultPresenter } from './organisation-search-result.presenter';
 import { Organisation } from '../organisation.entity';
+import { hasSelectedFilters } from '../../search/helpers/has-selected-filters.helper';
 
 export class SearchPresenter {
   constructor(
@@ -47,6 +48,7 @@ export class SearchPresenter {
           (industry) => industry.name,
         ),
       },
+      hasSelectedFilters: hasSelectedFilters(this.filterInput),
     };
   }
 }

--- a/src/professions/admin/list-entry.presenter.spec.ts
+++ b/src/professions/admin/list-entry.presenter.spec.ts
@@ -71,7 +71,7 @@ describe('ListEntryPresenter', () => {
 
           { html: 'Published' },
           {
-            html: `<a href="/admin/professions/profession-id/versions/version-id">${translationOf(
+            html: `<a class="govuk-link" href="/admin/professions/profession-id/versions/version-id">${translationOf(
               'professions.admin.viewDetails',
             )}</a>`,
           },
@@ -126,7 +126,7 @@ describe('ListEntryPresenter', () => {
           { text: 'Editor' },
           { html: 'Draft' },
           {
-            html: `<a href="/admin/professions/profession-id/versions/version-id">${translationOf(
+            html: `<a class="govuk-link" href="/admin/professions/profession-id/versions/version-id">${translationOf(
               'professions.admin.viewDetails',
             )}</a>`,
           },
@@ -183,7 +183,7 @@ describe('ListEntryPresenter', () => {
           { text: 'Editor' },
           { html: 'Archived' },
           {
-            html: `<a href="/admin/professions/profession-id/versions/version-id">${translationOf(
+            html: `<a class="govuk-link" href="/admin/professions/profession-id/versions/version-id">${translationOf(
               'professions.admin.viewDetails',
             )}</a>`,
           },

--- a/src/professions/admin/list-entry.presenter.ts
+++ b/src/professions/admin/list-entry.presenter.ts
@@ -84,7 +84,7 @@ export class ListEntryPresenter {
       )
     ).join(', ');
 
-    const viewDetails = `<a href="/admin/professions/${
+    const viewDetails = `<a class="govuk-link" href="/admin/professions/${
       this.profession.id
     }/versions/${this.profession.versionId}">${await this.i18nService.translate(
       'professions.admin.viewDetails',

--- a/src/professions/search/interfaces/index-template.interface.ts
+++ b/src/professions/search/interfaces/index-template.interface.ts
@@ -13,4 +13,6 @@ export interface IndexTemplate {
   nationsCheckboxItems: CheckboxItems[];
 
   industriesCheckboxItems: CheckboxItems[];
+
+  hasSelectedFilters: boolean;
 }

--- a/src/professions/search/search.presenter.spec.ts
+++ b/src/professions/search/search.presenter.spec.ts
@@ -10,6 +10,9 @@ import industryFactory from '../../testutils/factories/industry';
 import professionFactory from '../../testutils/factories/profession';
 import { createMockI18nService } from '../../testutils/create-mock-i18n-service';
 import { IndexTemplate } from './interfaces/index-template.interface';
+import { hasSelectedFilters } from '../../search/helpers/has-selected-filters.helper';
+
+jest.mock('../../search/helpers/has-selected-filters.helper');
 
 const industry1 = industryFactory.build({
   name: 'industries.example1',
@@ -68,6 +71,7 @@ describe('SearchPresenter', () => {
         i18nService,
       );
 
+      (hasSelectedFilters as jest.Mock).mockReturnValue(true);
       const result = await presenter.present();
 
       const industriesCheckboxItems = await new IndustriesCheckboxPresenter(
@@ -104,7 +108,10 @@ describe('SearchPresenter', () => {
             i18nService,
           ).present(),
         ],
+        hasSelectedFilters: true,
       };
+
+      expect(hasSelectedFilters).toHaveBeenCalledWith(filterInput);
 
       expect(result).toEqual(expected);
     });

--- a/src/professions/search/search.presenter.ts
+++ b/src/professions/search/search.presenter.ts
@@ -7,6 +7,7 @@ import { Profession } from '../profession.entity';
 import { FilterInput } from '../../common/interfaces/filter-input.interface';
 import { IndexTemplate } from './interfaces/index-template.interface';
 import { ProfessionSearchResultPresenter } from './profession-search-result.presenter';
+import { hasSelectedFilters } from '../../search/helpers/has-selected-filters.helper';
 
 export class SearchPresenter {
   constructor(
@@ -50,6 +51,7 @@ export class SearchPresenter {
           (industry) => industry.name,
         ),
       },
+      hasSelectedFilters: hasSelectedFilters(this.filterInput),
     };
   }
 }

--- a/src/search/helpers/has-selected-filters.helper.spec.ts
+++ b/src/search/helpers/has-selected-filters.helper.spec.ts
@@ -1,0 +1,88 @@
+import { FilterInput } from '../../common/interfaces/filter-input.interface';
+import { Nation } from '../../nations/nation';
+import { RegulationType } from '../../professions/profession-version.entity';
+import industryFactory from '../../testutils/factories/industry';
+import organisationFactory from '../../testutils/factories/organisation';
+import { hasSelectedFilters } from './has-selected-filters.helper';
+
+describe('hasSelectedFilters', () => {
+  describe('when a keyword is entered', () => {
+    it('sets hasSelectedFilters to true', async () => {
+      const filterInput: FilterInput = {
+        nations: [],
+        industries: [],
+        keywords: 'Example Keywords',
+      };
+
+      expect(hasSelectedFilters(filterInput)).toEqual(true);
+    });
+  });
+
+  describe('when a nation is selected', () => {
+    it('sets hasSelectedFilters to true', async () => {
+      const filterInput: FilterInput = {
+        nations: [{} as Nation],
+        industries: [],
+        keywords: '',
+      };
+
+      expect(hasSelectedFilters(filterInput)).toEqual(true);
+    });
+  });
+
+  describe('when an industry is selected', () => {
+    it('sets hasSelectedFilters to true', async () => {
+      const filterInput: FilterInput = {
+        nations: [],
+        industries: [industryFactory.build()],
+        keywords: '',
+        organisations: undefined,
+        regulationTypes: undefined,
+      };
+
+      expect(hasSelectedFilters(filterInput)).toEqual(true);
+    });
+  });
+
+  describe('when an organisation is selected', () => {
+    it('sets hasSelectedFilters to true', async () => {
+      const filterInput: FilterInput = {
+        nations: [],
+        industries: [],
+        keywords: '',
+        organisations: [organisationFactory.build()],
+        regulationTypes: undefined,
+      };
+
+      expect(hasSelectedFilters(filterInput)).toEqual(true);
+    });
+  });
+
+  describe('when a regulation type is selected', () => {
+    it('sets hasSelectedFilters to true', async () => {
+      const filterInput: FilterInput = {
+        nations: [],
+        industries: [],
+        keywords: '',
+        organisations: undefined,
+        regulationTypes: [RegulationType.Licensing],
+      };
+
+      expect(hasSelectedFilters(filterInput)).toEqual(true);
+    });
+  });
+
+  describe('when no filters are selected', () => {
+    it('sets hasSelectedFilters to false', async () => {
+      const filterInput: FilterInput = {
+        nations: [],
+        industries: [],
+        keywords: '',
+        organisations: undefined,
+        regulationTypes: undefined,
+      };
+
+      expect(hasSelectedFilters(filterInput)).toEqual(false);
+    });
+  });
+});

--- a/src/search/helpers/has-selected-filters.helper.ts
+++ b/src/search/helpers/has-selected-filters.helper.ts
@@ -1,0 +1,11 @@
+import { FilterInput } from '../../common/interfaces/filter-input.interface';
+
+export function hasSelectedFilters(filterInput: FilterInput): boolean {
+  return (
+    filterInput.keywords?.length > 0 ||
+    filterInput.industries?.length > 0 ||
+    filterInput.nations?.length > 0 ||
+    filterInput.organisations?.length > 0 ||
+    filterInput.regulationTypes?.length > 0
+  );
+}

--- a/views/admin/organisations/index.njk
+++ b/views/admin/organisations/index.njk
@@ -43,6 +43,7 @@
 
         {% ifAsync view === 'overview' %}
           {% set filterTextPrefix = "organisations.admin" %}
+          {% set emptyFiltersHref = "/admin/organisations" %}
           {% include "../../shared/_horizontal-filter.njk" %}
         {% endif %}
     </div>

--- a/views/admin/professions/index.njk
+++ b/views/admin/professions/index.njk
@@ -39,6 +39,7 @@
         {% set regulationTypesCheckboxItems = false %}
       {% endif %}
       {% set filterTextPrefix = "professions.admin" %}
+      {% set emptyFiltersHref = "/admin/professions" %}
       {% include "../../shared/_horizontal-filter.njk" %}
     </div>
   </div>

--- a/views/organisations/search/index.njk
+++ b/views/organisations/search/index.njk
@@ -9,6 +9,14 @@
 
     <div class="govuk-grid-column-one-third">
 
+      <p class="govuk-body-m rpr-listing__results-found--mobile">
+        {% if (organisations.length === 1) %}
+          {{ ("organisations.search.foundSingular" | t({ count: "<span class='govuk-!-font-size-36 govuk-!-font-weight-bold'>" + organisations.length + "</span>" }) | safe) }}
+        {% else %}
+          {{ ("organisations.search.foundPlural" | t({ count: "<span class='govuk-!-font-size-36 govuk-!-font-weight-bold'>" + organisations.length + "</span>" }) | safe) }}
+        {% endif %}
+      </p>
+
       {% set filterTextPrefix = "organisations.search" %}
       {% include "../../shared/_vertical-filter.njk" %}
 
@@ -19,7 +27,7 @@
       {% set filterCriteriaTextPrefix = "organisations.search" %}
       {% include "../../shared/_filter-criteria.njk" %}
 
-      <p class="govuk-body-m">
+      <p class="govuk-body-m rpr-listing__results-found--desktop">
         {% if (organisations.length === 1) %}
           {{ ("organisations.search.foundSingular" | t({ count: "<span class='govuk-!-font-size-36 govuk-!-font-weight-bold'>" + organisations.length + "</span>" }) | safe) }}
         {% else %}

--- a/views/organisations/search/index.njk
+++ b/views/organisations/search/index.njk
@@ -18,6 +18,7 @@
       </p>
 
       {% set filterTextPrefix = "organisations.search" %}
+      {% set emptyFiltersHref = "/regulatory-authorities/search" %}
       {% include "../../shared/_vertical-filter.njk" %}
 
     </div>

--- a/views/professions/search/index.njk
+++ b/views/professions/search/index.njk
@@ -18,6 +18,7 @@
       </p>
 
       {% set filterTextPrefix = "professions.search" %}
+      {% set emptyFiltersHref = "/professions/search" %}
       {% include "../../shared/_vertical-filter.njk" %}
 
     </div>

--- a/views/professions/search/index.njk
+++ b/views/professions/search/index.njk
@@ -9,6 +9,14 @@
 
     <div class="govuk-grid-column-one-third">
 
+      <p class="govuk-body-m rpr-listing__results-found--mobile">
+        {% if (professions.length === 1) %}
+          {{ ("professions.search.foundSingular" | t({ count: "<span class='govuk-!-font-size-36 govuk-!-font-weight-bold'>" + professions.length + "</span>" }) | safe) }}
+        {% else %}
+          {{ ("professions.search.foundPlural" | t({ count: "<span class='govuk-!-font-size-36 govuk-!-font-weight-bold'>" + professions.length + "</span>" }) | safe) }}
+        {% endif %}
+      </p>
+
       {% set filterTextPrefix = "professions.search" %}
       {% include "../../shared/_vertical-filter.njk" %}
 
@@ -19,7 +27,7 @@
       {% set filterCriteriaTextPrefix = "professions.search" %}
       {% include "../../shared/_filter-criteria.njk" %}
 
-      <p class="govuk-body-m">
+      <p class="govuk-body-m rpr-listing__results-found--desktop">
         {% if (professions.length === 1) %}
           {{ ("professions.search.foundSingular" | t({ count: "<span class='govuk-!-font-size-36 govuk-!-font-weight-bold'>" + professions.length + "</span>" }) | safe) }}
         {% else %}

--- a/views/shared/_filter.njk
+++ b/views/shared/_filter.njk
@@ -4,7 +4,7 @@
 
 <form action="" method="get" class="form">
   <div class="{{ filterRowClass }}">
-     <div class="{{ filterColumnClass }}">
+    <div class="{{ filterColumnClass }}">
       {{ govukInput({
         label: {
           text: (filterTextPrefix + ".filter.keywords.label") | t,
@@ -100,8 +100,11 @@
 
   <div class="{{ filterRowClass }}">
     <div class="{{ filterButtonColumnClass }}">
+      <p class="govuk-body-m">
+        <a class="govuk-link" href="{{emptyFiltersHref}}">{{"app.filters.clearAllButton" | t}}</a>
+      </p>
       {{ govukButton({
-        text: (filterTextPrefix + ".filter.button") | t,
+        text: "app.filters.filterButton" | t,
         classes: filterButtonClasses
       }) }}
     </div>

--- a/views/shared/_horizontal-filter.njk
+++ b/views/shared/_horizontal-filter.njk
@@ -27,7 +27,7 @@
 
 <div class="rpr-internal-listing__filters-container">
   <details class="govuk-details" data-module="govuk-details">
-    <summary class="govuk-details__summary rpr-internal-listing__fitlers-details-summary">
+    <summary class="govuk-details__summary rpr-internal-listing__filters-details-summary">
       <span class="govuk-details__summary-text">{{ "professions.admin.showFilters" | t }}</span>
     </summary>
     <div class="govuk-details__text">

--- a/views/shared/_vertical-filter.njk
+++ b/views/shared/_vertical-filter.njk
@@ -1,7 +1,12 @@
 {% set filterKeywordsWidthClass = 'govuk-input--width-10%' %}
 {% set filterCheckboxClasses = 'govuk-checkboxes--small rpr-listing__filter' %}
 
-<div class="rpr-listing__filters-container">
-  {% include "./_filter.njk" %}
-</div>
+<details class="govuk-details rpr-listing__filters-container" data-module="govuk-details" open="open">
+  <summary class="govuk-details__summary rpr-listing__filters-details-summary">
+    <span class="govuk-details__summary-text">{{ "professions.admin.showFilters" | t }}</span>
+  </summary>
+  <div class="govuk-details__text rpr-listing__filters-details-text">
+    {% include "./_filter.njk" %}
+  </div>
+</details>
 <div class="govuk-!-padding-bottom-9"></div>

--- a/views/shared/_vertical-filter.njk
+++ b/views/shared/_vertical-filter.njk
@@ -1,7 +1,7 @@
 {% set filterKeywordsWidthClass = 'govuk-input--width-10%' %}
 {% set filterCheckboxClasses = 'govuk-checkboxes--small rpr-listing__filter' %}
 
-<details class="govuk-details rpr-listing__filters-container" data-module="govuk-details" open="open">
+<details class="govuk-details rpr-listing__filters-container {{ 'rpr-listing__filters--searched' if hasSelectedFilters }}" data-module="govuk-details" open>
   <summary class="govuk-details__summary rpr-listing__filters-details-summary">
     <span class="govuk-details__summary-text">{{ "professions.admin.showFilters" | t }}</span>
   </summary>


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR

- Adds "Clear all filters" button for internal and public-facing index pages
- Moves number of results above filters on mobile view
- Collapses filters when users have searched on the public facing site on mobile
- Adds "govuk-link" to "View details" links internally

## Screenshots of UI changes

### Before

#### No clear all filters on admin pages

![image](https://user-images.githubusercontent.com/19826940/159502477-82f03387-3a66-4023-b132-cbf4556d43a9.png)

![image](https://user-images.githubusercontent.com/19826940/159502570-4eecb2d5-0e63-4f09-9d7e-cb666d7a6c4a.png)


#### Pre-search on mobile

![image](https://user-images.githubusercontent.com/19826940/159501790-fc8b1c16-2902-4fd8-8976-dda8555399a9.png)


### After

#### Clear all filters on admin pages

![image](https://user-images.githubusercontent.com/19826940/159502809-f868dcc4-80b3-473d-8891-ac5a0d154225.png)

![image](https://user-images.githubusercontent.com/19826940/159502742-581814ff-269e-47ab-b502-3aa313990d88.png)


#### Pre-search on mobile

![image](https://user-images.githubusercontent.com/19826940/159501286-a2a7da3f-ef12-4a6c-b8b2-b00756a0b4ec.png)

#### Post-search on mobile

![image](https://user-images.githubusercontent.com/19826940/159501694-3c5ff939-253d-4f1e-8e7e-ca7d1b1dfd3f.png)

