### PR TITLE
(2305) Add placeholder organisation user and admin user dashboards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [unreleased]
 
+### Added
+
+- Placeholder dashboard for viewing recognition decision data
+
 ## [release-015] - 2022-04-06
 
 ### Added

--- a/assets/stylesheets/application.scss
+++ b/assets/stylesheets/application.scss
@@ -118,6 +118,24 @@ $small-screen: 768px;
       }
     }
 
+    &__manage-decisions-container {
+      margin: 0;
+    }
+
+    &__manage-decisions-container-left {
+      float: left;
+      @media screen and (max-width: $small-screen) {
+        float: none;
+      }
+    }
+
+    &__manage-decisions-container-right {
+      float: right;
+      @media screen and (max-width: $small-screen) {
+        float: none;
+      }
+    }
+
     &__filters-container {
       background-color: govuk-colour('light-grey');
       padding: 1rem;

--- a/cypress/integration/admin/decisions/index.spec.ts
+++ b/cypress/integration/admin/decisions/index.spec.ts
@@ -1,0 +1,122 @@
+import { format } from 'date-fns';
+
+type SeedDecisionDataset = {
+  profession: string;
+  organisation: string;
+  year: number;
+  status: string;
+};
+
+describe('Listing decision datasets', () => {
+  context('When I am logged in as admin', () => {
+    beforeEach(() => {
+      cy.loginAuth0('admin');
+      cy.visitAndCheckAccessibility('/admin/decisions');
+    });
+
+    it('Lists all decision datasets', () => {
+      cy.readFile('./seeds/test/decision-datasets.json').then(
+        (datasets: SeedDecisionDataset[]) => {
+          const datasetsToShow = getDisplayedDatasets(datasets);
+
+          cy.translate('decisions.admin.dashboard.search.foundPlural', {
+            count: datasetsToShow.length,
+          }).then((foundText) => {
+            cy.get('body').should('contain', foundText);
+          });
+
+          datasetsToShow.forEach((dataset, index) => {
+            cy.get('tbody tr')
+              .eq(index)
+              .then(($row) => {
+                cy.wrap($row).should('contain', dataset.profession);
+                cy.wrap($row).should('contain', dataset.year.toString());
+
+                cy.get('[data-cy=changed-by-text]').should('not.exist');
+                cy.wrap($row).should(
+                  'contain',
+                  format(new Date(), 'd MMM yyyy'),
+                );
+
+                cy.translate(`app.status.${dataset.status}`).then((status) => {
+                  cy.wrap($row).should('contain', status);
+                });
+              });
+          });
+        },
+      );
+    });
+  });
+
+  context('When I am logged in as organisation admin', () => {
+    beforeEach(() => {
+      cy.loginAuth0('orgadmin');
+      cy.visitAndCheckAccessibility('/admin/decisions');
+    });
+
+    it('Lists decision datasets for my organisation', () => {
+      cy.readFile('./seeds/test/decision-datasets.json').then(
+        (datasets: SeedDecisionDataset[]) => {
+          const datasetsToShow = getDisplayedDatasets(datasets).filter(
+            (dataset) => dataset.organisation === 'Department for Education',
+          );
+
+          cy.translate('decisions.admin.dashboard.search.foundPlural', {
+            count: datasetsToShow.length,
+          }).then((foundText) => {
+            cy.get('body').should('contain', foundText);
+          });
+
+          datasetsToShow.forEach((dataset, index) => {
+            cy.get('tbody tr')
+              .eq(index)
+              .then(($row) => {
+                cy.wrap($row).should('contain', dataset.profession);
+                cy.wrap($row).should('contain', dataset.year.toString());
+
+                cy.get('[data-cy=changed-by-text]').should('not.exist');
+                cy.wrap($row).should(
+                  'contain',
+                  format(new Date(), 'd MMM yyyy'),
+                );
+
+                cy.translate(`app.status.${dataset.status}`).then((status) => {
+                  cy.wrap($row).should('contain', status);
+                });
+              });
+          });
+        },
+      );
+    });
+  });
+});
+
+function getDisplayedDatasets(
+  datasets: SeedDecisionDataset[],
+): SeedDecisionDataset[] {
+  const result = datasets.filter((dataset) =>
+    ['live', 'draft'].includes(dataset.status),
+  );
+
+  result.sort((dataset1, dataset2) => {
+    const professionComparison = dataset1.profession.localeCompare(
+      dataset2.profession,
+    );
+
+    if (professionComparison) {
+      return professionComparison;
+    }
+
+    const organisationComparison = dataset1.organisation.localeCompare(
+      dataset2.organisation,
+    );
+
+    if (organisationComparison) {
+      return organisationComparison;
+    }
+
+    return dataset2.year - dataset1.year;
+  });
+
+  return result;
+}

--- a/seeds/development/decision-datasets.json
+++ b/seeds/development/decision-datasets.json
@@ -60,5 +60,58 @@
         ]
       }
     ]
+  },
+  {
+    "profession": "Secondary School Teacher in State maintained schools (England)",
+    "organisation": "Department for Education",
+    "year": 2018,
+    "status": "live",
+    "routes": [
+      {
+        "name": "Degree",
+        "countries": [
+          {
+            "country": "Morocco",
+            "decisions": {
+              "yes": 6,
+              "no": 4,
+              "yesAfterComp": 1,
+              "noAfterComp": 9
+            }
+          },
+          {
+            "country": "Poland",
+            "decisions": {
+              "yes": 8,
+              "no": 0,
+              "yesAfterComp": 1,
+              "noAfterComp": 7
+            }
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "profession": "Secondary School Teacher in State maintained schools (England)",
+    "organisation": "Department for Education",
+    "year": 2019,
+    "status": "live",
+    "routes": [
+      {
+        "name": "Other qualification",
+        "countries": [
+          {
+            "country": "Canada",
+            "decisions": {
+              "yes": 4,
+              "no": 5,
+              "yesAfterComp": 7,
+              "noAfterComp": 8
+            }
+          }
+        ]
+      }
+    ]
   }
 ]

--- a/seeds/development/decision-datasets.json
+++ b/seeds/development/decision-datasets.json
@@ -2,7 +2,7 @@
   {
     "profession": "Registered Trademark Attorney",
     "organisation": "Law Society of England and Wales",
-    "year": 2022,
+    "year": 2018,
     "status": "live",
     "routes": [
       {
@@ -33,7 +33,7 @@
   {
     "profession": "Registered Trademark Attorney",
     "organisation": "Alternative Law Society",
-    "year": 2022,
+    "year": 2018,
     "status": "draft",
     "routes": [
       {

--- a/seeds/test/decision-datasets.json
+++ b/seeds/test/decision-datasets.json
@@ -60,5 +60,58 @@
         ]
       }
     ]
+  },
+  {
+    "profession": "Secondary School Teacher in State maintained schools (England)",
+    "organisation": "Department for Education",
+    "year": 2018,
+    "status": "live",
+    "routes": [
+      {
+        "name": "Degree",
+        "countries": [
+          {
+            "country": "Morocco",
+            "decisions": {
+              "yes": 6,
+              "no": 4,
+              "yesAfterComp": 1,
+              "noAfterComp": 9
+            }
+          },
+          {
+            "country": "Poland",
+            "decisions": {
+              "yes": 8,
+              "no": 0,
+              "yesAfterComp": 1,
+              "noAfterComp": 7
+            }
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "profession": "Secondary School Teacher in State maintained schools (England)",
+    "organisation": "Department for Education",
+    "year": 2019,
+    "status": "live",
+    "routes": [
+      {
+        "name": "Other qualification",
+        "countries": [
+          {
+            "country": "Canada",
+            "decisions": {
+              "yes": 4,
+              "no": 5,
+              "yesAfterComp": 7,
+              "noAfterComp": 8
+            }
+          }
+        ]
+      }
+    ]
   }
 ]

--- a/seeds/test/decision-datasets.json
+++ b/seeds/test/decision-datasets.json
@@ -2,7 +2,7 @@
   {
     "profession": "Registered Trademark Attorney",
     "organisation": "Law Society of England and Wales",
-    "year": 2022,
+    "year": 2018,
     "status": "live",
     "routes": [
       {
@@ -33,7 +33,7 @@
   {
     "profession": "Registered Trademark Attorney",
     "organisation": "Alternative Law Society",
-    "year": 2022,
+    "year": 2018,
     "status": "draft",
     "routes": [
       {

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -24,6 +24,7 @@ import { SearchController as OrganisationSearchController } from './organisation
 import { OrganisationsController } from './organisations/organisations.controller';
 import { ProfessionsController } from './professions/professions.controller';
 import { LandingController } from './landing/landing.controller';
+import { DecisionsModule } from './decisions/decisions.module';
 
 @Module({
   imports: [
@@ -58,6 +59,7 @@ import { LandingController } from './landing/landing.controller';
     LegislationsModule,
     OrganisationsModule,
     IndustriesModule,
+    DecisionsModule,
   ],
   controllers: [AppController, LandingController],
   providers: [MailerConsumer],

--- a/src/db/migrate/1649255029983-RenameDecisionDatasetStautsEnum.ts
+++ b/src/db/migrate/1649255029983-RenameDecisionDatasetStautsEnum.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class RenameDecisionDatasetStautsEnum1649255029983
+  implements MigrationInterface
+{
+  name = 'RenameDecisionDatasetStautsEnum1649255029983';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "decision-datasets" ALTER COLUMN "status" SET DEFAULT 'unconfirmed'`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "decision-datasets" ALTER COLUMN "status" SET DEFAULT 'unconfirmed'-datasets_status_enum"`,
+    );
+  }
+}

--- a/src/decisions/admin/decision.controller.spec.ts
+++ b/src/decisions/admin/decision.controller.spec.ts
@@ -1,0 +1,126 @@
+import { createMock, DeepMocked } from '@golevelup/ts-jest';
+import { Test, TestingModule } from '@nestjs/testing';
+import { I18nService } from 'nestjs-i18n';
+import { createMockI18nService } from '../../testutils/create-mock-i18n-service';
+import { createDefaultMockRequest } from '../../testutils/factories/create-default-mock-request';
+import decisionDatasetFactory from '../../testutils/factories/decision-dataset';
+import organisationFactory from '../../testutils/factories/organisation';
+import userFactory from '../../testutils/factories/user';
+import * as getActingUserModule from '../../users/helpers/get-acting-user.helper';
+import { DecisionDatasetsService } from '../decision-datasets.service';
+import { DecisionsController } from './decisions.controller';
+import { IndexTemplate } from './interfaces/index-template.interface';
+import { DecisionDatasetsPresenter } from './presenters/decision-datasets.presenter';
+
+jest.mock('./presenters/decision-datasets.presenter');
+
+const mockIndexTemplate: IndexTemplate = {
+  organisation: 'Example Organisation',
+  decisionDatasetsTable: {
+    head: [],
+    rows: [],
+  },
+};
+
+describe('DecisionsController', () => {
+  let controller: DecisionsController;
+
+  let decisionsDatasetsService: DeepMocked<DecisionDatasetsService>;
+  let i18nService: DeepMocked<I18nService>;
+
+  beforeEach(async () => {
+    decisionsDatasetsService = createMock<DecisionDatasetsService>();
+    i18nService = createMockI18nService();
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [DecisionsController],
+      providers: [
+        {
+          provide: DecisionDatasetsService,
+          useValue: decisionsDatasetsService,
+        },
+        {
+          provide: I18nService,
+          useValue: i18nService,
+        },
+      ],
+    }).compile();
+
+    controller = module.get<DecisionsController>(DecisionsController);
+  });
+
+  describe('index', () => {
+    describe('when called by a service owner user', () => {
+      it('presents all decision datasets', async () => {
+        const request = createDefaultMockRequest();
+
+        jest.spyOn(getActingUserModule, 'getActingUser').mockReturnValue(
+          userFactory.build({
+            serviceOwner: true,
+            organisation: null,
+          }),
+        );
+
+        const datasets = decisionDatasetFactory.buildList(3);
+
+        decisionsDatasetsService.all.mockResolvedValue(datasets);
+        (
+          DecisionDatasetsPresenter.prototype.present as jest.Mock
+        ).mockResolvedValue(mockIndexTemplate);
+
+        const result = await controller.index(request);
+
+        expect(result).toEqual(mockIndexTemplate);
+
+        expect(DecisionDatasetsPresenter).toBeCalledWith(
+          null,
+          datasets,
+          i18nService,
+        );
+        expect(decisionsDatasetsService.all).toBeCalled();
+        expect(decisionsDatasetsService.allForOrganisation).not.toBeCalled();
+      });
+    });
+
+    describe('when called by a non-service owner user', () => {
+      it("presents decision datasets for the user's organisation", async () => {
+        const request = createDefaultMockRequest();
+
+        const organisation = organisationFactory.build();
+
+        jest.spyOn(getActingUserModule, 'getActingUser').mockReturnValue(
+          userFactory.build({
+            serviceOwner: false,
+            organisation,
+          }),
+        );
+
+        const datasets = decisionDatasetFactory.buildList(3);
+
+        decisionsDatasetsService.allForOrganisation.mockResolvedValue(datasets);
+        (
+          DecisionDatasetsPresenter.prototype.present as jest.Mock
+        ).mockResolvedValue(mockIndexTemplate);
+
+        const result = await controller.index(request);
+
+        expect(result).toEqual(mockIndexTemplate);
+
+        expect(DecisionDatasetsPresenter).toBeCalledWith(
+          organisation,
+          datasets,
+          i18nService,
+        );
+        expect(decisionsDatasetsService.allForOrganisation).toBeCalledWith(
+          organisation,
+        );
+        expect(decisionsDatasetsService.all).not.toBeCalled();
+      });
+    });
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+    jest.restoreAllMocks();
+  });
+});

--- a/src/decisions/admin/decisions.controller.ts
+++ b/src/decisions/admin/decisions.controller.ts
@@ -1,0 +1,53 @@
+import { Controller, Get, Render, Req, UseGuards } from '@nestjs/common';
+import { I18nService } from 'nestjs-i18n';
+
+import { AuthenticationGuard } from '../../common/authentication.guard';
+import { BackLink } from '../../common/decorators/back-link.decorator';
+import { RequestWithAppSession } from '../../common/interfaces/request-with-app-session.interface';
+import { UserPermission } from '../../users/user-permission';
+import { Permissions } from '../../common/permissions.decorator';
+import { getActingUser } from '../../users/helpers/get-acting-user.helper';
+import { DecisionDatasetsService } from '../decision-datasets.service';
+import { IndexTemplate } from './interfaces/index-template.interface';
+import { DecisionDatasetsPresenter } from './presenters/decision-datasets.presenter';
+
+@UseGuards(AuthenticationGuard)
+@Controller('admin/decisions')
+export class DecisionsController {
+  constructor(
+    private readonly decisionDatasetsService: DecisionDatasetsService,
+    private readonly i18Service: I18nService,
+  ) {}
+
+  @Get()
+  @Permissions(
+    UserPermission.UploadDecisionData,
+    UserPermission.DownloadDecisionData,
+    UserPermission.ViewDecisionData,
+  )
+  @Render('admin/decisions/index')
+  @BackLink('/admin/dashboard')
+  async index(@Req() request: RequestWithAppSession): Promise<IndexTemplate> {
+    return this.createListEntries(request);
+  }
+
+  private async createListEntries(
+    request: RequestWithAppSession,
+  ): Promise<IndexTemplate> {
+    const actingUser = getActingUser(request);
+
+    const showAllOrgs = actingUser.serviceOwner;
+
+    const userOrganisation = showAllOrgs ? null : actingUser.organisation;
+
+    const allDecisionDatasets = await (showAllOrgs
+      ? this.decisionDatasetsService.all()
+      : this.decisionDatasetsService.allForOrganisation(userOrganisation));
+
+    return new DecisionDatasetsPresenter(
+      userOrganisation,
+      allDecisionDatasets,
+      this.i18Service,
+    ).present();
+  }
+}

--- a/src/decisions/admin/interfaces/index-template.interface.ts
+++ b/src/decisions/admin/interfaces/index-template.interface.ts
@@ -1,0 +1,7 @@
+import { Table } from '../../../common/interfaces/table';
+
+export interface IndexTemplate {
+  organisation: string;
+
+  decisionDatasetsTable: Table;
+}

--- a/src/decisions/admin/presenters/decision-datasets.presenter.spec.ts
+++ b/src/decisions/admin/presenters/decision-datasets.presenter.spec.ts
@@ -1,0 +1,111 @@
+import { TableRow } from '../../../common/interfaces/table-row';
+import { createMockI18nService } from '../../../testutils/create-mock-i18n-service';
+import decisionDatasetFactory from '../../../testutils/factories/decision-dataset';
+import organisationFactory from '../../../testutils/factories/organisation';
+import { translationOf } from '../../../testutils/translation-of';
+import { IndexTemplate } from '../interfaces/index-template.interface';
+import { DecisionDatasetsPresenter } from './decision-datasets.presenter';
+import { ListEntryPresenter } from './list-entry.presenter';
+
+jest.mock('./list-entry.presenter');
+
+const mockTableRow: TableRow = [
+  {
+    text: 'Mock table cell',
+  },
+];
+
+const mockTableHeadingRow: TableRow = [
+  {
+    text: 'Mock table heading cell',
+  },
+];
+
+describe('DecisionDatasetsPresenter', () => {
+  describe('table', () => {
+    describe('when given a user organisation', () => {
+      it('returns a populated IndexTemplate', async () => {
+        const i18nService = createMockI18nService();
+
+        const organisation = organisationFactory.build();
+        const datasets = decisionDatasetFactory.buildList(3);
+
+        const presenter = new DecisionDatasetsPresenter(
+          organisation,
+          datasets,
+          i18nService,
+        );
+
+        (ListEntryPresenter.headings as jest.Mock).mockReturnValue(
+          mockTableHeadingRow,
+        );
+        (ListEntryPresenter.prototype.tableRow as jest.Mock).mockResolvedValue(
+          mockTableRow,
+        );
+
+        const expected: IndexTemplate = {
+          organisation: 'Example Organisation',
+          decisionDatasetsTable: {
+            caption: translationOf(
+              'decisions.admin.dashboard.search.foundPlural',
+            ),
+            captionClasses: 'govuk-table__caption--m',
+            firstCellIsHeader: true,
+            head: mockTableHeadingRow,
+            rows: [mockTableRow, mockTableRow, mockTableRow],
+          },
+        };
+
+        const result = await presenter.present();
+
+        expect(result).toEqual(expected);
+        expect(ListEntryPresenter.headings).toBeCalled();
+        expect(ListEntryPresenter.prototype.tableRow).toBeCalledTimes(3);
+      });
+    });
+
+    describe('when given no user organisation', () => {
+      it('returns a populated IndexTemplate', async () => {
+        const i18nService = createMockI18nService();
+
+        const datasets = decisionDatasetFactory.buildList(3);
+
+        const presenter = new DecisionDatasetsPresenter(
+          null,
+          datasets,
+          i18nService,
+        );
+
+        (ListEntryPresenter.headings as jest.Mock).mockReturnValue(
+          mockTableHeadingRow,
+        );
+        (ListEntryPresenter.prototype.tableRow as jest.Mock).mockResolvedValue(
+          mockTableRow,
+        );
+
+        const expected: IndexTemplate = {
+          organisation: translationOf('app.beis'),
+          decisionDatasetsTable: {
+            caption: translationOf(
+              'decisions.admin.dashboard.search.foundPlural',
+            ),
+            captionClasses: 'govuk-table__caption--m',
+            firstCellIsHeader: true,
+            head: mockTableHeadingRow,
+            rows: [mockTableRow, mockTableRow, mockTableRow],
+          },
+        };
+
+        const result = await presenter.present();
+
+        expect(result).toEqual(expected);
+        expect(ListEntryPresenter.headings).toBeCalled();
+        expect(ListEntryPresenter.prototype.tableRow).toBeCalledTimes(3);
+      });
+    });
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+});

--- a/src/decisions/admin/presenters/decision-datasets.presenter.ts
+++ b/src/decisions/admin/presenters/decision-datasets.presenter.ts
@@ -1,0 +1,60 @@
+import { I18nService } from 'nestjs-i18n';
+import { IndexTemplate } from './../interfaces/index-template.interface';
+import { ListEntryPresenter } from './list-entry.presenter';
+import { Organisation } from '../../../organisations/organisation.entity';
+import { Table } from '../../../common/interfaces/table';
+import { DecisionDataset } from '../../decision-dataset.entity';
+
+export class DecisionDatasetsPresenter {
+  constructor(
+    private readonly userOrganisation: Organisation | null,
+    private readonly decisionDatasets: DecisionDataset[],
+    private readonly i18nService: I18nService,
+  ) {}
+
+  async present(): Promise<IndexTemplate> {
+    const organisation = !this.userOrganisation
+      ? this.i18nService.translate('app.beis')
+      : this.userOrganisation.name;
+
+    return {
+      organisation,
+      decisionDatasetsTable: await this.table(),
+    };
+  }
+
+  private async table(): Promise<Table> {
+    const headings = ListEntryPresenter.headings(this.i18nService);
+
+    const rows = await Promise.all(
+      this.decisionDatasets.map(async (dataset) =>
+        new ListEntryPresenter(dataset, this.i18nService).tableRow(),
+      ),
+    );
+
+    const numberOfResults = rows.length;
+
+    const caption =
+      numberOfResults === 1
+        ? this.i18nService.translate<string>(
+            'decisions.admin.dashboard.search.foundSingular',
+            {
+              args: { count: numberOfResults },
+            },
+          )
+        : this.i18nService.translate<string>(
+            'decisions.admin.dashboard.search.foundPlural',
+            {
+              args: { count: numberOfResults },
+            },
+          );
+
+    return {
+      caption,
+      captionClasses: 'govuk-table__caption--m',
+      firstCellIsHeader: true,
+      head: headings,
+      rows: rows,
+    };
+  }
+}

--- a/src/decisions/admin/presenters/list-entry.presenter.spec.ts
+++ b/src/decisions/admin/presenters/list-entry.presenter.spec.ts
@@ -1,0 +1,87 @@
+import { TableRow } from '../../../common/interfaces/table-row';
+import * as formatDateModule from '../../../common/utils';
+import * as formatStatusModule from '../../../helpers/format-status.helper';
+import { createMockI18nService } from '../../../testutils/create-mock-i18n-service';
+import { dateOf } from '../../../testutils/date-of';
+import decisionDatasetFactory from '../../../testutils/factories/decision-dataset';
+import { statusOf } from '../../../testutils/status-of';
+import { translationOf } from '../../../testutils/translation-of';
+import { DecisionDatasetStatus } from '../../decision-dataset.entity';
+import { ListEntryPresenter } from './list-entry.presenter';
+
+describe('ListEntryPresenter', () => {
+  describe('tableRow', () => {
+    it('returns a table row for the given DecisionDataset', async () => {
+      const formatStatusSpy = jest
+        .spyOn(formatStatusModule, 'formatStatus')
+        .mockImplementation(async (status) => statusOf(status));
+      const formatDateSpy = jest
+        .spyOn(formatDateModule, 'formatDate')
+        .mockImplementation(dateOf);
+
+      const i18nService = createMockI18nService();
+      const dataset = decisionDatasetFactory.build({
+        year: 2013,
+        status: DecisionDatasetStatus.Draft,
+        updated_at: new Date(2022, 6, 12),
+      });
+
+      const presenter = new ListEntryPresenter(dataset, i18nService);
+
+      const expected: TableRow = [
+        { text: 'Example Profession' },
+        { text: '2013' },
+        { text: dateOf(new Date(2022, 6, 12)) },
+        { html: await statusOf(DecisionDatasetStatus.Draft) },
+        {
+          html: `<a class="govuk-link" href="/admin/decisions/${
+            dataset.profession.id
+          }/${dataset.organisation.id}/2013">${translationOf(
+            'decisions.admin.dashboard.viewDetails',
+          )}</a>`,
+        },
+      ];
+
+      const result = await presenter.tableRow();
+
+      expect(result).toEqual(expected);
+      expect(formatStatusSpy).toBeCalledWith(
+        DecisionDatasetStatus.Draft,
+        i18nService,
+      );
+      expect(formatDateSpy).toBeCalledWith(new Date(2022, 6, 12));
+    });
+  });
+
+  describe('headers', () => {
+    it('returns a table row of headings', () => {
+      const expected: TableRow = [
+        {
+          text: translationOf(
+            'decisions.admin.dashboard.tableHeading.profession',
+          ),
+        },
+        { text: translationOf('decisions.admin.dashboard.tableHeading.year') },
+        {
+          text: translationOf(
+            'decisions.admin.dashboard.tableHeading.lastModified',
+          ),
+        },
+        {
+          text: translationOf('decisions.admin.dashboard.tableHeading.status'),
+        },
+        {
+          text: translationOf('decisions.admin.dashboard.tableHeading.actions'),
+        },
+      ];
+
+      expect(ListEntryPresenter.headings(createMockI18nService())).toEqual(
+        expected,
+      );
+    });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+});

--- a/src/decisions/admin/presenters/list-entry.presenter.ts
+++ b/src/decisions/admin/presenters/list-entry.presenter.ts
@@ -1,0 +1,63 @@
+import { I18nService } from 'nestjs-i18n';
+import { TableCell } from '../../../common/interfaces/table-cell';
+import { TableRow } from '../../../common/interfaces/table-row';
+import { escape } from '../../../helpers/escape.helper';
+import { DecisionDataset } from '../../decision-dataset.entity';
+import { formatDate } from '../../../common/utils';
+import { formatStatus } from '../../../helpers/format-status.helper';
+
+type Field = 'profession' | 'year' | 'lastModified' | 'status' | 'actions';
+
+const fields: Field[] = [
+  'profession',
+  'year',
+  'lastModified',
+  'status',
+  'actions',
+];
+
+export class ListEntryPresenter {
+  static headings(i18nService: I18nService): TableRow {
+    return fields
+      .map((field) =>
+        i18nService.translate<string>(
+          `decisions.admin.dashboard.tableHeading.${field}`,
+        ),
+      )
+      .map((text) => ({ text }));
+  }
+
+  constructor(
+    private readonly dataset: DecisionDataset,
+    private readonly i18nService: I18nService,
+  ) {}
+
+  async tableRow(): Promise<TableRow> {
+    const viewDetails = `<a class="govuk-link" href="/admin/decisions/${
+      this.dataset.profession.id
+    }/${this.dataset.organisation.id}/${
+      this.dataset.year
+    }">${this.i18nService.translate<string>(
+      'decisions.admin.dashboard.viewDetails',
+      {
+        args: {
+          profession: escape(this.dataset.profession.name),
+          organisation: escape(this.dataset.organisation.name),
+          year: this.dataset.year.toString(),
+        },
+      },
+    )}</a>`;
+
+    const entries: { [K in Field]: TableCell } = {
+      profession: { text: this.dataset.profession.name },
+      year: { text: this.dataset.year.toString() },
+      lastModified: { text: formatDate(this.dataset.updated_at) },
+      status: {
+        html: await formatStatus(this.dataset.status, this.i18nService),
+      },
+      actions: { html: viewDetails },
+    };
+
+    return fields.map((field) => entries[field]);
+  }
+}

--- a/src/decisions/decision-dataset.entity.ts
+++ b/src/decisions/decision-dataset.entity.ts
@@ -10,7 +10,7 @@ import { Profession } from '../professions/profession.entity';
 import { User } from '../users/user.entity';
 import { DecisionRoute } from './interfaces/decision-route.interface';
 
-export enum DecisionStatus {
+export enum DecisionDatasetStatus {
   Unconfirmed = 'unconfirmed',
   Draft = 'draft',
   Live = 'live',
@@ -29,10 +29,10 @@ export class DecisionDataset {
 
   @Column({
     type: 'enum',
-    enum: DecisionStatus,
-    default: DecisionStatus.Unconfirmed,
+    enum: DecisionDatasetStatus,
+    default: DecisionDatasetStatus.Unconfirmed,
   })
-  status: DecisionStatus;
+  status: DecisionDatasetStatus;
 
   @Column({ type: 'json' })
   routes: DecisionRoute[];

--- a/src/decisions/decision-dataset.seeder.ts
+++ b/src/decisions/decision-dataset.seeder.ts
@@ -4,7 +4,10 @@ import { Seeder } from 'nestjs-seeder';
 import { InjectRepository } from '@nestjs/typeorm';
 import { InjectData } from '../common/decorators/seeds.decorator';
 import { Organisation } from '../organisations/organisation.entity';
-import { DecisionDataset, DecisionStatus } from './decision-dataset.entity';
+import {
+  DecisionDataset,
+  DecisionDatasetStatus,
+} from './decision-dataset.entity';
 import { Profession } from '../professions/profession.entity';
 import { DecisionRoute } from './interfaces/decision-route.interface';
 
@@ -12,7 +15,7 @@ type SeedDecisionDataset = {
   profession: string;
   organisation: string;
   year: number;
-  status: DecisionStatus;
+  status: DecisionDatasetStatus;
   routes: DecisionRoute[];
 };
 

--- a/src/decisions/decision-datasets.service.spec.ts
+++ b/src/decisions/decision-datasets.service.spec.ts
@@ -44,7 +44,7 @@ describe('DecisionDatasetsService', () => {
           organisation: { id: 'organisation-uuid' },
           year: 2024,
         },
-        relations: ['profession', 'organisation'],
+        relations: ['profession', 'organisation', 'user'],
       });
     });
   });

--- a/src/decisions/decision-datasets.service.spec.ts
+++ b/src/decisions/decision-datasets.service.spec.ts
@@ -1,9 +1,13 @@
 import { createMock } from '@golevelup/ts-jest';
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { Repository, SelectQueryBuilder } from 'typeorm';
 import decisionDatasetFactory from '../testutils/factories/decision-dataset';
-import { DecisionDataset } from './decision-dataset.entity';
+import organisationFactory from '../testutils/factories/organisation';
+import {
+  DecisionDataset,
+  DecisionDatasetStatus,
+} from './decision-dataset.entity';
 import { DecisionDatasetsService as DecisionDatasetsService } from './decision-datasets.service';
 
 describe('DecisionDatasetsService', () => {
@@ -49,6 +53,87 @@ describe('DecisionDatasetsService', () => {
     });
   });
 
+  describe('all', () => {
+    it('returns all live and draft DecisionDatasets', async () => {
+      const datasets = decisionDatasetFactory.buildList(3);
+
+      const queryBuilder = createMock<SelectQueryBuilder<DecisionDataset>>({
+        leftJoinAndSelect: () => queryBuilder,
+        where: () => queryBuilder,
+        orderBy: () => queryBuilder,
+        getMany: async () => datasets,
+      });
+
+      jest
+        .spyOn(repo, 'createQueryBuilder')
+        .mockImplementation(() => queryBuilder);
+
+      const result = await service.all();
+
+      expect(result).toEqual(datasets);
+      expect(queryBuilder).toHaveJoined([
+        'decisionDataset.profession',
+        'decisionDataset.organisation',
+        'decisionDataset.user',
+      ]);
+      expect(queryBuilder.where).toBeCalledWith(
+        'decisionDataset.status IN(:...status)',
+        {
+          status: [DecisionDatasetStatus.Live, DecisionDatasetStatus.Draft],
+        },
+      );
+      expect(queryBuilder.orderBy).toBeCalledWith({
+        'profession.name': 'ASC',
+        'organisation.name': 'ASC',
+        year: 'DESC',
+      });
+      expect(queryBuilder.getMany).toBeCalledWith();
+    });
+  });
+
+  describe('allForOrganisation', () => {
+    it('returns all live and draft DecisionDatasets for the given organisation', async () => {
+      const datasets = decisionDatasetFactory.buildList(3);
+      const organisation = organisationFactory.build();
+
+      const queryBuilder = createMock<SelectQueryBuilder<DecisionDataset>>({
+        leftJoinAndSelect: () => queryBuilder,
+        where: () => queryBuilder,
+        andWhere: () => queryBuilder,
+        orderBy: () => queryBuilder,
+        getMany: async () => datasets,
+      });
+
+      jest
+        .spyOn(repo, 'createQueryBuilder')
+        .mockImplementation(() => queryBuilder);
+
+      const result = await service.allForOrganisation(organisation);
+
+      expect(result).toEqual(datasets);
+      expect(queryBuilder).toHaveJoined([
+        'decisionDataset.profession',
+        'decisionDataset.organisation',
+        'decisionDataset.user',
+      ]);
+      expect(queryBuilder.where).toBeCalledWith(
+        'decisionDataset.status IN(:...status)',
+        {
+          status: [DecisionDatasetStatus.Live, DecisionDatasetStatus.Draft],
+        },
+      );
+      expect(queryBuilder.andWhere).toBeCalledWith({
+        organisation: { id: organisation.id },
+      });
+      expect(queryBuilder.orderBy).toBeCalledWith({
+        'profession.name': 'ASC',
+        'organisation.name': 'ASC',
+        year: 'DESC',
+      });
+      expect(queryBuilder.getMany).toBeCalledWith();
+    });
+  });
+
   describe('save', () => {
     it('saves the DecisionDataset', async () => {
       const dataset = decisionDatasetFactory.build();
@@ -58,5 +143,9 @@ describe('DecisionDatasetsService', () => {
       expect(result).toEqual(dataset);
       expect(repoSpy).toBeCalledWith(dataset);
     });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
   });
 });

--- a/src/decisions/decision-datasets.service.ts
+++ b/src/decisions/decision-datasets.service.ts
@@ -21,7 +21,7 @@ export class DecisionDatasetsService {
         organisation: { id: organisationId },
         year,
       },
-      relations: ['profession', 'organisation'],
+      relations: ['profession', 'organisation', 'user'],
     });
   }
 

--- a/src/decisions/decisions.module.ts
+++ b/src/decisions/decisions.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { DecisionsController } from './admin/decisions.controller';
+import { DecisionDatasetsService } from './decision-datasets.service';
+import { DecisionDataset } from './decision-dataset.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([DecisionDataset])],
+  providers: [DecisionDatasetsService],
+  controllers: [DecisionsController],
+})
+export class DecisionsModule {}

--- a/src/helpers/format-status.helper.ts
+++ b/src/helpers/format-status.helper.ts
@@ -1,9 +1,13 @@
 import { I18nService } from 'nestjs-i18n';
+import { DecisionDatasetStatus } from '../decisions/decision-dataset.entity';
 import { OrganisationVersionStatus } from '../organisations/organisation-version.entity';
 import { ProfessionVersionStatus } from '../professions/profession-version.entity';
 
 export async function formatStatus(
-  status: ProfessionVersionStatus | OrganisationVersionStatus,
+  status:
+    | ProfessionVersionStatus
+    | OrganisationVersionStatus
+    | DecisionDatasetStatus,
   i18nSerice: I18nService,
 ): Promise<string> {
   let colourClass: string;

--- a/src/i18n/en/decisions.json
+++ b/src/i18n/en/decisions.json
@@ -1,0 +1,21 @@
+{
+  "admin": {
+    "dashboard": {
+      "heading": "Recognition decision data",
+      "addButtonLabel": "Add decision data",
+      "manageHeading": "Manage existing decision data",
+      "viewDetails": "View details <span class='govuk-visually-hidden'>about {year} {organisaition} {profession} decision data</span>",
+      "tableHeading": {
+        "profession": "Profession",
+        "year": "Year",
+        "lastModified": "Last updated",
+        "status": "Status",
+        "actions": "Actions"
+      },
+      "search": {
+        "foundSingular": "{count} decision dataset found",
+        "foundPlural": "{count} decision datasets found"
+      }
+    }
+  }
+}

--- a/src/professions/admin/presenters/professions.presenter.ts
+++ b/src/professions/admin/presenters/professions.presenter.ts
@@ -17,7 +17,7 @@ export type ProfessionsPresenterView = 'overview' | 'single-organisation';
 export class ProfessionsPresenter {
   constructor(
     private readonly filterInput: FilterInput,
-    private readonly userOrganisaiton: Organisation | null,
+    private readonly userOrganisation: Organisation | null,
     private readonly allNations: Nation[],
     private readonly allOrganisations: Organisation[],
     private readonly allIndustries: Industry[],
@@ -29,7 +29,7 @@ export class ProfessionsPresenter {
     const organisation =
       view === 'overview'
         ? await this.i18nService.translate('app.beis')
-        : this.userOrganisaiton.name;
+        : this.userOrganisation.name;
 
     const nationsCheckboxItems = await new NationsCheckboxPresenter(
       this.allNations,

--- a/src/professions/professions.module.ts
+++ b/src/professions/professions.module.ts
@@ -29,6 +29,7 @@ import { OrganisationVersion } from '../organisations/organisation-version.entit
 import { ProfessionsSearchService } from './professions-search.service';
 import { OrganisationsSearchService } from '../organisations/organisations-search.service';
 import { SearchModule } from '../search/search.module';
+
 @Module({
   imports: [
     TypeOrmModule.forFeature([Profession]),

--- a/src/testutils/date-of.ts
+++ b/src/testutils/date-of.ts
@@ -1,0 +1,3 @@
+export function dateOf(date: Date): string {
+  return `Date of '${date.toString()}'`;
+}

--- a/src/testutils/factories/decision-dataset.ts
+++ b/src/testutils/factories/decision-dataset.ts
@@ -1,7 +1,7 @@
 import { Factory } from 'fishery';
 import {
   DecisionDataset,
-  DecisionStatus,
+  DecisionDatasetStatus,
 } from '../../decisions/decision-dataset.entity';
 import organisationFactory from './organisation';
 import professionFactory from './profession';
@@ -11,7 +11,7 @@ export default Factory.define<DecisionDataset>(({ sequence }) => ({
   profession: professionFactory.build(),
   organisation: organisationFactory.build(),
   year: sequence,
-  status: DecisionStatus.Live,
+  status: DecisionDatasetStatus.Live,
   routes: [],
   user: userFactory.build(),
   created_at: new Date(),

--- a/views/admin/decisions/index.njk
+++ b/views/admin/decisions/index.njk
@@ -1,0 +1,45 @@
+{% set bodyClasses = "rpr-internal__listing rpr-internal__page" %}
+{% extends "admin/base.njk" %}
+
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/table/macro.njk" import govukTable %}
+
+{% set title = ("decisions.admin.dashboard.heading" | t) %}
+
+{% block content %}
+  <h1 class="govuk-heading-xl">
+    <span class="govuk-caption-l">{{ organisation }}</span>
+    {{ title }}
+  </h1>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+
+      <div class="rpr-internal-listing__manage-decisions-container">
+        <div class="rpr-internal-listing__manage-decisions-container-left">
+          <h2 class="govuk-heading-l">{{ "decisions.admin.dashboard.manageHeading" | t }}</h2>
+        </div>
+        <div class="rpr-internal-listing__manage-professions-container-right">
+          {% if 'uploadDecisionData' in permissions %}
+            <form action="/admin/decisions" method="post" class="form">
+              {{ govukButton({
+                text: "decisions.admin.dashboard.addButtonLabel" | t
+              }) }}
+            </form>
+          {% endif %}    
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="govuk-grid-row">
+
+    <div class="govuk-grid-column-full">
+      <div class='rpr-internal__table-container'>
+        {{ govukTable(decisionDatasetsTable) }}
+      </div>
+    </div>
+
+  </div>
+
+{% endblock %}

--- a/views/admin/professions/index.njk
+++ b/views/admin/professions/index.njk
@@ -1,10 +1,7 @@
 {% set bodyClasses = "rpr-internal__listing rpr-internal__page" %}
 {% extends "admin/base.njk" %}
 
-{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
-{% from "govuk/components/input/macro.njk" import govukInput %}
-{% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
 {% from "govuk/components/table/macro.njk" import govukTable %}
 
 {% set title = ("professions.admin.heading" | t) %}

--- a/views/admin/professions/index.njk
+++ b/views/admin/professions/index.njk
@@ -17,7 +17,7 @@
 
       <div class="rpr-internal-listing__manage-professions-container">
         <div class="rpr-internal-listing__manage-professions-container-left">
-          <h2 class="govuk-heading-l">Manage existing professions</h2>
+          <h2 class="govuk-heading-l">{{ "professions.admin.manageHeading" | t }}</h2>
         </div>
         <div class="rpr-internal-listing__manage-professions-container-right">
           {% if 'createProfession' in permissions %}


### PR DESCRIPTION
# Changes in this PR

- Placeholder dashboard for viewing recognition decision data

This is very much a placeholder page to set the groundwork for future work. Notably this punts on differing columns for service owner/non-service owner users, and figuring out who should have permission to view this page (currently admins only)

## Screenshots of UI changes

### Before

n/a

### After

![localhost_3000_admin_decisions](https://user-images.githubusercontent.com/94137563/162173171-62897bbb-b5b1-4672-a380-2ddb372d0951.png)

