### PR TITLE
(2225) Add the regulation type filter to the public pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [unreleased]
 
+### Added
+
+- Support for searching by regulation type in public-facing Profession and Organisation search
+
 ### Changed
 
 - Use Opensearch for searching Organisations

--- a/cypress/integration/organisations/search/search.spec.ts
+++ b/cypress/integration/organisations/search/search.spec.ts
@@ -102,6 +102,47 @@ describe('Searching an organisation', () => {
     });
   });
 
+  it('I can filter by regulation type', () => {
+    cy.readFile('./seeds/test/professions.json').then((professions) => {
+      const cerificatedProfessions = professions.filter((profession) =>
+        profession.versions.some(
+          (version) =>
+            version.status === 'live' &&
+            version.regulationType === 'certification',
+        ),
+      );
+
+      const organisations = new Set(
+        cerificatedProfessions.map((profession) => profession.organisation),
+      );
+
+      cy.translate('professions.regulationTypes.certification.name').then(
+        (nameLabel) => {
+          cy.get('label').contains(nameLabel).parent().find('input').check();
+        },
+      );
+
+      cy.get('button').click();
+      cy.checkAccessibility();
+
+      cy.translate('professions.regulationTypes.certification.name').then(
+        (nameLabel) => {
+          cy.get('label')
+            .contains(nameLabel)
+            .parent()
+            .find('input')
+            .should('be.checked');
+        },
+      );
+
+      checkResultLength(organisations.size);
+
+      organisations.forEach((organisation) => {
+        cy.get('body').should('contain', organisation);
+      });
+    });
+  });
+
   it('I can filter by keyword', () => {
     cy.get('input[name="keywords"]').type('Installers');
 

--- a/cypress/integration/organisations/search/search.spec.ts
+++ b/cypress/integration/organisations/search/search.spec.ts
@@ -48,6 +48,42 @@ describe('Searching an organisation', () => {
     cy.get('body').should('contain', 'General Medical Council');
   });
 
+  it('I can filter by keyword', () => {
+    cy.get('input[name="keywords"]').type('Installers');
+
+    cy.get('button').click();
+    cy.checkAccessibility();
+
+    cy.get('input[name="keywords"]').should('have.value', 'Installers');
+
+    cy.get('body').should('contain', 'Council of Registered Gas Installers');
+    checkResultLength(1);
+  });
+
+  it('I can use the back button to go back to my search results', () => {
+    cy.get('input[name="keywords"]').type('Education');
+
+    cy.translate('industries.education').then((nameLabel) => {
+      cy.get('label').contains(nameLabel).parent().find('input').check();
+    });
+
+    cy.get('input[name="nations[]"][value="GB-ENG"]').check();
+
+    cy.get('button').click();
+
+    cy.get('a').contains('Department for Education').click();
+
+    cy.translate('app.backToSearch').then((label) => {
+      cy.get('[data-cy=back-link]').should('contain', label);
+      cy.get('[data-cy=back-link]')
+        .invoke('attr', 'href')
+        .should(
+          'match',
+          /regulatory-authorities\/search\?keywords=Education&industries%5B%5D=.+&nations%5B%5D=GB-ENG/,
+        );
+    });
+  });
+
   it('I can filter by nation', () => {
     cy.readFile('./seeds/test/professions.json').then((professions) => {
       const scottishProfessions = professions.filter((profession) =>
@@ -140,42 +176,6 @@ describe('Searching an organisation', () => {
       organisations.forEach((organisation) => {
         cy.get('body').should('contain', organisation);
       });
-    });
-  });
-
-  it('I can filter by keyword', () => {
-    cy.get('input[name="keywords"]').type('Installers');
-
-    cy.get('button').click();
-    cy.checkAccessibility();
-
-    cy.get('input[name="keywords"]').should('have.value', 'Installers');
-
-    cy.get('body').should('contain', 'Council of Registered Gas Installers');
-    checkResultLength(1);
-  });
-
-  it('I can use the back button to go back to my search results', () => {
-    cy.get('input[name="keywords"]').type('Education');
-
-    cy.translate('industries.education').then((nameLabel) => {
-      cy.get('label').contains(nameLabel).parent().find('input').check();
-    });
-
-    cy.get('input[name="nations[]"][value="GB-ENG"]').check();
-
-    cy.get('button').click();
-
-    cy.get('a').contains('Department for Education').click();
-
-    cy.translate('app.backToSearch').then((label) => {
-      cy.get('[data-cy=back-link]').should('contain', label);
-      cy.get('[data-cy=back-link]')
-        .invoke('attr', 'href')
-        .should(
-          'match',
-          /regulatory-authorities\/search\?keywords=Education&industries%5B%5D=.+&nations%5B%5D=GB-ENG/,
-        );
     });
   });
 

--- a/cypress/integration/professions/search/search.spec.ts
+++ b/cypress/integration/professions/search/search.spec.ts
@@ -52,6 +52,31 @@ describe('Searching a profession', () => {
     );
   });
 
+  it('I can filter by keyword', () => {
+    cy.get('input[name="keywords"]').type('Attorney');
+
+    cy.get('button').click();
+    cy.checkAccessibility();
+
+    cy.get('input[name="keywords"]').should('have.value', 'Attorney');
+
+    cy.get('body').should('contain', 'Registered Trademark Attorney');
+    cy.get('body').should(
+      'not.contain',
+      'Secondary School Teacher in State maintained schools (England)',
+    );
+  });
+
+  it('The search uses a professions keywords to filter', () => {
+    cy.get('input[name="keywords"]').type('Adjudicator');
+    cy.get('button').click();
+    cy.get('body').should('contain', 'Registered Trademark Attorney');
+    cy.get('body').should(
+      'not.contain',
+      'Secondary School Teacher in State maintained schools (England)',
+    );
+  });
+
   it('I can filter by nation', () => {
     cy.get('input[name="nations[]"][value="GB-WLS"]').check();
 
@@ -115,31 +140,6 @@ describe('Searching a profession', () => {
       'Secondary School Teacher in State maintained schools (England)',
     );
     cy.get('body').should('not.contain', 'Registered Trademark Attorney');
-  });
-
-  it('I can filter by keyword', () => {
-    cy.get('input[name="keywords"]').type('Attorney');
-
-    cy.get('button').click();
-    cy.checkAccessibility();
-
-    cy.get('input[name="keywords"]').should('have.value', 'Attorney');
-
-    cy.get('body').should('contain', 'Registered Trademark Attorney');
-    cy.get('body').should(
-      'not.contain',
-      'Secondary School Teacher in State maintained schools (England)',
-    );
-  });
-
-  it('The search uses a professions keywords to filter', () => {
-    cy.get('input[name="keywords"]').type('Adjudicator');
-    cy.get('button').click();
-    cy.get('body').should('contain', 'Registered Trademark Attorney');
-    cy.get('body').should(
-      'not.contain',
-      'Secondary School Teacher in State maintained schools (England)',
-    );
   });
 
   it('I can use the back button to go back to my search results', () => {

--- a/cypress/integration/professions/search/search.spec.ts
+++ b/cypress/integration/professions/search/search.spec.ts
@@ -56,8 +56,8 @@ describe('Searching a profession', () => {
     cy.get('input[name="nations[]"][value="GB-WLS"]').check();
 
     cy.get('button').click();
-
     cy.checkAccessibility();
+
     cy.get('input[name="nations[]"][value="GB-WLS"]').should('be.checked');
 
     cy.get('body').should('contain', 'Registered Trademark Attorney');
@@ -82,6 +82,33 @@ describe('Searching a profession', () => {
         .find('input')
         .should('be.checked');
     });
+
+    cy.get('body').should(
+      'contain',
+      'Secondary School Teacher in State maintained schools (England)',
+    );
+    cy.get('body').should('not.contain', 'Registered Trademark Attorney');
+  });
+
+  it('I can filter by regulation type', () => {
+    cy.translate('professions.regulationTypes.licensing.name').then(
+      (nameLabel) => {
+        cy.get('label').contains(nameLabel).parent().find('input').check();
+      },
+    );
+
+    cy.get('button').click();
+    cy.checkAccessibility();
+
+    cy.translate('professions.regulationTypes.licensing.name').then(
+      (nameLabel) => {
+        cy.get('label')
+          .contains(nameLabel)
+          .parent()
+          .find('input')
+          .should('be.checked');
+      },
+    );
 
     cy.get('body').should(
       'contain',

--- a/src/i18n/en/organisations.json
+++ b/src/i18n/en/organisations.json
@@ -130,7 +130,8 @@
     "labels": {
       "keywords": "Keywords:",
       "nations": "Nations:",
-      "industries": "Industries:"
+      "industries": "Industries:",
+      "regulationTypes": "Regulation types:"
     },
     "foundSingular": "{count} regulatory authority found",
     "foundPlural": "{count} regulatory authorities found",
@@ -145,6 +146,10 @@
       },
       "industries": {
         "label": "Sectors",
+        "hint": "Select all that apply."
+      },
+      "regulationTypes": {
+        "label": "Regulation types",
         "hint": "Select all that apply."
       },
       "button": "Filter results"

--- a/src/i18n/en/professions.json
+++ b/src/i18n/en/professions.json
@@ -304,7 +304,8 @@
     "labels": {
       "keywords": "Keywords:",
       "nations": "Nations:",
-      "industries": "Sectors:"
+      "industries": "Sectors:",
+      "regulationTypes": "Regulation types:"
     },
     "profession": {
       "regulators": "Regulators",
@@ -321,6 +322,10 @@
       },
       "industries": {
         "label": "Sectors",
+        "hint": "Select all that apply."
+      },
+      "regulationTypes": {
+        "label": "Regulation types",
         "hint": "Select all that apply."
       },
       "button": "Filter results"

--- a/src/organisations/search/dto/filter.dto.ts
+++ b/src/organisations/search/dto/filter.dto.ts
@@ -1,5 +1,8 @@
+import { RegulationType } from '../../../professions/profession-version.entity';
+
 export class FilterDto {
   keywords = '';
   nations: string[] = [];
   industries: string[] = [];
+  regulationTypes: RegulationType[] = [];
 }

--- a/src/organisations/search/interfaces/index-template.interface.ts
+++ b/src/organisations/search/interfaces/index-template.interface.ts
@@ -5,14 +5,17 @@ export interface IndexTemplate {
   organisations: OrganisationSearchResultTemplate[];
 
   filters: {
-    industries: string[];
-    nations: string[];
     keywords: string;
+    nations: string[];
+    industries: string[];
+    regulationTypes: string[];
   };
 
   nationsCheckboxItems: CheckboxItems[];
 
   industriesCheckboxItems: CheckboxItems[];
+
+  regulationTypesCheckboxItems: CheckboxItems[];
 
   hasSelectedFilters: boolean;
 }

--- a/src/organisations/search/search.controller.spec.ts
+++ b/src/organisations/search/search.controller.spec.ts
@@ -12,6 +12,8 @@ import { createMockI18nService } from '../../testutils/create-mock-i18n-service'
 import { OrganisationVersionsService } from '../organisation-versions.service';
 
 import { IndustriesService } from '../../industries/industries.service';
+import { RegulationType } from '../../professions/profession-version.entity';
+import { FilterInput } from '../../common/interfaces/filter-input.interface';
 
 const industry1 = industryFactory.build({
   name: 'industries.example1',
@@ -95,8 +97,9 @@ describe('SearchController', () => {
         const result = await controller.index(
           {
             keywords: '',
-            industries: [],
             nations: [],
+            industries: [],
+            regulationTypes: [],
           },
           request,
         );
@@ -104,8 +107,9 @@ describe('SearchController', () => {
         const expected = await new SearchPresenter(
           {
             keywords: '',
-            industries: [],
             nations: [],
+            industries: [],
+            regulationTypes: [],
           },
           Nation.all(),
           industries,
@@ -120,17 +124,19 @@ describe('SearchController', () => {
         await controller.index(
           {
             keywords: '',
-            industries: [],
             nations: [],
+            industries: [],
+            regulationTypes: [],
           },
           request,
         );
 
         expect(organisationVersionsService.searchLive).toHaveBeenCalledWith({
           keywords: '',
-          industries: [],
           nations: [],
-        });
+          industries: [],
+          regulationTypes: [],
+        } as FilterInput);
       });
     });
 
@@ -138,8 +144,9 @@ describe('SearchController', () => {
       const result = await controller.index(
         {
           keywords: 'example search',
-          industries: [industry1.id, industry2.id],
           nations: ['GB-NIR'],
+          industries: [industry1.id, industry2.id],
+          regulationTypes: [RegulationType.Licensing],
         },
         request,
       );
@@ -149,6 +156,7 @@ describe('SearchController', () => {
           keywords: 'example search',
           industries: [industry1, industry2],
           nations: [Nation.find('GB-NIR')],
+          regulationTypes: [RegulationType.Licensing],
         },
         Nation.all(),
         industries,
@@ -160,9 +168,10 @@ describe('SearchController', () => {
 
       expect(organisationVersionsService.searchLive).toHaveBeenCalledWith({
         keywords: 'example search',
-        industries: [industry1, industry2],
         nations: [Nation.find('GB-NIR')],
-      });
+        industries: [industry1, industry2],
+        regulationTypes: [RegulationType.Licensing],
+      } as FilterInput);
     });
 
     it('should set the searchResultUrl', async () => {
@@ -173,8 +182,9 @@ describe('SearchController', () => {
       await controller.index(
         {
           keywords: '',
-          industries: [],
           nations: [],
+          industries: [],
+          regulationTypes: [],
         },
         request,
       );

--- a/src/organisations/search/search.presenter.spec.ts
+++ b/src/organisations/search/search.presenter.spec.ts
@@ -11,6 +11,8 @@ import { OrganisationSearchResultPresenter } from './organisation-search-result.
 import organisationFactory from '../../testutils/factories/organisation';
 import industryFactory from '../../testutils/factories/industry';
 import { hasSelectedFilters } from '../../search/helpers/has-selected-filters.helper';
+import { RegulationType } from '../../professions/profession-version.entity';
+import { RegulationTypesCheckboxPresenter } from '../../professions/admin/presenters/regulation-types-checkbox.presenter';
 
 jest.mock('../../search/helpers/has-selected-filters.helper');
 
@@ -52,9 +54,10 @@ describe('SearchPresenter', () => {
   describe('present', () => {
     it('should return a IndexTemplate', async () => {
       const filterInput: FilterInput = {
+        keywords: 'Example Keywords',
         nations: [nations[0]],
         industries: [industry2],
-        keywords: 'Example Keywords',
+        regulationTypes: [RegulationType.Accreditation],
       };
 
       const presenter = new SearchPresenter(
@@ -68,26 +71,34 @@ describe('SearchPresenter', () => {
       (hasSelectedFilters as jest.Mock).mockReturnValue(true);
       const result = await presenter.present();
 
-      const industriesCheckboxItems = await new IndustriesCheckboxPresenter(
-        industries,
-        [industry2],
-        i18nService,
-      ).checkboxItems();
-
       const nationsCheckboxItems = await new NationsCheckboxPresenter(
         Nation.all(),
         [Nation.find('GB-ENG')],
         i18nService,
       ).checkboxItems();
 
+      const industriesCheckboxItems = await new IndustriesCheckboxPresenter(
+        industries,
+        [industry2],
+        i18nService,
+      ).checkboxItems();
+
+      const regulationTypesCheckboxItems =
+        await new RegulationTypesCheckboxPresenter(
+          [RegulationType.Accreditation],
+          i18nService,
+        ).checkboxItems();
+
       const expected: IndexTemplate = {
         filters: {
-          industries: ['industries.example2'],
           keywords: 'Example Keywords',
           nations: ['nations.england'],
+          industries: ['industries.example2'],
+          regulationTypes: [RegulationType.Accreditation],
         },
-        industriesCheckboxItems,
         nationsCheckboxItems,
+        industriesCheckboxItems,
+        regulationTypesCheckboxItems,
         organisations: [
           await new OrganisationSearchResultPresenter(organisation1).present(),
           await new OrganisationSearchResultPresenter(organisation2).present(),

--- a/src/organisations/search/search.presenter.ts
+++ b/src/organisations/search/search.presenter.ts
@@ -8,6 +8,7 @@ import { IndexTemplate } from './interfaces/index-template.interface';
 import { OrganisationSearchResultPresenter } from './organisation-search-result.presenter';
 import { Organisation } from '../organisation.entity';
 import { hasSelectedFilters } from '../../search/helpers/has-selected-filters.helper';
+import { RegulationTypesCheckboxPresenter } from '../../professions/admin/presenters/regulation-types-checkbox.presenter';
 
 export class SearchPresenter {
   constructor(
@@ -31,6 +32,12 @@ export class SearchPresenter {
       this.i18nService,
     ).checkboxItems();
 
+    const regulationTypesCheckboxItems =
+      await new RegulationTypesCheckboxPresenter(
+        this.filterInput.regulationTypes,
+        this.i18nService,
+      ).checkboxItems();
+
     const displayOrganisations = await Promise.all(
       this.filteredOrganisations.map(async (organisation) =>
         new OrganisationSearchResultPresenter(organisation).present(),
@@ -41,12 +48,14 @@ export class SearchPresenter {
       organisations: displayOrganisations,
       nationsCheckboxItems,
       industriesCheckboxItems,
+      regulationTypesCheckboxItems,
       filters: {
         keywords: this.filterInput.keywords,
         nations: this.filterInput.nations.map((nation) => nation.name),
         industries: this.filterInput.industries.map(
           (industry) => industry.name,
         ),
+        regulationTypes: this.filterInput.regulationTypes,
       },
       hasSelectedFilters: hasSelectedFilters(this.filterInput),
     };

--- a/src/professions/profession-versions.service.ts
+++ b/src/professions/profession-versions.service.ts
@@ -194,6 +194,15 @@ export class ProfessionVersionsService {
       });
     }
 
+    if (filter.regulationTypes?.length) {
+      query = query.andWhere(
+        'professionVersion.regulationType IN(:...regulationTypes)',
+        {
+          regulationTypes: filter.regulationTypes,
+        },
+      );
+    }
+
     const versions = await query.getMany();
 
     return versions.map((version) =>

--- a/src/professions/search/dto/filter.dto.ts
+++ b/src/professions/search/dto/filter.dto.ts
@@ -1,5 +1,8 @@
+import { RegulationType } from '../../profession-version.entity';
+
 export class FilterDto {
   keywords = '';
   nations: string[] = [];
   industries: string[] = [];
+  regulationTypes: RegulationType[] = [];
 }

--- a/src/professions/search/interfaces/index-template.interface.ts
+++ b/src/professions/search/interfaces/index-template.interface.ts
@@ -5,14 +5,17 @@ export interface IndexTemplate {
   professions: ProfessionSearchResultTemplate[];
 
   filters: {
-    industries: string[];
-    nations: string[];
     keywords: string;
+    nations: string[];
+    industries: string[];
+    regulationTypes: string[];
   };
 
   nationsCheckboxItems: CheckboxItems[];
 
   industriesCheckboxItems: CheckboxItems[];
+
+  regulationTypesCheckboxItems: CheckboxItems[];
 
   hasSelectedFilters: boolean;
 }

--- a/src/professions/search/search.controller.spec.ts
+++ b/src/professions/search/search.controller.spec.ts
@@ -11,6 +11,8 @@ import industryFactory from '../../testutils/factories/industry';
 import professionFactory from '../../testutils/factories/profession';
 import { createMockI18nService } from '../../testutils/create-mock-i18n-service';
 import { ProfessionVersionsService } from '../profession-versions.service';
+import { RegulationType } from '../profession-version.entity';
+import { FilterInput } from '../../common/interfaces/filter-input.interface';
 
 describe('SearchController', () => {
   let controller: SearchController;
@@ -68,8 +70,9 @@ describe('SearchController', () => {
         const result = await controller.index(
           {
             keywords: '',
-            industries: [],
             nations: [],
+            industries: [],
+            regulationTypes: [],
           },
           request,
         );
@@ -77,8 +80,9 @@ describe('SearchController', () => {
         const expected = await new SearchPresenter(
           {
             keywords: '',
-            industries: [],
             nations: [],
+            industries: [],
+            regulationTypes: [],
           },
           Nation.all(),
           industries,
@@ -93,8 +97,9 @@ describe('SearchController', () => {
         await controller.index(
           {
             keywords: '',
-            industries: [],
             nations: [],
+            industries: [],
+            regulationTypes: [],
           },
           request,
         );
@@ -127,8 +132,9 @@ describe('SearchController', () => {
       const result = await controller.index(
         {
           keywords: 'example search',
-          industries: [industry1.id, industry2.id],
           nations: ['GB-SCT'],
+          industries: [industry1.id, industry2.id],
+          regulationTypes: [RegulationType.Certification],
         },
         request,
       );
@@ -136,8 +142,9 @@ describe('SearchController', () => {
       const expected = await new SearchPresenter(
         {
           keywords: 'example search',
-          industries: [industry1, industry2],
           nations: [Nation.find('GB-SCT')],
+          industries: [industry1, industry2],
+          regulationTypes: [RegulationType.Certification],
         },
         Nation.all(),
         industries,
@@ -149,9 +156,10 @@ describe('SearchController', () => {
 
       expect(professionVersionsService.searchLive).toHaveBeenCalledWith({
         keywords: 'example search',
-        industries: [industry1, industry2],
         nations: [Nation.find('GB-SCT')],
-      });
+        industries: [industry1, industry2],
+        regulationTypes: [RegulationType.Certification],
+      } as FilterInput);
     });
 
     it('should call the search service with the provided filters', async () => {
@@ -161,17 +169,25 @@ describe('SearchController', () => {
       await controller.index(
         {
           keywords: 'example search',
-          industries: [industry1.id, industry2.id],
           nations: ['GB-SCT'],
+          industries: [industry1.id, industry2.id],
+          regulationTypes: [
+            RegulationType.Certification,
+            RegulationType.Accreditation,
+          ],
         },
         request,
       );
 
       expect(professionVersionsService.searchLive).toHaveBeenCalledWith({
         keywords: 'example search',
-        industries: [industry1, industry2],
         nations: [Nation.find('GB-SCT')],
-      });
+        industries: [industry1, industry2],
+        regulationTypes: [
+          RegulationType.Certification,
+          RegulationType.Accreditation,
+        ],
+      } as FilterInput);
     });
   });
 
@@ -183,8 +199,9 @@ describe('SearchController', () => {
     await controller.index(
       {
         keywords: '',
-        industries: [],
         nations: [],
+        industries: [],
+        regulationTypes: [],
       },
       request,
     );

--- a/src/professions/search/search.presenter.spec.ts
+++ b/src/professions/search/search.presenter.spec.ts
@@ -11,6 +11,8 @@ import professionFactory from '../../testutils/factories/profession';
 import { createMockI18nService } from '../../testutils/create-mock-i18n-service';
 import { IndexTemplate } from './interfaces/index-template.interface';
 import { hasSelectedFilters } from '../../search/helpers/has-selected-filters.helper';
+import { RegulationType } from '../profession-version.entity';
+import { RegulationTypesCheckboxPresenter } from '../admin/presenters/regulation-types-checkbox.presenter';
 
 jest.mock('../../search/helpers/has-selected-filters.helper');
 
@@ -58,9 +60,13 @@ describe('SearchPresenter', () => {
   describe('present', () => {
     it('should return a IndexTemplate', async () => {
       const filterInput: FilterInput = {
+        keywords: 'Example Keywords',
         nations: [nations[0]],
         industries: [industry2],
-        keywords: 'Example Keywords',
+        regulationTypes: [
+          RegulationType.Certification,
+          RegulationType.Licensing,
+        ],
       };
 
       const presenter = new SearchPresenter(
@@ -74,26 +80,37 @@ describe('SearchPresenter', () => {
       (hasSelectedFilters as jest.Mock).mockReturnValue(true);
       const result = await presenter.present();
 
-      const industriesCheckboxItems = await new IndustriesCheckboxPresenter(
-        industries,
-        [industry2],
-        i18nService,
-      ).checkboxItems();
-
       const nationsCheckboxItems = await new NationsCheckboxPresenter(
         Nation.all(),
         [Nation.find('GB-ENG')],
         i18nService,
       ).checkboxItems();
 
+      const industriesCheckboxItems = await new IndustriesCheckboxPresenter(
+        industries,
+        [industry2],
+        i18nService,
+      ).checkboxItems();
+
+      const regulationTypesCheckboxItems =
+        await new RegulationTypesCheckboxPresenter(
+          [RegulationType.Certification, RegulationType.Licensing],
+          i18nService,
+        ).checkboxItems();
+
       const expected: IndexTemplate = {
         filters: {
-          industries: ['industries.example2'],
           keywords: 'Example Keywords',
+          industries: ['industries.example2'],
           nations: ['nations.england'],
+          regulationTypes: [
+            RegulationType.Certification,
+            RegulationType.Licensing,
+          ],
         },
-        industriesCheckboxItems,
         nationsCheckboxItems,
+        industriesCheckboxItems,
+        regulationTypesCheckboxItems,
         professions: [
           await new ProfessionSearchResultPresenter(
             profession1,

--- a/src/professions/search/search.presenter.ts
+++ b/src/professions/search/search.presenter.ts
@@ -8,6 +8,7 @@ import { FilterInput } from '../../common/interfaces/filter-input.interface';
 import { IndexTemplate } from './interfaces/index-template.interface';
 import { ProfessionSearchResultPresenter } from './profession-search-result.presenter';
 import { hasSelectedFilters } from '../../search/helpers/has-selected-filters.helper';
+import { RegulationTypesCheckboxPresenter } from '../admin/presenters/regulation-types-checkbox.presenter';
 
 export class SearchPresenter {
   constructor(
@@ -31,6 +32,12 @@ export class SearchPresenter {
       this.i18nService,
     ).checkboxItems();
 
+    const regulationTypesCheckboxItems =
+      await new RegulationTypesCheckboxPresenter(
+        this.filterInput.regulationTypes,
+        this.i18nService,
+      ).checkboxItems();
+
     const displayProfessions = await Promise.all(
       this.filteredProfessions.map(async (profession) =>
         new ProfessionSearchResultPresenter(
@@ -44,12 +51,14 @@ export class SearchPresenter {
       professions: displayProfessions,
       nationsCheckboxItems,
       industriesCheckboxItems,
+      regulationTypesCheckboxItems,
       filters: {
         keywords: this.filterInput.keywords,
         nations: this.filterInput.nations.map((nation) => nation.name),
         industries: this.filterInput.industries.map(
           (industry) => industry.name,
         ),
+        regulationTypes: this.filterInput.regulationTypes,
       },
       hasSelectedFilters: hasSelectedFilters(this.filterInput),
     };


### PR DESCRIPTION
# Changes in this PR

Support for searching by regulation type in public-facing Profession and Organisation search

## Screenshots of UI changes

### Before
![localhost_3000_professions_search](https://user-images.githubusercontent.com/94137563/159918535-23fb60f5-7306-446f-a663-f312552cce7a.png)
![localhost_3000_regulatory-authorities_search](https://user-images.githubusercontent.com/94137563/159918545-6e46e814-890f-4941-8296-b39abf157151.png)

### After
![localhost_3000_professions_search_keywords= regulationTypes%5B%5D=licensing](https://user-images.githubusercontent.com/94137563/159918525-d1854a62-2428-4910-8b79-6ed137a328ba.png)
![localhost_3000_regulatory-authorities_search_keywords= regulationTypes%5B%5D=licensing regulationTypes%5B%5D=accreditation](https://user-images.githubusercontent.com/94137563/159918514-e6167d03-9276-4cfb-9aaf-ccf16d32bf93.png)

