### PR TITLE
(2327) Ensure admin organisation view still renders when a Regulator is removed from a Profession

### DIFF
--- a/src/organisations/presenters/organisation.presenter.spec.ts
+++ b/src/organisations/presenters/organisation.presenter.spec.ts
@@ -227,6 +227,33 @@ describe('OrganisationPresenter', () => {
           );
         });
       });
+
+      describe('when there are no professionToOrganisations on the regulator', () => {
+        it('returns empty text for industries', async () => {
+          const professionToOrganisations = [];
+
+          const organisation = organisationFactory.build({
+            lastModified: new Date('01-01-2022'),
+            changedByUser: userFactory.build({ name: 'beis-rpr' }),
+            status: OrganisationVersionStatus.Draft,
+            professionToOrganisations: professionToOrganisations,
+          });
+          (escape as jest.Mock).mockImplementation(escapeOf);
+          (formatStatus as jest.Mock).mockImplementation(statusOf);
+
+          jest.spyOn(nationsHelperModule, 'getNationsFromProfessions');
+
+          const i18nService = createMockI18nService();
+
+          const presenter = new OrganisationPresenter(
+            organisation,
+            i18nService,
+          );
+          const tableRow = await presenter.tableRow();
+
+          expect(tableRow[2]).toEqual({ text: '' });
+        });
+      });
     });
   });
 

--- a/src/organisations/presenters/organisation.presenter.ts
+++ b/src/organisations/presenters/organisation.presenter.ts
@@ -209,11 +209,12 @@ export class OrganisationPresenter {
   }
 
   private professions(): Profession[] {
-    return this.organisation.professionToOrganisations.map(
-      (professionToOrganisation) =>
+    return this.organisation.professionToOrganisations
+      .filter((e) => e.profession)
+      .map((professionToOrganisation) =>
         Profession.withLatestLiveOrDraftVersion(
           professionToOrganisation.profession,
         ),
-    );
+      );
   }
 }


### PR DESCRIPTION
# Changes in this PR

Add guard against `ProfessionToOrganisation`s with a `null` `Profession`.

There's currently an issue with the underlying data when setting a new Regulator on a Profession, where the ProfessionToOrganisation isn't removed from the Regulator, but its `Profession` is set to `null`. This was causing the view to break.

As a temporary fix to this issue, while we fix the underlying data, we're allowing the page to render without errors - we'll run a migration to fix the data once this is solved.

<!-- Do you need to update the changelog? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->





