### PR TITLE
Use `transpile-only` when running console scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "build": "nest build",
     "build:assets": "encore dev",
     "build:assets:prod": "encore production",
+    "console": "ts-node --transpile-only ./src/console.ts",
     "heroku-postbuild": "npm run build && npm run build:assets:prod",
     "typeorm": "node --require ts-node/register ./node_modules/typeorm/cli.js",
     "typeorm:migration:generate": "npm run build && npm run typeorm -- migration:generate -n",
@@ -40,8 +41,8 @@
     "seed:production": "NODE_ENV=production node dist/seeder",
     "seed:test:refresh": "npm run build && NODE_ENV=test node dist/seeder --refresh",
     "opensearch:test:purge": "curl -X DELETE 'http://admin:admin@localhost:9200/professions_test' &> /dev/null && curl -X DELETE 'http://admin:admin@localhost:9200/organisations_test' &> /dev/null",
-    "opensearch:reseed:professions": "ts-node ./src/console.ts opensearch:reseed:professions",
-    "opensearch:reseed:organisations": "ts-node ./src/console.ts opensearch:reseed:organisations",
+    "opensearch:reseed:professions": "npm run console -- opensearch:reseed:professions",
+    "opensearch:reseed:organisations": "npm run console --  opensearch:reseed:organisations",
     "heroku:set-callback-urls": "ts-node util/set-callback-urls.ts",
     "bull:repl": "bull-repl"
   },


### PR DESCRIPTION
This gives a lower memory footprint and stops an issue where the type information isn’t loaded in prod.

I've also added a `console` script that the two seeding tasks rely on to be a bit more DRY.