### PR TITLE
(2254) Ensure organisation has at least one live version before being able to publish a profession

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Only allow users to edit a Profession if they are a central user, or in that Profession's primary Organisation
 - Allow a central user to create a draft Profession with only a name and an Organisation
 - Validate that all necessary fields are completed before a Profession is published
+- Validate that all associated Organisations are published before a Profession is published
 
 ## [release-009] - 2022-03-11
 

--- a/cypress/integration/admin/professions/new.spec.ts
+++ b/cypress/integration/admin/professions/new.spec.ts
@@ -60,12 +60,10 @@ describe('Adding a new profession', () => {
       });
 
       cy.checkAccessibility({ 'color-contrast': { enabled: false } });
-      cy.checkPublishBlocked([
-        'scope',
-        'regulatedActivities',
-        'qualifications',
-        'legislation',
-      ]);
+      cy.checkPublishBlocked(
+        ['scope', 'regulatedActivities', 'qualifications', 'legislation'],
+        [],
+      );
       cy.clickSummaryListRowChangeLink('professions.form.label.scope.nations');
       // Conditional radio buttons add an additional `aria-expanded` field,
       // so ignore that rule on this page
@@ -92,11 +90,10 @@ describe('Adding a new profession', () => {
       });
 
       cy.checkAccessibility({ 'color-contrast': { enabled: false } });
-      cy.checkPublishBlocked([
-        'regulatedActivities',
-        'qualifications',
-        'legislation',
-      ]);
+      cy.checkPublishBlocked(
+        ['regulatedActivities', 'qualifications', 'legislation'],
+        [],
+      );
       cy.clickSummaryListRowChangeLink(
         'professions.form.label.registration.registrationRequirements',
       );
@@ -128,11 +125,10 @@ describe('Adding a new profession', () => {
       });
 
       cy.checkAccessibility({ 'color-contrast': { enabled: false } });
-      cy.checkPublishBlocked([
-        'regulatedActivities',
-        'qualifications',
-        'legislation',
-      ]);
+      cy.checkPublishBlocked(
+        ['regulatedActivities', 'qualifications', 'legislation'],
+        [],
+      );
       cy.clickSummaryListRowChangeLink(
         'professions.form.label.regulatedActivities.regulationType',
       );
@@ -164,7 +160,7 @@ describe('Adding a new profession', () => {
       });
 
       cy.checkAccessibility({ 'color-contrast': { enabled: false } });
-      cy.checkPublishBlocked(['qualifications', 'legislation']);
+      cy.checkPublishBlocked(['qualifications', 'legislation'], []);
       cy.clickSummaryListRowChangeLink(
         'professions.form.label.qualifications.routesToObtain',
       );
@@ -194,7 +190,7 @@ describe('Adding a new profession', () => {
       });
 
       cy.checkAccessibility({ 'color-contrast': { enabled: false } });
-      cy.checkPublishBlocked(['legislation']);
+      cy.checkPublishBlocked(['legislation'], []);
       cy.clickSummaryListRowChangeLink(
         'professions.form.label.legislation.nationalLegislation',
       );

--- a/cypress/integration/admin/professions/publish.spec.ts
+++ b/cypress/integration/admin/professions/publish.spec.ts
@@ -258,6 +258,24 @@ describe('Publishing professions', () => {
       );
     });
 
+    it('Does not allows me to publish a draft profession with a draft organisation from the profession page', () => {
+      cy.get('a').contains('Regulated professions').click();
+      cy.checkAccessibility();
+
+      cy.contains('Profession with draft organisation')
+        .parent('tr')
+        .within(() => {
+          cy.get('a').contains('View details').click();
+        });
+
+      cy.checkAccessibility({ 'color-contrast': { enabled: false } });
+      cy.translate('app.status.draft').then((status) => {
+        cy.get('h2[data-status]').should('contain', status);
+      });
+
+      cy.checkPublishBlocked([], ['Draft Organisation']);
+    });
+
     it('Does not allows me to publish a draft profession with missing fields from the Check Your Answers page', () => {
       cy.get('a').contains('Regulated professions').click();
       cy.checkAccessibility();
@@ -282,6 +300,28 @@ describe('Publishing professions', () => {
         [],
         false,
       );
+    });
+
+    it('Does not allows me to publish a draft profession with a draft organisation from the Check Your Answers page', () => {
+      cy.get('a').contains('Regulated professions').click();
+      cy.checkAccessibility();
+
+      cy.contains('Profession with draft organisation')
+        .parent('tr')
+        .within(() => {
+          cy.get('a').contains('View details').click();
+        });
+
+      cy.checkAccessibility({ 'color-contrast': { enabled: false } });
+      cy.translate('app.status.draft').then((status) => {
+        cy.get('h2[data-status]').should('contain', status);
+      });
+
+      cy.translate('professions.admin.button.edit.draft').then((buttonText) => {
+        cy.contains(buttonText).click();
+      });
+
+      cy.checkPublishBlocked([], ['Draft Organisation'], false);
     });
   });
 

--- a/cypress/integration/admin/professions/publish.spec.ts
+++ b/cypress/integration/admin/professions/publish.spec.ts
@@ -129,7 +129,7 @@ describe('Publishing professions', () => {
       });
 
       cy.get('[data-cy=changed-by-text]').should('not.exist');
-      cy.checkPublishBlocked(['regulatedActivities', 'qualifications']);
+      cy.checkPublishBlocked(['regulatedActivities', 'qualifications'], []);
 
       cy.translate('professions.admin.button.edit.draft').then((buttonText) => {
         cy.contains(buttonText).click();
@@ -252,12 +252,10 @@ describe('Publishing professions', () => {
         cy.get('h2[data-status]').should('contain', status);
       });
 
-      cy.checkPublishBlocked([
-        'scope',
-        'regulatedActivities',
-        'qualifications',
-        'legislation',
-      ]);
+      cy.checkPublishBlocked(
+        ['scope', 'regulatedActivities', 'qualifications', 'legislation'],
+        [],
+      );
     });
 
     it('Does not allows me to publish a draft profession with missing fields from the Check Your Answers page', () => {
@@ -281,6 +279,7 @@ describe('Publishing professions', () => {
 
       cy.checkPublishBlocked(
         ['scope', 'regulatedActivities', 'qualifications', 'legislation'],
+        [],
         false,
       );
     });
@@ -324,12 +323,10 @@ describe('Publishing professions', () => {
       });
 
       cy.checkAccessibility({ 'color-contrast': { enabled: false } });
-      cy.checkPublishBlocked([
-        'scope',
-        'regulatedActivities',
-        'qualifications',
-        'legislation',
-      ]);
+      cy.checkPublishBlocked(
+        ['scope', 'regulatedActivities', 'qualifications', 'legislation'],
+        [],
+      );
       cy.clickSummaryListRowChangeLink('professions.form.label.scope.nations');
       // Conditional radio buttons add an additional `aria-expanded` field,
       // so ignore that rule on this page
@@ -356,11 +353,10 @@ describe('Publishing professions', () => {
       });
 
       cy.checkAccessibility({ 'color-contrast': { enabled: false } });
-      cy.checkPublishBlocked([
-        'regulatedActivities',
-        'qualifications',
-        'legislation',
-      ]);
+      cy.checkPublishBlocked(
+        ['regulatedActivities', 'qualifications', 'legislation'],
+        [],
+      );
       cy.clickSummaryListRowChangeLink(
         'professions.form.label.registration.registrationRequirements',
       );
@@ -381,11 +377,10 @@ describe('Publishing professions', () => {
       });
 
       cy.checkAccessibility({ 'color-contrast': { enabled: false } });
-      cy.checkPublishBlocked([
-        'regulatedActivities',
-        'qualifications',
-        'legislation',
-      ]);
+      cy.checkPublishBlocked(
+        ['regulatedActivities', 'qualifications', 'legislation'],
+        [],
+      );
       cy.clickSummaryListRowChangeLink(
         'professions.form.label.regulatedActivities.regulationType',
       );
@@ -417,7 +412,7 @@ describe('Publishing professions', () => {
       });
 
       cy.checkAccessibility({ 'color-contrast': { enabled: false } });
-      cy.checkPublishBlocked(['qualifications', 'legislation']);
+      cy.checkPublishBlocked(['qualifications', 'legislation'], []);
       cy.clickSummaryListRowChangeLink(
         'professions.form.label.qualifications.routesToObtain',
       );
@@ -447,7 +442,7 @@ describe('Publishing professions', () => {
       });
 
       cy.checkAccessibility({ 'color-contrast': { enabled: false } });
-      cy.checkPublishBlocked(['legislation']);
+      cy.checkPublishBlocked(['legislation'], []);
       cy.clickSummaryListRowChangeLink(
         'professions.form.label.legislation.nationalLegislation',
       );

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -243,7 +243,11 @@ Cypress.Commands.add(
 
 Cypress.Commands.add(
   'checkPublishBlocked',
-  (missingSections: string[], shouldHaveButton = true) => {
+  (
+    incompleteSections: string[],
+    organisationsNotLive: string[],
+    shouldHaveButton = true,
+  ) => {
     return cy
       .translate('professions.admin.publish.blocked.heading')
       .then((heading) => {
@@ -251,17 +255,35 @@ Cypress.Commands.add(
           .contains(heading)
           .parent()
           .within(() => {
-            cy.get('li').should('have.length', missingSections.length);
-            missingSections.forEach((missingSection) => {
-              cy.translate(`professions.form.headings.${missingSection}`).then(
-                (section) => {
-                  cy.translate(`professions.admin.publish.blocked.missing`, {
+            cy.get('li').should(
+              'have.length',
+              incompleteSections.length + organisationsNotLive.length,
+            );
+
+            incompleteSections.forEach((incompleteSection) => {
+              cy.translate(
+                `professions.form.headings.${incompleteSection}`,
+              ).then((section) => {
+                cy.translate(
+                  `professions.admin.publish.blocked.incompleteSection`,
+                  {
                     section,
-                  }).then((sectionText) => {
-                    cy.get('li').should('contain', sectionText);
-                  });
+                  },
+                ).then((blockerText) => {
+                  cy.get('li').should('contain', blockerText);
+                });
+              });
+            });
+
+            organisationsNotLive.forEach((organisationNotLive) => {
+              cy.translate(
+                `professions.admin.publish.blocked.organisationNotLive`,
+                {
+                  organisation: organisationNotLive,
                 },
-              );
+              ).then((blockerText) => {
+                cy.get('li').should('contain', blockerText);
+              });
             });
           });
 

--- a/cypress/support/index.ts
+++ b/cypress/support/index.ts
@@ -65,7 +65,8 @@ declare global {
         statuses: ('live' | 'archived' | 'draft')[],
       ): Chainable<string>;
       checkPublishBlocked(
-        missingSections: string[],
+        incompleteSections: string[],
+        organisationsNotLive: string[],
         shouldHaveButton?: boolean,
       ): Chainable<string>;
       checkPublishNotBlocked(): Chainable<string>;

--- a/seeds/development/professions.json
+++ b/seeds/development/professions.json
@@ -115,6 +115,24 @@
     ]
   },
   {
+    "name": "Profession with draft organisation",
+    "slug": "profession-with-draft-organisation",
+    "organisation": "Draft Organisation",
+    "additionalOrganisation": null,
+    "versions": [
+      {
+        "occupationLocations": ["GB-ENG", "GB-NIR"],
+        "industries": ["industries.finance"],
+        "description": "A description of the profession",
+        "regulationType": "accreditation",
+        "reservedActivities": "Some reserved activities",
+        "legislations": ["Legal Services Act 2007"],
+        "qualification": "To teach in a state school in England, you must have a degree, and gain Qualified Teacher Status (QTS) by following a programme of Initial Teacher Training (ITT). You must have achieved minimum requirements in GCSE English, maths, and science if you wish to teach at primary-level. You can teach in independent schools, academies, and free schools in England without QTS, but it’s a definite advantage to have it.",
+        "status": "draft"
+      }
+    ]
+  },
+  {
     "name": "Draft Profession",
     "slug": "draft-profession",
     "organisation": "Council of Registered Gas Installers",

--- a/seeds/test/professions.json
+++ b/seeds/test/professions.json
@@ -115,6 +115,24 @@
     ]
   },
   {
+    "name": "Profession with draft organisation",
+    "slug": "profession-with-draft-organisation",
+    "organisation": "Draft Organisation",
+    "additionalOrganisation": null,
+    "versions": [
+      {
+        "occupationLocations": ["GB-ENG", "GB-NIR"],
+        "industries": ["industries.finance"],
+        "description": "A description of the profession",
+        "regulationType": "accreditation",
+        "reservedActivities": "Some reserved activities",
+        "legislations": ["Legal Services Act 2007"],
+        "qualification": "To teach in a state school in England, you must have a degree, and gain Qualified Teacher Status (QTS) by following a programme of Initial Teacher Training (ITT). You must have achieved minimum requirements in GCSE English, maths, and science if you wish to teach at primary-level. You can teach in independent schools, academies, and free schools in England without QTS, but it’s a definite advantage to have it.",
+        "status": "draft"
+      }
+    ]
+  },
+  {
     "name": "Draft Profession",
     "slug": "draft-profession",
     "organisation": "Council of Registered Gas Installers",

--- a/src/i18n/en/professions.json
+++ b/src/i18n/en/professions.json
@@ -280,7 +280,8 @@
       },
       "blocked": {
         "heading": "This page is not ready to publish. Before you can publish, check:",
-        "missing": "{section} is complete"
+        "incompleteSection": "{section} is complete",
+        "organisationNotLive": "{organisation} is published"
       }
     },
     "status": {

--- a/src/professions/admin/top-level-information.controller.spec.ts
+++ b/src/professions/admin/top-level-information.controller.spec.ts
@@ -62,9 +62,7 @@ describe('TopLevelInformationController', () => {
         professionsService.findWithVersions.mockResolvedValue(blankProfession);
 
         const organisations = organisationFactory.buildList(2);
-        organisationVersionsService.allLiveAndDraft.mockResolvedValue(
-          organisations,
-        );
+        organisationVersionsService.allLive.mockResolvedValue(organisations);
 
         const regulatedAuthoritiesSelectPresenter =
           new RegulatedAuthoritiesSelectPresenter(organisations, null);
@@ -113,9 +111,7 @@ describe('TopLevelInformationController', () => {
           additionalOrganisation,
           organisationFactory.build(),
         ];
-        organisationVersionsService.allLiveAndDraft.mockResolvedValue(
-          organisations,
-        );
+        organisationVersionsService.allLive.mockResolvedValue(organisations);
         const regulatedAuthoritiesSelectPresenterWithSelectedOrganisation =
           new RegulatedAuthoritiesSelectPresenter(organisations, organisation);
 

--- a/src/professions/admin/top-level-information.controller.ts
+++ b/src/professions/admin/top-level-information.controller.ts
@@ -148,7 +148,7 @@ export class TopLevelInformationController {
     errors: object | undefined = undefined,
   ): Promise<void> {
     const regulatedAuthorities =
-      await this.organisationVersionsService.allLiveAndDraft();
+      await this.organisationVersionsService.allLive();
 
     const regulatedAuthoritiesSelectArgs =
       new RegulatedAuthoritiesSelectPresenter(

--- a/src/professions/helpers/get-publication-blockers.helper.spec.ts
+++ b/src/professions/helpers/get-publication-blockers.helper.spec.ts
@@ -1,4 +1,8 @@
 import { Legislation } from '../../legislations/legislation.entity';
+import { OrganisationVersionStatus } from '../../organisations/organisation-version.entity';
+import organisationFactory from '../../testutils/factories/organisation';
+import organisationVersionFactory from '../../testutils/factories/organisation-version';
+import professionFactory from '../../testutils/factories/profession';
 import professionVersionFactory from '../../testutils/factories/profession-version';
 import {
   getPublicationBlockers,
@@ -8,9 +12,9 @@ import {
 describe('getPublicationBlockers', () => {
   describe('when given a just created ProfessionVersion', () => {
     it('returns all publish blockers', () => {
-      const version = professionVersionFactory
-        .justCreated('version-id')
-        .build();
+      const version = professionVersionFactory.justCreated('version-id').build({
+        profession: professionFactory.build(),
+      });
 
       expect(getPublicationBlockers(version)).toEqual([
         {
@@ -29,21 +33,44 @@ describe('getPublicationBlockers', () => {
           type: 'incomplete-section',
           section: 'legislation',
         },
+        {
+          type: 'organisation-not-live',
+          organisation: version.profession.organisation,
+        },
       ] as PublicationBlocker[]);
     });
   });
 
-  describe('when given a complete ProfessionVersion', () => {
+  describe('when given a complete ProfessionVersion with a live Organisation', () => {
     it('returns an empty array', () => {
-      const version = professionVersionFactory.build();
+      const version = professionVersionFactory.build({
+        profession: professionFactory.build({
+          organisation: organisationFactory.build({
+            versions: [
+              organisationVersionFactory.build({
+                status: OrganisationVersionStatus.Live,
+              }),
+            ],
+          }),
+        }),
+      });
 
       expect(getPublicationBlockers(version)).toEqual([]);
     });
   });
 
   describe('when given a ProfessionVersion with empty industries', () => {
-    it('returns the "scope" publish blocked', () => {
+    it('returns the "scope" publish blocker', () => {
       const version = professionVersionFactory.build({
+        profession: professionFactory.build({
+          organisation: organisationFactory.build({
+            versions: [
+              organisationVersionFactory.build({
+                status: OrganisationVersionStatus.Live,
+              }),
+            ],
+          }),
+        }),
         industries: [],
       });
 
@@ -57,8 +84,17 @@ describe('getPublicationBlockers', () => {
   });
 
   describe('when given a ProfessionVersion with empty nations', () => {
-    it('returns the "scope" publish blocked', () => {
+    it('returns the "scope" publish blocker', () => {
       const version = professionVersionFactory.build({
+        profession: professionFactory.build({
+          organisation: organisationFactory.build({
+            versions: [
+              organisationVersionFactory.build({
+                status: OrganisationVersionStatus.Live,
+              }),
+            ],
+          }),
+        }),
         occupationLocations: [],
       });
 
@@ -72,8 +108,17 @@ describe('getPublicationBlockers', () => {
   });
 
   describe('when given a ProfessionVersion with an empty regulations summary', () => {
-    it('returns the "regulatedActivities" publish blocked', () => {
+    it('returns the "regulatedActivities" publish blocker', () => {
       const version = professionVersionFactory.build({
+        profession: professionFactory.build({
+          organisation: organisationFactory.build({
+            versions: [
+              organisationVersionFactory.build({
+                status: OrganisationVersionStatus.Live,
+              }),
+            ],
+          }),
+        }),
         description: '',
       });
 
@@ -87,8 +132,17 @@ describe('getPublicationBlockers', () => {
   });
 
   describe('when given a ProfessionVersion with an undefined regulation type', () => {
-    it('returns the "regulatedActivities" publish blocked', () => {
+    it('returns the "regulatedActivities" publish blocker', () => {
       const version = professionVersionFactory.build({
+        profession: professionFactory.build({
+          organisation: organisationFactory.build({
+            versions: [
+              organisationVersionFactory.build({
+                status: OrganisationVersionStatus.Live,
+              }),
+            ],
+          }),
+        }),
         regulationType: undefined,
       });
 
@@ -102,8 +156,17 @@ describe('getPublicationBlockers', () => {
   });
 
   describe('when given a ProfessionVersion with an empty reserved activities', () => {
-    it('returns the "regulatedActivities" publish blocked', () => {
+    it('returns the "regulatedActivities" publish blocker', () => {
       const version = professionVersionFactory.build({
+        profession: professionFactory.build({
+          organisation: organisationFactory.build({
+            versions: [
+              organisationVersionFactory.build({
+                status: OrganisationVersionStatus.Live,
+              }),
+            ],
+          }),
+        }),
         reservedActivities: '',
       });
 
@@ -117,8 +180,17 @@ describe('getPublicationBlockers', () => {
   });
 
   describe('when given a ProfessionVersion with an undefined qualification', () => {
-    it('returns the "qualifications" publish blocked', () => {
+    it('returns the "qualifications" publish blocker', () => {
       const version = professionVersionFactory.build({
+        profession: professionFactory.build({
+          organisation: organisationFactory.build({
+            versions: [
+              organisationVersionFactory.build({
+                status: OrganisationVersionStatus.Live,
+              }),
+            ],
+          }),
+        }),
         qualification: undefined,
       });
 
@@ -132,8 +204,17 @@ describe('getPublicationBlockers', () => {
   });
 
   describe('when given a ProfessionVersion with an empty qualification route', () => {
-    it('returns the "qualifications" publish blocked', () => {
+    it('returns the "qualifications" publish blocker', () => {
       const version = professionVersionFactory.build({
+        profession: professionFactory.build({
+          organisation: organisationFactory.build({
+            versions: [
+              organisationVersionFactory.build({
+                status: OrganisationVersionStatus.Live,
+              }),
+            ],
+          }),
+        }),
         qualification: { routesToObtain: '' },
       });
 
@@ -147,8 +228,17 @@ describe('getPublicationBlockers', () => {
   });
 
   describe('when given a ProfessionVersion with an undefined legislations', () => {
-    it('returns the "legislation" publish blocked', () => {
+    it('returns the "legislation" publish blocker', () => {
       const version = professionVersionFactory.build({
+        profession: professionFactory.build({
+          organisation: organisationFactory.build({
+            versions: [
+              organisationVersionFactory.build({
+                status: OrganisationVersionStatus.Live,
+              }),
+            ],
+          }),
+        }),
         legislations: undefined,
       });
 
@@ -162,8 +252,17 @@ describe('getPublicationBlockers', () => {
   });
 
   describe('when given a ProfessionVersion with an empty legislation name', () => {
-    it('returns the "legislation" publish blocked', () => {
+    it('returns the "legislation" publish blocker', () => {
       const version = professionVersionFactory.build({
+        profession: professionFactory.build({
+          organisation: organisationFactory.build({
+            versions: [
+              organisationVersionFactory.build({
+                status: OrganisationVersionStatus.Live,
+              }),
+            ],
+          }),
+        }),
         legislations: [new Legislation()],
       });
 
@@ -171,6 +270,99 @@ describe('getPublicationBlockers', () => {
         {
           type: 'incomplete-section',
           section: 'legislation',
+        },
+      ] as PublicationBlocker[]);
+    });
+  });
+
+  describe('when given a ProfessionVersion with an no live Organisation', () => {
+    it('returns the "organisation-not-live" publish blocker', () => {
+      const version = professionVersionFactory.build({
+        profession: professionFactory.build({
+          organisation: organisationFactory.build({
+            versions: [
+              organisationVersionFactory.build({
+                status: OrganisationVersionStatus.Draft,
+              }),
+              organisationVersionFactory.build({
+                status: OrganisationVersionStatus.Archived,
+              }),
+            ],
+          }),
+        }),
+      });
+
+      expect(getPublicationBlockers(version)).toEqual([
+        {
+          type: 'organisation-not-live',
+          organisation: version.profession.organisation,
+        },
+      ] as PublicationBlocker[]);
+    });
+  });
+
+  describe('when given a ProfessionVersion with an additional Organisation with no live versions', () => {
+    it('returns the "organisation-not-live" publish blocker', () => {
+      const version = professionVersionFactory.build({
+        profession: professionFactory.build({
+          organisation: organisationFactory.build({
+            versions: [
+              organisationVersionFactory.build({
+                status: OrganisationVersionStatus.Live,
+              }),
+            ],
+          }),
+          additionalOrganisation: organisationFactory.build({
+            versions: [
+              organisationVersionFactory.build({
+                status: OrganisationVersionStatus.Draft,
+              }),
+              organisationVersionFactory.build({
+                status: OrganisationVersionStatus.Archived,
+              }),
+            ],
+          }),
+        }),
+      });
+
+      expect(getPublicationBlockers(version)).toEqual([
+        {
+          type: 'organisation-not-live',
+          organisation: version.profession.additionalOrganisation,
+        },
+      ] as PublicationBlocker[]);
+    });
+  });
+
+  describe('when given a ProfessionVersion with an Organisation and an additional Organisation that both have no live versions', () => {
+    it('returns two "organisation-not-live" publish blockers', () => {
+      const version = professionVersionFactory.build({
+        profession: professionFactory.build({
+          organisation: organisationFactory.build({
+            versions: [
+              organisationVersionFactory.build({
+                status: OrganisationVersionStatus.Draft,
+              }),
+            ],
+          }),
+          additionalOrganisation: organisationFactory.build({
+            versions: [
+              organisationVersionFactory.build({
+                status: OrganisationVersionStatus.Archived,
+              }),
+            ],
+          }),
+        }),
+      });
+
+      expect(getPublicationBlockers(version)).toEqual([
+        {
+          type: 'organisation-not-live',
+          organisation: version.profession.organisation,
+        },
+        {
+          type: 'organisation-not-live',
+          organisation: version.profession.additionalOrganisation,
         },
       ] as PublicationBlocker[]);
     });

--- a/views/shared/_publication-blockers.njk
+++ b/views/shared/_publication-blockers.njk
@@ -5,7 +5,9 @@
       {%for blocker in publicationBlockers %}
         {% if blocker.type === "incomplete-section" %}
           {% set sectionName = (("professions.form.headings." + blocker.section) | t) %}
-          <li class="govuk-body-s">{{ "professions.admin.publish.blocked.missing" | t({section: sectionName}) }}</li>
+          <li class="govuk-body-s">{{ "professions.admin.publish.blocked.incompleteSection" | t({section: sectionName}) }}</li>
+        {% elif blocker.type === "organisation-not-live" %}
+           <li class="govuk-body-s">{{ "professions.admin.publish.blocked.organisationNotLive" | t({organisation: blocker.organisation.name}) }}</li>
         {% endif %}
       {% endfor %}
     </ul>


### PR DESCRIPTION
# Changes in this PR

* Validate that all associated Organisations are published before a Profession is published.

This is an extension of PR #463 and builds on top of that branch. The (2245) branch will be rebased onto main once that is merged. Only the last 5 commits on this PR are new

## Screenshots of UI changes

### Before
![localhost_3000_admin_professions_1e148ca2-72b9-4286-aa1e-fd1bed38eaf3_versions_44dd5a39-ac30-4cfc-924a-5c64fb6eb0ae (1)](https://user-images.githubusercontent.com/94137563/159747848-96bc1f79-0e68-4972-b7ea-974b5a77a8f0.png)

### After
![localhost_3000_admin_professions_1e148ca2-72b9-4286-aa1e-fd1bed38eaf3_versions_44dd5a39-ac30-4cfc-924a-5c64fb6eb0ae](https://user-images.githubusercontent.com/94137563/159747880-0ce5f252-d4c2-4b74-96f0-290932557f2a.png)

