### PR TITLE
(2309) Add admin "show" page showing decision data for organisation-level users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 - Placeholder dashboard for viewing recognition decision data
+- Placeholder page for showing a single decision dataset
 
 ## [release-015] - 2022-04-06
 

--- a/assets/stylesheets/application.scss
+++ b/assets/stylesheets/application.scss
@@ -82,6 +82,19 @@ $small-screen: 768px;
   }
 }
 
+.rpr-decision-data {
+  &__overview {
+    .govuk-summary-list__key,
+    .govuk-summary-list__value {
+      padding: 3px 0;
+    }
+  }
+
+  &__table-container {
+    overflow-x: auto;
+  }
+}
+
 .rpr-internal {
   &__page {
     .govuk-header__container {

--- a/cypress/integration/admin/decisions/show.spec.ts
+++ b/cypress/integration/admin/decisions/show.spec.ts
@@ -1,0 +1,79 @@
+describe('Listing decision datasets', () => {
+  context('When I am logged in as admin', () => {
+    beforeEach(() => {
+      cy.loginAuth0('admin');
+      cy.visitAndCheckAccessibility('/admin/decisions');
+    });
+
+    it('I can view a decision dataset', () => {
+      cy.get('tr')
+        .contains(
+          'Secondary School Teacher in State maintained schools (England)',
+        )
+        .parent()
+        .within(() => {
+          cy.get('a').contains('View details').click();
+        });
+
+      cy.checkAccessibility();
+
+      cy.translate('decisions.show.heading').then((heading) => {
+        cy.get('body').should('contain', heading);
+      });
+
+      cy.get('body').should(
+        'contain',
+        'Secondary School Teacher in State maintained schools (England)',
+      );
+
+      cy.checkSummaryListRowValue(
+        'decisions.show.regulator',
+        'Department for Education',
+      );
+
+      cy.checkSummaryListRowValue('decisions.show.year', '2019');
+
+      cy.get('table caption').should('contain', 'EEA Route');
+      cy.get('table caption')
+        .contains('EEA Route')
+        .parent()
+        .parent()
+        .within(() => {
+          cy.checkTable(
+            [
+              'decisions.show.tableHeading.country',
+              'decisions.show.tableHeading.yes',
+              'decisions.show.tableHeading.yesAfterComp',
+              'decisions.show.tableHeading.no',
+              'decisions.show.tableHeading.noAfterComp',
+            ],
+            [
+              ['Morocco', '6', '1', '4', '9'],
+              ['Poland', '8', '1', '0', '7'],
+            ],
+          );
+        });
+
+      cy.get('table caption').should('contain', 'International Route');
+      cy.get('table caption')
+        .contains('International Route')
+        .parent()
+        .parent()
+        .within(() => {
+          cy.checkTable(
+            [
+              'decisions.show.tableHeading.country',
+              'decisions.show.tableHeading.yes',
+              'decisions.show.tableHeading.yesAfterComp',
+              'decisions.show.tableHeading.no',
+              'decisions.show.tableHeading.noAfterComp',
+            ],
+            [
+              ['Germany', '1', '7', '2', '4'],
+              ['Italy', '5', '1', '8', '3'],
+            ],
+          );
+        });
+    });
+  });
+});

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -311,6 +311,26 @@ Cypress.Commands.add('checkPublishNotBlocked', () => {
     });
 });
 
+Cypress.Commands.add('checkTable', (headings: string[], rows: string[][]) => {
+  headings.forEach((heading, index) => {
+    cy.translate(heading).then((translatedHeading) => {
+      cy.get('table thead tr th')
+        .eq(index)
+        .should('contain', translatedHeading);
+    });
+  });
+
+  rows.forEach((row, rowIndex) => {
+    cy.get('table tbody tr')
+      .eq(rowIndex)
+      .within(() => {
+        row.forEach((cell, cellIndex) => {
+          cy.get('td').eq(cellIndex).should('contain', cell);
+        });
+      });
+  });
+});
+
 Cypress.Commands.add('visitAndCheckAccessibility', (url: string) => {
   cy.visit(url);
   cy.checkAccessibility();

--- a/cypress/support/index.ts
+++ b/cypress/support/index.ts
@@ -69,6 +69,7 @@ declare global {
         shouldHaveButton?: boolean,
       ): Chainable<string>;
       checkPublishNotBlocked(): Chainable<string>;
+      checkTable(headings: string[], rows: string[][]): void;
       visitAndCheckAccessibility(url: string): void;
       checkAccessibility(rules?: AxeRules): void;
       visitInternalDashboard(): void;

--- a/seeds/development/decision-datasets.json
+++ b/seeds/development/decision-datasets.json
@@ -64,11 +64,11 @@
   {
     "profession": "Secondary School Teacher in State maintained schools (England)",
     "organisation": "Department for Education",
-    "year": 2018,
+    "year": 2019,
     "status": "live",
     "routes": [
       {
-        "name": "Degree",
+        "name": "EEA Route",
         "countries": [
           {
             "country": "Morocco",
@@ -89,13 +89,36 @@
             }
           }
         ]
+      },
+      {
+        "name": "International Route",
+        "countries": [
+          {
+            "country": "Germany",
+            "decisions": {
+              "yes": 1,
+              "no": 2,
+              "yesAfterComp": 7,
+              "noAfterComp": 4
+            }
+          },
+          {
+            "country": "Italy",
+            "decisions": {
+              "yes": 5,
+              "no": 8,
+              "yesAfterComp": 1,
+              "noAfterComp": 3
+            }
+          }
+        ]
       }
     ]
   },
   {
     "profession": "Secondary School Teacher in State maintained schools (England)",
     "organisation": "Department for Education",
-    "year": 2019,
+    "year": 2018,
     "status": "live",
     "routes": [
       {

--- a/seeds/test/decision-datasets.json
+++ b/seeds/test/decision-datasets.json
@@ -64,11 +64,11 @@
   {
     "profession": "Secondary School Teacher in State maintained schools (England)",
     "organisation": "Department for Education",
-    "year": 2018,
+    "year": 2019,
     "status": "live",
     "routes": [
       {
-        "name": "Degree",
+        "name": "EEA Route",
         "countries": [
           {
             "country": "Morocco",
@@ -89,13 +89,36 @@
             }
           }
         ]
+      },
+      {
+        "name": "International Route",
+        "countries": [
+          {
+            "country": "Germany",
+            "decisions": {
+              "yes": 1,
+              "no": 2,
+              "yesAfterComp": 7,
+              "noAfterComp": 4
+            }
+          },
+          {
+            "country": "Italy",
+            "decisions": {
+              "yes": 5,
+              "no": 8,
+              "yesAfterComp": 1,
+              "noAfterComp": 3
+            }
+          }
+        ]
       }
     ]
   },
   {
     "profession": "Secondary School Teacher in State maintained schools (England)",
     "organisation": "Department for Education",
-    "year": 2019,
+    "year": 2018,
     "status": "live",
     "routes": [
       {

--- a/src/common/interfaces/table.ts
+++ b/src/common/interfaces/table.ts
@@ -1,6 +1,7 @@
 import { TableRow } from './table-row';
 
 export interface Table {
+  classes?: string;
   firstCellIsHeader?: boolean;
   head: TableRow;
   rows: TableRow[];

--- a/src/decisions/admin/decision.controller.spec.ts
+++ b/src/decisions/admin/decision.controller.spec.ts
@@ -72,13 +72,15 @@ describe('DecisionsController', () => {
 
         expect(result).toEqual(mockIndexTemplate);
 
-        expect(DecisionDatasetsPresenter).toBeCalledWith(
+        expect(DecisionDatasetsPresenter).toHaveBeenCalledWith(
           null,
           datasets,
           i18nService,
         );
-        expect(decisionsDatasetsService.all).toBeCalled();
-        expect(decisionsDatasetsService.allForOrganisation).not.toBeCalled();
+        expect(decisionsDatasetsService.all).toHaveBeenCalled();
+        expect(
+          decisionsDatasetsService.allForOrganisation,
+        ).not.toHaveBeenCalled();
       });
     });
 
@@ -106,15 +108,15 @@ describe('DecisionsController', () => {
 
         expect(result).toEqual(mockIndexTemplate);
 
-        expect(DecisionDatasetsPresenter).toBeCalledWith(
+        expect(DecisionDatasetsPresenter).toHaveBeenCalledWith(
           organisation,
           datasets,
           i18nService,
         );
-        expect(decisionsDatasetsService.allForOrganisation).toBeCalledWith(
-          organisation,
-        );
-        expect(decisionsDatasetsService.all).not.toBeCalled();
+        expect(
+          decisionsDatasetsService.allForOrganisation,
+        ).toHaveBeenCalledWith(organisation);
+        expect(decisionsDatasetsService.all).not.toHaveBeenCalled();
       });
     });
   });

--- a/src/decisions/admin/decisions.controller.ts
+++ b/src/decisions/admin/decisions.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Render, Req, UseGuards } from '@nestjs/common';
+import { Controller, Get, Param, Render, Req, UseGuards } from '@nestjs/common';
 import { I18nService } from 'nestjs-i18n';
 
 import { AuthenticationGuard } from '../../common/authentication.guard';
@@ -9,13 +9,19 @@ import { Permissions } from '../../common/permissions.decorator';
 import { getActingUser } from '../../users/helpers/get-acting-user.helper';
 import { DecisionDatasetsService } from '../decision-datasets.service';
 import { IndexTemplate } from './interfaces/index-template.interface';
+import { ShowTemplate } from './interfaces/show-template.interface';
+import { ProfessionsService } from '../../professions/professions.service';
+import { checkCanViewProfession } from '../../users/helpers/check-can-view-profession';
+import { checkCanViewOrganisation } from '../../users/helpers/check-can-view-organisation';
 import { DecisionDatasetsPresenter } from './presenters/decision-datasets.presenter';
+import { DecisionDatasetPresenter } from '../presenters/decision-dataset.presenter';
 
 @UseGuards(AuthenticationGuard)
 @Controller('admin/decisions')
 export class DecisionsController {
   constructor(
     private readonly decisionDatasetsService: DecisionDatasetsService,
+    private readonly professionsService: ProfessionsService,
     private readonly i18Service: I18nService,
   ) {}
 
@@ -29,6 +35,47 @@ export class DecisionsController {
   @BackLink('/admin/dashboard')
   async index(@Req() request: RequestWithAppSession): Promise<IndexTemplate> {
     return this.createListEntries(request);
+  }
+
+  @Get(':professionId/:organisationId/:year')
+  @Permissions(
+    UserPermission.UploadDecisionData,
+    UserPermission.DownloadDecisionData,
+    UserPermission.ViewDecisionData,
+  )
+  @Render('admin/decisions/show')
+  @BackLink('/admin/decisions')
+  async show(
+    @Param('professionId') professionId: string,
+    @Param('organisationId') organisationId: string,
+    @Param('year') year: string,
+    @Req() request: RequestWithAppSession,
+  ): Promise<ShowTemplate> {
+    const profession = await this.professionsService.findWithVersions(
+      professionId,
+    );
+
+    checkCanViewProfession(request, profession);
+
+    const dataset = await this.decisionDatasetsService.find(
+      professionId,
+      organisationId,
+      parseInt(year),
+    );
+
+    checkCanViewOrganisation(request, dataset.organisation);
+
+    const presenter = new DecisionDatasetPresenter(
+      dataset.routes,
+      this.i18Service,
+    );
+
+    return {
+      profession: profession,
+      organisation: dataset.organisation,
+      year: dataset.year.toString(),
+      tables: presenter.tables(),
+    };
   }
 
   private async createListEntries(

--- a/src/decisions/admin/interfaces/show-template.interface.ts
+++ b/src/decisions/admin/interfaces/show-template.interface.ts
@@ -1,0 +1,10 @@
+import { Table } from '../../../common/interfaces/table';
+import { Organisation } from '../../../organisations/organisation.entity';
+import { Profession } from '../../../professions/profession.entity';
+
+export interface ShowTemplate {
+  profession: Profession;
+  organisation: Organisation;
+  year: string;
+  tables: Table[];
+}

--- a/src/decisions/decisions.module.ts
+++ b/src/decisions/decisions.module.ts
@@ -3,10 +3,15 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { DecisionsController } from './admin/decisions.controller';
 import { DecisionDatasetsService } from './decision-datasets.service';
 import { DecisionDataset } from './decision-dataset.entity';
+import { Profession } from '../professions/profession.entity';
+import { ProfessionsService } from '../professions/professions.service';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([DecisionDataset])],
-  providers: [DecisionDatasetsService],
+  imports: [
+    TypeOrmModule.forFeature([DecisionDataset]),
+    TypeOrmModule.forFeature([Profession]),
+  ],
+  providers: [DecisionDatasetsService, ProfessionsService],
   controllers: [DecisionsController],
 })
 export class DecisionsModule {}

--- a/src/decisions/presenters/decision-dataset.presenter.ts
+++ b/src/decisions/presenters/decision-dataset.presenter.ts
@@ -1,0 +1,71 @@
+import { I18nService } from 'nestjs-i18n';
+import { Table } from '../../common/interfaces/table';
+import { TableRow } from '../../common/interfaces/table-row';
+import { DecisionRoute } from '../interfaces/decision-route.interface';
+
+export class DecisionDatasetPresenter {
+  constructor(
+    private readonly routes: DecisionRoute[],
+    private readonly i18nService: I18nService,
+  ) {}
+
+  tables(): Table[] {
+    const head: TableRow = [
+      {
+        text: this.i18nService.translate<string>(
+          'decisions.show.tableHeading.country',
+        ),
+      },
+      {
+        text: this.i18nService.translate<string>(
+          'decisions.show.tableHeading.yes',
+        ),
+      },
+      {
+        text: this.i18nService.translate<string>(
+          'decisions.show.tableHeading.yesAfterComp',
+        ),
+      },
+      {
+        text: this.i18nService.translate<string>(
+          'decisions.show.tableHeading.no',
+        ),
+      },
+      {
+        text: this.i18nService.translate<string>(
+          'decisions.show.tableHeading.noAfterComp',
+        ),
+      },
+    ];
+
+    return this.routes.map((route) => {
+      const table: Table = {
+        classes: 'rpr-decision-data__table-container',
+        captionClasses: 'govuk-table__caption--l',
+        caption: route.name,
+        head,
+        rows: route.countries.map((country) => {
+          return [
+            {
+              text: country.country,
+            },
+            {
+              text: country.decisions.yes.toString(),
+            },
+            {
+              text: country.decisions.yesAfterComp.toString(),
+            },
+            {
+              text: country.decisions.no.toString(),
+            },
+            {
+              text: country.decisions.noAfterComp.toString(),
+            },
+          ];
+        }),
+      };
+
+      return table;
+    });
+  }
+}

--- a/src/decisions/presenters/decsion-dataset.presenter.spec.ts
+++ b/src/decisions/presenters/decsion-dataset.presenter.spec.ts
@@ -1,0 +1,148 @@
+import { Table } from '../../common/interfaces/table';
+import { TableRow } from '../../common/interfaces/table-row';
+import { createMockI18nService } from '../../testutils/create-mock-i18n-service';
+import { translationOf } from '../../testutils/translation-of';
+import { DecisionRoute } from '../interfaces/decision-route.interface';
+import { DecisionDatasetPresenter } from './decision-dataset.presenter';
+
+describe('DecisionDatasetPresenter', () => {
+  describe('tables', () => {
+    it('returns a tables of decision data', () => {
+      const i18nService = createMockI18nService();
+
+      const routes: DecisionRoute[] = [
+        {
+          name: 'Example route 1',
+          countries: [
+            {
+              country: 'Example country 1',
+              decisions: {
+                yes: 4,
+                no: 5,
+                yesAfterComp: 6,
+                noAfterComp: 7,
+              },
+            },
+            {
+              country: 'Example country 2',
+              decisions: {
+                yes: 5,
+                no: 8,
+                yesAfterComp: 0,
+                noAfterComp: 4,
+              },
+            },
+          ],
+        },
+        {
+          name: 'Example route 2',
+          countries: [
+            {
+              country: 'Example country 3',
+              decisions: {
+                yes: 1,
+                no: 3,
+                yesAfterComp: 11,
+                noAfterComp: 2,
+              },
+            },
+          ],
+        },
+      ];
+
+      const presenter = new DecisionDatasetPresenter(routes, i18nService);
+
+      const expectedHead: TableRow = [
+        {
+          text: translationOf('decisions.show.tableHeading.country'),
+        },
+        {
+          text: translationOf('decisions.show.tableHeading.yes'),
+        },
+        {
+          text: translationOf('decisions.show.tableHeading.yesAfterComp'),
+        },
+        {
+          text: translationOf('decisions.show.tableHeading.no'),
+        },
+        {
+          text: translationOf('decisions.show.tableHeading.noAfterComp'),
+        },
+      ];
+
+      const expected: Table[] = [
+        {
+          caption: 'Example route 1',
+          classes: 'rpr-decision-data__table-container',
+          captionClasses: 'govuk-table__caption--l',
+          head: expectedHead,
+          rows: [
+            [
+              {
+                text: 'Example country 1',
+              },
+              {
+                text: '4',
+              },
+              {
+                text: '6',
+              },
+              {
+                text: '5',
+              },
+              {
+                text: '7',
+              },
+            ],
+            [
+              {
+                text: 'Example country 2',
+              },
+              {
+                text: '5',
+              },
+              {
+                text: '0',
+              },
+              {
+                text: '8',
+              },
+              {
+                text: '4',
+              },
+            ],
+          ],
+        },
+        {
+          caption: 'Example route 2',
+          classes: 'rpr-decision-data__table-container',
+          captionClasses: 'govuk-table__caption--l',
+          head: expectedHead,
+          rows: [
+            [
+              {
+                text: 'Example country 3',
+              },
+              {
+                text: '1',
+              },
+              {
+                text: '11',
+              },
+              {
+                text: '3',
+              },
+              {
+                text: '2',
+              },
+            ],
+          ],
+        },
+      ];
+
+      const result = presenter.tables();
+
+      expect(expected).toEqual(result);
+    });
+  });
+});

--- a/src/i18n/en/decisions.json
+++ b/src/i18n/en/decisions.json
@@ -17,5 +17,14 @@
         "foundPlural": "{count} decision datasets found"
       }
     }
+  },
+  "show": {
+    "tableHeading": {
+      "country": "Country of qualification",
+      "yes": "Yes",
+      "no": "No",
+      "yesAfterComp": "Yes (after compensatory measure)",
+      "noAfterComp": "No (after compensatory measure)"
+    }
   }
 }

--- a/src/i18n/en/decisions.json
+++ b/src/i18n/en/decisions.json
@@ -19,6 +19,9 @@
     }
   },
   "show": {
+    "heading": "Recognition decision data",
+    "regulator": "Regulator",
+    "year": "Year",
     "tableHeading": {
       "country": "Country of qualification",
       "yes": "Yes",

--- a/views/admin/decisions/show.njk
+++ b/views/admin/decisions/show.njk
@@ -1,0 +1,16 @@
+{% set bodyClasses = "rpr-internal__page rpr-details__page" %}
+{% extends "admin/base.njk" %}
+
+{% set title = ("decisions.show.heading" | t) %}
+
+{% block content %}
+  {% include "../../_messages.njk" %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-three-quarters">
+      {% include "../../decisions/_decision-tables.njk" %}
+    </div>
+    <div class="govuk-grid-column-one-quarter">
+    </div>
+  </div>
+
+{% endblock %}

--- a/views/decisions/_decision-tables.njk
+++ b/views/decisions/_decision-tables.njk
@@ -1,0 +1,39 @@
+{% from "govuk/components/table/macro.njk" import govukTable %}
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+
+<h1 class="govuk-heading-xl">
+  {{ "decisions.show.heading" | t }}
+  <span class="govuk-caption-l">{{ profession.name }}</span>
+</h1>
+
+{{
+  govukSummaryList({
+  classes: "govuk-summary-list--no-border rpr-decision-data__overview",
+    rows: [
+      {
+        key: {
+          text: ("decisions.show.regulator" | t)
+        },
+        value: {
+          text: organisation.name
+        }
+      },
+      {
+        key: {
+          text: ("decisions.show.year" | t)
+        },
+        value: {
+          text: year
+        }
+      }
+    ]
+  })
+}}
+
+{% for table in tables %}
+
+  <div>
+    {{ govukTable(table) }}
+  </div>
+
+{% endfor %}


### PR DESCRIPTION
# Changes in this PR

- Placeholder page for showing a single decision dataset

## Screenshots of UI changes

### Before

N/A

### After

![localhost_3000_admin_decisions_e6fac99e-9ea2-4be8-bfe7-1c2dcf8bf6e6_cce0a88a-b688-486e-b4a9-52fccc68cee1_2022](https://user-images.githubusercontent.com/94137563/162256988-d69ba182-ac26-48df-968d-b92cc9866fc1.png)