### PR TITLE
(2273) Hide admin view link for non tier one organisations

### DIFF
--- a/src/professions/admin/presenters/list-entry.presenter.ts
+++ b/src/professions/admin/presenters/list-entry.presenter.ts
@@ -6,8 +6,10 @@ import { Nation } from '../../../nations/nation';
 import { getOrganisationsFromProfession } from '../../helpers/get-organisations-from-profession.helper';
 import { ProfessionPresenter } from '../../presenters/profession.presenter';
 import { Profession } from '../../profession.entity';
+import { User } from '../../../users/user.entity';
 import { ProfessionsPresenterView } from './professions.presenter';
 import { NationsListPresenter } from './../../../nations/presenters/nations-list.presenter';
+import { belongsToTierOneOrganisation } from '../../../users/helpers/belongs-to-tier-one-organisation';
 
 type Field =
   | 'profession'
@@ -60,6 +62,7 @@ export class ListEntryPresenter {
   constructor(
     private readonly profession: Profession,
     private readonly i18nService: I18nService,
+    private readonly actingUser: User,
   ) {}
 
   async tableRow(contents: ProfessionsPresenterView): Promise<TableRow> {
@@ -84,12 +87,19 @@ export class ListEntryPresenter {
       )
     ).join(', ');
 
-    const viewDetails = `<a class="govuk-link" href="/admin/professions/${
-      this.profession.id
-    }/versions/${this.profession.versionId}">${await this.i18nService.translate(
-      'professions.admin.viewDetails',
-      { args: { name: escape(this.profession.name) } },
-    )}</a>`;
+    let viewDetails: string;
+
+    if (belongsToTierOneOrganisation(this.profession, this.actingUser)) {
+      viewDetails = `<a class="govuk-link" href="/admin/professions/${
+        this.profession.id
+      }/versions/${
+        this.profession.versionId
+      }">${await this.i18nService.translate('professions.admin.viewDetails', {
+        args: { name: escape(this.profession.name) },
+      })}</a>`;
+    } else {
+      viewDetails = '';
+    }
 
     const organisations = getOrganisationsFromProfession(this.profession)
       .map((organisation) => organisation.name)

--- a/src/professions/admin/presenters/professions.presenter.spec.ts
+++ b/src/professions/admin/presenters/professions.presenter.spec.ts
@@ -12,6 +12,7 @@ import { ListEntryPresenter } from './list-entry.presenter';
 import industryFactory from '../../../testutils/factories/industry';
 import organisationFactory from '../../../testutils/factories/organisation';
 import professionFactory from '../../../testutils/factories/profession';
+import userFactory from '../../../testutils/factories/user';
 import { translationOf } from '../../../testutils/translation-of';
 import { RegulationType } from '../../profession-version.entity';
 import { RegulationTypesCheckboxPresenter } from './regulation-types-checkbox.presenter';
@@ -92,6 +93,7 @@ describe('ProfessionsPresenter', () => {
       industries,
       [profession1, profession2, profession3],
       i18nService,
+      userFactory.build(),
     );
   });
 
@@ -111,9 +113,11 @@ describe('ProfessionsPresenter', () => {
           head: await ListEntryPresenter.headings(i18nService, 'overview'),
           rows: await Promise.all(
             [profession1, profession2, profession3].map((profession) =>
-              new ListEntryPresenter(profession, i18nService).tableRow(
-                'overview',
-              ),
+              new ListEntryPresenter(
+                profession,
+                i18nService,
+                userFactory.build(),
+              ).tableRow('overview'),
             ),
           ),
         },
@@ -167,9 +171,11 @@ describe('ProfessionsPresenter', () => {
           ),
           rows: await Promise.all(
             [profession1, profession2, profession3].map((profession) =>
-              new ListEntryPresenter(profession, i18nService).tableRow(
-                'single-organisation',
-              ),
+              new ListEntryPresenter(
+                profession,
+                i18nService,
+                userFactory.build(),
+              ).tableRow('single-organisation'),
             ),
           ),
         },
@@ -228,6 +234,7 @@ describe('ProfessionsPresenter', () => {
             industries,
             foundProfessions,
             i18nService,
+            userFactory.build(),
           );
 
           const result = await presenter.present('overview');
@@ -261,6 +268,7 @@ describe('ProfessionsPresenter', () => {
             industries,
             foundProfessions,
             i18nService,
+            userFactory.build(),
           );
 
           const result = await presenter.present('overview');

--- a/src/professions/admin/presenters/professions.presenter.ts
+++ b/src/professions/admin/presenters/professions.presenter.ts
@@ -8,6 +8,7 @@ import { FilterInput } from '../../../common/interfaces/filter-input.interface';
 import { IndexTemplate } from './../interfaces/index-template.interface';
 import { ListEntryPresenter } from './../presenters/list-entry.presenter';
 import { Organisation } from '../../../organisations/organisation.entity';
+import { User } from '../../../users/user.entity';
 import { OrganisationsCheckboxPresenter } from '../../../organisations/organisations-checkbox-presenter';
 import { Table } from '../../../common/interfaces/table';
 import { RegulationTypesCheckboxPresenter } from './regulation-types-checkbox.presenter';
@@ -23,6 +24,7 @@ export class ProfessionsPresenter {
     private readonly allIndustries: Industry[],
     private readonly filteredProfessions: Profession[],
     private readonly i18nService: I18nService,
+    private readonly actingUser: User,
   ) {}
 
   async present(view: ProfessionsPresenterView): Promise<IndexTemplate> {
@@ -57,7 +59,7 @@ export class ProfessionsPresenter {
     return {
       view,
       organisation,
-      professionsTable: await this.table(view),
+      professionsTable: await this.table(view, this.actingUser),
       nationsCheckboxItems,
       organisationsCheckboxItems,
       industriesCheckboxItems,
@@ -76,12 +78,19 @@ export class ProfessionsPresenter {
     };
   }
 
-  private async table(view: ProfessionsPresenterView): Promise<Table> {
+  private async table(
+    view: ProfessionsPresenterView,
+    actingUser: User,
+  ): Promise<Table> {
     const headings = await ListEntryPresenter.headings(this.i18nService, view);
 
     const rows = await Promise.all(
       this.filteredProfessions.map(async (profession) =>
-        new ListEntryPresenter(profession, this.i18nService).tableRow(view),
+        new ListEntryPresenter(
+          profession,
+          this.i18nService,
+          actingUser,
+        ).tableRow(view),
       ),
     );
 

--- a/src/professions/admin/professions.controller.spec.ts
+++ b/src/professions/admin/professions.controller.spec.ts
@@ -8,6 +8,7 @@ import { Nation } from '../../nations/nation';
 import { Organisation } from '../../organisations/organisation.entity';
 import { FilterInput } from '../../common/interfaces/filter-input.interface';
 import { Profession } from '../profession.entity';
+import { User } from '../../users/user.entity';
 import { ProfessionsService } from '../professions.service';
 import { ProfessionsController as ProfessionsController } from './professions.controller';
 import { ProfessionsPresenter } from './presenters/professions.presenter';
@@ -202,10 +203,12 @@ describe('ProfessionsController', () => {
 
   describe('index', () => {
     describe('when the user is a service owner', () => {
+      let user: User;
+
       beforeEach(() => {
-        (getActingUser as jest.Mock).mockReturnValue(
-          userFactory.build({ serviceOwner: true }),
-        );
+        user = userFactory.build({ serviceOwner: true });
+
+        (getActingUser as jest.Mock).mockReturnValue(user);
       });
 
       it('returns template params poulated to show an overview of professions', async () => {
@@ -221,6 +224,7 @@ describe('ProfessionsController', () => {
           },
           null,
           [profession1, profession2, profession3],
+          user,
         ).present('overview');
 
         expect(result).toEqual(expected);
@@ -245,6 +249,7 @@ describe('ProfessionsController', () => {
           },
           null,
           [profession3],
+          user,
         ).present('overview');
 
         expect(result).toEqual(expected);
@@ -274,6 +279,7 @@ describe('ProfessionsController', () => {
           },
           null,
           [profession1],
+          user,
         ).present('overview');
 
         expect(result).toEqual(expected);
@@ -303,6 +309,7 @@ describe('ProfessionsController', () => {
           },
           null,
           [profession3],
+          user,
         ).present('overview');
 
         expect(result).toEqual(expected);
@@ -332,6 +339,7 @@ describe('ProfessionsController', () => {
           },
           null,
           [profession3],
+          user,
         ).present('overview');
 
         expect(result).toEqual(expected);
@@ -361,6 +369,7 @@ describe('ProfessionsController', () => {
           },
           null,
           [profession1],
+          user,
         ).present('overview');
 
         expect(result).toEqual(expected);
@@ -368,13 +377,15 @@ describe('ProfessionsController', () => {
     });
 
     describe('when the user is not a service owner', () => {
+      let user: User;
+
       beforeEach(() => {
-        (getActingUser as jest.Mock).mockReturnValue(
-          userFactory.build({
-            serviceOwner: false,
-            organisation: organisation1,
-          }),
-        );
+        user = userFactory.build({
+          serviceOwner: false,
+          organisation: organisation1,
+        });
+
+        (getActingUser as jest.Mock).mockReturnValue(user);
       });
 
       it('returns template params poulated to show professions for a single organisation', async () => {
@@ -388,6 +399,7 @@ describe('ProfessionsController', () => {
           },
           organisation1,
           [profession1, profession2],
+          user,
         ).present('single-organisation');
 
         expect(result).toEqual(expected);
@@ -412,6 +424,7 @@ describe('ProfessionsController', () => {
           },
           organisation1,
           [profession1],
+          user,
         ).present('single-organisation');
 
         expect(result).toEqual(expected);
@@ -436,6 +449,7 @@ describe('ProfessionsController', () => {
           },
           organisation1,
           [profession2],
+          user,
         ).present('single-organisation');
 
         expect(result).toEqual(expected);
@@ -453,6 +467,7 @@ function createPresenter(
   filterInput: FilterInput,
   userOrganisation: Organisation | null,
   professions: Profession[],
+  user: User,
 ): ProfessionsPresenter {
   return new ProfessionsPresenter(
     filterInput,
@@ -462,5 +477,6 @@ function createPresenter(
     industries,
     professions,
     i18nService,
+    user,
   );
 }

--- a/src/professions/admin/professions.controller.ts
+++ b/src/professions/admin/professions.controller.ts
@@ -127,6 +127,7 @@ export class ProfessionsController {
       allIndustries,
       filteredProfessions,
       this.i18Service,
+      actingUser,
     ).present(view);
   }
 }

--- a/src/users/helpers/belongs-to-tier-one-organisation.spec.ts
+++ b/src/users/helpers/belongs-to-tier-one-organisation.spec.ts
@@ -1,0 +1,64 @@
+import { belongsToTierOneOrganisation } from './belongs-to-tier-one-organisation';
+import userFactory from '../../testutils/factories/user';
+import organisationFactory from '../../testutils/factories/organisation';
+import professionFactory from '../../testutils/factories/profession';
+import * as getTierOneOrganisationsFromProfessionModule from '../../professions/helpers/get-tier-one-organisations-from-profession.helper';
+
+describe('belongsToTierOneOrganisation', () => {
+  describe('when the profession has no tier one organisations', () => {
+    it('should return false', () => {
+      const profession = professionFactory.build();
+      const user = userFactory.build();
+
+      const getTierOneOrganisationsFromProfessionSpy = jest.spyOn(
+        getTierOneOrganisationsFromProfessionModule,
+        'getTierOneOrganisationsFromProfession',
+      );
+
+      getTierOneOrganisationsFromProfessionSpy.mockReturnValue([]);
+
+      expect(belongsToTierOneOrganisation(profession, user)).toBeFalsy();
+    });
+  });
+
+  describe('when the profession has a tier one organisation, that the user does not belong to', () => {
+    it('should return false', () => {
+      const tierOneOrganisation = organisationFactory.build();
+      const otherOrganisation = organisationFactory.build();
+
+      const profession = professionFactory.build();
+      const user = userFactory.build({ organisation: otherOrganisation });
+
+      const getTierOneOrganisationsFromProfessionSpy = jest.spyOn(
+        getTierOneOrganisationsFromProfessionModule,
+        'getTierOneOrganisationsFromProfession',
+      );
+
+      getTierOneOrganisationsFromProfessionSpy.mockReturnValue([
+        tierOneOrganisation,
+      ]);
+
+      expect(belongsToTierOneOrganisation(profession, user)).toBeFalsy();
+    });
+  });
+
+  describe('when the profession has a tier one organisation, that the user belongs to', () => {
+    it('should return truthy', () => {
+      const tierOneOrganisation = organisationFactory.build();
+
+      const profession = professionFactory.build();
+      const user = userFactory.build({ organisation: tierOneOrganisation });
+
+      const getTierOneOrganisationsFromProfessionSpy = jest.spyOn(
+        getTierOneOrganisationsFromProfessionModule,
+        'getTierOneOrganisationsFromProfession',
+      );
+
+      getTierOneOrganisationsFromProfessionSpy.mockReturnValue([
+        tierOneOrganisation,
+      ]);
+
+      expect(belongsToTierOneOrganisation(profession, user)).toBeTruthy();
+    });
+  });
+});

--- a/src/users/helpers/belongs-to-tier-one-organisation.ts
+++ b/src/users/helpers/belongs-to-tier-one-organisation.ts
@@ -1,0 +1,12 @@
+import { getTierOneOrganisationsFromProfession } from '../../professions/helpers/get-tier-one-organisations-from-profession.helper';
+import { Profession } from '../../professions/profession.entity';
+import { User } from '../../users/user.entity';
+
+export function belongsToTierOneOrganisation(
+  profession: Profession,
+  actingUser: User,
+) {
+  return getTierOneOrganisationsFromProfession(profession).some(
+    (organisation) => organisation.id === actingUser.organisation.id,
+  );
+}

--- a/src/users/helpers/check-can-view-profession.ts
+++ b/src/users/helpers/check-can-view-profession.ts
@@ -1,7 +1,7 @@
 import { RequestWithAppSession } from '../../common/interfaces/request-with-app-session.interface';
 import { Profession } from '../../professions/profession.entity';
 import { getActingUser } from './get-acting-user.helper';
-import { getTierOneOrganisationsFromProfession } from '../../professions/helpers/get-tier-one-organisations-from-profession.helper';
+import { belongsToTierOneOrganisation } from './belongs-to-tier-one-organisation';
 import { UnauthorizedException } from '@nestjs/common';
 
 export function checkCanViewProfession(
@@ -14,11 +14,7 @@ export function checkCanViewProfession(
     return;
   }
 
-  const belongsToTierOneOrganisation = getTierOneOrganisationsFromProfession(
-    profession,
-  ).some((organisation) => organisation.id === actingUser.organisation.id);
-
-  if (!belongsToTierOneOrganisation) {
+  if (!belongsToTierOneOrganisation(profession, actingUser)) {
     throw new UnauthorizedException();
   }
 }


### PR DESCRIPTION
This hides the view details link for users who do not belong to an organisation’s tier one organisations, as clicking on the link will not allow them to view/edit the profession.

## Screenshots

### Before

![image](https://user-images.githubusercontent.com/109774/162906029-24bdcb31-6c5d-4653-95c5-3ddce844fd41.png)

### After

![image](https://user-images.githubusercontent.com/109774/162906081-06b6d69f-9e85-435b-85f1-7c7ddc04a6be.png)
