### PR TITLE
(2282) Display search results in alphabetical order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Use Opensearch for searching Organisations
 - Backlink on public show pages takes the user back to the search results
 - Updated second legislation label text to be clearer for admins
+- Fix bug with organisations and professions not being displayed in alphabetical order
+- Order users alphabetically
 
 ## [release-010] - 2022-03-22
 

--- a/cypress/integration/admin/organisations/index.spec.ts
+++ b/cypress/integration/admin/organisations/index.spec.ts
@@ -69,7 +69,10 @@ describe('Listing organisations', () => {
     it('Organisations are sorted alphabetically', () => {
       cy.get('tbody tr th').then((elements) => {
         const names = elements.map((_, element) => element.innerText).toArray();
-        cy.wrap(names).should('deep.equal', names.sort());
+        cy.wrap(names).should(
+          'deep.equal',
+          [...names].sort((a: string, b: string) => a.localeCompare(b)),
+        );
       });
     });
 

--- a/cypress/integration/admin/professions/index.spec.ts
+++ b/cypress/integration/admin/professions/index.spec.ts
@@ -43,7 +43,10 @@ describe('Listing professions', () => {
     it('Professions are sorted alphabetically', () => {
       cy.get('tbody tr th').then((elements) => {
         const names = elements.map((_, element) => element.innerText).toArray();
-        cy.wrap(names).should('deep.equal', names.sort());
+        cy.wrap(names).should(
+          'deep.equal',
+          [...names].sort((a: string, b: string) => a.localeCompare(b)),
+        );
       });
     });
 

--- a/cypress/integration/admin/user/index.spec.ts
+++ b/cypress/integration/admin/user/index.spec.ts
@@ -4,7 +4,7 @@ describe('Listing professions', () => {
       cy.loginAuth0();
     });
 
-    it('All users are listed', () => {
+    it('All users are listed alphabetically', () => {
       cy.visitAndCheckAccessibility('/admin/users');
 
       cy.translate('app.beis').then((beis) => {
@@ -17,6 +17,16 @@ describe('Listing professions', () => {
           cy.get('tbody td').should('contain', user.email);
         });
 
+        cy.get('tbody th').then((elements) => {
+          const names = elements
+            .map((_, element) => element.innerText)
+            .toArray();
+          cy.wrap(names).should(
+            'deep.equal',
+            [...names].sort((a: string, b: string) => a.localeCompare(b)),
+          );
+        });
+
         cy.get('tbody tr').should('have.length', users.length);
       });
     });
@@ -27,7 +37,7 @@ describe('Listing professions', () => {
       cy.loginAuth0('orgadmin');
     });
 
-    it('Users for the organisation are listed', () => {
+    it('Users for the organisation are listed alphabetically', () => {
       cy.visitAndCheckAccessibility('/admin/users');
 
       cy.get('h1 span').should('contain', 'Department for Education');
@@ -40,6 +50,16 @@ describe('Listing professions', () => {
         organisationUsers.forEach((user) => {
           cy.get('tbody th').should('contain', user.name);
           cy.get('tbody td').should('contain', user.email);
+        });
+
+        cy.get('tbody th').then((elements) => {
+          const names = elements
+            .map((_, element) => element.innerText)
+            .toArray();
+          cy.wrap(names).should(
+            'deep.equal',
+            [...names].sort((a: string, b: string) => a.localeCompare(b)),
+          );
         });
 
         cy.get('tbody tr').should('have.length', organisationUsers.length);

--- a/cypress/integration/organisations/search/search.spec.ts
+++ b/cypress/integration/organisations/search/search.spec.ts
@@ -30,7 +30,11 @@ describe('Searching an organisation', () => {
   it('Organisations are sorted alphabetically', () => {
     cy.get('h2').then((elements) => {
       const names = elements.map((_, element) => element.innerText).toArray();
-      cy.wrap(names).should('deep.equal', names.sort());
+
+      cy.wrap(names).should(
+        'deep.equal',
+        [...names].sort((a: string, b: string) => a.localeCompare(b)),
+      );
     });
   });
 

--- a/cypress/integration/professions/search/search.spec.ts
+++ b/cypress/integration/professions/search/search.spec.ts
@@ -21,9 +21,13 @@ describe('Searching a profession', () => {
   });
 
   it('Professions are sorted alphabetically', () => {
-    cy.get('h2').then((elements) => {
+    cy.get('a.rpr-listing__profession-title').then((elements) => {
       const names = elements.map((_, element) => element.innerText).toArray();
-      cy.wrap(names).should('deep.equal', names.sort());
+
+      cy.wrap(names).should(
+        'deep.equal',
+        [...names].sort((a: string, b: string) => a.localeCompare(b)),
+      );
     });
   });
 

--- a/src/organisations/organisation-versions.service.spec.ts
+++ b/src/organisations/organisation-versions.service.spec.ts
@@ -403,6 +403,7 @@ describe('OrganisationVersionsService', () => {
 
       expect(queryBuilder.distinctOn).toHaveBeenCalledWith([
         'organisationVersion.organisation',
+        'organisation.name',
         'professions.id',
       ]);
 
@@ -422,7 +423,7 @@ describe('OrganisationVersionsService', () => {
       );
 
       expect(queryBuilder.orderBy).toHaveBeenCalledWith(
-        'organisationVersion.organisation, professions.id, professionVersions.created_at, organisationVersion.created_at',
+        'organisation.name, organisationVersion.organisation, professions.id, professionVersions.created_at, organisationVersion.created_at',
         'DESC',
       );
     });
@@ -1003,6 +1004,7 @@ describe('OrganisationVersionsService', () => {
 
       expect(queryBuilder.distinctOn).toHaveBeenCalledWith([
         'organisationVersion.organisation',
+        'organisation.name',
         'professions.id',
       ]);
 
@@ -1022,7 +1024,7 @@ describe('OrganisationVersionsService', () => {
       );
 
       expect(queryBuilder.orderBy).toHaveBeenCalledWith(
-        'organisationVersion.organisation, professions.id, professionVersions.created_at, organisationVersion.created_at',
+        'organisation.name, organisationVersion.organisation, professions.id, professionVersions.created_at, organisationVersion.created_at',
         'DESC',
       );
     });

--- a/src/organisations/organisation-versions.service.spec.ts
+++ b/src/organisations/organisation-versions.service.spec.ts
@@ -822,6 +822,7 @@ describe('OrganisationVersionsService', () => {
       leftJoinAndSelect: () => queryBuilder,
       where: () => queryBuilder,
       andWhere: () => queryBuilder,
+      orderBy: () => queryBuilder,
       getMany: async () => versions,
     });
 
@@ -861,6 +862,8 @@ describe('OrganisationVersionsService', () => {
         'professionVersions.industries',
         'industries',
       );
+
+      expect(queryBuilder.orderBy).toHaveBeenCalledWith('organisation.name');
 
       expect(queryBuilder.where).toHaveBeenCalledWith(
         'organisationVersion.status = :status',

--- a/src/organisations/organisation-versions.service.ts
+++ b/src/organisations/organisation-versions.service.ts
@@ -90,12 +90,11 @@ export class OrganisationVersionsService {
   }
 
   async searchLive(filter: FilterInput): Promise<Organisation[]> {
-    const query = this.versionsWithJoins().where(
-      'organisationVersion.status = :status',
-      {
+    const query = this.versionsWithJoins()
+      .orderBy('organisation.name')
+      .where('organisationVersion.status = :status', {
         status: OrganisationVersionStatus.Live,
-      },
-    );
+      });
 
     return await this.filter(query, filter);
   }

--- a/src/organisations/organisation-versions.service.ts
+++ b/src/organisations/organisation-versions.service.ts
@@ -118,7 +118,11 @@ export class OrganisationVersionsService {
 
   async searchWithLatestVersion(filter: FilterInput): Promise<Organisation[]> {
     const query = this.versionsWithJoins()
-      .distinctOn(['organisationVersion.organisation', 'professions.id'])
+      .distinctOn([
+        'organisationVersion.organisation',
+        'organisation.name',
+        'professions.id',
+      ])
       .where(
         '(organisationVersion.status IN(:...organisationStatus)) AND (professionVersions.status IN(:...professionStatus) OR professionVersions.status IS NULL)',
         {
@@ -134,7 +138,7 @@ export class OrganisationVersionsService {
         },
       )
       .orderBy(
-        'organisationVersion.organisation, professions.id, professionVersions.created_at, organisationVersion.created_at',
+        'organisation.name, organisationVersion.organisation, professions.id, professionVersions.created_at, organisationVersion.created_at',
         'DESC',
       );
 
@@ -143,7 +147,11 @@ export class OrganisationVersionsService {
 
   async allWithLatestVersion(): Promise<Organisation[]> {
     const versions = await this.versionsWithJoins()
-      .distinctOn(['organisationVersion.organisation', 'professions.id'])
+      .distinctOn([
+        'organisationVersion.organisation',
+        'organisation.name',
+        'professions.id',
+      ])
       .where(
         '(organisationVersion.status IN(:...organisationStatus)) AND (professionVersions.status IN(:...professionStatus) OR professionVersions.status IS NULL)',
         {
@@ -159,7 +167,7 @@ export class OrganisationVersionsService {
         },
       )
       .orderBy(
-        'organisationVersion.organisation, professions.id, professionVersions.created_at, organisationVersion.created_at',
+        'organisation.name, organisationVersion.organisation, professions.id, professionVersions.created_at, organisationVersion.created_at',
         'DESC',
       )
       .getMany();

--- a/src/professions/profession-versions.service.spec.ts
+++ b/src/professions/profession-versions.service.spec.ts
@@ -511,6 +511,7 @@ describe('ProfessionVersionsService', () => {
 
       expect(queryBuilder.distinctOn).toHaveBeenCalledWith([
         'professionVersion.profession',
+        'profession.name',
       ]);
 
       expect(queryBuilder).toHaveJoined([
@@ -535,7 +536,7 @@ describe('ProfessionVersionsService', () => {
       );
 
       expect(queryBuilder.orderBy).toHaveBeenCalledWith(
-        'professionVersion.profession, professionVersion.created_at',
+        'profession.name, professionVersion.profession, professionVersion.created_at',
         'DESC',
       );
     });
@@ -571,6 +572,7 @@ describe('ProfessionVersionsService', () => {
 
       expect(queryBuilder.distinctOn).toHaveBeenCalledWith([
         'professionVersion.profession',
+        'profession.name',
       ]);
 
       expect(queryBuilder).toHaveJoined([
@@ -602,7 +604,7 @@ describe('ProfessionVersionsService', () => {
       );
 
       expect(queryBuilder.orderBy).toHaveBeenCalledWith(
-        'professionVersion.profession, professionVersion.created_at',
+        'profession.name, professionVersion.profession, professionVersion.created_at',
         'DESC',
       );
     });
@@ -632,6 +634,7 @@ describe('ProfessionVersionsService', () => {
 
       expect(queryBuilder.distinctOn).toHaveBeenCalledWith([
         'professionVersion.profession',
+        'profession.name',
       ]);
 
       expect(queryBuilder).toHaveJoined([
@@ -656,7 +659,7 @@ describe('ProfessionVersionsService', () => {
       });
 
       expect(queryBuilder.orderBy).toHaveBeenCalledWith(
-        'professionVersion.profession, professionVersion.created_at',
+        'profession.name, professionVersion.profession, professionVersion.created_at',
         'DESC',
       );
     });

--- a/src/professions/profession-versions.service.spec.ts
+++ b/src/professions/profession-versions.service.spec.ts
@@ -838,6 +838,7 @@ describe('ProfessionVersionsService', () => {
       leftJoinAndSelect: () => queryBuilder,
       where: () => queryBuilder,
       andWhere: () => queryBuilder,
+      orderBy: () => queryBuilder,
       getMany: async () => versions,
     });
 

--- a/src/professions/profession-versions.service.ts
+++ b/src/professions/profession-versions.service.ts
@@ -164,12 +164,11 @@ export class ProfessionVersionsService {
   }
 
   async searchLive(filter: FilterInput): Promise<Profession[]> {
-    let query = this.versionsWithJoins().where(
-      'professionVersion.status = :status',
-      {
+    let query = this.versionsWithJoins()
+      .orderBy('profession.name')
+      .where('professionVersion.status = :status', {
         status: ProfessionVersionStatus.Live,
-      },
-    );
+      });
 
     if (filter.keywords?.length) {
       const ids = await this.searchService.search(filter.keywords);

--- a/src/professions/profession-versions.service.ts
+++ b/src/professions/profession-versions.service.ts
@@ -212,7 +212,7 @@ export class ProfessionVersionsService {
 
   async allWithLatestVersion(): Promise<Profession[]> {
     const versions = await this.versionsWithJoins()
-      .distinctOn(['professionVersion.profession'])
+      .distinctOn(['professionVersion.profession', 'profession.name'])
       .where('professionVersion.status IN(:...status)', {
         status: [
           ProfessionVersionStatus.Live,
@@ -221,7 +221,7 @@ export class ProfessionVersionsService {
         ],
       })
       .orderBy(
-        'professionVersion.profession, professionVersion.created_at',
+        'profession.name, professionVersion.profession, professionVersion.created_at',
         'DESC',
       )
       .getMany();
@@ -235,7 +235,7 @@ export class ProfessionVersionsService {
     organisation: Organisation,
   ): Promise<Profession[]> {
     const versions = await this.versionsWithJoins()
-      .distinctOn(['professionVersion.profession'])
+      .distinctOn(['professionVersion.profession', 'profession.name'])
       .where('professionVersion.status IN(:...status)', {
         status: [
           ProfessionVersionStatus.Live,
@@ -247,7 +247,7 @@ export class ProfessionVersionsService {
         organisationId: organisation.id,
       })
       .orderBy(
-        'professionVersion.profession, professionVersion.created_at',
+        'profession.name, professionVersion.profession, professionVersion.created_at',
         'DESC',
       )
       .getMany();
@@ -259,13 +259,13 @@ export class ProfessionVersionsService {
 
   async latestVersion(profession: Profession): Promise<ProfessionVersion> {
     return await this.versionsWithJoins()
-      .distinctOn(['professionVersion.profession'])
+      .distinctOn(['professionVersion.profession', 'profession.name'])
       .where('professionVersion.status IN(:...status)', {
         status: [ProfessionVersionStatus.Live, ProfessionVersionStatus.Draft],
       })
       .where({ profession: profession })
       .orderBy(
-        'professionVersion.profession, professionVersion.created_at',
+        'profession.name, professionVersion.profession, professionVersion.created_at',
         'DESC',
       )
       .getOne();

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -17,16 +17,24 @@ export class UsersService {
     return this.repository.find();
   }
 
-  allConfirmed(): Promise<User[]> {
-    return this.repository.find({
-      where: { confirmed: true, archived: false },
-    });
+  async allConfirmed(): Promise<User[]> {
+    return this.repository
+      .createQueryBuilder('user')
+      .where('user.confirmed = true AND user.archived = false')
+      .orderBy('LOWER(user.name)')
+      .getMany();
   }
 
   allConfirmedForOrganisation(organisation: Organisation): Promise<User[]> {
-    return this.repository.find({
-      where: { confirmed: true, archived: false, organisation },
-    });
+    return this.repository
+      .createQueryBuilder('user')
+      .where('user.confirmed = true AND user.archived = false')
+      .leftJoinAndSelect('user.organisation', 'organisation')
+      .andWhere('organisation.id = :organisationId', {
+        organisationId: organisation.id,
+      })
+      .orderBy('LOWER(user.name)')
+      .getMany();
   }
 
   find(id: string): Promise<User> {


### PR DESCRIPTION
# Changes in this PR

Ensures we're displaying professions and organisations in alphabetical order whenever they're shown in lists.

We were initially doing this in most places, but forgot to make sure we were doing this when we switched to DB-level searching rather than code-level - this wasn't caught by our e2e tests due to our reliance on the `sort` function in tests, which actually orders an array in-place, and was always returning true for our assertions.

## Screenshots of UI changes

### Before

![image](https://user-images.githubusercontent.com/19826940/159730840-bbaed656-862a-4546-ba74-3680a847ed53.png)

![image](https://user-images.githubusercontent.com/19826940/159730906-e581c86d-cc4e-4287-9bc8-678ef29a1a96.png)

![image](https://user-images.githubusercontent.com/19826940/159731024-6f9f9d35-06bf-45da-a98e-d9abf470f0da.png)

![image](https://user-images.githubusercontent.com/19826940/159731082-9e0e5676-823a-42d7-978d-e59fb731b4b9.png)

#### Users

![image](https://user-images.githubusercontent.com/19826940/159751365-c73c1e28-c748-4311-b534-3794c431bb79.png)



### After

![image](https://user-images.githubusercontent.com/19826940/159730581-3e793fb5-649f-4793-b9e2-995b171ab351.png)

![image](https://user-images.githubusercontent.com/19826940/159730637-8e9c5a38-0fa5-4588-9267-e98f47ace73c.png)

![image](https://user-images.githubusercontent.com/19826940/159730688-f9cd98f7-387f-4f98-bfe6-d6eff94e94db.png)

![image](https://user-images.githubusercontent.com/19826940/159730724-9e123993-4904-4a05-a8bb-cef03db3038a.png)

#### Users

![image](https://user-images.githubusercontent.com/19826940/159751229-f3b15c7a-261f-4e6b-87c4-7be0ffca00ec.png)
