### PR TITLE
add build command to bootstrap script

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -12,6 +12,9 @@ echo "==> Installing application dependencies..."
 nodenv install --skip-existing
 npm install
 
+echo "==> Building..."
+npm run build
+
 echo "==> Building assets..."
 
 npm run build:assets


### PR DESCRIPTION
# Changes in this PR
When setting up the repo for the first time the 'bootstrap' script failed as the `npm run build:assets` command depends on the 'dist/seeder.js' file created by 'npm run build' which isn't included in 'bootstrap'.

This PR adds the 'npm run build' command to the 'bootstrap' script in order to make the setup process smoother for future onboarding.