### PR TITLE
(2196) Change the unauthorised error message to correct unauthorized to UK spelling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - Small revisions to sign in/out text to follow GOV.UK style guidelines
+- Use UK spelling of "authorised" on error page
 
 ## [release-013] - 2022-03-29
 

--- a/src/i18n/en/errors.json
+++ b/src/i18n/en/errors.json
@@ -1,6 +1,6 @@
 {
   "forbidden": {
-    "heading": "You have not been authorized to see this page",
+    "heading": "You have not been authorised to see this page",
     "message": "Whilst you have successfully signed in you have not been authorised to see this page.",
     "resolution": "Please try <a href='/login' class='govuk-link'>signing in</a> again.",
     "help": "If you believe this to be in error, please contact the person who invited you to the service."


### PR DESCRIPTION
# Changes in this PR

- Use UK spelling of "authorised" on error page
