### PR TITLE
(Fix) Navigate to profession page in e2e test

### DIFF
--- a/cypress/integration/professions/show.spec.ts
+++ b/cypress/integration/professions/show.spec.ts
@@ -1,6 +1,8 @@
 describe('Showing a profession', () => {
   it('I can view a profession', () => {
-    cy.visitAndCheckAccessibility('/professions/registered-trademark-attorney');
+    cy.visitAndCheckAccessibility('/professions/search');
+    cy.get('a').contains('Registered Trademark Attorney').click();
+    cy.checkAccessibility();
 
     cy.translate('app.backToSearch').then((backLink) => {
       cy.get('body').should('contain', backLink);


### PR DESCRIPTION
# Changes in this PR

Visits profession via search results in `show.spec` to ensure backlink is visible in test.

Visiting the profession url directly meant we had no search results url in the session here, so the back link wasn't displayed. This is by design, so users who arrive on a page e.g. via Google search results don't expect to go back to Google search results when clicking a back link.

<!-- Do you need to update the changelog? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->


