### PR TITLE
(2263) Show alternate text for 2nd legislation for admins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Use Opensearch for searching Organisations
 - Backlink on public show pages takes the user back to the search results
+- Updated second legislation label text to be clearer for admins
 
 ## [release-010] - 2022-03-22
 

--- a/cypress/integration/admin/professions/show.spec.ts
+++ b/cypress/integration/admin/professions/show.spec.ts
@@ -160,6 +160,15 @@ describe('Listing professions', () => {
         'The Trade Marks Act 1994',
       );
 
+      cy.translate(
+        'professions.show.legislation.secondNationalLegislation',
+      ).then((label) => {
+        cy.get('body').should('contain', label);
+      });
+      cy.translate('professions.show.legislation.secondLink').then((label) => {
+        cy.get('body').should('contain', label);
+      });
+
       cy.translate('professions.show.overview.heading').then((heading) => {
         cy.get('body').should('contain', heading);
       });
@@ -281,6 +290,19 @@ describe('Listing professions', () => {
         'professions.show.legislation.nationalLegislation',
         "The Education (School Teachers' Qualifications) (England) Regulations 2003/1662 (as amended)",
       );
+
+      cy.translate('professions.show.legislation.heading').then((heading) => {
+        cy.get('body').should('contain', heading);
+      });
+
+      cy.translate(
+        'professions.show.legislation.secondNationalLegislation',
+      ).then((label) => {
+        cy.get('body').should('contain', label);
+      });
+      cy.translate('professions.show.legislation.secondLink').then((label) => {
+        cy.get('body').should('contain', label);
+      });
 
       cy.translate('professions.show.overview.heading').then((heading) => {
         cy.get('body').should('contain', heading);

--- a/src/i18n/en/professions.json
+++ b/src/i18n/en/professions.json
@@ -195,7 +195,9 @@
     "legislation": {
       "heading": "Legislation",
       "nationalLegislation": "National legislation",
-      "legislationLink": "Legislation link"
+      "legislationLink": "Legislation link",
+      "secondNationalLegislation": "Title of other act or charter",
+      "secondLink": "Website link to other legislation"
     }
   },
   "admin": {

--- a/views/professions/_profession-details.njk
+++ b/views/professions/_profession-details.njk
@@ -187,12 +187,15 @@
 <h2 class="govuk-heading-m rpr-details__section-title">{{ "professions.show.legislation.heading" | t}}</h2>
 
 {% for legislation in ((profession.legislations | pad(2)) if showEmptyProfessionDetails else profession.legislations) %}
+  {% set legislationLocalisationId = "professions.show.legislation.secondNationalLegislation" if (showEmptyProfessionDetails and loop.index > 1) else "professions.show.legislation.nationalLegislation" %}
+  {% set legislationLinkLocalisationId = "professions.show.legislation.secondLink" if (showEmptyProfessionDetails and loop.index > 1) else "professions.show.legislation.legislationLink" %}
+
   {{ govukSummaryList({
     classes: 'govuk-summary-list--no-border',
     rows: [
       {
         key: {
-          html: ( "professions.show.legislation.nationalLegislation" | t) + "<span class=\"govuk-visually-hidden\"> " + loop.index + "</span>"
+          html: (legislationLocalisationId | t) + "<span class=\"govuk-visually-hidden\"> " + loop.index + "</span>"
         },
         value: {
           html: legislation.name | multiline
@@ -200,7 +203,7 @@
       },
       {
         key: {
-          html: ( "professions.show.legislation.legislationLink" | t) + "<span class=\"govuk-visually-hidden\"> " + loop.index + "</span>"
+          html: (legislationLinkLocalisationId | t) + "<span class=\"govuk-visually-hidden\"> " + loop.index + "</span>"
         },
         value: {
           html: legislation.url | link


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR

Displays optional label text to admins for the second legislation when viewing a profession. This was based on UAT feedback. We don't show empty fields to members of the public, but it makes sense to show `(optional)` text on the field
here so as not to confuse admin users.

## Screenshots of UI changes

### Before

![image](https://user-images.githubusercontent.com/19826940/159537804-9e7d35e1-be29-4f0c-92c5-79f250ef9d6d.png)


### After

<img width="782" alt="image" src="https://user-images.githubusercontent.com/19826940/159684787-cb7adddc-128b-4527-b196-c2853a70c506.png">

