### PR TITLE
Set 14 day expiry time on invitation email links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Updated second legislation label text to be clearer for admins
 - Fix bug with organisations and professions not being displayed in alphabetical order
 - Order users alphabetically
+- Increase expiry time on invitation email links to 14 days
 
 ## [release-010] - 2022-03-22
 

--- a/src/users/auth0.service.spec.ts
+++ b/src/users/auth0.service.spec.ts
@@ -63,6 +63,7 @@ describe('Auth0Service', () => {
           managementClient.createPasswordChangeTicket,
         ).toHaveBeenCalledWith({
           result_url: `${process.env['HOST_URL']}/admin`,
+          ttl_sec: 1209600,
           user_id: 123,
         });
 

--- a/src/users/auth0.service.ts
+++ b/src/users/auth0.service.ts
@@ -61,6 +61,7 @@ export class Auth0Service {
     const passwordChangeTicket = await client.createPasswordChangeTicket({
       result_url: `${process.env['HOST_URL']}/admin`,
       user_id: user.user_id,
+      ttl_sec: 1209600,
     });
 
     return {


### PR DESCRIPTION
# Changes in this PR

Sets the `ttl_sec` (time before expiry in seconds) of links on the invitation email to 14 days, rather than 5, as 5 is too short, and regulators are not getting around to setting up their accounts on time.
