### PR TITLE
(Fix) Bump nestjs-i18n to 8.3.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "govuk-frontend": "^4.0.1",
         "jwt-decode": "^3.1.2",
         "method-override": "^3.0.0",
-        "nestjs-i18n": "8.3.0",
+        "nestjs-i18n": "^8.3.2",
         "nestjs-opensearch": "^0.0.1",
         "nestjs-seeder": "^0.2.0",
         "notifications-node-client": "^5.1.1",
@@ -14195,9 +14195,9 @@
       "peer": true
     },
     "node_modules/nestjs-i18n": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/nestjs-i18n/-/nestjs-i18n-8.3.0.tgz",
-      "integrity": "sha512-NTFgnhhccgLlnl31VZtAUyOg0BH6ZB2dVQFGv4rPdUY0UNTysUDSF/lhwtME/A7IlH6tWI2M2lXY9pynVVjyGw==",
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/nestjs-i18n/-/nestjs-i18n-8.3.2.tgz",
+      "integrity": "sha512-9JDqhRt9tqL7zblm41s+PHQ+OO4tYcMHr4qsBR0sarl0eLJ5NXOEesONIR04JmCIIQjbUMXFJtBr1xXurgEfcA==",
       "dependencies": {
         "accept-language-parser": "^1.5.0",
         "chokidar": "^3.5.3",
@@ -34111,9 +34111,9 @@
       "peer": true
     },
     "nestjs-i18n": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/nestjs-i18n/-/nestjs-i18n-8.3.0.tgz",
-      "integrity": "sha512-NTFgnhhccgLlnl31VZtAUyOg0BH6ZB2dVQFGv4rPdUY0UNTysUDSF/lhwtME/A7IlH6tWI2M2lXY9pynVVjyGw==",
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/nestjs-i18n/-/nestjs-i18n-8.3.2.tgz",
+      "integrity": "sha512-9JDqhRt9tqL7zblm41s+PHQ+OO4tYcMHr4qsBR0sarl0eLJ5NXOEesONIR04JmCIIQjbUMXFJtBr1xXurgEfcA==",
       "requires": {
         "accept-language-parser": "^1.5.0",
         "chokidar": "^3.5.3",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "govuk-frontend": "^4.0.1",
     "jwt-decode": "^3.1.2",
     "method-override": "^3.0.0",
-    "nestjs-i18n": "8.3.0",
+    "nestjs-i18n": "^8.3.2",
     "nestjs-opensearch": "^0.0.1",
     "nestjs-seeder": "^0.2.0",
     "notifications-node-client": "^5.1.1",

--- a/src/i18n/en/app.json
+++ b/src/i18n/en/app.json
@@ -40,10 +40,7 @@
   "pages": {
     "index": {
       "heading": "Check which professions are regulated in the UK",
-      "intro": [
-        "Some professions in the UK are regulated. This can mean there is a legal requirement to have certain qualifications or experience. Other professions are regulated by chartered bodies granting a certain status.",
-        "If a profession is regulated, you may need certain professional qualifications or experience to:"
-      ],
+      "intro": "<p class='govuk-body'>Some professions in the UK are regulated. This can mean there is a legal requirement to have certain qualifications or experience. Other professions are regulated by chartered bodies granting a certain status.</p><p class='govuk-body'>If a profession is regulated, you may need certain professional qualifications or experience to:</p>",
       "ifAProfessionIsRegulated": {
         "professionalActivities": "carry out certain professional activities",
         "professionalTitle": "use a professional title, like ‘architect’"

--- a/views/index.njk
+++ b/views/index.njk
@@ -10,9 +10,7 @@
         {{ title }}
       </h1>
 
-      {% for _i, paragraph in ("app.pages.index.intro" | t) %}
-        <p class="govuk-body">{{ paragraph }}</p>
-      {% endfor %}
+      {{ "app.pages.index.intro" | t | safe }}
 
       <ul class="govuk-list govuk-list--bullet">
         <li>


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR

Bumps `nestjs-i18n` to 8.3.2 after updating the index template to output html from the intro translation.

We were previously trying to translate an array in the template here, which led to strangely outputed characters when we updated`nestjs-i18n`.

We may want to convert this template to not use translated text at all, but for now, this allows us to update the version of `nestjs-i18n`.
