### PR TITLE
(2268) Remove the external authentication step once beis confirm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix bug with organisations and professions not being displayed in alphabetical order
 - Order users alphabetically
 - Increase expiry time on invitation email links to 14 days
+- Remove "double authentication" step from internal pages
 
 ## [release-010] - 2022-03-22
 

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -5,12 +5,6 @@ import { getActingUser } from './users/helpers/get-acting-user.helper';
 import { getUserOrganisation } from './users/helpers/get-user-organisation';
 @Controller()
 export class AppController {
-  @Get()
-  @Render('index')
-  index() {
-    // do nothing.
-  }
-
   @Get('/admin')
   @UseGuards(AuthenticationGuard)
   @Render('admin/dashboard')

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,6 +1,6 @@
 process.env.NODE_ENV ||= 'development';
 
-import { Module } from '@nestjs/common';
+import { MiddlewareConsumer, Module, NestModule } from '@nestjs/common';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { I18nModule, I18nJsonParser } from 'nestjs-i18n';
 import { BullModule } from '@nestjs/bull';
@@ -18,6 +18,11 @@ import { IndustriesModule } from './industries/industries.module';
 
 import dbConfiguration from './config/db.config';
 import redisConfiguration from './config/redis.config';
+import basicAuth from 'express-basic-auth';
+import { SearchController as ProfessionSearchController } from './professions/search/search.controller';
+import { SearchController as OrganisationSearchController } from './organisations/search/search.controller';
+import { OrganisationsController } from './organisations/organisations.controller';
+import { ProfessionsController } from './professions/professions.controller';
 import { LandingController } from './landing/landing.controller';
 
 @Module({
@@ -58,4 +63,30 @@ import { LandingController } from './landing/landing.controller';
   controllers: [AppController, LandingController],
   providers: [MailerConsumer],
 })
-export class AppModule {}
+export class AppModule implements NestModule {
+  configure(consumer: MiddlewareConsumer) {
+    if (
+      process.env['BASIC_AUTH_USERNAME'] &&
+      process.env['BASIC_AUTH_PASSWORD']
+    ) {
+      consumer
+        .apply(
+          basicAuth({
+            users: {
+              [process.env['BASIC_AUTH_USERNAME']]:
+                process.env['BASIC_AUTH_PASSWORD'],
+            },
+            challenge: true,
+            realm: process.env['HOST_URL'],
+          }),
+        )
+        .forRoutes(
+          LandingController,
+          OrganisationsController,
+          ProfessionsController,
+          ProfessionSearchController,
+          OrganisationSearchController,
+        );
+    }
+  }
+}

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -18,6 +18,7 @@ import { IndustriesModule } from './industries/industries.module';
 
 import dbConfiguration from './config/db.config';
 import redisConfiguration from './config/redis.config';
+import { LandingController } from './landing/landing.controller';
 
 @Module({
   imports: [
@@ -54,7 +55,7 @@ import redisConfiguration from './config/redis.config';
     OrganisationsModule,
     IndustriesModule,
   ],
-  controllers: [AppController],
+  controllers: [AppController, LandingController],
   providers: [MailerConsumer],
 })
 export class AppModule {}

--- a/src/landing/landing.controller.spec.ts
+++ b/src/landing/landing.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { LandingController } from './landing.controller';
+
+describe('LandingController', () => {
+  let landingController: LandingController;
+
+  beforeEach(async () => {
+    const app: TestingModule = await Test.createTestingModule({
+      controllers: [LandingController],
+    }).compile();
+
+    landingController = app.get<LandingController>(LandingController);
+  });
+
+  describe('index', () => {
+    it('return without error', () => {
+      expect(landingController.index()).toEqual(undefined);
+    });
+  });
+});

--- a/src/landing/landing.controller.ts
+++ b/src/landing/landing.controller.ts
@@ -1,0 +1,10 @@
+import { Controller, Get, Render } from '@nestjs/common';
+
+@Controller()
+export class LandingController {
+  @Get()
+  @Render('index')
+  index(): void {
+    // do nothing.
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,7 +7,6 @@ import path from 'path';
 import session from 'express-session';
 import methodOverride from 'method-override';
 import connectFlash from 'connect-flash';
-import basicAuth from 'express-basic-auth';
 
 import { AppModule } from './app.module';
 import { AuthenticationMidleware } from './middleware/authentication.middleware';
@@ -64,23 +63,6 @@ async function bootstrap() {
 
   // Add global variables to the application to be used in the templates
   app.use(globalLocals);
-
-  // Add basic auth to the application if the environment variables are set
-  if (
-    process.env['BASIC_AUTH_USERNAME'] &&
-    process.env['BASIC_AUTH_PASSWORD']
-  ) {
-    app.use(
-      basicAuth({
-        users: {
-          [process.env['BASIC_AUTH_USERNAME']]:
-            process.env['BASIC_AUTH_PASSWORD'],
-        },
-        challenge: true,
-        realm: process.env['HOST_URL'],
-      }),
-    );
-  }
 
   if (process.env['CANONICAL_HOSTNAME']) {
     app.use(redirectToCanonicalHostname);


### PR DESCRIPTION
# Changes in this PR

- Remove "double authentication" step from internal pages

We some non-`/admin` pages unprotected where it makes sense. `/callback` and `/logout` need to remain unprotected, and it seemed right to leave pages linked to from the footer of the admin pages unprotected 