### PR TITLE
(2288) Show enforcement bodies and qualifying bodies on professions page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Placeholder dashboard for viewing recognition decision data
 - Placeholder page for showing a single decision dataset
+- Show Awarding Bodies against profession
+- Show Enforcement Bodies against profession
 
 ## [release-015] - 2022-04-06
 

--- a/src/i18n/en/professions.json
+++ b/src/i18n/en/professions.json
@@ -196,6 +196,10 @@
       "nations": "Nations",
       "industry": "Sectors"
     },
+    "enforcementBodies": {
+      "heading": "Enforcement bodies",
+      "regulators": "Regulators"
+    },
     "bodies": {
       "heading": "Regulatory / professional bodies",
       "regulatedAuthority": "Regulated authority",

--- a/src/i18n/en/professions.json
+++ b/src/i18n/en/professions.json
@@ -222,6 +222,7 @@
       "moreInformationUrl": "More about qualification",
       "ukRecognition": "Routes to recognition within the UK",
       "ukRecognitionUrl": "More about recognition within the UK",
+      "awardingBodies": "Awarding bodies",
       "otherCountriesRecognition": {
         "routes": {
           "label": "Recognition for professionals outside the UK",

--- a/src/professions/admin/profession-versions.controller.spec.ts
+++ b/src/professions/admin/profession-versions.controller.spec.ts
@@ -20,6 +20,7 @@ import { Profession } from '../profession.entity';
 import { ProfessionPresenter } from '../presenters/profession.presenter';
 import { getActingUser } from '../../users/helpers/get-acting-user.helper';
 import * as getGroupedTierOneOrganisationsFromProfessionModule from './../helpers/get-grouped-tier-one-organisations-from-profession.helper';
+import * as getOrganisationsFromProfessionByRoleModule from './../helpers/get-organisations-from-profession-by-role';
 import { GroupedTierOneOrganisations } from './../helpers/get-grouped-tier-one-organisations-from-profession.helper';
 import { createDefaultMockRequest } from '../../testutils/factories/create-default-mock-request';
 import organisationFactory from '../../testutils/factories/organisation';
@@ -194,6 +195,14 @@ describe('ProfessionVersionsController', () => {
           )
           .mockReturnValue(expectedOrganisations);
 
+        const expectedAwardingBodies = organisationFactory.buildList(5);
+        const getOrganisationsFromProfessionByRoleSpy = jest
+          .spyOn(
+            getOrganisationsFromProfessionByRoleModule,
+            'getOrganisationsFromProfessionByRole',
+          )
+          .mockReturnValue(expectedAwardingBodies);
+
         (
           NationsListPresenter.prototype.htmlList as jest.Mock
         ).mockResolvedValue(mockNationsHtml);
@@ -219,6 +228,7 @@ describe('ProfessionVersionsController', () => {
           qualifications: await new QualificationPresenter(
             professionWithVersion.qualification,
             createMockI18nService(),
+            expectedAwardingBodies,
           ).summaryList(true, true),
           nations: mockNationsHtml,
           industries: ['Translation of `industries.example`'],
@@ -240,6 +250,11 @@ describe('ProfessionVersionsController', () => {
         expect(
           getGroupedTierOneOrganisationsFromProfessionSpy,
         ).toHaveBeenCalledWith(professionWithVersion, 'latestVersion');
+        expect(getOrganisationsFromProfessionByRoleSpy).toHaveBeenCalledWith(
+          professionWithVersion,
+          OrganisationRole.AwardingBody,
+          'latestVersion',
+        );
       });
     });
 
@@ -302,6 +317,7 @@ describe('ProfessionVersionsController', () => {
           qualifications: await new QualificationPresenter(
             professionWithVersion.qualification,
             createMockI18nService(),
+            [],
           ).summaryList(true, true),
           nations: mockNationsHtml,
           industries: [translationOf('industries.example')],
@@ -390,6 +406,7 @@ describe('ProfessionVersionsController', () => {
           qualifications: await new QualificationPresenter(
             undefined,
             createMockI18nService(),
+            [],
           ).summaryList(true, true),
           nations: mockNationsHtml,
           industries: [],

--- a/src/professions/admin/profession-versions.controller.spec.ts
+++ b/src/professions/admin/profession-versions.controller.spec.ts
@@ -29,6 +29,7 @@ import * as getPublicationBlockersModule from '../helpers/get-publication-blocke
 import { NationsListPresenter } from '../../nations/presenters/nations-list.presenter';
 import { Nation } from '../../nations/nation';
 import { ShowTemplate } from './interfaces/show-template.interface';
+import { organisationList } from './../presenters/organisation-list';
 
 jest.mock('../../organisations/organisation.entity');
 jest.mock('../presenters/profession.presenter');
@@ -196,12 +197,18 @@ describe('ProfessionVersionsController', () => {
           .mockReturnValue(expectedOrganisations);
 
         const expectedAwardingBodies = organisationFactory.buildList(5);
+        const expectedEnforcementBodies = organisationFactory.buildList(3);
+
         const getOrganisationsFromProfessionByRoleSpy = jest
           .spyOn(
             getOrganisationsFromProfessionByRoleModule,
             'getOrganisationsFromProfessionByRole',
           )
-          .mockReturnValue(expectedAwardingBodies);
+          .mockImplementation((_profession, role) =>
+            role === OrganisationRole.AwardingBody
+              ? expectedAwardingBodies
+              : expectedEnforcementBodies,
+          );
 
         (
           NationsListPresenter.prototype.htmlList as jest.Mock
@@ -233,6 +240,7 @@ describe('ProfessionVersionsController', () => {
           nations: mockNationsHtml,
           industries: ['Translation of `industries.example`'],
           organisations: expectedOrganisations,
+          enforcementBodies: organisationList(expectedEnforcementBodies),
           publicationBlockers: [],
         } as ShowTemplate);
 
@@ -253,6 +261,11 @@ describe('ProfessionVersionsController', () => {
         expect(getOrganisationsFromProfessionByRoleSpy).toHaveBeenCalledWith(
           professionWithVersion,
           OrganisationRole.AwardingBody,
+          'latestVersion',
+        );
+        expect(getOrganisationsFromProfessionByRoleSpy).toHaveBeenCalledWith(
+          professionWithVersion,
+          OrganisationRole.EnforcementBody,
           'latestVersion',
         );
       });
@@ -322,6 +335,7 @@ describe('ProfessionVersionsController', () => {
           nations: mockNationsHtml,
           industries: [translationOf('industries.example')],
           organisations: expectedOrganisations,
+          enforcementBodies: organisationList([]),
           publicationBlockers: [
             {
               type: 'incomplete-section',
@@ -411,6 +425,7 @@ describe('ProfessionVersionsController', () => {
           nations: mockNationsHtml,
           industries: [],
           organisations: expectedOrganisations,
+          enforcementBodies: organisationList([]),
           publicationBlockers: [
             {
               type: 'incomplete-section',

--- a/src/professions/admin/profession-versions.controller.ts
+++ b/src/professions/admin/profession-versions.controller.ts
@@ -30,6 +30,7 @@ import { NationsListPresenter } from '../../nations/presenters/nations-list.pres
 import { getGroupedTierOneOrganisationsFromProfession } from './../helpers/get-grouped-tier-one-organisations-from-profession.helper';
 import { getOrganisationsFromProfessionByRole } from './../helpers/get-organisations-from-profession-by-role';
 import { OrganisationRole } from './../profession-to-organisation.entity';
+import { organisationList } from './../presenters/organisation-list';
 
 @UseGuards(AuthenticationGuard)
 @Controller('/admin/professions')
@@ -84,6 +85,12 @@ export class ProfessionVersionsController {
       'latestVersion',
     );
 
+    const enforcementBodies = getOrganisationsFromProfessionByRole(
+      profession,
+      OrganisationRole.EnforcementBody,
+      'latestVersion',
+    );
+
     const nations = new NationsListPresenter(
       (profession.occupationLocations || []).map((code) => Nation.find(code)),
       this.i18nService,
@@ -111,6 +118,7 @@ export class ProfessionVersionsController {
       ),
       nations: await nations.htmlList(),
       industries,
+      enforcementBodies: organisationList(enforcementBodies),
       organisations: tierOneOrganisations,
       publicationBlockers: getPublicationBlockers(version),
     };

--- a/src/professions/admin/profession-versions.controller.ts
+++ b/src/professions/admin/profession-versions.controller.ts
@@ -28,6 +28,8 @@ import { checkCanViewProfession } from '../../users/helpers/check-can-view-profe
 import { getPublicationBlockers } from '../helpers/get-publication-blockers.helper';
 import { NationsListPresenter } from '../../nations/presenters/nations-list.presenter';
 import { getGroupedTierOneOrganisationsFromProfession } from './../helpers/get-grouped-tier-one-organisations-from-profession.helper';
+import { getOrganisationsFromProfessionByRole } from './../helpers/get-organisations-from-profession-by-role';
+import { OrganisationRole } from './../profession-to-organisation.entity';
 
 @UseGuards(AuthenticationGuard)
 @Controller('/admin/professions')
@@ -76,6 +78,12 @@ export class ProfessionVersionsController {
       'latestVersion',
     );
 
+    const awardingBodies = getOrganisationsFromProfessionByRole(
+      profession,
+      OrganisationRole.AwardingBody,
+      'latestVersion',
+    );
+
     const nations = new NationsListPresenter(
       (profession.occupationLocations || []).map((code) => Nation.find(code)),
       this.i18nService,
@@ -88,6 +96,7 @@ export class ProfessionVersionsController {
     const qualification = new QualificationPresenter(
       profession.qualification,
       this.i18nService,
+      awardingBodies,
     );
 
     return {

--- a/src/professions/helpers/get-organisations-from-profession-by-role.spec.ts
+++ b/src/professions/helpers/get-organisations-from-profession-by-role.spec.ts
@@ -1,0 +1,147 @@
+import organisationFactory from '../../testutils/factories/organisation';
+import professionFactory from '../../testutils/factories/profession';
+import { getOrganisationsFromProfessionByRole } from './get-organisations-from-profession-by-role';
+import {
+  OrganisationRole,
+  ProfessionToOrganisation,
+} from '../profession-to-organisation.entity';
+import { Organisation } from '../../organisations/organisation.entity';
+
+jest.mock('../../organisations/organisation.entity');
+
+describe('getOrganisationsFromProfessionByRole', () => {
+  describe('when the Profession has one organisation matching that query', () => {
+    it('returns a single-element array containing only that organisation', () => {
+      const organisation = organisationFactory.build();
+
+      const profession = professionFactory.build({
+        professionToOrganisations: [
+          {
+            organisation: organisation,
+            role: OrganisationRole.PrimaryRegulator,
+          },
+        ] as ProfessionToOrganisation[],
+      });
+
+      (Organisation.withLatestVersion as jest.Mock).mockImplementation(
+        (organisation) => organisation,
+      );
+
+      expect(
+        getOrganisationsFromProfessionByRole(
+          profession,
+          OrganisationRole.PrimaryRegulator,
+          'latestVersion',
+        ),
+      ).toEqual([organisation]);
+
+      expect(Organisation.withLatestVersion).toHaveBeenCalledWith(organisation);
+    });
+  });
+
+  describe('when I request the latest live version', () => {
+    it('builds organisations matching my query with their latest live version', () => {
+      const organisation = organisationFactory.build();
+
+      const profession = professionFactory.build({
+        professionToOrganisations: [
+          {
+            organisation: organisation,
+            role: OrganisationRole.PrimaryRegulator,
+          },
+        ] as ProfessionToOrganisation[],
+      });
+
+      getOrganisationsFromProfessionByRole(
+        profession,
+        OrganisationRole.PrimaryRegulator,
+        'latestLiveVersion',
+      );
+
+      expect(Organisation.withLatestLiveVersion).toHaveBeenCalledWith(
+        organisation,
+      );
+    });
+  });
+
+  describe('when the Profession has a mixture of organisations', () => {
+    it('returns a single-element array containing only that organisation', () => {
+      const organisation1 = organisationFactory.build();
+      const organisation2 = organisationFactory.build();
+
+      const profession = professionFactory.build({
+        professionToOrganisations: [
+          {
+            organisation: organisation1,
+            role: OrganisationRole.PrimaryRegulator,
+          },
+          {
+            organisation: organisation2,
+            role: OrganisationRole.AdditionalRegulator,
+          },
+        ] as ProfessionToOrganisation[],
+      });
+
+      (Organisation.withLatestVersion as jest.Mock).mockImplementation(
+        (organisation) => organisation,
+      );
+
+      expect(
+        getOrganisationsFromProfessionByRole(
+          profession,
+          OrganisationRole.PrimaryRegulator,
+          'latestVersion',
+        ),
+      ).toEqual([organisation1]);
+
+      expect(Organisation.withLatestVersion).toHaveBeenCalledWith(
+        organisation1,
+      );
+    });
+  });
+
+  describe('when the profession has some organisations without versions', () => {
+    it('should filter out those organisations', () => {
+      const organisation1 = organisationFactory.build();
+      const organisation2 = organisationFactory.build();
+      const organisation3 = organisationFactory.build();
+
+      const profession = professionFactory.build({
+        professionToOrganisations: [
+          {
+            organisation: organisation1,
+            role: OrganisationRole.PrimaryRegulator,
+          },
+          {
+            organisation: organisation2,
+            role: OrganisationRole.AdditionalRegulator,
+          },
+          {
+            organisation: organisation3,
+            role: OrganisationRole.AdditionalRegulator,
+          },
+        ] as ProfessionToOrganisation[],
+      });
+
+      (Organisation.withLatestVersion as jest.Mock).mockImplementation(
+        (organisation) =>
+          organisation.id === organisation3.id ? undefined : organisation,
+      );
+
+      expect(
+        getOrganisationsFromProfessionByRole(
+          profession,
+          OrganisationRole.AdditionalRegulator,
+          'latestVersion',
+        ),
+      ).toEqual([organisation2]);
+
+      expect(Organisation.withLatestVersion).toHaveBeenCalledWith(
+        organisation2,
+      );
+      expect(Organisation.withLatestVersion).toHaveBeenCalledWith(
+        organisation3,
+      );
+    });
+  });
+});

--- a/src/professions/helpers/get-organisations-from-profession-by-role.ts
+++ b/src/professions/helpers/get-organisations-from-profession-by-role.ts
@@ -1,0 +1,18 @@
+import { Profession } from '../profession.entity';
+import { OrganisationRole } from './../profession-to-organisation.entity';
+import { Organisation } from './../../organisations/organisation.entity';
+
+export function getOrganisationsFromProfessionByRole(
+  profession: Profession,
+  role: OrganisationRole,
+  organisationType: 'latestLiveVersion' | 'latestVersion',
+): Organisation[] {
+  return profession.professionToOrganisations
+    .filter((relation) => relation.role === role)
+    .map((relation) =>
+      organisationType === 'latestLiveVersion'
+        ? Organisation.withLatestLiveVersion(relation.organisation)
+        : Organisation.withLatestVersion(relation.organisation),
+    )
+    .filter((n) => n);
+}

--- a/src/professions/interfaces/show-template.interface.ts
+++ b/src/professions/interfaces/show-template.interface.ts
@@ -14,4 +14,5 @@ export interface ShowTemplate {
   nations: string;
   industries: string[];
   organisations: GroupedTierOneOrganisations;
+  enforcementBodies: string;
 }

--- a/src/professions/presenters/organisation-list.spec.ts
+++ b/src/professions/presenters/organisation-list.spec.ts
@@ -1,0 +1,25 @@
+import organisationFactory from '../../testutils/factories/organisation';
+import { organisationList } from './organisation-list';
+
+describe('organisationList', () => {
+  it('displays organisations in a HTML list', () => {
+    const organisations = organisationFactory.buildList(3);
+
+    const list = organisationList(organisations);
+
+    expect(list).toMatch('<ul class="govuk-list">');
+    expect(list).toMatch('</ul>');
+
+    for (const organisation of organisations) {
+      expect(list).toMatch(
+        `<li><a class="govuk-link" href="/regulatory-authorities/${organisation.slug}">${organisation.name}</a></li>`,
+      );
+    }
+  });
+
+  it('returns an empty string when there are no organisations', () => {
+    const list = organisationList([]);
+
+    expect(list).toEqual('');
+  });
+});

--- a/src/professions/presenters/organisation-list.ts
+++ b/src/professions/presenters/organisation-list.ts
@@ -1,0 +1,17 @@
+import { Organisation } from '../../organisations/organisation.entity';
+
+export function organisationList(organisations: Organisation[]): string {
+  if (organisations.length === 0) {
+    return '';
+  }
+
+  let list = '<ul class="govuk-list">';
+
+  for (const organisation of organisations) {
+    list += `<li><a class="govuk-link" href="/regulatory-authorities/${organisation.slug}">${organisation.name}</a></li>`;
+  }
+
+  list += '</ul>';
+
+  return list;
+}

--- a/src/professions/professions.controller.spec.ts
+++ b/src/professions/professions.controller.spec.ts
@@ -6,6 +6,7 @@ import QualificationPresenter from '../qualifications/presenters/qualification.p
 import { createMockI18nService } from '../testutils/create-mock-i18n-service';
 import industryFactory from '../testutils/factories/industry';
 import professionFactory from '../testutils/factories/profession';
+import organisationFactory from '../testutils/factories/organisation';
 import { translationOf } from '../testutils/translation-of';
 import { ProfessionVersionsService } from './profession-versions.service';
 
@@ -14,9 +15,12 @@ import { ProfessionsController } from './professions.controller';
 import { Organisation } from '../organisations/organisation.entity';
 import * as getGroupedTierOneOrganisationsFromProfessionModule from './helpers/get-grouped-tier-one-organisations-from-profession.helper';
 import { GroupedTierOneOrganisations } from './helpers/get-grouped-tier-one-organisations-from-profession.helper';
+import * as getOrganisationsFromProfessionByRoleModule from './helpers/get-organisations-from-profession-by-role';
+
 import { NationsListPresenter } from '../nations/presenters/nations-list.presenter';
 import { Nation } from '../nations/nation';
 import { ShowTemplate } from './interfaces/show-template.interface';
+import { OrganisationRole } from './profession-to-organisation.entity';
 
 jest.mock('../organisations/organisation.entity');
 jest.mock('../nations/presenters/nations-list.presenter');
@@ -74,6 +78,14 @@ describe('ProfessionsController', () => {
         )
         .mockReturnValue(expectedOrganisations);
 
+      const expectedAwardingBodies = organisationFactory.buildList(5);
+      const getOrganisationsFromProfessionByRoleSpy = jest
+        .spyOn(
+          getOrganisationsFromProfessionByRoleModule,
+          'getOrganisationsFromProfessionByRole',
+        )
+        .mockReturnValue(expectedAwardingBodies);
+
       (Organisation.withLatestLiveVersion as jest.Mock).mockImplementation(
         (organisation) => organisation,
       );
@@ -89,6 +101,7 @@ describe('ProfessionsController', () => {
         qualifications: await new QualificationPresenter(
           profession.qualification,
           createMockI18nService(),
+          expectedAwardingBodies,
         ).summaryList(false, true),
         nations: mockNationsHtml,
         industries: [translationOf('industries.example')],
@@ -105,6 +118,11 @@ describe('ProfessionsController', () => {
       expect(
         getGroupedTierOneOrganisationsFromProfessionSpy,
       ).toHaveBeenCalledWith(profession, 'latestLiveVersion');
+      expect(getOrganisationsFromProfessionByRoleSpy).toHaveBeenCalledWith(
+        profession,
+        OrganisationRole.AwardingBody,
+        'latestLiveVersion',
+      );
     });
 
     describe('publishing with missing data', () => {

--- a/src/professions/professions.controller.spec.ts
+++ b/src/professions/professions.controller.spec.ts
@@ -21,6 +21,7 @@ import { NationsListPresenter } from '../nations/presenters/nations-list.present
 import { Nation } from '../nations/nation';
 import { ShowTemplate } from './interfaces/show-template.interface';
 import { OrganisationRole } from './profession-to-organisation.entity';
+import { organisationList } from './presenters/organisation-list';
 
 jest.mock('../organisations/organisation.entity');
 jest.mock('../nations/presenters/nations-list.presenter');
@@ -79,12 +80,18 @@ describe('ProfessionsController', () => {
         .mockReturnValue(expectedOrganisations);
 
       const expectedAwardingBodies = organisationFactory.buildList(5);
+      const expectedEnforcementBodies = organisationFactory.buildList(3);
+
       const getOrganisationsFromProfessionByRoleSpy = jest
         .spyOn(
           getOrganisationsFromProfessionByRoleModule,
           'getOrganisationsFromProfessionByRole',
         )
-        .mockReturnValue(expectedAwardingBodies);
+        .mockImplementation((_profession, role) =>
+          role === OrganisationRole.AwardingBody
+            ? expectedAwardingBodies
+            : expectedEnforcementBodies,
+        );
 
       (Organisation.withLatestLiveVersion as jest.Mock).mockImplementation(
         (organisation) => organisation,
@@ -105,6 +112,7 @@ describe('ProfessionsController', () => {
         ).summaryList(false, true),
         nations: mockNationsHtml,
         industries: [translationOf('industries.example')],
+        enforcementBodies: organisationList(expectedEnforcementBodies),
         organisations: expectedOrganisations,
       } as ShowTemplate);
 
@@ -121,6 +129,11 @@ describe('ProfessionsController', () => {
       expect(getOrganisationsFromProfessionByRoleSpy).toHaveBeenCalledWith(
         profession,
         OrganisationRole.AwardingBody,
+        'latestLiveVersion',
+      );
+      expect(getOrganisationsFromProfessionByRoleSpy).toHaveBeenCalledWith(
+        profession,
+        OrganisationRole.EnforcementBody,
         'latestLiveVersion',
       );
     });
@@ -203,6 +216,7 @@ describe('ProfessionsController', () => {
             nations: mockNationsHtml,
             industries: [translationOf('industries.example')],
             organisations: expectedOrganisations,
+            enforcementBodies: organisationList([]),
           } as ShowTemplate);
         });
       });

--- a/src/professions/professions.controller.ts
+++ b/src/professions/professions.controller.ts
@@ -16,6 +16,8 @@ import { getGroupedTierOneOrganisationsFromProfession } from './helpers/get-grou
 import { getOrganisationsFromProfessionByRole } from './helpers/get-organisations-from-profession-by-role';
 import { isUK } from '../helpers/nations.helper';
 import { NationsListPresenter } from '../nations/presenters/nations-list.presenter';
+import { organisationList } from './presenters/organisation-list';
+
 import { OrganisationRole } from './profession-to-organisation.entity';
 @Controller()
 export class ProfessionsController {
@@ -52,6 +54,12 @@ export class ProfessionsController {
       'latestLiveVersion',
     );
 
+    const enforcementBodies = getOrganisationsFromProfessionByRole(
+      profession,
+      OrganisationRole.EnforcementBody,
+      'latestLiveVersion',
+    );
+
     const nations = new NationsListPresenter(
       (profession.occupationLocations || []).map((code) => Nation.find(code)),
       this.i18nService,
@@ -81,6 +89,7 @@ export class ProfessionsController {
         : null,
       nations: await nations.htmlList(),
       industries,
+      enforcementBodies: organisationList(enforcementBodies),
       organisations: tierOneOrganisations,
     };
   }

--- a/src/professions/professions.controller.ts
+++ b/src/professions/professions.controller.ts
@@ -13,9 +13,10 @@ import { ShowTemplate } from './interfaces/show-template.interface';
 import { BackLink } from '../common/decorators/back-link.decorator';
 import { ProfessionVersionsService } from './profession-versions.service';
 import { getGroupedTierOneOrganisationsFromProfession } from './helpers/get-grouped-tier-one-organisations-from-profession.helper';
+import { getOrganisationsFromProfessionByRole } from './helpers/get-organisations-from-profession-by-role';
 import { isUK } from '../helpers/nations.helper';
 import { NationsListPresenter } from '../nations/presenters/nations-list.presenter';
-
+import { OrganisationRole } from './profession-to-organisation.entity';
 @Controller()
 export class ProfessionsController {
   constructor(
@@ -45,6 +46,12 @@ export class ProfessionsController {
       'latestLiveVersion',
     );
 
+    const awardingBodies = getOrganisationsFromProfessionByRole(
+      profession,
+      OrganisationRole.AwardingBody,
+      'latestLiveVersion',
+    );
+
     const nations = new NationsListPresenter(
       (profession.occupationLocations || []).map((code) => Nation.find(code)),
       this.i18nService,
@@ -55,7 +62,11 @@ export class ProfessionsController {
     );
 
     const qualification = profession.qualification
-      ? new QualificationPresenter(profession.qualification, this.i18nService)
+      ? new QualificationPresenter(
+          profession.qualification,
+          this.i18nService,
+          awardingBodies,
+        )
       : null;
 
     return {

--- a/src/qualifications/presenters/qualification.presenter.spec.ts
+++ b/src/qualifications/presenters/qualification.presenter.spec.ts
@@ -1,4 +1,5 @@
 import qualificationFactory from '../../testutils/factories/qualification';
+import organisationFactory from '../../testutils/factories/organisation';
 import QualificationPresenter from './qualification.presenter';
 import { formatMultilineString } from '../../helpers/format-multiline-string.helper';
 import { multilineOf } from '../../testutils/multiline-of';
@@ -465,6 +466,40 @@ describe(QualificationPresenter, () => {
               ukSummaryList: null,
             });
           });
+        });
+      });
+
+      describe('when awarding bodies are present', () => {
+        it('adds a list of awarding bodies', async () => {
+          const qualification = qualificationFactory.build({
+            url: '',
+            otherCountriesRecognitionRoutes: null,
+          });
+          const organisations = organisationFactory.buildList(3);
+
+          const presenter = new QualificationPresenter(
+            qualification,
+            createMockI18nService(),
+            organisations,
+          );
+
+          const summaryList = await presenter.summaryList(true, false);
+          const awardingBodyRole = summaryList.overviewSummaryList.rows.find(
+            (r) =>
+              r.key['text'] ===
+              translationOf('professions.show.qualification.awardingBodies'),
+          );
+          const html = awardingBodyRole.value['html'];
+
+          expect(html).toMatch('<ul class="govuk-list">');
+
+          expect(html).toMatch('</ul>');
+
+          for (const organisation of organisations) {
+            expect(html).toMatch(
+              `<li><a class="govuk-link" href="/regulatory-authorities/${organisation.slug}">${organisation.name}</a></li>`,
+            );
+          }
         });
       });
     });

--- a/src/qualifications/presenters/qualification.presenter.ts
+++ b/src/qualifications/presenters/qualification.presenter.ts
@@ -3,11 +3,13 @@ import { Qualification } from '../qualification.entity';
 import { I18nService } from 'nestjs-i18n';
 import { SummaryList } from '../../common/interfaces/summary-list';
 import { formatLink } from '../../helpers/format-link.helper';
+import { Organisation } from '../../organisations/organisation.entity';
 
 export default class QualificationPresenter {
   constructor(
     private readonly qualification: Qualification,
     private readonly i18nService: I18nService,
+    private readonly awardingBodies?: Organisation[],
   ) {}
 
   readonly routesToObtain = formatMultilineString(
@@ -76,6 +78,14 @@ export default class QualificationPresenter {
         overviewSummaryList,
         'professions.show.qualification.moreInformationUrl',
         this.moreInformationUrl,
+      );
+    }
+
+    if (this.awardingBodies?.length) {
+      await this.addHtmlRow(
+        overviewSummaryList,
+        'professions.show.qualification.awardingBodies',
+        this.listAwardingBodies(),
       );
     }
 
@@ -161,5 +171,17 @@ export default class QualificationPresenter {
       key: { text: await this.i18nService.translate(key) },
       value: { html: value },
     });
+  }
+
+  private listAwardingBodies(): string {
+    let list = '<ul class="govuk-list">';
+
+    for (const organisation of this.awardingBodies) {
+      list += `<li><a class="govuk-link" href="/regulatory-authorities/${organisation.slug}">${organisation.name}</a></li>`;
+    }
+
+    list += '</ul>';
+
+    return list;
   }
 }

--- a/views/professions/_profession-details.njk
+++ b/views/professions/_profession-details.njk
@@ -223,6 +223,28 @@
 
 {% endif %}
 
+{% if (enforcementBodies) %}
+
+  <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+
+  <h2 class="govuk-heading-l">{{ "professions.show.enforcementBodies.heading" | t}}</h2>
+
+  {{ govukSummaryList({
+    classes: 'govuk-summary-list--no-border',
+    rows: [
+      {
+        key: {
+          text:  "professions.show.enforcementBodies.regulators" | t
+        },
+        value: {
+          html: enforcementBodies
+        }
+      }
+    ]
+  }) }}
+
+{% endif %}
+
 {% if (profession.legislations | length) or showEmptyProfessionDetails %}
 
 <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">

--- a/views/professions/show.njk.spec.ts
+++ b/views/professions/show.njk.spec.ts
@@ -98,4 +98,44 @@ describe('show.njk', () => {
       },
     );
   });
+
+  it('should show enforcement bodies', () => {
+    const profession = professionFactory.build();
+    const enforcementBodies = 'STUB_ENFORCEMENT_BODIES';
+
+    nunjucks.render(
+      'professions/show.njk',
+      { enforcementBodies, profession },
+      function (_err, res) {
+        expect(res).toMatch(
+          translationOf('professions.show.enforcementBodies.heading'),
+        );
+
+        expect(res).toMatch(
+          translationOf('professions.show.enforcementBodies.regulators'),
+        );
+
+        expect(res).toMatch('STUB_ENFORCEMENT_BODIES');
+      },
+    );
+  });
+
+  it('should not show enforcement bodies when there are none', () => {
+    const profession = professionFactory.build();
+    const enforcementBodies = '';
+
+    nunjucks.render(
+      'professions/show.njk',
+      { enforcementBodies, profession },
+      function (_err, res) {
+        expect(res).not.toMatch(
+          translationOf('professions.show.enforcementBodies.heading'),
+        );
+
+        expect(res).not.toMatch(
+          translationOf('professions.show.enforcementBodies.regulators'),
+        );
+      },
+    );
+  });
 });


### PR DESCRIPTION
This adds enforcement bodies and qualifying bodies on the professions show pages. Enforcement bodies are shown in their own new section, and Awarding Bodies are shown in the Qualifications and Experience section

## Screenshot 

![image](https://user-images.githubusercontent.com/109774/162436585-32e6f41e-ce53-4051-b5fa-b5fab61b056a.png)
