### PR TITLE
Add conditional link to admin organisation page from profession 

### DIFF
--- a/views/admin/professions/show.njk
+++ b/views/admin/professions/show.njk
@@ -7,7 +7,7 @@
   {% include "../../_messages.njk" %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      {% set showEmptyProfessionDetails = true %}
+      {% set view = 'admin' %}
       {% include "../../professions/_profession-details.njk" %}
     </div>
     <div class="govuk-grid-column-one-third">

--- a/views/admin/professions/show.njk.spec.ts
+++ b/views/admin/professions/show.njk.spec.ts
@@ -1,0 +1,47 @@
+import { JSDOM } from 'jsdom';
+import * as nunjucks from 'nunjucks';
+
+import { nunjucksEnvironment } from '../../testutils/nunjucksEnvironment';
+
+import organisationFactory from '../../../src/testutils/factories/organisation';
+import professionFactory from '../../../src/testutils/factories/profession';
+
+describe('show.njk', () => {
+  beforeAll(async () => {
+    await nunjucksEnvironment();
+  });
+
+  it('should link to admin-facing page for organisation', () => {
+    const profession = professionFactory.build();
+    const organisation1 = organisationFactory.build({
+      id: 'organisation-id',
+      versionId: 'version-id',
+    });
+    const organisations = {
+      role1: [organisation1],
+    };
+
+    nunjucks.render(
+      'admin/professions/show.njk',
+      {
+        profession,
+        organisations,
+        permissions: [],
+        canChangeProfession: () => {
+          return true;
+        },
+      },
+      function (_err, res) {
+        const dom = new JSDOM(res);
+
+        const links = dom.window.document.querySelectorAll(
+          '.rpr-details__sub-group .govuk-link',
+        );
+
+        expect(links[0].getAttribute('href')).toEqual(
+          '/admin/organisations/organisation-id/versions/version-id',
+        );
+      },
+    );
+  });
+});

--- a/views/professions/_profession-details.njk
+++ b/views/professions/_profession-details.njk
@@ -1,5 +1,7 @@
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 
+{% set showEmptyProfessionDetails = (view === 'admin') %}
+
 <span class="govuk-caption-l">{{ organisation.name }}</span>
 
 <h1 class="govuk-heading-xl">{{ profession.name }}</h1>
@@ -61,6 +63,13 @@
   <div class="rpr-details__sub-group">
     {% for organisation in orgs %}
       <h3 class="govuk-heading-m rpr-details__sub-group-title">{{ ("organisations.label.roles." +  role) | t }}</h3>
+      {% set organisationLink %}
+        {% if view === 'admin' %}
+          <a href="/admin/organisations/{{organisation.id}}/versions/{{organisation.versionId}}" class="govuk-link" >{{organisation.name | escape}}</a>
+        {% else %}
+          <a href="/regulatory-authorities/{{organisation.slug}}" class="govuk-link">{{organisation.name | escape}}</a>
+        {% endif %}
+      {% endset %}
 
       {{ govukSummaryList({
         classes: 'govuk-summary-list--no-border',
@@ -70,7 +79,7 @@
               text: ("professions.show.bodies.regulatedAuthority" | t)
             },
             value: {
-              html: "<a href='"+ ("/regulatory-authorities/" + organisation.slug) +"' class='govuk-link'>"+ organisation.name | escape +"</a>"
+              html: organisationLink
             }
           },
           {

--- a/views/professions/show.njk.spec.ts
+++ b/views/professions/show.njk.spec.ts
@@ -7,10 +7,7 @@ import { nunjucksEnvironment } from '../testutils/nunjucksEnvironment';
 import organisationFactory from '../../src/testutils/factories/organisation';
 import professionFactory from '../../src/testutils/factories/profession';
 
-import {
-  ProfessionToOrganisation,
-  OrganisationRole,
-} from '../../src/professions/profession-to-organisation.entity';
+import { ProfessionToOrganisation } from '../../src/professions/profession-to-organisation.entity';
 
 describe('show.njk', () => {
   beforeAll(async () => {
@@ -134,6 +131,32 @@ describe('show.njk', () => {
 
         expect(res).not.toMatch(
           translationOf('professions.show.enforcementBodies.regulators'),
+        );
+      },
+    );
+  });
+
+  it('should link to public facing page for organisation when user is not an admin', () => {
+    const profession = professionFactory.build();
+    const organisation1 = organisationFactory.build({
+      slug: 'organisation-1',
+    });
+
+    const organisations = {
+      role1: [organisation1],
+    };
+
+    nunjucks.render(
+      'professions/show.njk',
+      { organisations, profession },
+      function (_err, res) {
+        const dom = new JSDOM(res);
+
+        const links = dom.window.document.querySelectorAll(
+          '.rpr-details__sub-group .govuk-link',
+        );
+        expect(links[0].getAttribute('href')).toEqual(
+          '/regulatory-authorities/organisation-1',
         );
       },
     );

--- a/views/professions/show.njk.spec.ts
+++ b/views/professions/show.njk.spec.ts
@@ -14,7 +14,7 @@ describe('show.njk', () => {
     await nunjucksEnvironment();
   });
 
-  it('should group organisations together', async () => {
+  it('should group organisations together', () => {
     const profession = professionFactory.build();
     const organisation1 = organisationFactory.build();
     const organisation2 = organisationFactory.build();


### PR DESCRIPTION
# Changes in this PR

When clicking on a link to 'View Detais' of an organisation from the professions page: 

- If logged in as admin it will be: `/admin/organisations/:organisationId/versions/:versionId`
- Otherwise: `regulatory-authorities/:organisationSlug` 

We opted to add these to the Nunjucks template spec as we only wanted to assert the link path is correct and a user journey


