### PR TITLE
(2168) Use "sign in" rather than "log in"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Allow professions to have multiple organisations via a join table
 
+### Changed
+
+- Small revisions to sign in/out text to follow GOV.UK style guidelines
+
 ## [release-013] - 2022-03-29
 
 ### Added

--- a/src/i18n/en/app.json
+++ b/src/i18n/en/app.json
@@ -8,7 +8,7 @@
   "start": "Start",
   "startButton": "Start now",
   "home": "Home",
-  "logout": "Logout",
+  "logout": "Sign out",
   "or": "Or",
   "privacyPolicy": "Privacy policy",
   "cookies": "Cookies",

--- a/src/i18n/en/errors.json
+++ b/src/i18n/en/errors.json
@@ -2,7 +2,7 @@
   "forbidden": {
     "heading": "You have not been authorized to see this page",
     "message": "Whilst you have successfully signed in you have not been authorised to see this page.",
-    "resolution": "Please try <a href='/login' class='govuk-link'>logging in</a> again.",
+    "resolution": "Please try <a href='/login' class='govuk-link'>signing in</a> again.",
     "help": "If you believe this to be in error, please contact the person who invited you to the service."
   },
   "generic": {


### PR DESCRIPTION
# Changes in this PR

- Small revisions to sign in/out text to follow GOV.UK style guidelines

This leaves alone the text on the cookies and privacy policy pages. These do contain reference to logging in, counter to GOV.UK guidelines, but AFAIK, these pages have had legal approval for their current content