### PR TITLE
(2267) Add overseas routes to recognition fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 - New landing page for central users
+- Add back other countries routes to recognition with new radio buttons
 
 ### Changed
 

--- a/cypress/integration/admin/professions/edit.spec.ts
+++ b/cypress/integration/admin/professions/edit.spec.ts
@@ -417,6 +417,13 @@ describe('Editing an existing profession', () => {
         cy.get('input[name="ukRecognition"]').type('Recognition in UK');
         cy.get('input[name="ukRecognitionUrl"]').type('http://example.com/uk');
 
+        cy.get('textarea[name="otherCountriesRecognitionSummary"]').type(
+          'Recognition in other countries',
+        );
+        cy.get('input[name="otherCountriesRecognitionUrl"]').type(
+          'http://example.com/other',
+        );
+
         cy.translate('app.continue').then((buttonText) => {
           cy.get('button').contains(buttonText).click();
         });
@@ -438,6 +445,15 @@ describe('Editing an existing profession', () => {
         cy.checkSummaryListRowValue(
           'professions.form.label.qualifications.ukRecognitionUrl',
           'http://example.com/uk',
+        );
+
+        cy.checkSummaryListRowValue(
+          'professions.form.label.qualifications.otherCountriesRecognition.summary',
+          'Recognition in other countries',
+        );
+        cy.checkSummaryListRowValue(
+          'professions.form.label.qualifications.otherCountriesRecognition.url',
+          'http://example.com/other',
         );
 
         cy.translate('professions.form.button.saveAsDraft').then(

--- a/cypress/integration/admin/professions/edit.spec.ts
+++ b/cypress/integration/admin/professions/edit.spec.ts
@@ -417,6 +417,9 @@ describe('Editing an existing profession', () => {
         cy.get('input[name="ukRecognition"]').type('Recognition in UK');
         cy.get('input[name="ukRecognitionUrl"]').type('http://example.com/uk');
 
+        cy.get(
+          'input[name="otherCountriesRecognitionRoutes"][value="some"]',
+        ).check();
         cy.get('textarea[name="otherCountriesRecognitionSummary"]').type(
           'Recognition in other countries',
         );
@@ -447,6 +450,15 @@ describe('Editing an existing profession', () => {
           'http://example.com/uk',
         );
 
+        cy.translate(
+          'professions.form.label.qualifications.otherCountriesRecognition.some',
+          (some: string) => {
+            cy.checkSummaryListRowValue(
+              'professions.form.label.qualifications.otherCountriesRecognition.routes.label',
+              some,
+            );
+          },
+        );
         cy.checkSummaryListRowValue(
           'professions.form.label.qualifications.otherCountriesRecognition.summary',
           'Recognition in other countries',

--- a/cypress/integration/admin/professions/edit.spec.ts
+++ b/cypress/integration/admin/professions/edit.spec.ts
@@ -414,7 +414,7 @@ describe('Editing an existing profession', () => {
           'http://example.com/more-info',
         );
 
-        cy.get('input[name="ukRecognition"]').type('Recognition in UK');
+        cy.get('textarea[name="ukRecognition"]').type('Recognition in UK');
         cy.get('input[name="ukRecognitionUrl"]').type('http://example.com/uk');
 
         cy.get(

--- a/cypress/integration/admin/professions/new.spec.ts
+++ b/cypress/integration/admin/professions/new.spec.ts
@@ -182,7 +182,7 @@ describe('Adding a new profession', () => {
         'http://example.com/more-info',
       );
 
-      cy.get('input[name="ukRecognition"]').type('Recognition in the UK');
+      cy.get('textarea[name="ukRecognition"]').type('Recognition in the UK');
       cy.get('input[name="ukRecognitionUrl"]').type('http://example.com/uk');
 
       cy.get(

--- a/cypress/integration/admin/professions/new.spec.ts
+++ b/cypress/integration/admin/professions/new.spec.ts
@@ -185,6 +185,9 @@ describe('Adding a new profession', () => {
       cy.get('input[name="ukRecognition"]').type('Recognition in the UK');
       cy.get('input[name="ukRecognitionUrl"]').type('http://example.com/uk');
 
+      cy.get(
+        'input[name="otherCountriesRecognitionRoutes"][value="some"]',
+      ).check();
       cy.get('textarea[name="otherCountriesRecognitionSummary"]').type(
         'Recognition in other countries',
       );
@@ -314,6 +317,15 @@ describe('Adding a new profession', () => {
       cy.checkSummaryListRowValue(
         'professions.form.label.qualifications.ukRecognitionUrl',
         'http://example.com/uk',
+      );
+      cy.translate(
+        'professions.form.label.qualifications.otherCountriesRecognition.some',
+        (some: string) => {
+          cy.checkSummaryListRowValue(
+            'professions.form.label.qualifications.otherCountriesRecognition.routes.label',
+            some,
+          );
+        },
       );
       cy.checkSummaryListRowValue(
         'professions.form.label.qualifications.otherCountriesRecognition.summary',

--- a/cypress/integration/admin/professions/new.spec.ts
+++ b/cypress/integration/admin/professions/new.spec.ts
@@ -185,6 +185,13 @@ describe('Adding a new profession', () => {
       cy.get('input[name="ukRecognition"]').type('Recognition in the UK');
       cy.get('input[name="ukRecognitionUrl"]').type('http://example.com/uk');
 
+      cy.get('textarea[name="otherCountriesRecognitionSummary"]').type(
+        'Recognition in other countries',
+      );
+      cy.get('input[name="otherCountriesRecognitionUrl"]').type(
+        'http://example.com/other',
+      );
+
       cy.translate('app.continue').then((buttonText) => {
         cy.get('button').contains(buttonText).click();
       });
@@ -307,6 +314,14 @@ describe('Adding a new profession', () => {
       cy.checkSummaryListRowValue(
         'professions.form.label.qualifications.ukRecognitionUrl',
         'http://example.com/uk',
+      );
+      cy.checkSummaryListRowValue(
+        'professions.form.label.qualifications.otherCountriesRecognition.summary',
+        'Recognition in other countries',
+      );
+      cy.checkSummaryListRowValue(
+        'professions.form.label.qualifications.otherCountriesRecognition.url',
+        'http://example.com/other',
       );
 
       cy.checkSummaryListRowValue(

--- a/cypress/integration/admin/professions/publish.spec.ts
+++ b/cypress/integration/admin/professions/publish.spec.ts
@@ -477,7 +477,7 @@ describe('Publishing professions', () => {
         'http://example.com/more-info',
       );
 
-      cy.get('input[name="ukRecognition"]').type('Recognition in the UK');
+      cy.get('textarea[name="ukRecognition"]').type('Recognition in the UK');
       cy.get('input[name="ukRecognitionUrl"]').type('http://example.com/uk');
       cy.get(
         'input[name="otherCountriesRecognitionRoutes"][value="some"]',

--- a/cypress/integration/admin/professions/publish.spec.ts
+++ b/cypress/integration/admin/professions/publish.spec.ts
@@ -139,6 +139,9 @@ describe('Publishing professions', () => {
         'professions.form.label.qualifications.routesToObtain',
       );
       cy.checkAccessibility();
+      cy.get(
+        'input[name="otherCountriesRecognitionRoutes"][value="some"]',
+      ).check();
       cy.get('textarea[name="routesToObtain"]').type('Routes to obtain');
       cy.translate('app.continue').then((buttonText) => {
         cy.get('button').contains(buttonText).click();
@@ -476,6 +479,9 @@ describe('Publishing professions', () => {
 
       cy.get('input[name="ukRecognition"]').type('Recognition in the UK');
       cy.get('input[name="ukRecognitionUrl"]').type('http://example.com/uk');
+      cy.get(
+        'input[name="otherCountriesRecognitionRoutes"][value="some"]',
+      ).check();
       cy.get('textarea[name="otherCountriesRecognitionSummary"]').type(
         'Recognition in other countries',
       );

--- a/cypress/integration/admin/professions/publish.spec.ts
+++ b/cypress/integration/admin/professions/publish.spec.ts
@@ -476,6 +476,12 @@ describe('Publishing professions', () => {
 
       cy.get('input[name="ukRecognition"]').type('Recognition in the UK');
       cy.get('input[name="ukRecognitionUrl"]').type('http://example.com/uk');
+      cy.get('textarea[name="otherCountriesRecognitionSummary"]').type(
+        'Recognition in other countries',
+      );
+      cy.get('input[name="otherCountriesRecognitionUrl"]').type(
+        'http://example.com/other',
+      );
 
       cy.translate('app.continue').then((buttonText) => {
         cy.get('button').contains(buttonText).click();

--- a/cypress/integration/admin/professions/show.spec.ts
+++ b/cypress/integration/admin/professions/show.spec.ts
@@ -135,6 +135,14 @@ describe('Listing professions', () => {
         'professions.show.qualification.moreInformationUrl',
         'https://www.sra.org.uk/become-solicitor/qualified-lawyers/',
       );
+      cy.translate(
+        'professions.show.qualification.otherCountriesRecognition.routes.none',
+      ).then((none) => {
+        cy.checkSummaryListRowValue(
+          'professions.show.qualification.otherCountriesRecognition.routes.label',
+          none,
+        );
+      });
 
       cy.translate('professions.show.registration.heading').then((heading) => {
         cy.get('body').should('contain', heading);
@@ -258,6 +266,14 @@ describe('Listing professions', () => {
         'professions.show.qualification.moreInformationUrl',
         '',
       );
+      cy.translate(
+        'professions.show.qualification.otherCountriesRecognition.routes.all',
+      ).then((all) => {
+        cy.checkSummaryListRowValue(
+          'professions.show.qualification.otherCountriesRecognition.routes.label',
+          all,
+        );
+      });
 
       cy.translate('professions.show.registration.heading').then((heading) => {
         cy.get('body').should('contain', heading);

--- a/cypress/integration/professions/show.spec.ts
+++ b/cypress/integration/professions/show.spec.ts
@@ -129,6 +129,15 @@ describe('Showing a profession', () => {
       'https://www.sra.org.uk/become-solicitor/qualified-lawyers/',
     );
 
+    cy.translate(
+      'professions.show.qualification.otherCountriesRecognition.routes.none',
+    ).then((none) => {
+      cy.checkSummaryListRowValue(
+        'professions.show.qualification.otherCountriesRecognition.routes.label',
+        none,
+      );
+    });
+
     cy.translate('professions.show.registration.heading').then((heading) => {
       cy.get('body').should('contain', heading);
     });
@@ -254,6 +263,16 @@ describe('Showing a profession', () => {
         cy.get('body').should('not.contain', moreInformationUrl);
       },
     );
+
+    cy.translate(
+      'professions.show.qualification.otherCountriesRecognition.routes.all',
+    ).then((all) => {
+      cy.checkSummaryListRowValue(
+        'professions.show.qualification.otherCountriesRecognition.routes.label',
+        all,
+      );
+    });
+
     cy.translate('professions.show.registration.heading').then((heading) => {
       cy.get('body').should('not.contain', heading);
     });

--- a/seeds/development/qualifications.json
+++ b/seeds/development/qualifications.json
@@ -1,18 +1,21 @@
 [
   {
     "routesToObtain": "Have a degree in any subject that is equivalent to a UK degree or level 6 qualification, or other qualification and/or experience equivalent to this.",
-    "url": "https://www.sra.org.uk/become-solicitor/qualified-lawyers/"
+    "url": "https://www.sra.org.uk/become-solicitor/qualified-lawyers/",
+    "otherCountriesRecognitionRoutes": "none"
   },
   {
     "routesToObtain": "To teach in a state school in England, you must have a degree, and gain Qualified Teacher Status (QTS) by following a programme of Initial Teacher Training (ITT). You must have achieved minimum requirements in GCSE English, maths, and science if you wish to teach at primary-level. You can teach in independent schools, academies, and free schools in England without QTS, but it’s a definite advantage to have it.",
-    "url": "https://www.ucas.com/postgraduate/teacher-training/train-teach-england/teacher-training-entry-requirements-england"
+    "url": "https://www.ucas.com/postgraduate/teacher-training/train-teach-england/teacher-training-entry-requirements-england",
+    "otherCountriesRecognitionRoutes": "none"
   },
   {
     "routesToObtain": "Evidence of gas safety competence is awarded through the process of proving to a recognised awarding body that you have the appropriate level of knowledge, understanding and practical skills to undertake gas work safely. All evidence of gas safety competence is sent by the awarding body electronically directly to Gas Safe Register and is only recognised once received from the awarding body concerned.",
-    "url": "https://www.euskills.co.uk/about/our-industries/gas/"
+    "url": "https://www.euskills.co.uk/about/our-industries/gas/",
+    "otherCountriesRecognitionRoutes": "some"
   },
   {
     "routesToObtain": "General post-secondary education",
-    "url": "http://www.example.com"
+    "otherCountriesRecognitionRoutes": "all"
   }
 ]

--- a/seeds/staging/qualifications.json
+++ b/seeds/staging/qualifications.json
@@ -1,18 +1,21 @@
 [
   {
     "routesToObtain": "Have a degree in any subject that is equivalent to a UK degree or level 6 qualification, or other qualification and/or experience equivalent to this.",
-    "url": "https://www.sra.org.uk/become-solicitor/qualified-lawyers/"
+    "url": "https://www.sra.org.uk/become-solicitor/qualified-lawyers/",
+    "otherCountriesRecognitionRoutes": "none"
   },
   {
     "routesToObtain": "To teach in a state school in England, you must have a degree, and gain Qualified Teacher Status (QTS) by following a programme of Initial Teacher Training (ITT). You must have achieved minimum requirements in GCSE English, maths, and science if you wish to teach at primary-level. You can teach in independent schools, academies, and free schools in England without QTS, but it’s a definite advantage to have it.",
-    "url": "https://www.ucas.com/postgraduate/teacher-training/train-teach-england/teacher-training-entry-requirements-england"
+    "url": "https://www.ucas.com/postgraduate/teacher-training/train-teach-england/teacher-training-entry-requirements-england",
+    "otherCountriesRecognitionRoutes": "none"
   },
   {
     "routesToObtain": "Evidence of gas safety competence is awarded through the process of proving to a recognised awarding body that you have the appropriate level of knowledge, understanding and practical skills to undertake gas work safely. All evidence of gas safety competence is sent by the awarding body electronically directly to Gas Safe Register and is only recognised once received from the awarding body concerned.",
-    "url": "https://www.euskills.co.uk/about/our-industries/gas/"
+    "url": "https://www.euskills.co.uk/about/our-industries/gas/",
+    "otherCountriesRecognitionRoutes": "some"
   },
   {
     "routesToObtain": "General post-secondary education",
-    "url": "http://www.example.com"
+    "otherCountriesRecognitionRoutes": "all"
   }
 ]

--- a/seeds/test/qualifications.json
+++ b/seeds/test/qualifications.json
@@ -1,17 +1,21 @@
 [
   {
     "routesToObtain": "Have a degree in any subject that is equivalent to a UK degree or level 6 qualification, or other qualification and/or experience equivalent to this.",
-    "url": "https://www.sra.org.uk/become-solicitor/qualified-lawyers/"
+    "url": "https://www.sra.org.uk/become-solicitor/qualified-lawyers/",
+    "otherCountriesRecognitionRoutes": "none"
   },
   {
     "routesToObtain": "To teach in a state school in England, you must have a degree, and gain Qualified Teacher Status (QTS) by following a programme of Initial Teacher Training (ITT). You must have achieved minimum requirements in GCSE English, maths, and science if you wish to teach at primary-level. You can teach in independent schools, academies, and free schools in England without QTS, but it’s a definite advantage to have it.",
-    "url": "https://www.ucas.com/postgraduate/teacher-training/train-teach-england/teacher-training-entry-requirements-england"
+    "url": "https://www.ucas.com/postgraduate/teacher-training/train-teach-england/teacher-training-entry-requirements-england",
+    "otherCountriesRecognitionRoutes": "none"
   },
   {
     "routesToObtain": "Evidence of gas safety competence is awarded through the process of proving to a recognised awarding body that you have the appropriate level of knowledge, understanding and practical skills to undertake gas work safely. All evidence of gas safety competence is sent by the awarding body electronically directly to Gas Safe Register and is only recognised once received from the awarding body concerned.",
-    "url": "https://www.euskills.co.uk/about/our-industries/gas/"
+    "url": "https://www.euskills.co.uk/about/our-industries/gas/",
+    "otherCountriesRecognitionRoutes": "some"
   },
   {
-    "routesToObtain": "General post-secondary education"
+    "routesToObtain": "General post-secondary education",
+    "otherCountriesRecognitionRoutes": "all"
   }
 ]

--- a/src/db/migrate/1648121943887-AddOtherCountriesRecognitionToQualifications.ts
+++ b/src/db/migrate/1648121943887-AddOtherCountriesRecognitionToQualifications.ts
@@ -1,0 +1,37 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddOtherCountriesRecognitionToQualifications1648121943887
+  implements MigrationInterface
+{
+  name = 'AddOtherCountriesRecognitionToQualifications1648121943887';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "qualifications" ADD "otherCountriesRecognitionSummary" character varying`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "qualifications" ADD "otherCountriesRecognitionUrl" character varying`,
+    );
+    await queryRunner.query(
+      `CREATE TYPE "public"."qualifications_othercountriesrecognitionroutes_enum" AS ENUM('none', 'some', 'all')`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "qualifications" ADD "otherCountriesRecognitionRoutes" "public"."qualifications_othercountriesrecognitionroutes_enum"`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "qualifications" DROP COLUMN "otherCountriesRecognitionRoutes"`,
+    );
+    await queryRunner.query(
+      `DROP TYPE "public"."qualifications_othercountriesrecognitionroutes_enum"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "qualifications" DROP COLUMN "otherCountriesRecognitionUrl"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "qualifications" DROP COLUMN "otherCountriesRecognitionSummary"`,
+    );
+  }
+}

--- a/src/i18n/en/professions.json
+++ b/src/i18n/en/professions.json
@@ -75,7 +75,7 @@
         "ukRecognitionUrl": "More about recognition within the UK (optional)",
         "otherCountriesRecognition": {
           "routes": {
-            "label": "What routes exist",
+            "label": "Routes to recognition for professionals outside the UK",
             "all": "Routes for professionals in all countries",
             "some": "Routes for professionals in some countries",
             "none": "No routes exist - all professionals must re-qualify"
@@ -154,6 +154,9 @@
         "ukRecognitionUrl": {
           "invalid": "Please enter a valid website address"
         },
+        "otherCountriesRecognitionRoutes": {
+          "empty": "Select what recognition routes exist for professionals qualified in another country"
+        },
         "otherCountriesRecognitionUrl": {
           "invalid": "Please enter a valid website address"
         }
@@ -203,6 +206,12 @@
       "ukRecognition": "Routes to recognition within the UK",
       "ukRecognitionUrl": "More about recognition within the UK",
       "otherCountriesRecognition": {
+        "routes": {
+          "label": "Recognition for overseas professionals",
+          "all": "All - there are routes to recognition for professionals from all countries",
+          "some": "Some - qualifications from some countries may be recognised, but professionals from other countries will have to re-qualify",
+          "none": "None - all professionals must re-qualify"
+        },
         "summary": "Summary of routes",
         "url": "More about recognition for professionals outside the UK"
       }

--- a/src/i18n/en/professions.json
+++ b/src/i18n/en/professions.json
@@ -74,6 +74,12 @@
         "ukRecognition": "Routes to recognition within the UK (optional)",
         "ukRecognitionUrl": "More about recognition within the UK (optional)",
         "otherCountriesRecognition": {
+          "routes": {
+            "label": "What routes exist",
+            "all": "Routes for professionals in all countries",
+            "some": "Routes for professionals in some countries",
+            "none": "No routes exist - all professionals must re-qualify"
+          },
           "summary": "Summary of routes (optional)",
           "summaryHint": "How qualifications and experience gained outside the UK may be recognised",
           "url": "More about recognition for professionals outside the UK (optional)",

--- a/src/i18n/en/professions.json
+++ b/src/i18n/en/professions.json
@@ -72,7 +72,13 @@
         "routesToObtain": "Routes to qualification for new professionals",
         "moreInformationUrl": "More about qualification (optional)",
         "ukRecognition": "Routes to recognition within the UK (optional)",
-        "ukRecognitionUrl": "More about recognition within the UK (optional)"
+        "ukRecognitionUrl": "More about recognition within the UK (optional)",
+        "otherCountriesRecognition": {
+          "summary": "Summary of routes (optional)",
+          "summaryHint": "How qualifications and experience gained outside the UK may be recognised",
+          "url": "More about recognition for professionals outside the UK (optional)",
+          "urlHint": "Website link to more information"
+        }
       },
       "legislation": {
         "nationalLegislation": "Title of relevant act or charter",
@@ -141,6 +147,9 @@
         },
         "ukRecognitionUrl": {
           "invalid": "Please enter a valid website address"
+        },
+        "otherCountriesRecognitionUrl": {
+          "invalid": "Please enter a valid website address"
         }
       },
       "legislation": {
@@ -186,7 +195,11 @@
       "routesToObtain": "Routes to qualification",
       "moreInformationUrl": "More about qualification",
       "ukRecognition": "Routes to recognition within the UK",
-      "ukRecognitionUrl": "More about recognition within the UK"
+      "ukRecognitionUrl": "More about recognition within the UK",
+      "otherCountriesRecognition": {
+        "summary": "Summary of routes",
+        "url": "More about recognition for professionals outside the UK"
+      }
     },
     "registration": {
       "heading": "Registration",

--- a/src/professions/admin/dto/qualifications.dto.ts
+++ b/src/professions/admin/dto/qualifications.dto.ts
@@ -26,4 +26,14 @@ export class QualificationsDto {
   @Transform(({ value }) => preprocessUrl(value))
   @ValidateIf((e) => e.ukRecognitionUrl)
   ukRecognitionUrl: string;
+
+  otherCountriesRecognitionSummary: string;
+
+  @IsUrl(urlOptions, {
+    message:
+      'professions.form.errors.qualification.otherCountriesRecognitionUrl.invalid',
+  })
+  @Transform(({ value }) => preprocessUrl(value))
+  @ValidateIf((e) => e.otherCountriesRecognitionUrl)
+  otherCountriesRecognitionUrl: string;
 }

--- a/src/professions/admin/dto/qualifications.dto.ts
+++ b/src/professions/admin/dto/qualifications.dto.ts
@@ -4,6 +4,7 @@ import {
   preprocessUrl,
   urlOptions,
 } from '../../../helpers/preprocess-url.helper';
+import { OtherCountriesRecognitionRoutes } from '../../../qualifications/qualification.entity';
 
 export class QualificationsDto {
   @IsNotEmpty({
@@ -26,6 +27,12 @@ export class QualificationsDto {
   @Transform(({ value }) => preprocessUrl(value))
   @ValidateIf((e) => e.ukRecognitionUrl)
   ukRecognitionUrl: string;
+
+  @IsNotEmpty({
+    message:
+      'professions.form.errors.qualification.otherCountriesRecognitionRoutes.empty',
+  })
+  otherCountriesRecognitionRoutes: OtherCountriesRecognitionRoutes;
 
   otherCountriesRecognitionSummary: string;
 

--- a/src/professions/admin/interfaces/qualifications.template.ts
+++ b/src/professions/admin/interfaces/qualifications.template.ts
@@ -3,6 +3,8 @@ export interface QualificationsTemplate {
   moreInformationUrl: string;
   ukRecognition: string;
   ukRecognitionUrl: string;
+  otherCountriesRecognitionSummary: string;
+  otherCountriesRecognitionUrl: string;
   captionText: string;
   isUK: boolean;
   errors: object | undefined;

--- a/src/professions/admin/interfaces/qualifications.template.ts
+++ b/src/professions/admin/interfaces/qualifications.template.ts
@@ -1,8 +1,11 @@
+import { RadioButtonArgs } from '../../../common/interfaces/radio-button-args.interface';
+
 export interface QualificationsTemplate {
   routesToObtain: string;
   moreInformationUrl: string;
   ukRecognition: string;
   ukRecognitionUrl: string;
+  otherCountriesRecognitionRoutesRadioButtonArgs: RadioButtonArgs[];
   otherCountriesRecognitionSummary: string;
   otherCountriesRecognitionUrl: string;
   captionText: string;

--- a/src/professions/admin/presenters/other-countries-recognition-routes-radio-buttons-presenter.spec.ts
+++ b/src/professions/admin/presenters/other-countries-recognition-routes-radio-buttons-presenter.spec.ts
@@ -1,0 +1,85 @@
+import { RadioButtonArgs } from '../../../common/interfaces/radio-button-args.interface';
+import { OtherCountriesRecognitionRoutes } from '../../../qualifications/qualification.entity';
+import { createMockI18nService } from '../../../testutils/create-mock-i18n-service';
+import { translationOf } from '../../../testutils/translation-of';
+import { OtherCountriesRecognitionRoutesRadioButtonsPresenter } from './other-countries-recognition-routes-radio-buttons-presenter';
+
+describe('OtherCountriesRecognitionRoutesRadioButtonsPresenter', () => {
+  describe('radioButtonArgs', () => {
+    describe('when the current route is empty', () => {
+      it('returns an array of `RadioButtonArgs`, with no option checked', async () => {
+        const i18nService = createMockI18nService();
+
+        const presenter =
+          new OtherCountriesRecognitionRoutesRadioButtonsPresenter(
+            null,
+            i18nService,
+          );
+
+        const expected: RadioButtonArgs[] = [
+          {
+            text: translationOf(
+              'professions.form.label.qualifications.otherCountriesRecognition.routes.none',
+            ),
+            value: 'none',
+            checked: false,
+          },
+          {
+            text: translationOf(
+              'professions.form.label.qualifications.otherCountriesRecognition.routes.some',
+            ),
+            value: 'some',
+            checked: false,
+          },
+          {
+            text: translationOf(
+              'professions.form.label.qualifications.otherCountriesRecognition.routes.all',
+            ),
+            value: 'all',
+            checked: false,
+          },
+        ];
+
+        await expect(presenter.radioButtonArgs()).resolves.toEqual(expected);
+      });
+    });
+
+    describe('when the route is non-empty', () => {
+      it('returns an array of `RadioButtonArgs`, with the route type checked', async () => {
+        const i18nService = createMockI18nService();
+
+        const presenter =
+          new OtherCountriesRecognitionRoutesRadioButtonsPresenter(
+            OtherCountriesRecognitionRoutes.All,
+            i18nService,
+          );
+
+        const expected: RadioButtonArgs[] = [
+          {
+            text: translationOf(
+              'professions.form.label.qualifications.otherCountriesRecognition.routes.none',
+            ),
+            value: OtherCountriesRecognitionRoutes.None,
+            checked: false,
+          },
+          {
+            text: translationOf(
+              'professions.form.label.qualifications.otherCountriesRecognition.routes.some',
+            ),
+            value: OtherCountriesRecognitionRoutes.Some,
+            checked: false,
+          },
+          {
+            text: translationOf(
+              'professions.form.label.qualifications.otherCountriesRecognition.routes.all',
+            ),
+            value: OtherCountriesRecognitionRoutes.All,
+            checked: true,
+          },
+        ];
+
+        await expect(presenter.radioButtonArgs()).resolves.toEqual(expected);
+      });
+    });
+  });
+});

--- a/src/professions/admin/presenters/other-countries-recognition-routes-radio-buttons-presenter.ts
+++ b/src/professions/admin/presenters/other-countries-recognition-routes-radio-buttons-presenter.ts
@@ -1,0 +1,22 @@
+import { I18nService } from 'nestjs-i18n';
+import { RadioButtonArgs } from '../../../common/interfaces/radio-button-args.interface';
+import { OtherCountriesRecognitionRoutes } from '../../../qualifications/qualification.entity';
+
+export class OtherCountriesRecognitionRoutesRadioButtonsPresenter {
+  constructor(
+    private readonly selectedRecognitionRoute: OtherCountriesRecognitionRoutes | null,
+    private readonly i18nService: I18nService,
+  ) {}
+
+  async radioButtonArgs(): Promise<RadioButtonArgs[]> {
+    return Promise.all(
+      Object.values(OtherCountriesRecognitionRoutes).map(async (route) => ({
+        text: await this.i18nService.translate(
+          `professions.form.label.qualifications.otherCountriesRecognition.routes.${route}`,
+        ),
+        value: route,
+        checked: this.selectedRecognitionRoute === route,
+      })),
+    );
+  }
+}

--- a/src/professions/admin/qualifications.controller.spec.ts
+++ b/src/professions/admin/qualifications.controller.spec.ts
@@ -17,6 +17,7 @@ import { translationOf } from '../../testutils/translation-of';
 import userFactory from '../../testutils/factories/user';
 import { createDefaultMockRequest } from '../../testutils/factories/create-default-mock-request';
 import { checkCanViewProfession } from '../../users/helpers/check-can-view-profession';
+import { OtherCountriesRecognitionRoutes } from '../../qualifications/qualification.entity';
 
 jest.mock('../../helpers/nations.helper');
 jest.mock('../../users/helpers/check-can-view-profession');
@@ -162,6 +163,8 @@ describe(QualificationsController, () => {
           moreInformationUrl: 'http://www.example.com/more-info',
           ukRecognition: 'ukRecognition',
           ukRecognitionUrl: 'http://example.com/uk',
+          otherCountriesRecognitionRoutes:
+            'all' as OtherCountriesRecognitionRoutes,
           otherCountriesRecognitionSummary:
             'other countries recognition summary',
           otherCountriesRecognitionUrl: 'http://example.com/overseas',
@@ -189,6 +192,8 @@ describe(QualificationsController, () => {
               url: 'http://www.example.com/more-info',
               ukRecognition: 'ukRecognition',
               ukRecognitionUrl: 'http://example.com/uk',
+              otherCountriesRecognitionRoutes:
+                'all' as OtherCountriesRecognitionRoutes,
               otherCountriesRecognitionSummary:
                 'other countries recognition summary',
               otherCountriesRecognitionUrl: 'http://example.com/overseas',
@@ -217,6 +222,8 @@ describe(QualificationsController, () => {
           moreInformationUrl: 'www.example.com/more-info ',
           ukRecognition: 'ukRecognition',
           ukRecognitionUrl: 'example.com/uk',
+          otherCountriesRecognitionRoutes:
+            'all' as OtherCountriesRecognitionRoutes,
           otherCountriesRecognitionSummary:
             'other countries recognition summary',
           otherCountriesRecognitionUrl: 'example.com/overseas',
@@ -244,6 +251,8 @@ describe(QualificationsController, () => {
               url: 'http://www.example.com/more-info',
               ukRecognition: 'ukRecognition',
               ukRecognitionUrl: 'http://example.com/uk',
+              otherCountriesRecognitionRoutes:
+                'all' as OtherCountriesRecognitionRoutes,
               otherCountriesRecognitionSummary:
                 'other countries recognition summary',
               otherCountriesRecognitionUrl: 'http://example.com/overseas',
@@ -272,6 +281,7 @@ describe(QualificationsController, () => {
           moreInformationUrl: 'not a url',
           ukRecognition: '',
           ukRecognitionUrl: 'not a url',
+          otherCountriesRecognitionRoutes: undefined,
           otherCountriesRecognitionSummary: '',
           otherCountriesRecognitionUrl: 'not a url',
         };
@@ -306,6 +316,9 @@ describe(QualificationsController, () => {
               ukRecognitionUrl: {
                 text: 'professions.form.errors.qualification.ukRecognitionUrl.invalid',
               },
+              otherCountriesRecognitionRoutes: {
+                text: 'professions.form.errors.qualification.otherCountriesRecognitionRoutes.empty',
+              },
               otherCountriesRecognitionUrl: {
                 text: 'professions.form.errors.qualification.otherCountriesRecognitionUrl.invalid',
               },
@@ -329,6 +342,8 @@ describe(QualificationsController, () => {
         moreInformationUrl: 'http://www.example.com/more-info',
         ukRecognition: 'ukRecognition',
         ukRecognitionUrl: 'http://example.com/uk',
+        otherCountriesRecognitionRoutes:
+          'all' as OtherCountriesRecognitionRoutes,
         otherCountriesRecognitionSummary: 'other countries recognition summary',
         otherCountriesRecognitionUrl: 'http://example.com/overseas',
       };

--- a/src/professions/admin/qualifications.controller.spec.ts
+++ b/src/professions/admin/qualifications.controller.spec.ts
@@ -81,6 +81,10 @@ describe(QualificationsController, () => {
             captionText: translationOf('professions.form.captions.edit'),
             ukRecognition: profession.qualification.ukRecognition,
             ukRecognitionUrl: profession.qualification.ukRecognitionUrl,
+            otherCountriesRecognitionSummary:
+              profession.qualification.otherCountriesRecognitionSummary,
+            otherCountriesRecognitionUrl:
+              profession.qualification.ukRecognitionUrl,
             isUK: false,
           }),
         );
@@ -158,6 +162,9 @@ describe(QualificationsController, () => {
           moreInformationUrl: 'http://www.example.com/more-info',
           ukRecognition: 'ukRecognition',
           ukRecognitionUrl: 'http://example.com/uk',
+          otherCountriesRecognitionSummary:
+            'other countries recognition summary',
+          otherCountriesRecognitionUrl: 'http://example.com/overseas',
         };
 
         professionsService.findWithVersions.mockResolvedValue(profession);
@@ -182,6 +189,9 @@ describe(QualificationsController, () => {
               url: 'http://www.example.com/more-info',
               ukRecognition: 'ukRecognition',
               ukRecognitionUrl: 'http://example.com/uk',
+              otherCountriesRecognitionSummary:
+                'other countries recognition summary',
+              otherCountriesRecognitionUrl: 'http://example.com/overseas',
             }),
           }),
         );
@@ -207,6 +217,9 @@ describe(QualificationsController, () => {
           moreInformationUrl: 'www.example.com/more-info ',
           ukRecognition: 'ukRecognition',
           ukRecognitionUrl: 'example.com/uk',
+          otherCountriesRecognitionSummary:
+            'other countries recognition summary',
+          otherCountriesRecognitionUrl: 'example.com/overseas',
         };
 
         professionsService.findWithVersions.mockResolvedValue(profession);
@@ -231,6 +244,9 @@ describe(QualificationsController, () => {
               url: 'http://www.example.com/more-info',
               ukRecognition: 'ukRecognition',
               ukRecognitionUrl: 'http://example.com/uk',
+              otherCountriesRecognitionSummary:
+                'other countries recognition summary',
+              otherCountriesRecognitionUrl: 'http://example.com/overseas',
             }),
           }),
         );
@@ -256,6 +272,8 @@ describe(QualificationsController, () => {
           moreInformationUrl: 'not a url',
           ukRecognition: '',
           ukRecognitionUrl: 'not a url',
+          otherCountriesRecognitionSummary: '',
+          otherCountriesRecognitionUrl: 'not a url',
         };
 
         professionsService.findWithVersions.mockResolvedValue(profession);
@@ -288,6 +306,9 @@ describe(QualificationsController, () => {
               ukRecognitionUrl: {
                 text: 'professions.form.errors.qualification.ukRecognitionUrl.invalid',
               },
+              otherCountriesRecognitionUrl: {
+                text: 'professions.form.errors.qualification.otherCountriesRecognitionUrl.invalid',
+              },
             },
           }),
         );
@@ -308,6 +329,8 @@ describe(QualificationsController, () => {
         moreInformationUrl: 'http://www.example.com/more-info',
         ukRecognition: 'ukRecognition',
         ukRecognitionUrl: 'http://example.com/uk',
+        otherCountriesRecognitionSummary: 'other countries recognition summary',
+        otherCountriesRecognitionUrl: 'http://example.com/overseas',
       };
 
       await controller.update(

--- a/src/professions/admin/qualifications.controller.ts
+++ b/src/professions/admin/qualifications.controller.ts
@@ -96,6 +96,10 @@ export class QualificationsController {
         url: submittedValues.moreInformationUrl,
         ukRecognition: submittedValues.ukRecognition,
         ukRecognitionUrl: submittedValues.ukRecognitionUrl,
+        otherCountriesRecognitionSummary:
+          submittedValues.otherCountriesRecognitionSummary,
+        otherCountriesRecognitionUrl:
+          submittedValues.otherCountriesRecognitionUrl,
       },
     };
 
@@ -133,6 +137,9 @@ export class QualificationsController {
       captionText: await ViewUtils.captionText(this.i18nService, profession),
       ukRecognition: qualification?.ukRecognition,
       ukRecognitionUrl: qualification?.ukRecognitionUrl,
+      otherCountriesRecognitionSummary:
+        qualification?.otherCountriesRecognitionSummary,
+      otherCountriesRecognitionUrl: qualification?.otherCountriesRecognitionUrl,
       isUK: version.occupationLocations
         ? isUK(version.occupationLocations)
         : false,

--- a/src/professions/admin/qualifications.controller.ts
+++ b/src/professions/admin/qualifications.controller.ts
@@ -27,6 +27,7 @@ import { ProfessionVersion } from '../profession-version.entity';
 import { Profession } from '../profession.entity';
 import { RequestWithAppSession } from '../../common/interfaces/request-with-app-session.interface';
 import { checkCanViewProfession } from '../../users/helpers/check-can-view-profession';
+import { OtherCountriesRecognitionRoutesRadioButtonsPresenter } from './presenters/other-countries-recognition-routes-radio-buttons-presenter';
 
 @UseGuards(AuthenticationGuard)
 @Controller('admin/professions')
@@ -96,6 +97,8 @@ export class QualificationsController {
         url: submittedValues.moreInformationUrl,
         ukRecognition: submittedValues.ukRecognition,
         ukRecognitionUrl: submittedValues.ukRecognitionUrl,
+        otherCountriesRecognitionRoutes:
+          submittedValues.otherCountriesRecognitionRoutes,
         otherCountriesRecognitionSummary:
           submittedValues.otherCountriesRecognitionSummary,
         otherCountriesRecognitionUrl:
@@ -137,6 +140,11 @@ export class QualificationsController {
       captionText: await ViewUtils.captionText(this.i18nService, profession),
       ukRecognition: qualification?.ukRecognition,
       ukRecognitionUrl: qualification?.ukRecognitionUrl,
+      otherCountriesRecognitionRoutesRadioButtonArgs:
+        await new OtherCountriesRecognitionRoutesRadioButtonsPresenter(
+          qualification?.otherCountriesRecognitionRoutes,
+          this.i18nService,
+        ).radioButtonArgs(),
       otherCountriesRecognitionSummary:
         qualification?.otherCountriesRecognitionSummary,
       otherCountriesRecognitionUrl: qualification?.otherCountriesRecognitionUrl,

--- a/src/professions/helpers/get-publication-blockers.helper.spec.ts
+++ b/src/professions/helpers/get-publication-blockers.helper.spec.ts
@@ -227,6 +227,32 @@ describe('getPublicationBlockers', () => {
     });
   });
 
+  describe('when given a ProfessionVersion with a qualification without other countries routes to recognition', () => {
+    it('returns the "qualifications" publish blocker', () => {
+      const version = professionVersionFactory.build({
+        profession: professionFactory.build({
+          organisation: organisationFactory.build({
+            versions: [
+              organisationVersionFactory.build({
+                status: OrganisationVersionStatus.Live,
+              }),
+            ],
+          }),
+        }),
+        qualification: {
+          otherCountriesRecognitionRoutes: null,
+        },
+      });
+
+      expect(getPublicationBlockers(version)).toEqual([
+        {
+          type: 'incomplete-section',
+          section: 'qualifications',
+        },
+      ] as PublicationBlocker[]);
+    });
+  });
+
   describe('when given a ProfessionVersion with an undefined legislations', () => {
     it('returns the "legislation" publish blocker', () => {
       const version = professionVersionFactory.build({

--- a/src/professions/helpers/get-publication-blockers.helper.ts
+++ b/src/professions/helpers/get-publication-blockers.helper.ts
@@ -42,7 +42,10 @@ export function getPublicationBlockers(
     });
   }
 
-  if (!version.qualification?.routesToObtain) {
+  if (
+    !version.qualification?.routesToObtain ||
+    !version.qualification?.otherCountriesRecognitionRoutes
+  ) {
     blockers.push({ type: 'incomplete-section', section: 'qualifications' });
   }
 

--- a/src/professions/professions.seeder.ts
+++ b/src/professions/professions.seeder.ts
@@ -6,7 +6,10 @@ import { InjectRepository } from '@nestjs/typeorm';
 
 import { Profession } from './profession.entity';
 import { Industry } from 'src/industries/industry.entity';
-import { Qualification } from 'src/qualifications/qualification.entity';
+import {
+  OtherCountriesRecognitionRoutes,
+  Qualification,
+} from 'src/qualifications/qualification.entity';
 import { Legislation } from 'src/legislations/legislation.entity';
 import { InjectData } from '../common/decorators/seeds.decorator';
 import { Organisation } from '../organisations/organisation.entity';
@@ -175,7 +178,13 @@ export class ProfessionsSeeder implements Seeder {
           // each time. We need to fix this, but in the interests of getting
           // seed data in, we'll just create a new entry each time
           qualification = await this.qualificationsRepository.save(
-            new Qualification(qualification.routesToObtain, qualification.url),
+            new Qualification(
+              qualification.routesToObtain,
+              qualification.url,
+              '',
+              '',
+              qualification.otherCountriesRecognitionRoutes as OtherCountriesRecognitionRoutes,
+            ),
           );
         }
 

--- a/src/qualifications/presenters/qualification.presenter.spec.ts
+++ b/src/qualifications/presenters/qualification.presenter.spec.ts
@@ -270,7 +270,7 @@ describe(QualificationPresenter, () => {
                     ),
                   },
                   value: {
-                    text: presenter.ukRecognition,
+                    html: presenter.ukRecognition,
                   },
                 },
                 {
@@ -462,7 +462,7 @@ describe(QualificationPresenter, () => {
           routesToObtain: multilineOf(undefined),
           moreInformationUrl: linkOf(undefined),
           qualification: undefined,
-          ukRecognition: undefined,
+          ukRecognition: multilineOf(undefined),
           ukRecognitionUrl: linkOf(undefined),
           adminSelectedOtherCountriesRecognitionRoutes: undefined,
           publicOtherCountriesRecognitionRoutes: undefined,

--- a/src/qualifications/presenters/qualification.presenter.spec.ts
+++ b/src/qualifications/presenters/qualification.presenter.spec.ts
@@ -88,6 +88,43 @@ describe(QualificationPresenter, () => {
       });
     });
 
+    describe('publicOtherCountriesRecognitionRoutes', () => {
+      describe('when other routes are set', () => {
+        it('returns a localisation id with the route', () => {
+          const qualification = qualificationFactory.build({
+            otherCountriesRecognitionRoutes:
+              OtherCountriesRecognitionRoutes.All,
+          });
+
+          const presenter = new QualificationPresenter(
+            qualification,
+            createMockI18nService(),
+          );
+
+          expect(presenter.publicOtherCountriesRecognitionRoutes).toEqual(
+            OtherCountriesRecognitionRoutes.All,
+          );
+        });
+      });
+
+      describe('when other countries routes are not set', () => {
+        it('returns null', () => {
+          const qualification = qualificationFactory.build({
+            otherCountriesRecognitionRoutes: null,
+          });
+
+          const presenter = new QualificationPresenter(
+            qualification,
+            createMockI18nService(),
+          );
+
+          expect(
+            presenter.adminSelectedOtherCountriesRecognitionRoutes,
+          ).toEqual(null);
+        });
+      });
+    });
+
     describe('ukRecognitionUrl', () => {
       it('returns a link', () => {
         (formatLink as jest.Mock).mockImplementation(linkOf);
@@ -146,6 +183,18 @@ describe(QualificationPresenter, () => {
                   },
                   value: {
                     html: presenter.moreInformationUrl,
+                  },
+                },
+                {
+                  key: {
+                    text: translationOf(
+                      'professions.show.qualification.otherCountriesRecognition.routes.label',
+                    ),
+                  },
+                  value: {
+                    text: translationOf(
+                      `professions.show.qualification.otherCountriesRecognition.routes.${presenter.publicOtherCountriesRecognitionRoutes}`,
+                    ),
                   },
                 },
                 {
@@ -237,6 +286,18 @@ describe(QualificationPresenter, () => {
                 {
                   key: {
                     text: translationOf(
+                      'professions.show.qualification.otherCountriesRecognition.routes.label',
+                    ),
+                  },
+                  value: {
+                    text: translationOf(
+                      `professions.show.qualification.otherCountriesRecognition.routes.${presenter.publicOtherCountriesRecognitionRoutes}`,
+                    ),
+                  },
+                },
+                {
+                  key: {
+                    text: translationOf(
                       'professions.show.qualification.otherCountriesRecognition.summary',
                     ),
                   },
@@ -305,6 +366,18 @@ describe(QualificationPresenter, () => {
                 {
                   key: {
                     text: translationOf(
+                      'professions.show.qualification.otherCountriesRecognition.routes.label',
+                    ),
+                  },
+                  value: {
+                    text: translationOf(
+                      `professions.show.qualification.otherCountriesRecognition.routes.${presenter.publicOtherCountriesRecognitionRoutes}`,
+                    ),
+                  },
+                },
+                {
+                  key: {
+                    text: translationOf(
                       'professions.show.qualification.otherCountriesRecognition.summary',
                     ),
                   },
@@ -357,6 +430,18 @@ describe(QualificationPresenter, () => {
                     html: presenter.routesToObtain,
                   },
                 },
+                {
+                  key: {
+                    text: translationOf(
+                      'professions.show.qualification.otherCountriesRecognition.routes.label',
+                    ),
+                  },
+                  value: {
+                    text: translationOf(
+                      `professions.show.qualification.otherCountriesRecognition.routes.${presenter.publicOtherCountriesRecognitionRoutes}`,
+                    ),
+                  },
+                },
               ],
             });
           });
@@ -380,6 +465,7 @@ describe(QualificationPresenter, () => {
           ukRecognition: undefined,
           ukRecognitionUrl: linkOf(undefined),
           adminSelectedOtherCountriesRecognitionRoutes: undefined,
+          publicOtherCountriesRecognitionRoutes: undefined,
           otherCountriesRecognitionSummary: undefined,
           otherCountriesRecognitionUrl: linkOf(undefined),
         }),

--- a/src/qualifications/presenters/qualification.presenter.spec.ts
+++ b/src/qualifications/presenters/qualification.presenter.spec.ts
@@ -6,6 +6,7 @@ import { createMockI18nService } from '../../testutils/create-mock-i18n-service'
 import { translationOf } from '../../testutils/translation-of';
 import { formatLink } from '../../helpers/format-link.helper';
 import { linkOf } from '../../testutils/link-of';
+import { OtherCountriesRecognitionRoutes } from '../qualification.entity';
 
 jest.mock('../../helpers/format-multiline-string.helper');
 jest.mock('../../helpers/format-link.helper');
@@ -47,6 +48,43 @@ describe(QualificationPresenter, () => {
         expect(presenter.moreInformationUrl).toEqual(
           linkOf('http://example.com'),
         );
+      });
+    });
+
+    describe('adminSelectedOtherCountriesRecognitionRoutes', () => {
+      describe('when other routes are set', () => {
+        it('returnsthe route', () => {
+          const qualification = qualificationFactory.build({
+            otherCountriesRecognitionRoutes:
+              OtherCountriesRecognitionRoutes.All,
+          });
+
+          const presenter = new QualificationPresenter(
+            qualification,
+            createMockI18nService(),
+          );
+
+          expect(
+            presenter.adminSelectedOtherCountriesRecognitionRoutes,
+          ).toEqual(OtherCountriesRecognitionRoutes.All);
+        });
+      });
+
+      describe('when other countries routes are not set', () => {
+        it('returns null', () => {
+          const qualification = qualificationFactory.build({
+            otherCountriesRecognitionRoutes: null,
+          });
+
+          const presenter = new QualificationPresenter(
+            qualification,
+            createMockI18nService(),
+          );
+
+          expect(
+            presenter.adminSelectedOtherCountriesRecognitionRoutes,
+          ).toEqual(null);
+        });
       });
     });
 
@@ -341,6 +379,7 @@ describe(QualificationPresenter, () => {
           qualification: undefined,
           ukRecognition: undefined,
           ukRecognitionUrl: linkOf(undefined),
+          adminSelectedOtherCountriesRecognitionRoutes: undefined,
           otherCountriesRecognitionSummary: undefined,
           otherCountriesRecognitionUrl: linkOf(undefined),
         }),

--- a/src/qualifications/presenters/qualification.presenter.spec.ts
+++ b/src/qualifications/presenters/qualification.presenter.spec.ts
@@ -204,7 +204,7 @@ describe(QualificationPresenter, () => {
                     ),
                   },
                   value: {
-                    text: presenter.otherCountriesRecognitionSummary,
+                    html: presenter.otherCountriesRecognitionSummary,
                   },
                 },
                 {
@@ -302,7 +302,7 @@ describe(QualificationPresenter, () => {
                     ),
                   },
                   value: {
-                    text: presenter.otherCountriesRecognitionSummary,
+                    html: presenter.otherCountriesRecognitionSummary,
                   },
                 },
                 {
@@ -382,7 +382,7 @@ describe(QualificationPresenter, () => {
                     ),
                   },
                   value: {
-                    text: presenter.otherCountriesRecognitionSummary,
+                    html: presenter.otherCountriesRecognitionSummary,
                   },
                 },
                 {
@@ -466,7 +466,7 @@ describe(QualificationPresenter, () => {
           ukRecognitionUrl: linkOf(undefined),
           adminSelectedOtherCountriesRecognitionRoutes: undefined,
           publicOtherCountriesRecognitionRoutes: undefined,
-          otherCountriesRecognitionSummary: undefined,
+          otherCountriesRecognitionSummary: multilineOf(undefined),
           otherCountriesRecognitionUrl: linkOf(undefined),
         }),
       );

--- a/src/qualifications/presenters/qualification.presenter.spec.ts
+++ b/src/qualifications/presenters/qualification.presenter.spec.ts
@@ -110,6 +110,26 @@ describe(QualificationPresenter, () => {
                     html: presenter.moreInformationUrl,
                   },
                 },
+                {
+                  key: {
+                    text: translationOf(
+                      'professions.show.qualification.otherCountriesRecognition.summary',
+                    ),
+                  },
+                  value: {
+                    text: presenter.otherCountriesRecognitionSummary,
+                  },
+                },
+                {
+                  key: {
+                    text: translationOf(
+                      'professions.show.qualification.otherCountriesRecognition.url',
+                    ),
+                  },
+                  value: {
+                    html: presenter.otherCountriesRecognitionUrl,
+                  },
+                },
               ],
             });
           });
@@ -176,6 +196,26 @@ describe(QualificationPresenter, () => {
                     html: presenter.ukRecognitionUrl,
                   },
                 },
+                {
+                  key: {
+                    text: translationOf(
+                      'professions.show.qualification.otherCountriesRecognition.summary',
+                    ),
+                  },
+                  value: {
+                    text: presenter.otherCountriesRecognitionSummary,
+                  },
+                },
+                {
+                  key: {
+                    text: translationOf(
+                      'professions.show.qualification.otherCountriesRecognition.url',
+                    ),
+                  },
+                  value: {
+                    html: presenter.otherCountriesRecognitionUrl,
+                  },
+                },
               ],
             });
           });
@@ -222,6 +262,26 @@ describe(QualificationPresenter, () => {
                   },
                   value: {
                     html: presenter.moreInformationUrl,
+                  },
+                },
+                {
+                  key: {
+                    text: translationOf(
+                      'professions.show.qualification.otherCountriesRecognition.summary',
+                    ),
+                  },
+                  value: {
+                    text: presenter.otherCountriesRecognitionSummary,
+                  },
+                },
+                {
+                  key: {
+                    text: translationOf(
+                      'professions.show.qualification.otherCountriesRecognition.url',
+                    ),
+                  },
+                  value: {
+                    html: presenter.otherCountriesRecognitionUrl,
                   },
                 },
               ],
@@ -281,6 +341,8 @@ describe(QualificationPresenter, () => {
           qualification: undefined,
           ukRecognition: undefined,
           ukRecognitionUrl: linkOf(undefined),
+          otherCountriesRecognitionSummary: undefined,
+          otherCountriesRecognitionUrl: linkOf(undefined),
         }),
       );
     });

--- a/src/qualifications/presenters/qualification.presenter.ts
+++ b/src/qualifications/presenters/qualification.presenter.ts
@@ -24,6 +24,13 @@ export default class QualificationPresenter {
     this.qualification && this.qualification.ukRecognitionUrl,
   );
 
+  readonly otherCountriesRecognitionSummary =
+    this.qualification && this.qualification.otherCountriesRecognitionSummary;
+
+  readonly otherCountriesRecognitionUrl = formatLink(
+    this.qualification && this.qualification.otherCountriesRecognitionUrl,
+  );
+
   async summaryList(
     showEmptyFields: boolean,
     showUKRecognitionFields: boolean,
@@ -65,6 +72,24 @@ export default class QualificationPresenter {
           this.ukRecognitionUrl,
         );
       }
+    }
+
+    // Only show this on the admin page until we've decided on the best way to present this to public users
+    if (showEmptyFields) {
+      await this.addTextRow(
+        summaryList,
+        'professions.show.qualification.otherCountriesRecognition.summary',
+        this.otherCountriesRecognitionSummary,
+      );
+    }
+
+    // Only show this on the admin page until we've decided on the best way to present this to public users
+    if (showEmptyFields) {
+      await this.addHtmlRow(
+        summaryList,
+        'professions.show.qualification.otherCountriesRecognition.url',
+        this.otherCountriesRecognitionUrl,
+      );
     }
 
     return summaryList;

--- a/src/qualifications/presenters/qualification.presenter.ts
+++ b/src/qualifications/presenters/qualification.presenter.ts
@@ -30,8 +30,9 @@ export default class QualificationPresenter {
   readonly publicOtherCountriesRecognitionRoutes =
     this.qualification && this.qualification.otherCountriesRecognitionRoutes;
 
-  readonly otherCountriesRecognitionSummary =
-    this.qualification && this.qualification.otherCountriesRecognitionSummary;
+  readonly otherCountriesRecognitionSummary = formatMultilineString(
+    this.qualification && this.qualification.otherCountriesRecognitionSummary,
+  );
 
   readonly otherCountriesRecognitionUrl = formatLink(
     this.qualification && this.qualification.otherCountriesRecognitionUrl,
@@ -92,7 +93,7 @@ export default class QualificationPresenter {
     }
 
     if (showEmptyFields || this.otherCountriesRecognitionSummary) {
-      await this.addTextRow(
+      await this.addHtmlRow(
         summaryList,
         'professions.show.qualification.otherCountriesRecognition.summary',
         this.otherCountriesRecognitionSummary,

--- a/src/qualifications/presenters/qualification.presenter.ts
+++ b/src/qualifications/presenters/qualification.presenter.ts
@@ -24,6 +24,9 @@ export default class QualificationPresenter {
     this.qualification && this.qualification.ukRecognitionUrl,
   );
 
+  readonly adminSelectedOtherCountriesRecognitionRoutes =
+    this.qualification && this.qualification.otherCountriesRecognitionRoutes;
+
   readonly otherCountriesRecognitionSummary =
     this.qualification && this.qualification.otherCountriesRecognitionSummary;
 

--- a/src/qualifications/presenters/qualification.presenter.ts
+++ b/src/qualifications/presenters/qualification.presenter.ts
@@ -17,8 +17,9 @@ export default class QualificationPresenter {
     this.qualification && this.qualification.url,
   );
 
-  readonly ukRecognition =
-    this.qualification && this.qualification.ukRecognition;
+  readonly ukRecognition = formatMultilineString(
+    this.qualification && this.qualification.ukRecognition,
+  );
 
   readonly ukRecognitionUrl = formatLink(
     this.qualification && this.qualification.ukRecognitionUrl,
@@ -65,7 +66,7 @@ export default class QualificationPresenter {
 
     if (showUKRecognitionFields) {
       if (showEmptyFields || this.ukRecognition) {
-        await this.addTextRow(
+        await this.addHtmlRow(
           summaryList,
           'professions.show.qualification.ukRecognition',
           this.ukRecognition,

--- a/src/qualifications/presenters/qualification.presenter.ts
+++ b/src/qualifications/presenters/qualification.presenter.ts
@@ -27,6 +27,9 @@ export default class QualificationPresenter {
   readonly adminSelectedOtherCountriesRecognitionRoutes =
     this.qualification && this.qualification.otherCountriesRecognitionRoutes;
 
+  readonly publicOtherCountriesRecognitionRoutes =
+    this.qualification && this.qualification.otherCountriesRecognitionRoutes;
+
   readonly otherCountriesRecognitionSummary =
     this.qualification && this.qualification.otherCountriesRecognitionSummary;
 
@@ -77,8 +80,18 @@ export default class QualificationPresenter {
       }
     }
 
-    // Only show this on the admin page until we've decided on the best way to present this to public users
-    if (showEmptyFields) {
+    if (showEmptyFields || this.publicOtherCountriesRecognitionRoutes) {
+      await this.addTextRow(
+        summaryList,
+        'professions.show.qualification.otherCountriesRecognition.routes.label',
+        this.publicOtherCountriesRecognitionRoutes &&
+          (await this.i18nService.translate(
+            `professions.show.qualification.otherCountriesRecognition.routes.${this.publicOtherCountriesRecognitionRoutes}`,
+          )),
+      );
+    }
+
+    if (showEmptyFields || this.otherCountriesRecognitionSummary) {
       await this.addTextRow(
         summaryList,
         'professions.show.qualification.otherCountriesRecognition.summary',
@@ -86,8 +99,7 @@ export default class QualificationPresenter {
       );
     }
 
-    // Only show this on the admin page until we've decided on the best way to present this to public users
-    if (showEmptyFields) {
+    if (showEmptyFields || this.otherCountriesRecognitionUrl) {
       await this.addHtmlRow(
         summaryList,
         'professions.show.qualification.otherCountriesRecognition.url',

--- a/src/qualifications/qualification.entity.ts
+++ b/src/qualifications/qualification.entity.ts
@@ -6,6 +6,12 @@ import {
   UpdateDateColumn,
 } from 'typeorm';
 
+export enum OtherCountriesRecognitionRoutes {
+  None = 'none',
+  Some = 'some',
+  All = 'all',
+}
+
 @Entity({ name: 'qualifications' })
 export class Qualification {
   @PrimaryGeneratedColumn('uuid')
@@ -22,6 +28,19 @@ export class Qualification {
 
   @Column({ nullable: true })
   ukRecognitionUrl: string;
+
+  @Column({ nullable: true })
+  otherCountriesRecognitionSummary: string;
+
+  @Column({ nullable: true })
+  otherCountriesRecognitionUrl: string;
+
+  @Column({
+    nullable: true,
+    type: 'enum',
+    enum: OtherCountriesRecognitionRoutes,
+  })
+  otherCountriesRecognitionRoutes: OtherCountriesRecognitionRoutes;
 
   @CreateDateColumn({
     type: 'timestamp',
@@ -41,10 +60,18 @@ export class Qualification {
     url?: string,
     ukRecognition?: string,
     ukRecognitionUrl?: string,
+    otherCountriesRecognitionRoutes?: OtherCountriesRecognitionRoutes,
+    otherCountriesRecognitionSummary?: string,
+    otherCountriesRecognitionUrl?: string,
   ) {
     this.routesToObtain = routesToObtain || '';
     this.url = url || '';
     this.ukRecognition = ukRecognition || '';
     this.ukRecognitionUrl = ukRecognitionUrl || '';
+    this.otherCountriesRecognitionRoutes =
+      otherCountriesRecognitionRoutes || null;
+    this.otherCountriesRecognitionSummary =
+      otherCountriesRecognitionSummary || '';
+    this.otherCountriesRecognitionUrl = otherCountriesRecognitionUrl || '';
   }
 }

--- a/src/qualifications/qualifications.seeder.ts
+++ b/src/qualifications/qualifications.seeder.ts
@@ -4,12 +4,16 @@ import { Repository } from 'typeorm';
 import { Seeder } from 'nestjs-seeder';
 import { InjectRepository } from '@nestjs/typeorm';
 
-import { Qualification } from './qualification.entity';
+import {
+  OtherCountriesRecognitionRoutes,
+  Qualification,
+} from './qualification.entity';
 import { InjectData } from '../common/decorators/seeds.decorator';
 
 type SeedQualification = {
   routesToObtain: string;
   url: string;
+  otherCountriesRecognitionRoutes: OtherCountriesRecognitionRoutes;
 };
 
 @Injectable()
@@ -24,7 +28,13 @@ export class QualificationsSeeder implements Seeder {
 
   async seed(): Promise<any> {
     const qualifications = this.data.map((qualification) => {
-      return new Qualification(qualification.routesToObtain, qualification.url);
+      return new Qualification(
+        qualification.routesToObtain,
+        qualification.url,
+        '',
+        '',
+        qualification.otherCountriesRecognitionRoutes as OtherCountriesRecognitionRoutes,
+      );
     });
 
     return this.qualificationsRepository.save(qualifications);

--- a/src/testutils/factories/qualification.ts
+++ b/src/testutils/factories/qualification.ts
@@ -8,6 +8,9 @@ export default Factory.define<Qualification>(({ sequence }) => ({
   professionVersion: undefined,
   ukRecognition: undefined,
   ukRecognitionUrl: undefined,
+  otherCountriesRecognitionRoutes: undefined,
+  otherCountriesRecognitionSummary: undefined,
+  otherCountriesRecognitionUrl: undefined,
   created_at: new Date(),
   updated_at: new Date(),
 }));

--- a/src/testutils/factories/qualification.ts
+++ b/src/testutils/factories/qualification.ts
@@ -1,5 +1,8 @@
 import { Factory } from 'fishery';
-import { Qualification } from '../../qualifications/qualification.entity';
+import {
+  OtherCountriesRecognitionRoutes,
+  Qualification,
+} from '../../qualifications/qualification.entity';
 
 export default Factory.define<Qualification>(({ sequence }) => ({
   id: sequence.toString(),
@@ -8,7 +11,7 @@ export default Factory.define<Qualification>(({ sequence }) => ({
   professionVersion: undefined,
   ukRecognition: undefined,
   ukRecognitionUrl: undefined,
-  otherCountriesRecognitionRoutes: undefined,
+  otherCountriesRecognitionRoutes: OtherCountriesRecognitionRoutes.All,
   otherCountriesRecognitionSummary: undefined,
   otherCountriesRecognitionUrl: undefined,
   created_at: new Date(),

--- a/src/testutils/multiline-of.ts
+++ b/src/testutils/multiline-of.ts
@@ -1,3 +1,7 @@
 export function multilineOf(text: string): string {
+  if (!text) {
+    return '';
+  }
+
   return `Multiline of '${text}'`;
 }

--- a/views/admin/professions/check-your-answers.njk
+++ b/views/admin/professions/check-your-answers.njk
@@ -306,7 +306,41 @@
                     }
                   ]
                 }
-              } if not isUK else undefined
+              } if not isUK else undefined,
+              {
+                key: {
+                  text: ("professions.form.label.qualifications.otherCountriesRecognition.summary" | t)
+                },
+                value: {
+                  text: qualification.otherCountriesRecognitionSummary
+                },
+                actions: {
+                  items: [
+                    {
+                      href: "/admin/professions/" + professionId + "/versions/" + versionId + "/qualifications/edit?change=true",
+                      text: ("app.change" | t),
+                      visuallyHiddenText: ("professions.form.label.qualifications.otherCountriesRecognition.summary" | t)
+                    }
+                  ]
+                }
+              },
+              {
+                key: {
+                  text: ("professions.form.label.qualifications.otherCountriesRecognition.url" | t)
+                },
+                value: {
+                  html: qualification.otherCountriesRecognitionUrl
+                },
+                actions: {
+                  items: [
+                    {
+                      href: "/admin/professions/" + professionId + "/versions/" + versionId + "/qualifications/edit?change=true",
+                      text: ("app.change" | t),
+                      visuallyHiddenText: ("professions.form.label.qualifications.otherCountriesRecognition.url" | t)
+                    }
+                  ]
+                }
+              }
             ]
           })
         }}

--- a/views/admin/professions/check-your-answers.njk
+++ b/views/admin/professions/check-your-answers.njk
@@ -329,7 +329,7 @@
                   text: ("professions.form.label.qualifications.otherCountriesRecognition.summary" | t)
                 },
                 value: {
-                  text: qualification.otherCountriesRecognitionSummary
+                  html: qualification.otherCountriesRecognitionSummary
                 },
                 actions: {
                   items: [

--- a/views/admin/professions/check-your-answers.njk
+++ b/views/admin/professions/check-your-answers.njk
@@ -309,6 +309,23 @@
               } if not isUK else undefined,
               {
                 key: {
+                  text: ("professions.form.label.qualifications.otherCountriesRecognition.routes.label" | t)
+                },
+                value: {
+                  text: (("professions.form.label.qualifications.otherCountriesRecognition.routes." + qualification.adminSelectedOtherCountriesRecognitionRoutes) | t) if qualification.adminSelectedOtherCountriesRecognitionRoutes else ""
+                },
+                actions: {
+                  items: [
+                    {
+                      href: "/admin/professions/" + professionId + "/versions/" + versionId + "/qualifications/edit?change=true",
+                      text: ("app.change" | t),
+                      visuallyHiddenText: ("professions.form.label.qualifications.otherCountriesRecognition.routes.label" | t)
+                    }
+                  ]
+                }
+              },
+              {
+                key: {
                   text: ("professions.form.label.qualifications.otherCountriesRecognition.summary" | t)
                 },
                 value: {

--- a/views/admin/professions/check-your-answers.njk
+++ b/views/admin/professions/check-your-answers.njk
@@ -278,7 +278,7 @@
                   text: ("professions.form.label.qualifications.ukRecognition" | t)
                 },
                 value: {
-                  text: qualification.ukRecognition
+                  html: qualification.ukRecognition
                 },
                 actions: {
                   items: [

--- a/views/admin/professions/qualifications.njk
+++ b/views/admin/professions/qualifications.njk
@@ -89,6 +89,41 @@
 
         {% endif %}
 
+        <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible" />
+
+        {{
+          govukTextarea({
+            label: {
+              text: ("professions.form.label.qualifications.otherCountriesRecognition.summary" | t),
+              classes: "govuk-label--m",
+              isPageHeading: false
+            },
+            id: "otherCountriesRecognitionSummary",
+            name: "otherCountriesRecognitionSummary",
+            value: otherCountriesRecognitionSummary,
+            rows: "7",
+            hint: {
+              text: ("professions.form.label.qualifications.otherCountriesRecognition.summaryHint" | t)
+            }
+          })
+        }}
+
+        {{
+          govukInput({
+            label: {
+              text: ("professions.form.label.qualifications.otherCountriesRecognition.url" | t),
+              classes: "govuk-label--m"
+            },
+            id: "otherCountriesRecognitionUrl",
+            name: "otherCountriesRecognitionUrl",
+            value: otherCountriesRecognitionUrl,
+            hint: {
+              text: ("professions.form.label.qualifications.otherCountriesRecognition.urlHint" | t)
+            },
+            errorMessage: errors.otherCountriesRecognitionUrl | tError
+          })
+        }}
+
         {{
           govukButton({
             id: "submit-button",

--- a/views/admin/professions/qualifications.njk
+++ b/views/admin/professions/qualifications.njk
@@ -89,7 +89,23 @@
 
         {% endif %}
 
-        <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible" />
+        <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible"/>
+
+        {{
+          govukRadios({
+            fieldset: {
+              legend: {
+                text: ("professions.form.label.qualifications.otherCountriesRecognition.routes.label" | t),
+                classes: "govuk-label--m",
+                isPageHeading: false
+              }
+            },
+            id: "otherCountriesRecognitionRoutes",
+            name: "otherCountriesRecognitionRoutes",
+            items: otherCountriesRecognitionRoutesRadioButtonArgs,
+            errorMessage: errors.otherCountriesRecognitionRoutes | tError
+          })
+        }}
 
         {{
           govukTextarea({

--- a/views/admin/professions/qualifications.njk
+++ b/views/admin/professions/qualifications.njk
@@ -56,14 +56,16 @@
         <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible" />
 
         {{
-          govukInput({
+          govukTextarea({
             label: {
               text: ("professions.form.label.qualifications.ukRecognition" | t),
-              classes: "govuk-label--m"
+              classes: "govuk-label--m",
+              isPageHeading: false
             },
             id: "ukRecognition",
             name: "ukRecognition",
             value: ukRecognition,
+            rows: "7",
             hint: {
               text: ("professions.form.hint.qualifications.ukRecognition" | t)
             },


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR

Re-adds summary of recognition routes and link to more information for professionals from other countries, which were removed a couple of weeks ago while we figured out the best way to collect and present this information to users. Also adds mandatory radio buttons for selecting the route itself.

## Screenshots of UI changes

### Before

#### Qualification page

![image](https://user-images.githubusercontent.com/19826940/160591565-ffca7373-ddb4-4d5c-94ef-4f0770058ba2.png)

#### Check your answers

![image](https://user-images.githubusercontent.com/19826940/160591530-d35e7cca-1463-41c5-9488-4df321fd8650.png)


#### Viewing a profession

![image](https://user-images.githubusercontent.com/19826940/160591450-e5375578-0e96-4403-aa38-0366b0b36a09.png)


### After

#### Qualification page

![image](https://user-images.githubusercontent.com/19826940/160591026-418feb8e-138c-4ddc-94b8-8ef89d68f3b1.png)

#### Check your answers page

![image](https://user-images.githubusercontent.com/19826940/160591089-5688f8b6-e275-43c8-a45a-caeac80ddeb1.png)

#### Viewing a profession

![image](https://user-images.githubusercontent.com/19826940/160591070-d3a91b4b-e9a3-45b2-acdb-3b6c11c89707.png)

