### PR TITLE
(2170) Ensure profession and org views go back to search results

### DIFF
--- a/cypress/integration/organisations/search/search.spec.ts
+++ b/cypress/integration/organisations/search/search.spec.ts
@@ -112,6 +112,30 @@ describe('Searching an organisation', () => {
     cy.get('body').should('contain', 'Council of Registered Gas Installers');
     checkResultLength(1);
   });
+
+  it('I can use the back button to go back to my search results', () => {
+    cy.get('input[name="keywords"]').type('Education');
+
+    cy.translate('industries.education').then((nameLabel) => {
+      cy.get('label').contains(nameLabel).parent().find('input').check();
+    });
+
+    cy.get('input[name="nations[]"][value="GB-ENG"]').check();
+
+    cy.get('button').click();
+
+    cy.get('a').contains('Department for Education').click();
+
+    cy.translate('app.backToSearch').then((label) => {
+      cy.get('[data-cy=back-link]').should('contain', label);
+      cy.get('[data-cy=back-link]')
+        .invoke('attr', 'href')
+        .should(
+          'match',
+          /regulatory-authorities\/search\?keywords=Education&industries%5B%5D=.+&nations%5B%5D=GB-ENG/,
+        );
+    });
+  });
 });
 
 function checkResultLength(expectedLength: number): void {

--- a/cypress/integration/organisations/show.spec.ts
+++ b/cypress/integration/organisations/show.spec.ts
@@ -22,6 +22,10 @@ describe('Showing organisations', () => {
         cy.get('body').should('contain', version.email);
         cy.get('body').should('contain', version.url);
 
+        cy.translate('app.backToSearch').then((backLink) => {
+          cy.get('body').should('contain', backLink);
+        });
+
         const professionsForOrganisation = professions.filter(
           (profession: any) => profession.organisation == organisation.name,
         );

--- a/cypress/integration/organisations/show.spec.ts
+++ b/cypress/integration/organisations/show.spec.ts
@@ -38,9 +38,7 @@ describe('Showing organisations', () => {
         cy.checkAccessibility();
         cy.get('body').should('not.contain', 'Edit this profession');
         cy.get('[data-cy=back-link]').click();
-        // This should really go back to the organisation page itself
-        // but we'll fix that in a future piece of work
-        cy.translate('professions.search.heading').then((heading) => {
+        cy.translate('organisations.search.heading').then((heading) => {
           cy.contains(heading);
         });
       });

--- a/cypress/integration/professions/search/search.spec.ts
+++ b/cypress/integration/professions/search/search.spec.ts
@@ -122,4 +122,32 @@ describe('Searching a profession', () => {
       'Secondary School Teacher in State maintained schools (England)',
     );
   });
+
+  it('I can use the back button to go back to my search results', () => {
+    cy.get('input[name="keywords"]').type('Education');
+
+    cy.translate('industries.education').then((nameLabel) => {
+      cy.get('label').contains(nameLabel).parent().find('input').check();
+    });
+
+    cy.get('input[name="nations[]"][value="GB-ENG"]').check();
+
+    cy.get('button').click();
+
+    cy.get('a')
+      .contains(
+        'Secondary School Teacher in State maintained schools (England)',
+      )
+      .click();
+
+    cy.translate('app.backToSearch').then((label) => {
+      cy.get('[data-cy=back-link]').should('contain', label);
+      cy.get('[data-cy=back-link]')
+        .invoke('attr', 'href')
+        .should(
+          'match',
+          /professions\/search\?keywords=Education&industries%5B%5D=.+&nations%5B%5D=GB-ENG/,
+        );
+    });
+  });
 });

--- a/cypress/integration/professions/show.spec.ts
+++ b/cypress/integration/professions/show.spec.ts
@@ -2,6 +2,10 @@ describe('Showing a profession', () => {
   it('I can view a profession', () => {
     cy.visitAndCheckAccessibility('/professions/registered-trademark-attorney');
 
+    cy.translate('app.backToSearch').then((backLink) => {
+      cy.get('body').should('contain', backLink);
+    });
+
     cy.get('body').should('contain', 'Registered Trademark Attorney');
 
     cy.translate('professions.show.overview.heading').then((heading) => {

--- a/src/common/back-link.interceptor.spec.ts
+++ b/src/common/back-link.interceptor.spec.ts
@@ -111,6 +111,17 @@ describe('BackLinkInterceptor', () => {
         expect(response.locals.backLink).toEqual('/foo/123');
       });
     });
+
+    describe('when the generator conditional returns undefined', () => {
+      it('should make the backlink undefined', () => {
+        const generator = () => undefined;
+        const interceptor = new BackLinkInterceptor(generator);
+
+        interceptor.intercept(context, next);
+
+        expect(response.locals.backLink).toEqual(undefined);
+      });
+    });
   });
 
   describe('when a link title is specified', () => {

--- a/src/common/back-link.interceptor.spec.ts
+++ b/src/common/back-link.interceptor.spec.ts
@@ -112,4 +112,17 @@ describe('BackLinkInterceptor', () => {
       });
     });
   });
+
+  describe('when a link title is specified', () => {
+    it('should add the backLink and the title to the call handler', () => {
+      const backLink = '/foo/bar';
+      const linkTitle = 'foo/bar';
+      const interceptor = new BackLinkInterceptor(backLink, linkTitle);
+
+      interceptor.intercept(context, next);
+
+      expect(response.locals.backLink).toEqual(backLink);
+      expect(response.locals.linkTitle).toEqual(linkTitle);
+    });
+  });
 });

--- a/src/common/back-link.interceptor.ts
+++ b/src/common/back-link.interceptor.ts
@@ -15,14 +15,17 @@ export type Generator = (request: Request) => string;
 @Injectable()
 export class BackLinkInterceptor<T> implements NestInterceptor<T, Response<T>> {
   private readonly backLink: string;
+  private readonly linkTitle: string;
   private readonly generator: Generator;
 
-  constructor(arg: string | Generator) {
+  constructor(arg: string | Generator, linkTitle = '') {
     if (typeof arg === 'string') {
       this.backLink = arg;
     } else {
       this.generator = arg;
     }
+
+    this.linkTitle = linkTitle;
   }
 
   intercept(
@@ -33,6 +36,7 @@ export class BackLinkInterceptor<T> implements NestInterceptor<T, Response<T>> {
     const response = context.switchToHttp().getResponse();
 
     response.locals.backLink = this.generateBackLink(request);
+    response.locals.linkTitle = this.linkTitle;
 
     return next.handle();
   }

--- a/src/common/back-link.interceptor.ts
+++ b/src/common/back-link.interceptor.ts
@@ -46,15 +46,17 @@ export class BackLinkInterceptor<T> implements NestInterceptor<T, Response<T>> {
 
     let backLink = this.backLink ? this.backLink : this.generator(request);
 
-    const matches = [...backLink.matchAll(regexp)];
+    if (backLink) {
+      const matches = [...backLink.matchAll(regexp)];
 
-    matches.forEach((match) => {
-      const key = match[1];
-      if (request.params[key]) {
-        backLink = backLink.replace(`:${key}`, request.params[key]);
-      }
-    });
+      matches.forEach((match) => {
+        const key = match[1];
+        if (request.params[key]) {
+          backLink = backLink.replace(`:${key}`, request.params[key]);
+        }
+      });
 
-    return backLink;
+      return backLink;
+    }
   }
 }

--- a/src/common/decorators/back-link.decorator.ts
+++ b/src/common/decorators/back-link.decorator.ts
@@ -1,5 +1,5 @@
 import { UseInterceptors } from '@nestjs/common';
 import { BackLinkInterceptor, Generator } from '../back-link.interceptor';
 
-export const BackLink = (arg: string | Generator) =>
-  UseInterceptors(new BackLinkInterceptor(arg));
+export const BackLink = (arg: string | Generator, linkTitle = '') =>
+  UseInterceptors(new BackLinkInterceptor(arg, linkTitle));

--- a/src/i18n/en/app.json
+++ b/src/i18n/en/app.json
@@ -2,6 +2,7 @@
   "name": "Regulated Professions Register",
   "superadmin": "You are a superadmin",
   "back": "Back",
+  "backToSearch": "Back to search results",
   "continue": "Continue",
   "change": "Change",
   "start": "Start",

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,0 +1,11 @@
+declare global {
+  interface Session {
+    searchResultUrl?: string;
+  }
+  namespace Express {
+    interface Request {
+      session: Session;
+    }
+  }
+}
+export {};

--- a/src/organisations/organisations.controller.ts
+++ b/src/organisations/organisations.controller.ts
@@ -14,7 +14,7 @@ export class OrganisationsController {
 
   @Get('/regulatory-authorities/:slug')
   @Render('organisations/show')
-  @BackLink('/regulatory-authorities/search')
+  @BackLink('/regulatory-authorities/search', 'app.backToSearch')
   async show(@Param('slug') slug: string): Promise<ShowTemplate> {
     const organisation = await this.organisationVersionsService.findLiveBySlug(
       slug,

--- a/src/organisations/organisations.controller.ts
+++ b/src/organisations/organisations.controller.ts
@@ -1,5 +1,6 @@
 import { Controller, Get, Render, Param } from '@nestjs/common';
 import { I18nService } from 'nestjs-i18n';
+import { Request } from 'express';
 
 import { OrganisationVersionsService } from './organisation-versions.service';
 import { ShowTemplate } from './interfaces/show-template.interface';
@@ -14,7 +15,10 @@ export class OrganisationsController {
 
   @Get('/regulatory-authorities/:slug')
   @Render('organisations/show')
-  @BackLink('/regulatory-authorities/search', 'app.backToSearch')
+  @BackLink(
+    (request: Request) => request.session.searchResultUrl,
+    'app.backToSearch',
+  )
   async show(@Param('slug') slug: string): Promise<ShowTemplate> {
     const organisation = await this.organisationVersionsService.findLiveBySlug(
       slug,

--- a/src/organisations/search/search.controller.ts
+++ b/src/organisations/search/search.controller.ts
@@ -1,5 +1,6 @@
-import { Query, Controller, Get, Render } from '@nestjs/common';
+import { Query, Controller, Get, Render, Req } from '@nestjs/common';
 import { I18nService } from 'nestjs-i18n';
+import { Request } from 'express';
 import { IndustriesService } from '../../industries/industries.service';
 import { Nation } from '../../nations/nation';
 import { OrganisationsFilterHelper } from '../helpers/organisations-filter.helper';
@@ -23,7 +24,12 @@ export class SearchController {
   @Get()
   @Render('organisations/search/index')
   @BackLink('/')
-  async index(@Query() filter: FilterDto): Promise<IndexTemplate> {
+  async index(
+    @Query() filter: FilterDto,
+    @Req() request: Request,
+  ): Promise<IndexTemplate> {
+    request.session.searchResultUrl = request.url;
+
     const allNations = Nation.all();
     const allIndustries = await this.industriesService.all();
 

--- a/src/professions/professions.controller.ts
+++ b/src/professions/professions.controller.ts
@@ -24,7 +24,7 @@ export class ProfessionsController {
 
   @Get('/professions/:slug')
   @Render('professions/show')
-  @BackLink('/professions/search')
+  @BackLink('/professions/search', 'app.backToSearch')
   async show(@Param('slug') slug: string): Promise<ShowTemplate> {
     const profession = await this.professionVersionsService.findLiveBySlug(
       slug,

--- a/src/professions/professions.controller.ts
+++ b/src/professions/professions.controller.ts
@@ -6,6 +6,7 @@ import {
   Render,
 } from '@nestjs/common';
 import { I18nService } from 'nestjs-i18n';
+import { Request } from 'express';
 import { Nation } from '../nations/nation';
 import QualificationPresenter from '../qualifications/presenters/qualification.presenter';
 import { ShowTemplate } from './interfaces/show-template.interface';
@@ -24,7 +25,10 @@ export class ProfessionsController {
 
   @Get('/professions/:slug')
   @Render('professions/show')
-  @BackLink('/professions/search', 'app.backToSearch')
+  @BackLink(
+    (request: Request) => request.session.searchResultUrl,
+    'app.backToSearch',
+  )
   async show(@Param('slug') slug: string): Promise<ShowTemplate> {
     const profession = await this.professionVersionsService.findLiveBySlug(
       slug,

--- a/src/professions/search/search.controller.ts
+++ b/src/professions/search/search.controller.ts
@@ -1,5 +1,6 @@
-import { Controller, Get, Query, Render } from '@nestjs/common';
+import { Controller, Get, Query, Render, Req } from '@nestjs/common';
 import { I18nService } from 'nestjs-i18n';
+import { Request } from 'express';
 import { IndustriesService } from '../../industries/industries.service';
 import { Nation } from '../../nations/nation';
 import { FilterDto } from './dto/filter.dto';
@@ -20,7 +21,12 @@ export class SearchController {
   @Get()
   @Render('professions/search/index')
   @BackLink('/')
-  async index(@Query() filter: FilterDto): Promise<IndexTemplate> {
+  async index(
+    @Query() filter: FilterDto,
+    @Req() request: Request,
+  ): Promise<IndexTemplate> {
+    request.session.searchResultUrl = request.url;
+
     const allNations = Nation.all();
     const allIndustries = await this.industriesService.all();
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,7 +17,8 @@
     "strictBindCallApply": false,
     "forceConsistentCasingInFileNames": false,
     "noFallthroughCasesInSwitch": false,
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "typeRoots": ["./node_modules/@types", "*.d.ts"]
   },
   "include": ["src"]
 }

--- a/views/_phase_banner.njk
+++ b/views/_phase_banner.njk
@@ -12,14 +12,26 @@
   }}
 
   {% if backLink %}
-    {{
-      govukBackLink({
-        text: ("app.back" | t),
-        href: backLink,
-        attributes: {
-          "data-cy": "back-link"
-        }
-      })
-    }}
+    {% if linkTitle %}
+      {{
+        govukBackLink({
+          text: (linkTitle | t),
+          href: backLink,
+          attributes: {
+            "data-cy": "back-link"
+          }
+        })
+      }}
+    {% else %}
+      {{
+        govukBackLink({
+          text: ("app.back" | t),
+          href: backLink,
+          attributes: {
+            "data-cy": "back-link"
+          }
+        })
+      }}
+    {% endif %}
   {% endif %}
 </div>


### PR DESCRIPTION
This sets the Back link on Profession and Organisation show pages to say "Back to search results" with a url that goes back to the search results. This is ensured by setting a `searchResultUrl` session variable whenever we make a search request.

## Screenshots

![image](https://user-images.githubusercontent.com/109774/159526655-6e26c52e-c256-4ccb-bfd5-c45118044c81.png)

![image](https://user-images.githubusercontent.com/109774/159526702-49f7e51a-aec9-40b2-8787-3035fae67917.png)
