### PR TITLE
(2288) Show multiple regulators and roles on professions page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [unreleased]
 
+### Changed
+
+- Show organisations grouped by their role on the profession view page
+
 ### Added
 
 - Placeholder dashboard for viewing recognition decision data

--- a/cypress/integration/admin/organisations/show.spec.ts
+++ b/cypress/integration/admin/organisations/show.spec.ts
@@ -28,7 +28,9 @@ describe('Showing organisations', () => {
 
               const professionsForOrganisation = professions.filter(
                 (profession: any) =>
-                  profession.organisation == organisation.name,
+                  profession.organisations.some(
+                    (item: any) => item.name == organisation.name,
+                  ),
               );
 
               professionsForOrganisation.forEach((profession: any) => {

--- a/cypress/integration/admin/professions/edit.spec.ts
+++ b/cypress/integration/admin/professions/edit.spec.ts
@@ -640,8 +640,23 @@ describe('Editing an existing profession', () => {
         format(new Date(), 'd MMM yyyy'),
       );
 
-      cy.get('h3').should('contain', 'Department for Education');
-      cy.get('h3').should('contain', 'Council of Registered Gas Installers');
+      cy.translate('organisations.label.roles.primaryRegulator').then(
+        (header) => {
+          cy.get('h3').should('contain', header);
+          cy.contains(header)
+            .parent('.rpr-details__sub-group')
+            .should('contain', 'Department for Education');
+        },
+      );
+
+      cy.translate('organisations.label.roles.qualifyingBody').then(
+        (header) => {
+          cy.get('h3').should('contain', header);
+          cy.contains(header)
+            .parent('.rpr-details__sub-group')
+            .should('contain', 'Council of Registered Gas Installers');
+        },
+      );
 
       cy.translate('professions.admin.update.confirmation.heading').then(
         (flashHeading) => {

--- a/cypress/integration/admin/professions/show.spec.ts
+++ b/cypress/integration/admin/professions/show.spec.ts
@@ -29,51 +29,68 @@ describe('Listing professions', () => {
         cy.checkSummaryListRowList('professions.show.overview.industry', [law]);
       });
 
-      cy.get('h3').should('contain', 'Law Society of England and Wales');
-      cy.get('h3')
-        .contains('Law Society of England and Wales')
-        .parent()
-        .within(() => {
-          cy.checkSummaryListRowMultilineValue(
-            'professions.show.bodies.address',
-            ['456 Example Street', 'London', 'EC1 1AB'],
-          );
-          cy.checkSummaryListRowValue(
-            'professions.show.bodies.emailAddress',
-            'law@example.com',
-          );
-          cy.checkSummaryListRowValue(
-            'professions.show.bodies.url',
-            'www.lawsociety.org.uk',
-          );
-          cy.checkSummaryListRowValue(
-            'professions.show.bodies.phoneNumber',
-            '+44 (0)123 456789',
-          );
-        });
+      cy.translate('organisations.label.roles.primaryRegulator').then(
+        (header) => {
+          cy.get('h3').should('contain', header);
 
-      cy.get('h3').should('contain', 'Alternative Law Society');
-      cy.get('h3')
-        .contains('Alternative Law Society')
-        .parent()
-        .within(() => {
-          cy.checkSummaryListRowMultilineValue(
-            'professions.show.bodies.address',
-            ['123 Example Street', 'London', 'WC1 1AB'],
-          );
-          cy.checkSummaryListRowValue(
-            'professions.show.bodies.emailAddress',
-            'alt-law@example.com',
-          );
-          cy.checkSummaryListRowValue(
-            'professions.show.bodies.url',
-            'www.alt-lawsociety.org.uk',
-          );
-          cy.checkSummaryListRowValue(
-            'professions.show.bodies.phoneNumber',
-            '+44 (0)123 987654',
-          );
-        });
+          cy.get('h3')
+            .contains(header)
+            .parent()
+            .within(() => {
+              cy.checkSummaryListRowValue(
+                'professions.show.bodies.regulatedAuthority',
+                'Law Society of England and Wales',
+              );
+              cy.checkSummaryListRowMultilineValue(
+                'professions.show.bodies.address',
+                ['456 Example Street', 'London', 'EC1 1AB'],
+              );
+              cy.checkSummaryListRowValue(
+                'professions.show.bodies.emailAddress',
+                'law@example.com',
+              );
+              cy.checkSummaryListRowValue(
+                'professions.show.bodies.url',
+                'www.lawsociety.org.uk',
+              );
+              cy.checkSummaryListRowValue(
+                'professions.show.bodies.phoneNumber',
+                '+44 (0)123 456789',
+              );
+            });
+        },
+      );
+
+      cy.translate('organisations.label.roles.additionalRegulator').then(
+        (header) => {
+          cy.get('h3').should('contain', header);
+          cy.get('h3')
+            .contains(header)
+            .parent()
+            .within(() => {
+              cy.checkSummaryListRowValue(
+                'professions.show.bodies.regulatedAuthority',
+                'Alternative Law Society',
+              );
+              cy.checkSummaryListRowMultilineValue(
+                'professions.show.bodies.address',
+                ['123 Example Street', 'London', 'WC1 1AB'],
+              );
+              cy.checkSummaryListRowValue(
+                'professions.show.bodies.emailAddress',
+                'alt-law@example.com',
+              );
+              cy.checkSummaryListRowValue(
+                'professions.show.bodies.url',
+                'www.alt-lawsociety.org.uk',
+              );
+              cy.checkSummaryListRowValue(
+                'professions.show.bodies.phoneNumber',
+                '+44 (0)123 987654',
+              );
+            });
+        },
+      );
 
       cy.translate('professions.show.regulatedActivities.heading').then(
         (heading) => {
@@ -243,25 +260,36 @@ describe('Listing professions', () => {
         ]);
       });
 
-      cy.get('h3').should('contain', 'Organisation with no optional fields');
-      cy.get('h3')
-        .contains('Organisation with no optional fields')
-        .parent()
-        .within(() => {
-          cy.checkSummaryListRowValue('professions.show.bodies.address', '');
-          cy.checkSummaryListRowValue(
-            'professions.show.bodies.emailAddress',
-            '',
-          );
-          cy.checkSummaryListRowValue(
-            'professions.show.bodies.url',
-            'http://www.example.com',
-          );
-          cy.checkSummaryListRowValue(
-            'professions.show.bodies.phoneNumber',
-            '',
-          );
-        });
+      cy.translate('organisations.label.roles.primaryRegulator').then(
+        (header) => {
+          cy.get('h3').should('contain', header);
+          cy.get('h3')
+            .contains(header)
+            .parent()
+            .within(() => {
+              cy.checkSummaryListRowValue(
+                'professions.show.bodies.regulatedAuthority',
+                'Organisation with no optional fields',
+              );
+              cy.checkSummaryListRowValue(
+                'professions.show.bodies.address',
+                '',
+              );
+              cy.checkSummaryListRowValue(
+                'professions.show.bodies.emailAddress',
+                '',
+              );
+              cy.checkSummaryListRowValue(
+                'professions.show.bodies.url',
+                'http://www.example.com',
+              );
+              cy.checkSummaryListRowValue(
+                'professions.show.bodies.phoneNumber',
+                '',
+              );
+            });
+        },
+      );
 
       cy.translate('professions.show.regulatedActivities.heading').then(
         (heading) => {

--- a/cypress/integration/organisations/search/search.spec.ts
+++ b/cypress/integration/organisations/search/search.spec.ts
@@ -252,10 +252,9 @@ function findMatchingOrganisations(filter: (profession: any) => boolean) {
 
     const organisationNames = matchingProfessions
       .map((profession) => [
-        profession.organisation,
-        profession.additionalOrganisation,
+        profession.organisations.map((organisation) => organisation.name),
       ])
-      .flat();
+      .flat(Infinity);
 
     cy.readFile('./seeds/test/organisations.json').then((organisations) => {
       const liveOrganisations = organisations.filter(

--- a/cypress/integration/organisations/show.spec.ts
+++ b/cypress/integration/organisations/show.spec.ts
@@ -27,7 +27,13 @@ describe('Showing organisations', () => {
         });
 
         const professionsForOrganisation = professions.filter(
-          (profession: any) => profession.organisation == organisation.name,
+          (profession: any) =>
+            profession.organisations.some(
+              (item: any) => item.name == organisation.name,
+            ) &&
+            profession.versions.some(
+              (version: any) => version.status === 'live',
+            ),
         );
 
         professionsForOrganisation.forEach((profession: any) => {

--- a/cypress/integration/professions/show.spec.ts
+++ b/cypress/integration/professions/show.spec.ts
@@ -22,51 +22,67 @@ describe('Showing a profession', () => {
       cy.checkSummaryListRowList('professions.show.overview.industry', [law]);
     });
 
-    cy.get('h3').should('contain', 'Law Society of England and Wales');
-    cy.get('h3')
-      .contains('Law Society of England and Wales')
-      .parent()
-      .within(() => {
-        cy.checkSummaryListRowMultilineValue(
-          'professions.show.bodies.address',
-          ['456 Example Street', 'London', 'EC1 1AB'],
-        );
-        cy.checkSummaryListRowValue(
-          'professions.show.bodies.emailAddress',
-          'law@example.com',
-        );
-        cy.checkSummaryListRowValue(
-          'professions.show.bodies.url',
-          'www.lawsociety.org.uk',
-        );
-        cy.checkSummaryListRowValue(
-          'professions.show.bodies.phoneNumber',
-          '+44 (0)123 456789',
-        );
-      });
+    cy.translate('organisations.label.roles.primaryRegulator').then(
+      (header) => {
+        cy.get('h3').should('contain', header);
+        cy.get('h3')
+          .contains(header)
+          .parent()
+          .within(() => {
+            cy.checkSummaryListRowValue(
+              'professions.show.bodies.regulatedAuthority',
+              'Law Society of England and Wales',
+            );
+            cy.checkSummaryListRowMultilineValue(
+              'professions.show.bodies.address',
+              ['456 Example Street', 'London', 'EC1 1AB'],
+            );
+            cy.checkSummaryListRowValue(
+              'professions.show.bodies.emailAddress',
+              'law@example.com',
+            );
+            cy.checkSummaryListRowValue(
+              'professions.show.bodies.url',
+              'www.lawsociety.org.uk',
+            );
+            cy.checkSummaryListRowValue(
+              'professions.show.bodies.phoneNumber',
+              '+44 (0)123 456789',
+            );
+          });
+      },
+    );
 
-    cy.get('h3').should('contain', 'Alternative Law Society');
-    cy.get('h3')
-      .contains('Alternative Law Society')
-      .parent()
-      .within(() => {
-        cy.checkSummaryListRowMultilineValue(
-          'professions.show.bodies.address',
-          ['123 Example Street', 'London', 'WC1 1AB'],
-        );
-        cy.checkSummaryListRowValue(
-          'professions.show.bodies.emailAddress',
-          'alt-law@example.com',
-        );
-        cy.checkSummaryListRowValue(
-          'professions.show.bodies.url',
-          'www.alt-lawsociety.org.uk',
-        );
-        cy.checkSummaryListRowValue(
-          'professions.show.bodies.phoneNumber',
-          '+44 (0)123 987654',
-        );
-      });
+    cy.translate('organisations.label.roles.additionalRegulator').then(
+      (header) => {
+        cy.get('h3').should('contain', header);
+        cy.get('h3')
+          .contains(header)
+          .parent()
+          .within(() => {
+            cy.checkSummaryListRowValue(
+              'professions.show.bodies.regulatedAuthority',
+              'Alternative Law Society',
+            );
+            cy.checkSummaryListRowMultilineValue(
+              'professions.show.bodies.address',
+              ['123 Example Street', 'London', 'WC1 1AB'],
+            );
+            cy.checkSummaryListRowValue(
+              'professions.show.bodies.emailAddress',
+              'alt-law@example.com',
+            );
+            cy.checkSummaryListRowValue(
+              'professions.show.bodies.url',
+              'www.alt-lawsociety.org.uk',
+            );
+            cy.checkSummaryListRowValue(
+              'professions.show.bodies.phoneNumber',
+              '+44 (0)123 987654',
+            );
+          });
+      },
+    );
 
     cy.translate('professions.show.regulatedActivities.heading').then(
       (heading) => {
@@ -233,32 +249,43 @@ describe('Showing a profession', () => {
       ]);
     });
 
-    cy.get('h3').should('contain', 'Organisation with no optional fields');
-    cy.get('h3')
-      .contains('Organisation with no optional fields')
-      .parent()
-      .within(($div) => {
-        cy.translate('professions.show.bodies.address').then((addressLabel) => {
-          cy.wrap($div).should('not.contain', addressLabel);
-        });
+    cy.translate('organisations.label.roles.primaryRegulator').then(
+      (header) => {
+        cy.get('h3').should('contain', header);
+        cy.get('h3')
+          .contains(header)
+          .parent()
+          .within(($div) => {
+            cy.checkSummaryListRowValue(
+              'professions.show.bodies.regulatedAuthority',
+              'Organisation with no optional fields',
+            );
 
-        cy.translate('professions.show.bodies.emailAddress').then(
-          (emailAddressLabel) => {
-            cy.wrap($div).should('not.contain', emailAddressLabel);
-          },
-        );
+            cy.translate('professions.show.bodies.address').then(
+              (addressLabel) => {
+                cy.wrap($div).should('not.contain', addressLabel);
+              },
+            );
 
-        cy.translate('professions.show.bodies.phoneNumber').then(
-          (phoneNumberLabel) => {
-            cy.wrap($div).should('not.contain', phoneNumberLabel);
-          },
-        );
+            cy.translate('professions.show.bodies.emailAddress').then(
+              (emailAddressLabel) => {
+                cy.wrap($div).should('not.contain', emailAddressLabel);
+              },
+            );
 
-        cy.checkSummaryListRowValue(
-          'professions.show.bodies.url',
-          'http://www.example.com',
-        );
-      });
+            cy.translate('professions.show.bodies.phoneNumber').then(
+              (phoneNumberLabel) => {
+                cy.wrap($div).should('not.contain', phoneNumberLabel);
+              },
+            );
+
+            cy.checkSummaryListRowValue(
+              'professions.show.bodies.url',
+              'http://www.example.com',
+            );
+          });
+      },
+    );
 
     cy.translate('professions.show.regulatedActivities.heading').then(
       (heading) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -61,6 +61,7 @@
         "@types/bull": "^3.15.8",
         "@types/express": "^4.17.13",
         "@types/jest": "^27.4.1",
+        "@types/jsdom": "^16.2.14",
         "@types/method-override": "^0.0.32",
         "@types/node": "^17.0.23",
         "@types/nunjucks": "^3.2.1",
@@ -3923,6 +3924,17 @@
         "pretty-format": "^27.0.0"
       }
     },
+    "node_modules/@types/jsdom": {
+      "version": "16.2.14",
+      "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-16.2.14.tgz",
+      "integrity": "sha512-6BAy1xXEmMuHeAJ4Fv4yXKwBDTGTOseExKE3OaHiNycdHdZw59KfYzrt0DkDluvwmik1HRt6QS7bImxUmpSy+w==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "@types/parse5": "*",
+        "@types/tough-cookie": "*"
+      }
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.9",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
@@ -3987,6 +3999,12 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
       "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA=="
+    },
+    "node_modules/@types/parse5": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@types/parse5/-/parse5-6.0.3.tgz",
+      "integrity": "sha512-SuT16Q1K51EAVPz1K29DJ/sXjhSQ0zjvsypYJ6tlwVsRV9jwW5Adq2ch8Dq8kDBCkYnELS7N7VNCSB5nC56t/g==",
+      "dev": true
     },
     "node_modules/@types/prettier": {
       "version": "2.4.3",
@@ -4081,6 +4099,12 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/tapable/-/tapable-1.0.8.tgz",
       "integrity": "sha512-ipixuVrh2OdNmauvtT51o3d8z12p6LtFW9in7U79der/kwejjdNchQC5UMn5u/KxNoM7VHHOs/l8KS8uHxhODQ=="
+    },
+    "node_modules/@types/tough-cookie": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.1.tgz",
+      "integrity": "sha512-Y0K95ThC3esLEYD6ZuqNek29lNX2EM1qxV8y2FTLUB0ff5wWrk7az+mLrnNFUnaXcgKye22+sFBRXOgpPILZNg==",
+      "dev": true
     },
     "node_modules/@types/uglify-js": {
       "version": "3.13.1",
@@ -26009,6 +26033,17 @@
         "pretty-format": "^27.0.0"
       }
     },
+    "@types/jsdom": {
+      "version": "16.2.14",
+      "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-16.2.14.tgz",
+      "integrity": "sha512-6BAy1xXEmMuHeAJ4Fv4yXKwBDTGTOseExKE3OaHiNycdHdZw59KfYzrt0DkDluvwmik1HRt6QS7bImxUmpSy+w==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "@types/parse5": "*",
+        "@types/tough-cookie": "*"
+      }
+    },
     "@types/json-schema": {
       "version": "7.0.9",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
@@ -26073,6 +26108,12 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
       "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA=="
+    },
+    "@types/parse5": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@types/parse5/-/parse5-6.0.3.tgz",
+      "integrity": "sha512-SuT16Q1K51EAVPz1K29DJ/sXjhSQ0zjvsypYJ6tlwVsRV9jwW5Adq2ch8Dq8kDBCkYnELS7N7VNCSB5nC56t/g==",
+      "dev": true
     },
     "@types/prettier": {
       "version": "2.4.3",
@@ -26167,6 +26208,12 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/tapable/-/tapable-1.0.8.tgz",
       "integrity": "sha512-ipixuVrh2OdNmauvtT51o3d8z12p6LtFW9in7U79der/kwejjdNchQC5UMn5u/KxNoM7VHHOs/l8KS8uHxhODQ=="
+    },
+    "@types/tough-cookie": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.1.tgz",
+      "integrity": "sha512-Y0K95ThC3esLEYD6ZuqNek29lNX2EM1qxV8y2FTLUB0ff5wWrk7az+mLrnNFUnaXcgKye22+sFBRXOgpPILZNg==",
+      "dev": true
     },
     "@types/uglify-js": {
       "version": "3.13.1",

--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
     "@types/bull": "^3.15.8",
     "@types/express": "^4.17.13",
     "@types/jest": "^27.4.1",
+    "@types/jsdom": "^16.2.14",
     "@types/method-override": "^0.0.32",
     "@types/node": "^17.0.23",
     "@types/nunjucks": "^3.2.1",
@@ -135,6 +136,10 @@
       "<rootDir>/db/migrate/"
     ],
     "rootDir": "src",
+    "roots": [
+      "",
+      "../views"
+    ],
     "testRegex": ".*\\.spec\\.ts$",
     "transform": {
       "^.+\\.(t|j)s$": "ts-jest"

--- a/seeds/development/professions.json
+++ b/seeds/development/professions.json
@@ -2,8 +2,16 @@
   {
     "name": "Registered Trademark Attorney",
     "slug": "registered-trademark-attorney",
-    "organisation": "Law Society of England and Wales",
-    "additionalOrganisation": "Alternative Law Society",
+    "organisations": [
+      {
+        "name": "Law Society of England and Wales",
+        "role": "primaryRegulator"
+      },
+      {
+        "name": "Alternative Law Society",
+        "role": "additionalRegulator"
+      }
+    ],
     "versions": [
       {
         "alternateName": "Patent Agent / Trademark agent",
@@ -17,7 +25,6 @@
         "reservedActivities": "England and Wales: the exercise of a right of audience; the conduct of litigation; reserved instrument activities; probate activities; the administration of oaths (see section 12 Legal Services Act 2007).",
         "protectedTitles": "Trade Mark Agent",
         "legislations": ["The Trade Marks Act 1994"],
-        "organisation": "Law Society of England and Wales",
         "mandatoryRegistration": "voluntary",
         "status": "live",
         "socCode": 2419,
@@ -28,8 +35,12 @@
   {
     "name": "Secondary School Teacher in State maintained schools (England)",
     "slug": "secondary-school-teacher-in-state-maintained-schools-england",
-    "organisation": "Department for Education",
-    "additionalOrganisation": null,
+    "organisations": [
+      {
+        "name": "Department for Education",
+        "role": "primaryRegulator"
+      }
+    ],
     "versions": [
       {
         "alternateName": "Secondary school teacher",
@@ -42,7 +53,6 @@
         "legislations": [
           "The Education (School Teachers' Qualifications) (England) Regulations 2003/1662 (as amended)"
         ],
-        "organisation": "Department for Education",
         "mandatoryRegistration": "mandatory",
         "status": "live",
         "socCode": 2313,
@@ -53,8 +63,16 @@
   {
     "name": "Profession with two tier-one Organisations",
     "slug": "profession-with-two-tier-one-organisations",
-    "organisation": "Department for Education",
-    "additionalOrganisation": "Organisation with no optional fields",
+    "organisations": [
+      {
+        "name": "Department for Education",
+        "role": "primaryRegulator"
+      },
+      {
+        "name": "Organisation with no optional fields",
+        "role": "primaryRegulator"
+      }
+    ],
     "versions": [
       {
         "alternateName": "Secondary school teacher",
@@ -67,7 +85,6 @@
         "legislations": [
           "The Education (School Teachers' Qualifications) (England) Regulations 2003/1662 (as amended)"
         ],
-        "organisation": "Department for Education",
         "mandatoryRegistration": "mandatory",
         "status": "live",
         "socCode": 2313,
@@ -78,8 +95,12 @@
   {
     "name": "Gas Safe Engineer",
     "slug": "gas-safe-engineer",
-    "organisation": "Council of Registered Gas Installers",
-    "additionalOrganisation": null,
+    "organisations": [
+      {
+        "name": "Council of Registered Gas Installers",
+        "role": "primaryRegulator"
+      }
+    ],
     "versions": [
       {
         "alternateName": "Registered Gas Engineer",
@@ -90,7 +111,6 @@
         "qualification": "Evidence of gas safety competence is awarded through the process of proving to a recognised awarding body that you have the appropriate level of knowledge, understanding and practical skills to undertake gas work safely. All evidence of gas safety competence is sent by the awarding body electronically directly to Gas Safe Register and is only recognised once received from the awarding body concerned.",
         "reservedActivities": "Gas Safe Register is the official list of gas engineers in the UK, Isle of Man and Guernsey. To work on gas appliances and installations you must be on the gas safe register. The register exists to protect the public from unsafe gas work (EN)",
         "legislations": ["Gas Safety (Installation and Use) Regulations 1998"],
-        "organisation": "Council of Registered Gas Installers",
         "mandatoryRegistration": "voluntary",
         "status": "draft",
         "socCode": 5315,
@@ -101,8 +121,12 @@
   {
     "name": "Orthodontic Therapist",
     "slug": "orthodontic-therapist",
-    "organisation": "General Medical Council",
-    "additionalOrganisation": null,
+    "organisations": [
+      {
+        "name": "General Medical Council",
+        "role": "primaryRegulator"
+      }
+    ],
     "versions": [
       {
         "alternateName": "Orthodontic Auxiliary",
@@ -122,8 +146,12 @@
   {
     "name": "Profession with no optional fields",
     "slug": "no-optional-fields",
-    "organisation": "Organisation with no optional fields",
-    "additionalOrganisation": null,
+    "organisations": [
+      {
+        "name": "Organisation with no optional fields",
+        "role": "primaryRegulator"
+      }
+    ],
     "versions": [
       {
         "occupationLocations": ["GB-ENG", "GB-NIR"],
@@ -142,8 +170,12 @@
   {
     "name": "Profession with draft organisation",
     "slug": "profession-with-draft-organisation",
-    "organisation": "Draft Organisation",
-    "additionalOrganisation": null,
+    "organisations": [
+      {
+        "name": "Draft Organisation",
+        "role": "primaryRegulator"
+      }
+    ],
     "versions": [
       {
         "occupationLocations": ["GB-ENG", "GB-NIR"],
@@ -160,8 +192,16 @@
   {
     "name": "Draft Profession",
     "slug": "draft-profession",
-    "organisation": "Council of Registered Gas Installers",
-    "additionalOrganisation": "Department for Education",
+    "organisations": [
+      {
+        "name": "Council of Registered Gas Installers",
+        "role": "primaryRegulator"
+      },
+      {
+        "name": "Department for Education",
+        "role": "additionalRegulator"
+      }
+    ],
     "versions": [
       {
         "status": "draft"

--- a/seeds/staging/professions.json
+++ b/seeds/staging/professions.json
@@ -2,8 +2,16 @@
   {
     "name": "Registered Trademark Attorney",
     "slug": "registered-trademark-attorney",
-    "organisation": "Law Society of England and Wales",
-    "additionalOrganisation": null,
+    "organisations": [
+      {
+        "name": "Law Society of England and Wales",
+        "role": "primaryRegulator"
+      },
+      {
+        "name": "Alternative Law Society",
+        "role": "additionalRegulator"
+      }
+    ],
     "versions": [
       {
         "alternateName": "Patent Agent / Trademark agent",
@@ -15,7 +23,6 @@
         "reservedActivities": "England and Wales: the exercise of a right of audience; the conduct of litigation; reserved instrument activities; probate activities; the administration of oaths (see section 12 Legal Services Act 2007).",
         "protectedTitles": "Trade Mark Agent",
         "legislations": ["The Trade Marks Act 1994"],
-        "organisation": "Law Society of England and Wales",
         "mandatoryRegistration": "voluntary",
         "status": "live",
         "socCode": 2419,
@@ -26,8 +33,12 @@
   {
     "name": "Secondary School Teacher in State maintained schools (England)",
     "slug": "secondary-school-teacher-in-state-maintained-schools-england",
-    "organisation": "Department for Education",
-    "additionalOrganisation": null,
+    "organisations": [
+      {
+        "name": "Department for Education",
+        "role": "primaryRegulator"
+      }
+    ],
     "versions": [
       {
         "alternateName": "Secondary school teacher",
@@ -40,7 +51,6 @@
         "legislations": [
           "The Education (School Teachers' Qualifications) (England) Regulations 2003/1662 (as amended)"
         ],
-        "organisation": "Department for Education",
         "mandatoryRegistration": "mandatory",
         "status": "live",
         "socCode": 2313,
@@ -51,8 +61,12 @@
   {
     "name": "Gas Safe Engineer",
     "slug": "gas-safe-engineer",
-    "organisation": "Council of Registered Gas Installers",
-    "additionalOrganisation": null,
+    "organisations": [
+      {
+        "name": "Council of Registered Gas Installers",
+        "role": "primaryRegulator"
+      }
+    ],
     "versions": [
       {
         "alternateName": "Registered Gas Engineer",
@@ -63,7 +77,6 @@
         "qualification": "Evidence of gas safety competence is awarded through the process of proving to a recognised awarding body that you have the appropriate level of knowledge, understanding and practical skills to undertake gas work safely. All evidence of gas safety competence is sent by the awarding body electronically directly to Gas Safe Register and is only recognised once received from the awarding body concerned.",
         "reservedActivities": "Gas Safe Register is the official list of gas engineers in the UK, Isle of Man and Guernsey. To work on gas appliances and installations you must be on the gas safe register. The register exists to protect the public from unsafe gas work (EN)",
         "legislations": ["Gas Safety (Installation and Use) Regulations 1998"],
-        "organisation": "Council of Registered Gas Installers",
         "mandatoryRegistration": "voluntary",
         "status": "draft",
         "socCode": 5315,
@@ -74,8 +87,16 @@
   {
     "name": "Draft Profession",
     "slug": "draft-profession",
-    "organisation": "Council of Registered Gas Installers",
-    "additionalOrganisation": null,
+    "organisations": [
+      {
+        "name": "Council of Registered Gas Installers",
+        "role": "primaryRegulator"
+      },
+      {
+        "name": "Department for Education",
+        "role": "additionalRegulator"
+      }
+    ],
     "versions": [
       {
         "status": "draft"

--- a/seeds/test/professions.json
+++ b/seeds/test/professions.json
@@ -2,8 +2,16 @@
   {
     "name": "Registered Trademark Attorney",
     "slug": "registered-trademark-attorney",
-    "organisation": "Law Society of England and Wales",
-    "additionalOrganisation": "Alternative Law Society",
+    "organisations": [
+      {
+        "name": "Law Society of England and Wales",
+        "role": "primaryRegulator"
+      },
+      {
+        "name": "Alternative Law Society",
+        "role": "additionalRegulator"
+      }
+    ],
     "versions": [
       {
         "alternateName": "Patent Agent / Trademark agent",
@@ -17,7 +25,6 @@
         "reservedActivities": "England and Wales: the exercise of a right of audience; the conduct of litigation; reserved instrument activities; probate activities; the administration of oaths (see section 12 Legal Services Act 2007).",
         "protectedTitles": "Trade Mark Agent",
         "legislations": ["The Trade Marks Act 1994"],
-        "organisation": "Law Society of England and Wales",
         "mandatoryRegistration": "voluntary",
         "status": "live",
         "socCode": 2419,
@@ -28,8 +35,12 @@
   {
     "name": "Secondary School Teacher in State maintained schools (England)",
     "slug": "secondary-school-teacher-in-state-maintained-schools-england",
-    "organisation": "Department for Education",
-    "additionalOrganisation": null,
+    "organisations": [
+      {
+        "name": "Department for Education",
+        "role": "primaryRegulator"
+      }
+    ],
     "versions": [
       {
         "alternateName": "Secondary school teacher",
@@ -42,7 +53,6 @@
         "legislations": [
           "The Education (School Teachers' Qualifications) (England) Regulations 2003/1662 (as amended)"
         ],
-        "organisation": "Department for Education",
         "mandatoryRegistration": "mandatory",
         "status": "live",
         "socCode": 2313,
@@ -53,8 +63,16 @@
   {
     "name": "Profession with two tier-one Organisations",
     "slug": "profession-with-two-tier-one-organisations",
-    "organisation": "Department for Education",
-    "additionalOrganisation": "Organisation with no optional fields",
+    "organisations": [
+      {
+        "name": "Department for Education",
+        "role": "primaryRegulator"
+      },
+      {
+        "name": "Organisation with no optional fields",
+        "role": "primaryRegulator"
+      }
+    ],
     "versions": [
       {
         "alternateName": "Secondary school teacher",
@@ -67,7 +85,6 @@
         "legislations": [
           "The Education (School Teachers' Qualifications) (England) Regulations 2003/1662 (as amended)"
         ],
-        "organisation": "Department for Education",
         "mandatoryRegistration": "mandatory",
         "status": "live",
         "socCode": 2313,
@@ -78,8 +95,12 @@
   {
     "name": "Gas Safe Engineer",
     "slug": "gas-safe-engineer",
-    "organisation": "Council of Registered Gas Installers",
-    "additionalOrganisation": null,
+    "organisations": [
+      {
+        "name": "Council of Registered Gas Installers",
+        "role": "primaryRegulator"
+      }
+    ],
     "versions": [
       {
         "alternateName": "Registered Gas Engineer",
@@ -90,7 +111,6 @@
         "qualification": "Evidence of gas safety competence is awarded through the process of proving to a recognised awarding body that you have the appropriate level of knowledge, understanding and practical skills to undertake gas work safely. All evidence of gas safety competence is sent by the awarding body electronically directly to Gas Safe Register and is only recognised once received from the awarding body concerned.",
         "reservedActivities": "Gas Safe Register is the official list of gas engineers in the UK, Isle of Man and Guernsey. To work on gas appliances and installations you must be on the gas safe register. The register exists to protect the public from unsafe gas work (EN)",
         "legislations": ["Gas Safety (Installation and Use) Regulations 1998"],
-        "organisation": "Council of Registered Gas Installers",
         "mandatoryRegistration": "voluntary",
         "status": "draft",
         "socCode": 5315,
@@ -101,8 +121,12 @@
   {
     "name": "Orthodontic Therapist",
     "slug": "orthodontic-therapist",
-    "organisation": "General Medical Council",
-    "additionalOrganisation": null,
+    "organisations": [
+      {
+        "name": "General Medical Council",
+        "role": "primaryRegulator"
+      }
+    ],
     "versions": [
       {
         "alternateName": "Orthodontic Auxiliary",
@@ -122,8 +146,12 @@
   {
     "name": "Profession with no optional fields",
     "slug": "no-optional-fields",
-    "organisation": "Organisation with no optional fields",
-    "additionalOrganisation": null,
+    "organisations": [
+      {
+        "name": "Organisation with no optional fields",
+        "role": "primaryRegulator"
+      }
+    ],
     "versions": [
       {
         "occupationLocations": ["GB-ENG", "GB-NIR"],
@@ -142,8 +170,12 @@
   {
     "name": "Profession with draft organisation",
     "slug": "profession-with-draft-organisation",
-    "organisation": "Draft Organisation",
-    "additionalOrganisation": null,
+    "organisations": [
+      {
+        "name": "Draft Organisation",
+        "role": "primaryRegulator"
+      }
+    ],
     "versions": [
       {
         "occupationLocations": ["GB-ENG", "GB-NIR"],
@@ -160,8 +192,16 @@
   {
     "name": "Draft Profession",
     "slug": "draft-profession",
-    "organisation": "Council of Registered Gas Installers",
-    "additionalOrganisation": "Department for Education",
+    "organisations": [
+      {
+        "name": "Council of Registered Gas Installers",
+        "role": "primaryRegulator"
+      },
+      {
+        "name": "Department for Education",
+        "role": "primaryRegulator"
+      }
+    ],
     "versions": [
       {
         "status": "draft"

--- a/src/common/interfaces/organisation-with-role.interface.ts
+++ b/src/common/interfaces/organisation-with-role.interface.ts
@@ -1,0 +1,6 @@
+import { Organisation } from '../../organisations/organisation.entity';
+import { OrganisationRole } from '../../professions/profession-to-organisation.entity';
+
+export interface OrganisationWithRole extends Organisation {
+  role: OrganisationRole;
+}

--- a/src/i18n/en/professions.json
+++ b/src/i18n/en/professions.json
@@ -192,6 +192,7 @@
   },
   "show": {
     "overview": {
+      "regulators": "Regulators",
       "nations": "Nations",
       "industry": "Sectors"
     },

--- a/src/professions/admin/profession-versions.controller.spec.ts
+++ b/src/professions/admin/profession-versions.controller.spec.ts
@@ -3,7 +3,6 @@ import { NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { Response } from 'express';
 import { I18nService } from 'nestjs-i18n';
-import { Organisation } from '../../organisations/organisation.entity';
 import {
   ProfessionToOrganisation,
   OrganisationRole,
@@ -20,6 +19,8 @@ import { ProfessionVersionsService } from '../profession-versions.service';
 import { Profession } from '../profession.entity';
 import { ProfessionPresenter } from '../presenters/profession.presenter';
 import { getActingUser } from '../../users/helpers/get-acting-user.helper';
+import * as getGroupedTierOneOrganisationsFromProfessionModule from './../helpers/get-grouped-tier-one-organisations-from-profession.helper';
+import { GroupedTierOneOrganisations } from './../helpers/get-grouped-tier-one-organisations-from-profession.helper';
 import { createDefaultMockRequest } from '../../testutils/factories/create-default-mock-request';
 import organisationFactory from '../../testutils/factories/organisation';
 import { checkCanViewProfession } from '../../users/helpers/check-can-view-profession';
@@ -155,188 +156,90 @@ describe('ProfessionVersionsController', () => {
     });
 
     describe('when the Profession is complete', () => {
-      describe('when the Profession has a single Organisation', () => {
-        it('should return populated template params', async () => {
-          const organisation = organisationFactory.build();
+      it('should return populated template params', async () => {
+        const organisation = organisationFactory.build();
 
-          const profession = professionFactory.build({
-            professionToOrganisations: [
-              {
-                organisation: organisation,
-                role: OrganisationRole.AdditionalRegulator,
-              },
-            ] as ProfessionToOrganisation[],
-          });
-
-          const version = professionVersionFactory.build({
-            profession: profession,
-            occupationLocations: ['GB-ENG'],
-            industries: [industryFactory.build({ name: 'industries.example' })],
-          });
-
-          const professionWithVersion = Profession.withVersion(
-            profession,
-            version,
-          );
-
-          professionVersionsService.findByIdWithProfession.mockResolvedValue(
-            version,
-          );
-          professionVersionsService.hasLiveVersion.mockResolvedValue(true);
-
-          (ProfessionPresenter as jest.Mock).mockReturnValue({});
-
-          (Organisation.withLatestVersion as jest.Mock).mockImplementation(
-            (organisation) => organisation,
-          );
-
-          (
-            NationsListPresenter.prototype.htmlList as jest.Mock
-          ).mockResolvedValue(mockNationsHtml);
-
-          const getPublicationBlockersSpy = jest
-            .spyOn(getPublicationBlockersModule, 'getPublicationBlockers')
-            .mockReturnValue([]);
-
-          const request = createDefaultMockRequest({
-            user: userFactory.build(),
-          });
-          const expectedOrganisations = [
+        const profession = professionFactory.build({
+          professionToOrganisations: [
             {
-              ...organisation,
+              organisation: organisation,
               role: OrganisationRole.AdditionalRegulator,
             },
-          ];
-
-          const result = await controller.show(
-            'profession-id',
-            'version-id',
-            request,
-          );
-
-          expect(result).toEqual({
-            profession: professionWithVersion,
-            presenter: {},
-            hasLiveVersion: true,
-            qualifications: await new QualificationPresenter(
-              professionWithVersion.qualification,
-              createMockI18nService(),
-            ).summaryList(true, true),
-            nations: mockNationsHtml,
-            industries: ['Translation of `industries.example`'],
-            organisations: expectedOrganisations,
-            publicationBlockers: [],
-          } as ShowTemplate);
-
-          expect(
-            professionVersionsService.findByIdWithProfession,
-          ).toHaveBeenCalledWith('profession-id', 'version-id');
-          expect(professionVersionsService.hasLiveVersion).toHaveBeenCalledWith(
-            professionWithVersion,
-          );
-          expect(getPublicationBlockersSpy).toHaveBeenCalledWith(version);
-          expect(NationsListPresenter).toHaveBeenCalledWith(
-            [Nation.find('GB-ENG')],
-            i18nService,
-          );
+          ] as ProfessionToOrganisation[],
         });
-      });
 
-      describe('when the Profession has an additional Organisation', () => {
-        it('should return populated template params', async () => {
-          const organisation1 = organisationFactory.build();
-          const organisation2 = organisationFactory.build();
-
-          const profession = professionFactory.build({
-            professionToOrganisations: [
-              {
-                organisation: organisation1,
-                role: OrganisationRole.AdditionalRegulator,
-              },
-              {
-                organisation: organisation2,
-                role: OrganisationRole.PrimaryRegulator,
-              },
-            ] as ProfessionToOrganisation[],
-          });
-
-          const version = professionVersionFactory.build({
-            profession: profession,
-            occupationLocations: ['GB-ENG'],
-            industries: [industryFactory.build({ name: 'industries.example' })],
-          });
-
-          const professionWithVersion = Profession.withVersion(
-            profession,
-            version,
-          );
-
-          professionVersionsService.findByIdWithProfession.mockResolvedValue(
-            version,
-          );
-          professionVersionsService.hasLiveVersion.mockResolvedValue(true);
-
-          (ProfessionPresenter as jest.Mock).mockReturnValue({});
-
-          (Organisation.withLatestVersion as jest.Mock).mockImplementation(
-            (organisation) => organisation,
-          );
-
-          (
-            NationsListPresenter.prototype.htmlList as jest.Mock
-          ).mockResolvedValue(mockNationsHtml);
-
-          const getPublicationBlockersSpy = jest
-            .spyOn(getPublicationBlockersModule, 'getPublicationBlockers')
-            .mockReturnValue([]);
-
-          const expectedOrganisations = [
-            {
-              ...organisation2,
-              role: OrganisationRole.PrimaryRegulator,
-            },
-            {
-              ...organisation1,
-              role: OrganisationRole.AdditionalRegulator,
-            },
-          ];
-
-          const request = createDefaultMockRequest({
-            user: userFactory.build(),
-          });
-
-          const result = await controller.show(
-            'profession-id',
-            'version-id',
-            request,
-          );
-
-          expect(result).toEqual({
-            profession: professionWithVersion,
-            presenter: {},
-            hasLiveVersion: true,
-            qualifications: await new QualificationPresenter(
-              professionWithVersion.qualification,
-              createMockI18nService(),
-            ).summaryList(true, true),
-            nations: mockNationsHtml,
-            industries: ['Translation of `industries.example`'],
-            organisations: expectedOrganisations,
-            publicationBlockers: [],
-          } as ShowTemplate);
-
-          expect(
-            professionVersionsService.findByIdWithProfession,
-          ).toHaveBeenCalledWith('profession-id', 'version-id');
-          expect(professionVersionsService.hasLiveVersion).toHaveBeenCalledWith(
-            professionWithVersion,
-          );
-          expect(getPublicationBlockersSpy).toHaveBeenCalledWith(version);
-          expect(NationsListPresenter).toHaveBeenCalledWith(
-            [Nation.find('GB-ENG')],
-            i18nService,
-          );
+        const version = professionVersionFactory.build({
+          profession: profession,
+          occupationLocations: ['GB-ENG'],
+          industries: [industryFactory.build({ name: 'industries.example' })],
         });
+
+        const professionWithVersion = Profession.withVersion(
+          profession,
+          version,
+        );
+
+        professionVersionsService.findByIdWithProfession.mockResolvedValue(
+          version,
+        );
+        professionVersionsService.hasLiveVersion.mockResolvedValue(true);
+
+        (ProfessionPresenter as jest.Mock).mockReturnValue({});
+
+        const expectedOrganisations = {} as GroupedTierOneOrganisations;
+        const getGroupedTierOneOrganisationsFromProfessionSpy = jest
+          .spyOn(
+            getGroupedTierOneOrganisationsFromProfessionModule,
+            'getGroupedTierOneOrganisationsFromProfession',
+          )
+          .mockReturnValue(expectedOrganisations);
+
+        (
+          NationsListPresenter.prototype.htmlList as jest.Mock
+        ).mockResolvedValue(mockNationsHtml);
+
+        const getPublicationBlockersSpy = jest
+          .spyOn(getPublicationBlockersModule, 'getPublicationBlockers')
+          .mockReturnValue([]);
+
+        const request = createDefaultMockRequest({
+          user: userFactory.build(),
+        });
+
+        const result = await controller.show(
+          'profession-id',
+          'version-id',
+          request,
+        );
+
+        expect(result).toEqual({
+          profession: professionWithVersion,
+          presenter: {},
+          hasLiveVersion: true,
+          qualifications: await new QualificationPresenter(
+            professionWithVersion.qualification,
+            createMockI18nService(),
+          ).summaryList(true, true),
+          nations: mockNationsHtml,
+          industries: ['Translation of `industries.example`'],
+          organisations: expectedOrganisations,
+          publicationBlockers: [],
+        } as ShowTemplate);
+
+        expect(
+          professionVersionsService.findByIdWithProfession,
+        ).toHaveBeenCalledWith('profession-id', 'version-id');
+        expect(professionVersionsService.hasLiveVersion).toHaveBeenCalledWith(
+          professionWithVersion,
+        );
+        expect(getPublicationBlockersSpy).toHaveBeenCalledWith(version);
+        expect(NationsListPresenter).toHaveBeenCalledWith(
+          [Nation.find('GB-ENG')],
+          i18nService,
+        );
+        expect(
+          getGroupedTierOneOrganisationsFromProfessionSpy,
+        ).toHaveBeenCalledWith(professionWithVersion, 'latestVersion');
       });
     });
 
@@ -363,9 +266,13 @@ describe('ProfessionVersionsController', () => {
 
         (ProfessionPresenter as jest.Mock).mockReturnValue({});
 
-        (Organisation.withLatestVersion as jest.Mock).mockImplementation(
-          (organisation) => organisation,
-        );
+        const expectedOrganisations = {} as GroupedTierOneOrganisations;
+        jest
+          .spyOn(
+            getGroupedTierOneOrganisationsFromProfessionModule,
+            'getGroupedTierOneOrganisationsFromProfession',
+          )
+          .mockReturnValue(expectedOrganisations);
 
         (
           NationsListPresenter.prototype.htmlList as jest.Mock
@@ -398,7 +305,7 @@ describe('ProfessionVersionsController', () => {
           ).summaryList(true, true),
           nations: mockNationsHtml,
           industries: [translationOf('industries.example')],
-          organisations: [profession.professionToOrganisations[0].organisation],
+          organisations: expectedOrganisations,
           publicationBlockers: [
             {
               type: 'incomplete-section',
@@ -443,9 +350,13 @@ describe('ProfessionVersionsController', () => {
 
         (ProfessionPresenter as jest.Mock).mockReturnValue({});
 
-        (Organisation.withLatestVersion as jest.Mock).mockImplementation(
-          (organisation) => organisation,
-        );
+        const expectedOrganisations = {} as GroupedTierOneOrganisations;
+        jest
+          .spyOn(
+            getGroupedTierOneOrganisationsFromProfessionModule,
+            'getGroupedTierOneOrganisationsFromProfession',
+          )
+          .mockReturnValue(expectedOrganisations);
 
         (
           NationsListPresenter.prototype.htmlList as jest.Mock
@@ -482,7 +393,7 @@ describe('ProfessionVersionsController', () => {
           ).summaryList(true, true),
           nations: mockNationsHtml,
           industries: [],
-          organisations: [profession.professionToOrganisations[0].organisation],
+          organisations: expectedOrganisations,
           publicationBlockers: [
             {
               type: 'incomplete-section',

--- a/src/professions/admin/profession-versions.controller.ts
+++ b/src/professions/admin/profession-versions.controller.ts
@@ -23,7 +23,7 @@ import { ProfessionVersionsService } from '../profession-versions.service';
 import { Profession } from '../profession.entity';
 import { ProfessionPresenter } from '../presenters/profession.presenter';
 import { getActingUser } from '../../users/helpers/get-acting-user.helper';
-import { getOrganisationsFromProfession } from '../helpers/get-organisations-from-profession.helper';
+import { sortOrganisationsByRole } from './../helpers/sort-organisations-by-role';
 import { ShowTemplate } from './interfaces/show-template.interface';
 import { isUK } from '../../helpers/nations.helper';
 import { checkCanViewProfession } from '../../users/helpers/check-can-view-profession';
@@ -72,8 +72,17 @@ export class ProfessionVersionsController {
       profession,
     );
 
-    const organisations = getOrganisationsFromProfession(profession).map(
-      (organisation) => Organisation.withLatestVersion(organisation),
+    const organisations = sortOrganisationsByRole(profession).map(
+      (professionToOrganisation) => {
+        const organisation = Organisation.withLatestVersion(
+          professionToOrganisation.organisation,
+        );
+
+        return {
+          ...organisation,
+          role: professionToOrganisation.role,
+        };
+      },
     );
 
     const nations = new NationsListPresenter(

--- a/src/professions/admin/profession-versions.controller.ts
+++ b/src/professions/admin/profession-versions.controller.ts
@@ -15,7 +15,6 @@ import { AuthenticationGuard } from '../../common/authentication.guard';
 import { BackLink } from '../../common/decorators/back-link.decorator';
 import { RequestWithAppSession } from '../../common/interfaces/request-with-app-session.interface';
 import { Nation } from '../../nations/nation';
-import { Organisation } from '../../organisations/organisation.entity';
 import QualificationPresenter from '../../qualifications/presenters/qualification.presenter';
 import { UserPermission } from '../../users/user-permission';
 import { Permissions } from '../../common/permissions.decorator';
@@ -23,12 +22,12 @@ import { ProfessionVersionsService } from '../profession-versions.service';
 import { Profession } from '../profession.entity';
 import { ProfessionPresenter } from '../presenters/profession.presenter';
 import { getActingUser } from '../../users/helpers/get-acting-user.helper';
-import { sortOrganisationsByRole } from './../helpers/sort-organisations-by-role';
 import { ShowTemplate } from './interfaces/show-template.interface';
 import { isUK } from '../../helpers/nations.helper';
 import { checkCanViewProfession } from '../../users/helpers/check-can-view-profession';
 import { getPublicationBlockers } from '../helpers/get-publication-blockers.helper';
 import { NationsListPresenter } from '../../nations/presenters/nations-list.presenter';
+import { getGroupedTierOneOrganisationsFromProfession } from './../helpers/get-grouped-tier-one-organisations-from-profession.helper';
 
 @UseGuards(AuthenticationGuard)
 @Controller('/admin/professions')
@@ -72,17 +71,9 @@ export class ProfessionVersionsController {
       profession,
     );
 
-    const organisations = sortOrganisationsByRole(profession).map(
-      (professionToOrganisation) => {
-        const organisation = Organisation.withLatestVersion(
-          professionToOrganisation.organisation,
-        );
-
-        return {
-          ...organisation,
-          role: professionToOrganisation.role,
-        };
-      },
+    const tierOneOrganisations = getGroupedTierOneOrganisationsFromProfession(
+      profession,
+      'latestVersion',
     );
 
     const nations = new NationsListPresenter(
@@ -111,7 +102,7 @@ export class ProfessionVersionsController {
       ),
       nations: await nations.htmlList(),
       industries,
-      organisations,
+      organisations: tierOneOrganisations,
       publicationBlockers: getPublicationBlockers(version),
     };
   }

--- a/src/professions/helpers/get-grouped-tier-one-organisations-from-profession.helper.spec.ts
+++ b/src/professions/helpers/get-grouped-tier-one-organisations-from-profession.helper.spec.ts
@@ -1,0 +1,73 @@
+import organisationFactory from '../../testutils/factories/organisation';
+import professionFactory from '../../testutils/factories/profession';
+import { getGroupedTierOneOrganisationsFromProfession } from './get-grouped-tier-one-organisations-from-profession.helper';
+import {
+  OrganisationRole,
+  ProfessionToOrganisation,
+} from '../profession-to-organisation.entity';
+
+describe('getGroupedTierOneOrganisationsFromProfession', () => {
+  it('should group all tier one organisations by their role', () => {
+    const organisation1 = organisationFactory.build();
+    const organisation2 = organisationFactory.build();
+    const organisation3 = organisationFactory.build();
+    const organisation4 = organisationFactory.build();
+    const organisation5 = organisationFactory.build();
+
+    const profession = professionFactory.build({
+      professionToOrganisations: [
+        {
+          organisation: organisation1,
+          role: OrganisationRole.PrimaryRegulator,
+        },
+        {
+          organisation: organisation2,
+          role: OrganisationRole.CharteredBody,
+        },
+        {
+          organisation: organisation3,
+          role: OrganisationRole.CharteredBody,
+        },
+        {
+          organisation: organisation4,
+          role: OrganisationRole.OversightBody,
+        },
+        {
+          organisation: organisation5,
+          role: OrganisationRole.AwardingBody,
+        },
+      ] as ProfessionToOrganisation[],
+    });
+
+    expect(getGroupedTierOneOrganisationsFromProfession(profession)).toEqual({
+      primaryRegulator: [organisation1],
+      charteredBody: [organisation2, organisation3],
+      oversightBody: [organisation4],
+    });
+  });
+
+  it('should return an empty list when there are no organisations', () => {
+    const profession = professionFactory.build({
+      professionToOrganisations: [],
+    });
+
+    expect(getGroupedTierOneOrganisationsFromProfession(profession)).toEqual(
+      {},
+    );
+  });
+
+  it('should return an empty list when therer are no tier one organisations', () => {
+    const profession = professionFactory.build({
+      professionToOrganisations: [
+        {
+          organisation: organisationFactory.build(),
+          role: OrganisationRole.AwardingBody,
+        },
+      ] as ProfessionToOrganisation[],
+    });
+
+    expect(getGroupedTierOneOrganisationsFromProfession(profession)).toEqual(
+      {},
+    );
+  });
+});

--- a/src/professions/helpers/get-grouped-tier-one-organisations-from-profession.helper.spec.ts
+++ b/src/professions/helpers/get-grouped-tier-one-organisations-from-profession.helper.spec.ts
@@ -5,44 +5,172 @@ import {
   OrganisationRole,
   ProfessionToOrganisation,
 } from '../profession-to-organisation.entity';
+import { Organisation } from '../../organisations/organisation.entity';
+
+jest.mock('../../organisations/organisation.entity');
 
 describe('getGroupedTierOneOrganisationsFromProfession', () => {
-  it('should group all tier one organisations by their role', () => {
-    const organisation1 = organisationFactory.build();
-    const organisation2 = organisationFactory.build();
-    const organisation3 = organisationFactory.build();
-    const organisation4 = organisationFactory.build();
-    const organisation5 = organisationFactory.build();
+  describe('when fetching the latest version', () => {
+    it('should group all tier one organisations by their role', () => {
+      const organisation1 = organisationFactory.build();
+      const organisation2 = organisationFactory.build();
+      const organisation3 = organisationFactory.build();
+      const organisation4 = organisationFactory.build();
+      const organisation5 = organisationFactory.build();
 
-    const profession = professionFactory.build({
-      professionToOrganisations: [
-        {
-          organisation: organisation1,
-          role: OrganisationRole.PrimaryRegulator,
-        },
-        {
-          organisation: organisation2,
-          role: OrganisationRole.CharteredBody,
-        },
-        {
-          organisation: organisation3,
-          role: OrganisationRole.CharteredBody,
-        },
-        {
-          organisation: organisation4,
-          role: OrganisationRole.OversightBody,
-        },
-        {
-          organisation: organisation5,
-          role: OrganisationRole.AwardingBody,
-        },
-      ] as ProfessionToOrganisation[],
+      const profession = professionFactory.build({
+        professionToOrganisations: [
+          {
+            organisation: organisation1,
+            role: OrganisationRole.PrimaryRegulator,
+          },
+          {
+            organisation: organisation2,
+            role: OrganisationRole.CharteredBody,
+          },
+          {
+            organisation: organisation3,
+            role: OrganisationRole.CharteredBody,
+          },
+          {
+            organisation: organisation4,
+            role: OrganisationRole.OversightBody,
+          },
+          {
+            organisation: organisation5,
+            role: OrganisationRole.AwardingBody,
+          },
+        ] as ProfessionToOrganisation[],
+      });
+
+      (Organisation.withLatestVersion as jest.Mock).mockImplementation(
+        (organisation) => organisation,
+      );
+
+      expect(
+        getGroupedTierOneOrganisationsFromProfession(
+          profession,
+          'latestVersion',
+        ),
+      ).toEqual({
+        primaryRegulator: [organisation1],
+        charteredBody: [organisation2, organisation3],
+        oversightBody: [organisation4],
+      });
+
+      expect(Organisation.withLatestVersion).toHaveBeenCalledWith(
+        organisation1,
+      );
+      expect(Organisation.withLatestVersion).toHaveBeenCalledWith(
+        organisation2,
+      );
+      expect(Organisation.withLatestVersion).toHaveBeenCalledWith(
+        organisation3,
+      );
+      expect(Organisation.withLatestVersion).toHaveBeenCalledWith(
+        organisation4,
+      );
+    });
+  });
+
+  describe('when fetching the latest live version', () => {
+    it('should group all tier one organisations by their role', () => {
+      const organisation1 = organisationFactory.build();
+      const organisation2 = organisationFactory.build();
+      const organisation3 = organisationFactory.build();
+      const organisation4 = organisationFactory.build();
+      const organisation5 = organisationFactory.build();
+
+      const profession = professionFactory.build({
+        professionToOrganisations: [
+          {
+            organisation: organisation1,
+            role: OrganisationRole.PrimaryRegulator,
+          },
+          {
+            organisation: organisation2,
+            role: OrganisationRole.CharteredBody,
+          },
+          {
+            organisation: organisation3,
+            role: OrganisationRole.CharteredBody,
+          },
+          {
+            organisation: organisation4,
+            role: OrganisationRole.OversightBody,
+          },
+          {
+            organisation: organisation5,
+            role: OrganisationRole.AwardingBody,
+          },
+        ] as ProfessionToOrganisation[],
+      });
+
+      (Organisation.withLatestLiveVersion as jest.Mock).mockImplementation(
+        (organisation) => organisation,
+      );
+
+      expect(
+        getGroupedTierOneOrganisationsFromProfession(
+          profession,
+          'latestLiveVersion',
+        ),
+      ).toEqual({
+        primaryRegulator: [organisation1],
+        charteredBody: [organisation2, organisation3],
+        oversightBody: [organisation4],
+      });
+
+      expect(Organisation.withLatestLiveVersion).toHaveBeenCalledWith(
+        organisation1,
+      );
+      expect(Organisation.withLatestLiveVersion).toHaveBeenCalledWith(
+        organisation2,
+      );
+      expect(Organisation.withLatestLiveVersion).toHaveBeenCalledWith(
+        organisation3,
+      );
+      expect(Organisation.withLatestLiveVersion).toHaveBeenCalledWith(
+        organisation4,
+      );
     });
 
-    expect(getGroupedTierOneOrganisationsFromProfession(profession)).toEqual({
-      primaryRegulator: [organisation1],
-      charteredBody: [organisation2, organisation3],
-      oversightBody: [organisation4],
+    it('should filter out any organisations that do not have a live version', () => {
+      const organisation1 = organisationFactory.build();
+      const organisation2 = organisationFactory.build();
+      const organisation3 = organisationFactory.build();
+
+      const profession = professionFactory.build({
+        professionToOrganisations: [
+          {
+            organisation: organisation1,
+            role: OrganisationRole.PrimaryRegulator,
+          },
+          {
+            organisation: organisation2,
+            role: OrganisationRole.CharteredBody,
+          },
+          {
+            organisation: organisation3,
+            role: OrganisationRole.CharteredBody,
+          },
+        ] as ProfessionToOrganisation[],
+      });
+
+      (Organisation.withLatestLiveVersion as jest.Mock).mockImplementation(
+        (organisation) =>
+          organisation.id === organisation3.id ? undefined : organisation,
+      );
+
+      expect(
+        getGroupedTierOneOrganisationsFromProfession(
+          profession,
+          'latestLiveVersion',
+        ),
+      ).toEqual({
+        primaryRegulator: [organisation1],
+        charteredBody: [organisation2],
+      });
     });
   });
 
@@ -51,9 +179,9 @@ describe('getGroupedTierOneOrganisationsFromProfession', () => {
       professionToOrganisations: [],
     });
 
-    expect(getGroupedTierOneOrganisationsFromProfession(profession)).toEqual(
-      {},
-    );
+    expect(
+      getGroupedTierOneOrganisationsFromProfession(profession, 'latestVersion'),
+    ).toEqual({});
   });
 
   it('should return an empty list when therer are no tier one organisations', () => {
@@ -66,8 +194,8 @@ describe('getGroupedTierOneOrganisationsFromProfession', () => {
       ] as ProfessionToOrganisation[],
     });
 
-    expect(getGroupedTierOneOrganisationsFromProfession(profession)).toEqual(
-      {},
-    );
+    expect(
+      getGroupedTierOneOrganisationsFromProfession(profession, 'latestVersion'),
+    ).toEqual({});
   });
 });

--- a/src/professions/helpers/get-grouped-tier-one-organisations-from-profession.helper.ts
+++ b/src/professions/helpers/get-grouped-tier-one-organisations-from-profession.helper.ts
@@ -1,0 +1,35 @@
+import { Profession } from '../profession.entity';
+import {
+  TierOneRoles,
+  TierOneRoleTypes,
+} from './../profession-to-organisation.entity';
+import { Organisation } from './../../organisations/organisation.entity';
+
+export type GroupedTierOneOrganisations = Record<
+  TierOneRoleTypes,
+  Organisation[]
+>;
+
+export function getGroupedTierOneOrganisationsFromProfession(
+  profession: Profession,
+): GroupedTierOneOrganisations {
+  const record = {} as GroupedTierOneOrganisations;
+  const roleOrder = Object.values(TierOneRoles as ReadonlyArray<string>);
+
+  if (!profession.professionToOrganisations.length) {
+    return record;
+  }
+
+  const tierOneRelations = profession.professionToOrganisations.filter(
+    (relation) => roleOrder.indexOf(relation.role) > -1,
+  );
+
+  const sortedTierOneRelations = tierOneRelations
+    .sort((a, b) => roleOrder.indexOf(a.role) - roleOrder.indexOf(b.role))
+    .filter((n) => n);
+
+  return sortedTierOneRelations.reduce((a, b) => {
+    a[b.role] = [...(a[b.role] || []), b.organisation];
+    return a;
+  }, record);
+}

--- a/src/professions/helpers/get-tier-one-organisations-from-profession.helper.ts
+++ b/src/professions/helpers/get-tier-one-organisations-from-profession.helper.ts
@@ -7,7 +7,9 @@ export function getTierOneOrganisationsFromProfession(
 ): Organisation[] {
   return (
     profession.professionToOrganisations
-      ?.filter((relation) => TierOneRoles.includes(relation.role))
+      ?.filter((relation) =>
+        (TierOneRoles as ReadonlyArray<string>).includes(relation.role),
+      )
       ?.map((relation) => relation.organisation)
       .filter((n) => n) || []
   );

--- a/src/professions/interfaces/show-template.interface.ts
+++ b/src/professions/interfaces/show-template.interface.ts
@@ -1,5 +1,5 @@
 import { SummaryList } from '../../common/interfaces/summary-list';
-import { OrganisationWithRole } from '../../common/interfaces/organisation-with-role.interface';
+import { GroupedTierOneOrganisations } from '../helpers/get-grouped-tier-one-organisations-from-profession.helper';
 import { ProfessionPresenter } from '../presenters/profession.presenter';
 import { Profession } from '../profession.entity';
 
@@ -13,5 +13,5 @@ export interface ShowTemplate {
   };
   nations: string;
   industries: string[];
-  organisations: OrganisationWithRole[];
+  organisations: GroupedTierOneOrganisations;
 }

--- a/src/professions/interfaces/show-template.interface.ts
+++ b/src/professions/interfaces/show-template.interface.ts
@@ -1,5 +1,5 @@
 import { SummaryList } from '../../common/interfaces/summary-list';
-import { Organisation } from '../../organisations/organisation.entity';
+import { OrganisationWithRole } from '../../common/interfaces/organisation-with-role.interface';
 import { ProfessionPresenter } from '../presenters/profession.presenter';
 import { Profession } from '../profession.entity';
 
@@ -13,5 +13,5 @@ export interface ShowTemplate {
   };
   nations: string;
   industries: string[];
-  organisations: Organisation[];
+  organisations: OrganisationWithRole[];
 }

--- a/src/professions/profession-to-organisation.entity.ts
+++ b/src/professions/profession-to-organisation.entity.ts
@@ -12,13 +12,15 @@ export enum OrganisationRole {
   AwardingBody = 'awardingBody',
 }
 
-export const TierOneRoles = [
+export const TierOneRoles = <const>[
   OrganisationRole.PrimaryRegulator,
   OrganisationRole.CharteredBody,
   OrganisationRole.QualifyingBody,
-  OrganisationRole.OversightBody,
   OrganisationRole.AdditionalRegulator,
+  OrganisationRole.OversightBody,
 ];
+
+export type TierOneRoleTypes = typeof TierOneRoles[number];
 
 @Entity({ name: 'professionToOrganisation' })
 export class ProfessionToOrganisation {

--- a/src/professions/professions.controller.ts
+++ b/src/professions/professions.controller.ts
@@ -11,9 +11,8 @@ import { Nation } from '../nations/nation';
 import QualificationPresenter from '../qualifications/presenters/qualification.presenter';
 import { ShowTemplate } from './interfaces/show-template.interface';
 import { BackLink } from '../common/decorators/back-link.decorator';
-import { Organisation } from '../organisations/organisation.entity';
 import { ProfessionVersionsService } from './profession-versions.service';
-import { sortOrganisationsByRole } from './helpers/sort-organisations-by-role';
+import { getGroupedTierOneOrganisationsFromProfession } from './helpers/get-grouped-tier-one-organisations-from-profession.helper';
 import { isUK } from '../helpers/nations.helper';
 import { NationsListPresenter } from '../nations/presenters/nations-list.presenter';
 
@@ -41,17 +40,9 @@ export class ProfessionsController {
       );
     }
 
-    const organisations = sortOrganisationsByRole(profession).map(
-      (professionToOrganisation) => {
-        const organisation = Organisation.withLatestLiveVersion(
-          professionToOrganisation.organisation,
-        );
-
-        return {
-          ...organisation,
-          role: professionToOrganisation.role,
-        };
-      },
+    const tierOneOrganisations = getGroupedTierOneOrganisationsFromProfession(
+      profession,
+      'latestLiveVersion',
     );
 
     const nations = new NationsListPresenter(
@@ -79,7 +70,7 @@ export class ProfessionsController {
         : null,
       nations: await nations.htmlList(),
       industries,
-      organisations,
+      organisations: tierOneOrganisations,
     };
   }
 }

--- a/src/professions/professions.controller.ts
+++ b/src/professions/professions.controller.ts
@@ -13,7 +13,7 @@ import { ShowTemplate } from './interfaces/show-template.interface';
 import { BackLink } from '../common/decorators/back-link.decorator';
 import { Organisation } from '../organisations/organisation.entity';
 import { ProfessionVersionsService } from './profession-versions.service';
-import { getOrganisationsFromProfession } from './helpers/get-organisations-from-profession.helper';
+import { sortOrganisationsByRole } from './helpers/sort-organisations-by-role';
 import { isUK } from '../helpers/nations.helper';
 import { NationsListPresenter } from '../nations/presenters/nations-list.presenter';
 
@@ -41,8 +41,17 @@ export class ProfessionsController {
       );
     }
 
-    const organisations = getOrganisationsFromProfession(profession).map(
-      (organisation) => Organisation.withLatestLiveVersion(organisation),
+    const organisations = sortOrganisationsByRole(profession).map(
+      (professionToOrganisation) => {
+        const organisation = Organisation.withLatestLiveVersion(
+          professionToOrganisation.organisation,
+        );
+
+        return {
+          ...organisation,
+          role: professionToOrganisation.role,
+        };
+      },
     );
 
     const nations = new NationsListPresenter(

--- a/views/professions/_profession-details.njk
+++ b/views/professions/_profession-details.njk
@@ -40,10 +40,18 @@
 
 {% for organisation in organisations %}
   <div class="rpr-details__sub-group">
-    <h3 class="govuk-heading-m rpr-details__sub-group-title">{{ organisation.name | escape }}</h3>
+    <h3 class="govuk-heading-m rpr-details__sub-group-title">{{ ("organisations.label.roles." +  organisation.role) | t }}</h3>
     {{ govukSummaryList({
       classes: 'govuk-summary-list--no-border',
       rows: [
+        {
+          key: {
+            text: ("professions.show.bodies.regulatedAuthority" | t)
+          },
+          value: {
+            html: "<a href='"+ ("/regulatory-authorities/" + organisation.slug) +"' class='govuk-link'>"+ organisation.name | escape +"</a>"
+          }
+        },
         {
           key: {
             text: ("professions.show.bodies.address" | t)

--- a/views/professions/_profession-details.njk
+++ b/views/professions/_profession-details.njk
@@ -38,54 +38,58 @@
 
 <h2 class="govuk-heading-l">{{ "professions.show.bodies.heading" | t }}</h2>
 
-{% for organisation in organisations %}
+{% for role, orgs in organisations %}
   <div class="rpr-details__sub-group">
-    <h3 class="govuk-heading-m rpr-details__sub-group-title">{{ ("organisations.label.roles." +  organisation.role) | t }}</h3>
-    {{ govukSummaryList({
-      classes: 'govuk-summary-list--no-border',
-      rows: [
-        {
-          key: {
-            text: ("professions.show.bodies.regulatedAuthority" | t)
+    {% for organisation in orgs %}
+      <h3 class="govuk-heading-m rpr-details__sub-group-title">{{ ("organisations.label.roles." +  role) | t }}</h3>
+
+      {{ govukSummaryList({
+        classes: 'govuk-summary-list--no-border',
+        rows: [
+          {
+            key: {
+              text: ("professions.show.bodies.regulatedAuthority" | t)
+            },
+            value: {
+              html: "<a href='"+ ("/regulatory-authorities/" + organisation.slug) +"' class='govuk-link'>"+ organisation.name | escape +"</a>"
+            }
           },
-          value: {
-            html: "<a href='"+ ("/regulatory-authorities/" + organisation.slug) +"' class='govuk-link'>"+ organisation.name | escape +"</a>"
-          }
-        },
-        {
-          key: {
-            text: ("professions.show.bodies.address" | t)
-          },
-          value: {
-            html: organisation.address | multiline
-          }
-        } if (organisation.address or showEmptyProfessionDetails) else undefined,
-        {
-          key: {
-            text: ("professions.show.bodies.emailAddress" | t)
-          },
-          value: {
-            html: organisation.email | email
-          }
-        } if (organisation.email or showEmptyProfessionDetails) else undefined,
-        {
-          key: {
-            text: ("professions.show.bodies.url" | t)
-          },
-          value: {
-            html: organisation.url | link
-          }
-        } if (organisation.url or showEmptyProfessionDetails) else undefined,
-        {
-          key: {
-            text: ("professions.show.bodies.phoneNumber" | t)
-          },
-          value: {
-            text: organisation.telephone | telephone
-          }
-        } if (organisation.telephone or showEmptyProfessionDetails) else undefined
-      ]
-    }) }}
+          {
+            key: {
+              text: ("professions.show.bodies.address" | t)
+            },
+            value: {
+              html: organisation.address | multiline
+            }
+          } if (organisation.address or showEmptyProfessionDetails) else undefined,
+          {
+            key: {
+              text: ("professions.show.bodies.emailAddress" | t)
+            },
+            value: {
+              html: organisation.email | email
+            }
+          } if (organisation.email or showEmptyProfessionDetails) else undefined,
+          {
+            key: {
+              text: ("professions.show.bodies.url" | t)
+            },
+            value: {
+              html: organisation.url | link
+            }
+          } if (organisation.url or showEmptyProfessionDetails) else undefined,
+          {
+            key: {
+              text: ("professions.show.bodies.phoneNumber" | t)
+            },
+            value: {
+              text: organisation.telephone | telephone
+            }
+          } if (organisation.telephone or showEmptyProfessionDetails) else undefined
+        ]
+      }) }}
+    {% endfor %}
+
   </div>
 {% endfor %}
 

--- a/views/professions/_profession-details.njk
+++ b/views/professions/_profession-details.njk
@@ -11,10 +11,29 @@
   {% endfor %}
   </ul>
 {% endset %}
+
+{% set regulatorsHtml %}
+  <ul class="govuk-list">
+    {% for professionToOrganisation in profession.professionToOrganisations %}
+      {% if professionToOrganisation.organisation %}
+        <li>{{ professionToOrganisation.organisation.name }}</li>
+      {% endif %}
+    {% endfor %}
+  </ul>
+{% endset %}
+
 {{
   govukSummaryList({
   classes: 'govuk-summary-list--no-border',
   rows: [
+    {
+      key: {
+        text: ("professions.show.overview.regulators" | t)
+      },
+      value: {
+        html: regulatorsHtml
+      }
+    },
     {
       key: {
         text: ("professions.show.overview.nations" | t)

--- a/views/professions/show.njk.spec.ts
+++ b/views/professions/show.njk.spec.ts
@@ -1,0 +1,54 @@
+import { JSDOM } from 'jsdom';
+import * as nunjucks from 'nunjucks';
+
+import { translationOf } from '../../src/testutils/translation-of';
+import { nunjucksEnvironment } from '../testutils/nunjucksEnvironment';
+
+import organisationFactory from '../../src/testutils/factories/organisation';
+import professionFactory from '../../src/testutils/factories/profession';
+
+describe('show.njk', () => {
+  beforeAll(async () => {
+    await nunjucksEnvironment();
+  });
+
+  it('should group organisations together', async () => {
+    const profession = professionFactory.build();
+    const organisation1 = organisationFactory.build();
+    const organisation2 = organisationFactory.build();
+    const organisation3 = organisationFactory.build();
+
+    const organisations = {
+      role1: [organisation1, organisation2],
+      role2: [organisation3],
+    };
+
+    nunjucks.render(
+      'professions/show.njk',
+      { organisations, profession },
+      function (_err, res) {
+        const dom = new JSDOM(res);
+
+        const subGroups = dom.window.document.querySelectorAll(
+          '.rpr-details__sub-group',
+        );
+
+        expect(subGroups.length).toEqual(2);
+
+        expect(subGroups[0].textContent).toMatch(
+          translationOf('organisations.label.roles.role1'),
+        );
+
+        expect(subGroups[0].textContent).toMatch(organisation1.name);
+
+        expect(subGroups[0].textContent).toMatch(organisation2.name);
+
+        expect(subGroups[1].textContent).toMatch(
+          translationOf('organisations.label.roles.role2'),
+        );
+
+        expect(subGroups[1].textContent).toMatch(organisation3.name);
+      },
+    );
+  });
+});

--- a/views/professions/show.njk.spec.ts
+++ b/views/professions/show.njk.spec.ts
@@ -7,6 +7,11 @@ import { nunjucksEnvironment } from '../testutils/nunjucksEnvironment';
 import organisationFactory from '../../src/testutils/factories/organisation';
 import professionFactory from '../../src/testutils/factories/profession';
 
+import {
+  ProfessionToOrganisation,
+  OrganisationRole,
+} from '../../src/professions/profession-to-organisation.entity';
+
 describe('show.njk', () => {
   beforeAll(async () => {
     await nunjucksEnvironment();
@@ -48,6 +53,48 @@ describe('show.njk', () => {
         );
 
         expect(subGroups[1].textContent).toMatch(organisation3.name);
+      },
+    );
+  });
+
+  it("should show a profession's organisations in the summary", () => {
+    const organisation1 = organisationFactory.build();
+    const organisation2 = organisationFactory.build();
+    const organisation3 = organisationFactory.build();
+
+    const profession = professionFactory.build({
+      professionToOrganisations: [
+        {
+          organisation: organisation1,
+        },
+        {
+          organisation: organisation2,
+        },
+        {
+          organisation: organisation3,
+        },
+      ] as ProfessionToOrganisation[],
+    });
+
+    nunjucks.render(
+      'professions/show.njk',
+      { profession },
+      function (_err, res) {
+        const dom = new JSDOM(res);
+
+        const rows = dom.window.document.querySelectorAll(
+          '.govuk-summary-list__row',
+        );
+
+        const regulatorRow = Array.from(rows).find((row) =>
+          row.textContent.includes(
+            translationOf('professions.show.overview.regulators'),
+          ),
+        );
+
+        expect(regulatorRow.textContent).toMatch(organisation1.name);
+        expect(regulatorRow.textContent).toMatch(organisation2.name);
+        expect(regulatorRow.textContent).toMatch(organisation3.name);
       },
     );
   });

--- a/views/testutils/nunjucksEnvironment.ts
+++ b/views/testutils/nunjucksEnvironment.ts
@@ -1,0 +1,27 @@
+import * as dotenv from 'dotenv';
+dotenv.config({ path: '.env.test' });
+
+import path from 'path';
+import { nunjucksConfig } from '../../src/config/nunjucks.config';
+import { createMockI18nService } from '../../src/testutils/create-mock-i18n-service';
+
+import { Test, TestingModule } from '@nestjs/testing';
+import { I18nService } from 'nestjs-i18n';
+import { NestExpressApplication } from '@nestjs/platform-express';
+
+export async function nunjucksEnvironment() {
+  const i18nService = createMockI18nService();
+
+  const module: TestingModule = await Test.createTestingModule({
+    providers: [{ provide: I18nService, useValue: i18nService }],
+  }).compile();
+
+  const views = [
+    path.join(__dirname, '..', '..', 'views'),
+    path.join(__dirname, '..', '..', 'node_modules', 'govuk-frontend'),
+  ];
+
+  const app = module.createNestApplication<NestExpressApplication>();
+
+  return await nunjucksConfig(app, views);
+}


### PR DESCRIPTION
This alters the regulator show pages to show their role above their details, and their name (as well as a link to the regulator page) in the summary list below

## Screenshots

### Before

![image](https://user-images.githubusercontent.com/109774/161976299-67c4c391-df85-4f6c-b5a0-fec9362fdea3.png)

### After

![image](https://user-images.githubusercontent.com/109774/162388035-5138de9d-54a3-4d02-80c5-3d33df2a3581.png)

