### PR TITLE
(2273) Hide actions for non tier 1 users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [unreleased]
+
+### Added
+
+- Hide edit and delete buttons for non Tier 1 users
+
 ## [release-016] - 2022-04-11
 
 ### Changed

--- a/src/common/global-locals.spec.ts
+++ b/src/common/global-locals.spec.ts
@@ -9,9 +9,13 @@ import { User } from '../users/user.entity';
 import { getPermissionsFromUser } from '../users/helpers/get-permissions-from-user.helper';
 import { UserPermission } from '../users/user-permission';
 import { getActingUser } from '../users/helpers/get-acting-user.helper';
+import { canChangeProfession } from '../users/helpers/can-change-profession';
+
+import professionFactory from '../testutils/factories/profession';
 
 jest.mock('../users/helpers/get-permissions-from-user.helper');
 jest.mock('../users/helpers/get-acting-user.helper');
+jest.mock('../users/helpers/can-change-profession');
 
 let request: DeepMocked<RequestWithAppSession>;
 let response: DeepMocked<Response>;
@@ -22,6 +26,7 @@ describe('globalLocals', () => {
     it('sets the expected variables', () => {
       createEnvironment();
       const user = createUserInEnvironment();
+      const profession = professionFactory.build();
 
       const permissions = [
         UserPermission.CreateOrganisation,
@@ -29,6 +34,7 @@ describe('globalLocals', () => {
       ];
 
       (getPermissionsFromUser as jest.Mock).mockReturnValue(permissions);
+      (canChangeProfession as jest.Mock).mockReturnValue(true);
 
       globalLocals(request, response, next);
 
@@ -36,8 +42,10 @@ describe('globalLocals', () => {
       expect(response.app.locals.user).toEqual(user);
       expect(response.app.locals.permissions).toEqual(permissions);
       expect(response.app.locals.currentUrl).toEqual('http://localhost/foo');
+      expect(response.app.locals.canChangeProfession(profession)).toEqual(true);
 
       expect(getPermissionsFromUser).toHaveBeenCalledWith(user);
+      expect(canChangeProfession).toHaveBeenCalledWith(user, profession);
     });
   });
 
@@ -51,8 +59,12 @@ describe('globalLocals', () => {
       expect(response.app.locals.user).toEqual(undefined);
       expect(response.app.locals.permissions).toEqual(undefined);
       expect(response.app.locals.currentUrl).toEqual('http://localhost/foo');
+      expect(
+        response.app.locals.canChangeProfession(professionFactory.build()),
+      ).toEqual(undefined);
 
       expect(getPermissionsFromUser).not.toHaveBeenCalled();
+      expect(canChangeProfession).not.toHaveBeenCalled();
     });
   });
 

--- a/src/common/global-locals.ts
+++ b/src/common/global-locals.ts
@@ -2,6 +2,8 @@ import { Response, NextFunction } from 'express';
 import { RequestWithAppSession } from './interfaces/request-with-app-session.interface';
 import { getPermissionsFromUser } from '../users/helpers/get-permissions-from-user.helper';
 import { getActingUser } from '../users/helpers/get-acting-user.helper';
+import { canChangeProfession } from '../users/helpers/can-change-profession';
+import { Profession } from '../professions/profession.entity';
 
 export function globalLocals(
   req: RequestWithAppSession,
@@ -16,6 +18,8 @@ export function globalLocals(
   res.app.locals.currentUrl = req.originalUrl;
   res.app.locals.infoMessages = req.flash('info');
   res.app.locals.successMessages = req.flash('success');
+  res.app.locals.canChangeProfession = (profession: Profession) =>
+    user && canChangeProfession(user, profession);
 
   next();
 }

--- a/src/decisions/admin/decision.controller.spec.ts
+++ b/src/decisions/admin/decision.controller.spec.ts
@@ -10,7 +10,7 @@ import organisationFactory from '../../testutils/factories/organisation';
 import professionFactory from '../../testutils/factories/profession';
 import userFactory from '../../testutils/factories/user';
 import * as checkCanViewOrganisationModule from '../../users/helpers/check-can-view-organisation';
-import * as checkCanViewProfessionModule from '../../users/helpers/check-can-view-profession';
+import * as checkCanChangeProfessionModule from '../../users/helpers/check-can-change-profession';
 import * as getActingUserModule from '../../users/helpers/get-acting-user.helper';
 import { DecisionDatasetsService } from '../decision-datasets.service';
 import { DecisionDatasetPresenter } from '../presenters/decision-dataset.presenter';
@@ -161,7 +161,7 @@ describe('DecisionsController', () => {
       const request = createDefaultMockRequest();
 
       const professionCheckSpy = jest
-        .spyOn(checkCanViewProfessionModule, 'checkCanViewProfession')
+        .spyOn(checkCanChangeProfessionModule, 'checkCanChangeProfession')
         .mockImplementation();
       const organisationCheckSpy = jest
         .spyOn(checkCanViewOrganisationModule, 'checkCanViewOrganisation')

--- a/src/decisions/admin/decisions.controller.ts
+++ b/src/decisions/admin/decisions.controller.ts
@@ -11,7 +11,7 @@ import { DecisionDatasetsService } from '../decision-datasets.service';
 import { IndexTemplate } from './interfaces/index-template.interface';
 import { ShowTemplate } from './interfaces/show-template.interface';
 import { ProfessionsService } from '../../professions/professions.service';
-import { checkCanViewProfession } from '../../users/helpers/check-can-view-profession';
+import { checkCanChangeProfession } from '../../users/helpers/check-can-change-profession';
 import { checkCanViewOrganisation } from '../../users/helpers/check-can-view-organisation';
 import { DecisionDatasetsPresenter } from './presenters/decision-datasets.presenter';
 import { DecisionDatasetPresenter } from '../presenters/decision-dataset.presenter';
@@ -55,7 +55,7 @@ export class DecisionsController {
       professionId,
     );
 
-    checkCanViewProfession(request, profession);
+    checkCanChangeProfession(request, profession);
 
     const dataset = await this.decisionDatasetsService.find(
       professionId,

--- a/src/professions/admin/check-your-answers.controller.spec.ts
+++ b/src/professions/admin/check-your-answers.controller.spec.ts
@@ -14,7 +14,7 @@ import professionVersionFactory from '../../testutils/factories/profession-versi
 import qualificationFactory from '../../testutils/factories/qualification';
 import userFactory from '../../testutils/factories/user';
 import { translationOf } from '../../testutils/translation-of';
-import { checkCanViewProfession } from '../../users/helpers/check-can-view-profession';
+import { checkCanChangeProfession } from '../../users/helpers/check-can-change-profession';
 import * as getPublicationBlockersModule from '../helpers/get-publication-blockers.helper';
 import { RegulationType } from '../profession-version.entity';
 import { ProfessionVersionsService } from '../profession-versions.service';
@@ -23,7 +23,7 @@ import { CheckYourAnswersController } from './check-your-answers.controller';
 import { ProfessionToOrganisation } from '../profession-to-organisation.entity';
 import { ProfessionToOrganisationsPresenter } from './presenters/profession-to-organisations.presenter';
 
-jest.mock('../../users/helpers/check-can-view-profession');
+jest.mock('../../users/helpers/check-can-change-profession');
 jest.mock('../../nations/presenters/nations-list.presenter');
 
 const mockNationsHtml = '<ul><li>Mock nations html</li></ul>';
@@ -296,7 +296,7 @@ describe('CheckYourAnswersController', () => {
 
       await controller.show('profession-id', 'version-id', 'false', request);
 
-      expect(checkCanViewProfession).toHaveBeenCalledWith(
+      expect(checkCanChangeProfession).toHaveBeenCalledWith(
         request,
         Profession.withVersion(profession, version),
       );

--- a/src/professions/admin/check-your-answers.controller.ts
+++ b/src/professions/admin/check-your-answers.controller.ts
@@ -23,7 +23,7 @@ import { BackLink } from '../../common/decorators/back-link.decorator';
 import { ProfessionVersionsService } from '../profession-versions.service';
 import { isUK } from '../../helpers/nations.helper';
 import { RequestWithAppSession } from '../../common/interfaces/request-with-app-session.interface';
-import { checkCanViewProfession } from '../../users/helpers/check-can-view-profession';
+import { checkCanChangeProfession } from '../../users/helpers/check-can-change-profession';
 import { getPublicationBlockers } from '../helpers/get-publication-blockers.helper';
 import { Profession } from '../profession.entity';
 import { NationsListPresenter } from '../../nations/presenters/nations-list.presenter';
@@ -58,7 +58,7 @@ export class CheckYourAnswersController {
       throw new Error('Version not found');
     }
 
-    checkCanViewProfession(request, profession);
+    checkCanChangeProfession(request, profession);
 
     const industryNames = version.industries.map((industry) =>
       this.i18nService.translate<string>(industry.name),

--- a/src/professions/admin/confirmation.controller.spec.ts
+++ b/src/professions/admin/confirmation.controller.spec.ts
@@ -10,14 +10,14 @@ import professionFactory from '../../testutils/factories/profession';
 import professionVersionFactory from '../../testutils/factories/profession-version';
 import userFactory from '../../testutils/factories/user';
 import { translationOf } from '../../testutils/translation-of';
-import { checkCanViewProfession } from '../../users/helpers/check-can-view-profession';
+import { checkCanChangeProfession } from '../../users/helpers/check-can-change-profession';
 import { ProfessionVersionsService } from '../profession-versions.service';
 import { ProfessionsService } from '../professions.service';
 import { ConfirmationController } from './confirmation.controller';
 
 jest.mock('../../common/flash-message');
 jest.mock('../../helpers/escape.helper');
-jest.mock('../../users/helpers/check-can-view-profession');
+jest.mock('../../users/helpers/check-can-change-profession');
 
 describe('ConfirmationController', () => {
   let controller: ConfirmationController;
@@ -145,7 +145,7 @@ describe('ConfirmationController', () => {
 
       await controller.create(res, req, 'profession-id', 'version-id');
 
-      expect(checkCanViewProfession).toHaveBeenCalledWith(req, profession);
+      expect(checkCanChangeProfession).toHaveBeenCalledWith(req, profession);
     });
   });
 

--- a/src/professions/admin/confirmation.controller.ts
+++ b/src/professions/admin/confirmation.controller.ts
@@ -9,7 +9,7 @@ import { I18nService } from 'nestjs-i18n';
 import { flashMessage } from '../../common/flash-message';
 import { escape } from '../../helpers/escape.helper';
 import { RequestWithAppSession } from '../../common/interfaces/request-with-app-session.interface';
-import { checkCanViewProfession } from '../../users/helpers/check-can-view-profession';
+import { checkCanChangeProfession } from '../../users/helpers/check-can-change-profession';
 @UseGuards(AuthenticationGuard)
 @Controller('admin/professions')
 export class ConfirmationController {
@@ -31,7 +31,7 @@ export class ConfirmationController {
       professionId,
     );
 
-    checkCanViewProfession(req, profession);
+    checkCanChangeProfession(req, profession);
 
     const version = await this.professionVersionsService.findWithProfession(
       versionId,

--- a/src/professions/admin/legislation.controller.spec.ts
+++ b/src/professions/admin/legislation.controller.spec.ts
@@ -9,13 +9,13 @@ import professionFactory from '../../testutils/factories/profession';
 import professionVersionFactory from '../../testutils/factories/profession-version';
 import userFactory from '../../testutils/factories/user';
 import { translationOf } from '../../testutils/translation-of';
-import { checkCanViewProfession } from '../../users/helpers/check-can-view-profession';
+import { checkCanChangeProfession } from '../../users/helpers/check-can-change-profession';
 import { ProfessionVersionsService } from '../profession-versions.service';
 import { ProfessionsService } from '../professions.service';
 import LegislationDto from './dto/legislation.dto';
 import { LegislationController } from './legislation.controller';
 
-jest.mock('../../users/helpers/check-can-view-profession');
+jest.mock('../../users/helpers/check-can-change-profession');
 
 describe(LegislationController, () => {
   let controller: LegislationController;
@@ -93,7 +93,7 @@ describe(LegislationController, () => {
 
         await controller.edit(response, 'profession-id', 'version-id', request);
 
-        expect(checkCanViewProfession).toHaveBeenCalledWith(
+        expect(checkCanChangeProfession).toHaveBeenCalledWith(
           request,
           profession,
         );
@@ -409,7 +409,10 @@ describe(LegislationController, () => {
         request,
       );
 
-      expect(checkCanViewProfession).toHaveBeenCalledWith(request, profession);
+      expect(checkCanChangeProfession).toHaveBeenCalledWith(
+        request,
+        profession,
+      );
     });
   });
 

--- a/src/professions/admin/legislation.controller.ts
+++ b/src/professions/admin/legislation.controller.ts
@@ -24,7 +24,7 @@ import { ProfessionVersionsService } from '../profession-versions.service';
 import { I18nService } from 'nestjs-i18n';
 import { Profession } from '../profession.entity';
 import { RequestWithAppSession } from '../../common/interfaces/request-with-app-session.interface';
-import { checkCanViewProfession } from '../../users/helpers/check-can-view-profession';
+import { checkCanChangeProfession } from '../../users/helpers/check-can-change-profession';
 
 @UseGuards(AuthenticationGuard)
 @Controller('admin/professions')
@@ -50,7 +50,7 @@ export class LegislationController {
       professionId,
     );
 
-    checkCanViewProfession(request, profession);
+    checkCanChangeProfession(request, profession);
 
     const version = await this.professionVersionsService.findWithProfession(
       versionId,
@@ -80,7 +80,7 @@ export class LegislationController {
       professionId,
     );
 
-    checkCanViewProfession(request, profession);
+    checkCanChangeProfession(request, profession);
 
     const validator = await Validator.validate(LegislationDto, legislationDto);
     const submittedValues = validator.obj;

--- a/src/professions/admin/organisations.controller.spec.ts
+++ b/src/professions/admin/organisations.controller.spec.ts
@@ -14,13 +14,13 @@ import { translationOf } from '../../testutils/translation-of';
 import { OrganisationVersionsService } from '../../organisations/organisation-versions.service';
 import { createDefaultMockRequest } from '../../testutils/factories/create-default-mock-request';
 import userFactory from '../../testutils/factories/user';
-import { checkCanViewProfession } from '../../users/helpers/check-can-view-profession';
+import { checkCanChangeProfession } from '../../users/helpers/check-can-change-profession';
 import {
   ProfessionToOrganisation,
   OrganisationRole,
 } from '../profession-to-organisation.entity';
 
-jest.mock('../../users/helpers/check-can-view-profession');
+jest.mock('../../users/helpers/check-can-change-profession');
 jest.mock('./presenters/regulated-authorities-select-presenter');
 
 describe('OrganisationsController', () => {
@@ -194,7 +194,7 @@ describe('OrganisationsController', () => {
 
         await controller.edit(response, 'profession-id', 'false', request);
 
-        expect(checkCanViewProfession).toHaveBeenCalledWith(
+        expect(checkCanChangeProfession).toHaveBeenCalledWith(
           request,
           profession,
         );
@@ -443,7 +443,10 @@ describe('OrganisationsController', () => {
         request,
       );
 
-      expect(checkCanViewProfession).toHaveBeenCalledWith(request, profession);
+      expect(checkCanChangeProfession).toHaveBeenCalledWith(
+        request,
+        profession,
+      );
     });
   });
 

--- a/src/professions/admin/organisations.controller.ts
+++ b/src/professions/admin/organisations.controller.ts
@@ -30,7 +30,7 @@ import { OrganisationsService } from '../../organisations/organisations.service'
 import { RegulatedAuthoritiesSelectPresenter } from './presenters/regulated-authorities-select-presenter';
 import { I18nService } from 'nestjs-i18n';
 import { OrganisationVersionsService } from '../../organisations/organisation-versions.service';
-import { checkCanViewProfession } from '../../users/helpers/check-can-view-profession';
+import { checkCanChangeProfession } from '../../users/helpers/check-can-change-profession';
 import { RequestWithAppSession } from '../../common/interfaces/request-with-app-session.interface';
 import {
   ProfessionToOrganisation,
@@ -64,7 +64,7 @@ export class OrganisationsController {
       professionId,
     );
 
-    checkCanViewProfession(req, profession);
+    checkCanChangeProfession(req, profession);
 
     const professionToOrganisations = sortOrganisationsByRole(profession);
 
@@ -95,7 +95,7 @@ export class OrganisationsController {
       professionId,
     );
 
-    checkCanViewProfession(req, profession);
+    checkCanChangeProfession(req, profession);
 
     const validator = await Validator.validate(
       OrganisationsDto,

--- a/src/professions/admin/profession-archive.controller.spec.ts
+++ b/src/professions/admin/profession-archive.controller.spec.ts
@@ -10,7 +10,7 @@ import professionFactory from '../../testutils/factories/profession';
 import professionVersionFactory from '../../testutils/factories/profession-version';
 import userFactory from '../../testutils/factories/user';
 import { translationOf } from '../../testutils/translation-of';
-import { checkCanViewProfession } from '../../users/helpers/check-can-view-profession';
+import { checkCanChangeProfession } from '../../users/helpers/check-can-change-profession';
 import { getActingUser } from '../../users/helpers/get-acting-user.helper';
 import { ProfessionVersionsService } from '../profession-versions.service';
 import { Profession } from '../profession.entity';
@@ -19,7 +19,7 @@ import { ProfessionArchiveController } from './profession-archive.controller';
 jest.mock('../../common/flash-message');
 jest.mock('../../users/helpers/get-acting-user.helper');
 jest.mock('../../helpers/escape.helper');
-jest.mock('../../users/helpers/check-can-view-profession');
+jest.mock('../../users/helpers/check-can-change-profession');
 
 describe('ProfessionArchiveController', () => {
   let controller: ProfessionArchiveController;
@@ -91,7 +91,7 @@ describe('ProfessionArchiveController', () => {
 
       await controller.new(profession.id, version.id, request);
 
-      expect(checkCanViewProfession).toHaveBeenCalledWith(
+      expect(checkCanChangeProfession).toHaveBeenCalledWith(
         request,
         Profession.withVersion(profession, version),
       );
@@ -174,7 +174,10 @@ describe('ProfessionArchiveController', () => {
 
       await controller.delete(request, res, profession.id, version.id);
 
-      expect(checkCanViewProfession).toHaveBeenCalledWith(request, profession);
+      expect(checkCanChangeProfession).toHaveBeenCalledWith(
+        request,
+        profession,
+      );
     });
   });
 });

--- a/src/professions/admin/profession-archive.controller.ts
+++ b/src/professions/admin/profession-archive.controller.ts
@@ -14,7 +14,7 @@ import { flashMessage } from '../../common/flash-message';
 import { RequestWithAppSession } from '../../common/interfaces/request-with-app-session.interface';
 import { Permissions } from '../../common/permissions.decorator';
 import { escape } from '../../helpers/escape.helper';
-import { checkCanViewProfession } from '../../users/helpers/check-can-view-profession';
+import { checkCanChangeProfession } from '../../users/helpers/check-can-change-profession';
 import { getActingUser } from '../../users/helpers/get-acting-user.helper';
 import { UserPermission } from '../../users/user-permission';
 import { ProfessionVersionsService } from '../profession-versions.service';
@@ -43,7 +43,7 @@ export class ProfessionArchiveController {
 
     const profession = Profession.withVersion(version.profession, version);
 
-    checkCanViewProfession(req, profession);
+    checkCanChangeProfession(req, profession);
 
     return { profession };
   }
@@ -61,7 +61,7 @@ export class ProfessionArchiveController {
       versionId,
     );
 
-    checkCanViewProfession(req, version.profession);
+    checkCanChangeProfession(req, version.profession);
 
     const versionToBeArchived = await this.professionVersionsService.create(
       version,

--- a/src/professions/admin/profession-publication.controller.spec.ts
+++ b/src/professions/admin/profession-publication.controller.spec.ts
@@ -11,7 +11,7 @@ import professionFactory from '../../testutils/factories/profession';
 import professionVersionFactory from '../../testutils/factories/profession-version';
 import userFactory from '../../testutils/factories/user';
 import { translationOf } from '../../testutils/translation-of';
-import { checkCanViewProfession } from '../../users/helpers/check-can-view-profession';
+import { checkCanChangeProfession } from '../../users/helpers/check-can-change-profession';
 import { getActingUser } from '../../users/helpers/get-acting-user.helper';
 import {
   getPublicationBlockers,
@@ -25,7 +25,7 @@ import { ProfessionPublicationController } from './profession-publication.contro
 jest.mock('../../common/flash-message');
 jest.mock('../../users/helpers/get-acting-user.helper');
 jest.mock('../../helpers/escape.helper');
-jest.mock('../../users/helpers/check-can-view-profession');
+jest.mock('../../users/helpers/check-can-change-profession');
 jest.mock('../helpers/get-publication-blockers.helper');
 
 describe('ProfessionPublicationController', () => {
@@ -104,7 +104,7 @@ describe('ProfessionPublicationController', () => {
 
       await controller.new(profession.id, version.id, request);
 
-      expect(checkCanViewProfession).toHaveBeenCalledWith(
+      expect(checkCanChangeProfession).toHaveBeenCalledWith(
         request,
         Profession.withVersion(profession, version),
       );
@@ -314,7 +314,7 @@ describe('ProfessionPublicationController', () => {
 
       await controller.create(req, res, profession.id, version.id);
 
-      expect(checkCanViewProfession).toHaveBeenCalledWith(req, profession);
+      expect(checkCanChangeProfession).toHaveBeenCalledWith(req, profession);
     });
   });
 

--- a/src/professions/admin/profession-publication.controller.ts
+++ b/src/professions/admin/profession-publication.controller.ts
@@ -16,7 +16,7 @@ import { RequestWithAppSession } from '../../common/interfaces/request-with-app-
 import { Permissions } from '../../common/permissions.decorator';
 import { escape } from '../../helpers/escape.helper';
 import { isConfirmed } from '../../helpers/is-confirmed';
-import { checkCanViewProfession } from '../../users/helpers/check-can-view-profession';
+import { checkCanChangeProfession } from '../../users/helpers/check-can-change-profession';
 import { getActingUser } from '../../users/helpers/get-acting-user.helper';
 import { UserPermission } from '../../users/user-permission';
 import { getPublicationBlockers } from '../helpers/get-publication-blockers.helper';
@@ -52,7 +52,7 @@ export class ProfessionPublicationController {
 
     const profession = Profession.withVersion(version.profession, version);
 
-    checkCanViewProfession(req, profession);
+    checkCanChangeProfession(req, profession);
 
     return { profession };
   }
@@ -72,7 +72,7 @@ export class ProfessionPublicationController {
 
     const profession = version.profession;
 
-    checkCanViewProfession(req, profession);
+    checkCanChangeProfession(req, profession);
 
     if (getPublicationBlockers(version).length) {
       throw new BadRequestException();

--- a/src/professions/admin/profession-versions.controller.spec.ts
+++ b/src/professions/admin/profession-versions.controller.spec.ts
@@ -24,7 +24,7 @@ import * as getOrganisationsFromProfessionByRoleModule from './../helpers/get-or
 import { GroupedTierOneOrganisations } from './../helpers/get-grouped-tier-one-organisations-from-profession.helper';
 import { createDefaultMockRequest } from '../../testutils/factories/create-default-mock-request';
 import organisationFactory from '../../testutils/factories/organisation';
-import { checkCanViewProfession } from '../../users/helpers/check-can-view-profession';
+import { checkCanChangeProfession } from '../../users/helpers/check-can-change-profession';
 import * as getPublicationBlockersModule from '../helpers/get-publication-blockers.helper';
 import { NationsListPresenter } from '../../nations/presenters/nations-list.presenter';
 import { Nation } from '../../nations/nation';
@@ -34,7 +34,7 @@ import { organisationList } from './../presenters/organisation-list';
 jest.mock('../../organisations/organisation.entity');
 jest.mock('../presenters/profession.presenter');
 jest.mock('../../users/helpers/get-acting-user.helper');
-jest.mock('../../users/helpers/check-can-view-profession');
+jest.mock('../../users/helpers/check-can-change-profession');
 jest.mock('../../nations/presenters/nations-list.presenter');
 
 const mockNationsHtml = '<ul><li>Mock nations html</li></ul>';
@@ -114,7 +114,7 @@ describe('ProfessionVersionsController', () => {
 
       await controller.create(res, req, 'some-uuid');
 
-      expect(checkCanViewProfession).toHaveBeenCalledWith(req, profession);
+      expect(checkCanChangeProfession).toHaveBeenCalledWith(req, profession);
     });
   });
 

--- a/src/professions/admin/profession-versions.controller.spec.ts
+++ b/src/professions/admin/profession-versions.controller.spec.ts
@@ -124,37 +124,9 @@ describe('ProfessionVersionsController', () => {
         undefined,
       );
 
-      const request = createDefaultMockRequest({ user: userFactory.build() });
-
       await expect(async () => {
-        await controller.show('profession-id', 'version-id', request);
+        await controller.show('profession-id', 'version-id');
       }).rejects.toThrowError(NotFoundException);
-    });
-
-    it('should check the user has permission to view the profession', async () => {
-      const profession = professionFactory.build();
-
-      const version = professionVersionFactory.build({
-        profession: profession,
-        occupationLocations: ['GB-ENG'],
-        industries: [industryFactory.build({ name: 'industries.example' })],
-      });
-
-      professionVersionsService.findByIdWithProfession.mockResolvedValue(
-        version,
-      );
-      professionVersionsService.hasLiveVersion.mockResolvedValue(true);
-
-      const request = createDefaultMockRequest({
-        user: userFactory.build(),
-      });
-
-      await controller.show('profession-id', 'version-id', request);
-
-      expect(checkCanViewProfession).toHaveBeenCalledWith(
-        request,
-        Profession.withVersion(profession, version),
-      );
     });
 
     describe('when the Profession is complete', () => {
@@ -218,15 +190,7 @@ describe('ProfessionVersionsController', () => {
           .spyOn(getPublicationBlockersModule, 'getPublicationBlockers')
           .mockReturnValue([]);
 
-        const request = createDefaultMockRequest({
-          user: userFactory.build(),
-        });
-
-        const result = await controller.show(
-          'profession-id',
-          'version-id',
-          request,
-        );
+        const result = await controller.show('profession-id', 'version-id');
 
         expect(result).toEqual({
           profession: professionWithVersion,
@@ -315,13 +279,7 @@ describe('ProfessionVersionsController', () => {
             },
           ]);
 
-        const request = createDefaultMockRequest({ user: userFactory.build() });
-
-        const result = await controller.show(
-          'profession-id',
-          'version-id',
-          request,
-        );
+        const result = await controller.show('profession-id', 'version-id');
 
         expect(result).toEqual({
           profession: professionWithVersion,
@@ -392,8 +350,6 @@ describe('ProfessionVersionsController', () => {
           NationsListPresenter.prototype.htmlList as jest.Mock
         ).mockResolvedValue(mockNationsHtml);
 
-        const request = createDefaultMockRequest({ user: userFactory.build() });
-
         const getPublicationBlockersSpy = jest
           .spyOn(getPublicationBlockersModule, 'getPublicationBlockers')
           .mockReturnValue([
@@ -407,11 +363,7 @@ describe('ProfessionVersionsController', () => {
             },
           ]);
 
-        const result = await controller.show(
-          'profession-id',
-          'version-id',
-          request,
-        );
+        const result = await controller.show('profession-id', 'version-id');
 
         expect(result).toEqual({
           profession: professionWithVersion,

--- a/src/professions/admin/profession-versions.controller.ts
+++ b/src/professions/admin/profession-versions.controller.ts
@@ -51,7 +51,6 @@ export class ProfessionVersionsController {
   async show(
     @Param('professionId') professionId: string,
     @Param('versionId') versionId: string,
-    @Req() req: RequestWithAppSession,
   ): Promise<ShowTemplate> {
     const version = await this.professionVersionsService.findByIdWithProfession(
       professionId,
@@ -65,9 +64,6 @@ export class ProfessionVersionsController {
     }
 
     const profession = Profession.withVersion(version.profession, version);
-
-    checkCanViewProfession(req, profession);
-
     const presenter = new ProfessionPresenter(profession, this.i18nService);
 
     const hasLiveVersion = await this.professionVersionsService.hasLiveVersion(

--- a/src/professions/admin/profession-versions.controller.ts
+++ b/src/professions/admin/profession-versions.controller.ts
@@ -24,7 +24,7 @@ import { ProfessionPresenter } from '../presenters/profession.presenter';
 import { getActingUser } from '../../users/helpers/get-acting-user.helper';
 import { ShowTemplate } from './interfaces/show-template.interface';
 import { isUK } from '../../helpers/nations.helper';
-import { checkCanViewProfession } from '../../users/helpers/check-can-view-profession';
+import { checkCanChangeProfession } from '../../users/helpers/check-can-change-profession';
 import { getPublicationBlockers } from '../helpers/get-publication-blockers.helper';
 import { NationsListPresenter } from '../../nations/presenters/nations-list.presenter';
 import { getGroupedTierOneOrganisationsFromProfession } from './../helpers/get-grouped-tier-one-organisations-from-profession.helper';
@@ -132,7 +132,7 @@ export class ProfessionVersionsController {
         professionId,
       );
 
-    checkCanViewProfession(req, latestVersion.profession);
+    checkCanChangeProfession(req, latestVersion.profession);
 
     const version = await this.professionVersionsService.create(
       latestVersion,

--- a/src/professions/admin/qualifications.controller.spec.ts
+++ b/src/professions/admin/qualifications.controller.spec.ts
@@ -15,11 +15,11 @@ import qualificationFactory from '../../testutils/factories/qualification';
 import { translationOf } from '../../testutils/translation-of';
 import userFactory from '../../testutils/factories/user';
 import { createDefaultMockRequest } from '../../testutils/factories/create-default-mock-request';
-import { checkCanViewProfession } from '../../users/helpers/check-can-view-profession';
+import { checkCanChangeProfession } from '../../users/helpers/check-can-change-profession';
 import { OtherCountriesRecognitionRoutes } from '../../qualifications/qualification.entity';
 
 jest.mock('../../helpers/nations.helper');
-jest.mock('../../users/helpers/check-can-view-profession');
+jest.mock('../../users/helpers/check-can-change-profession');
 
 describe(QualificationsController, () => {
   let controller: QualificationsController;
@@ -141,7 +141,10 @@ describe(QualificationsController, () => {
 
       await controller.edit(response, 'profession-id', 'version-id', request);
 
-      expect(checkCanViewProfession).toHaveBeenCalledWith(request, profession);
+      expect(checkCanChangeProfession).toHaveBeenCalledWith(
+        request,
+        profession,
+      );
     });
   });
 
@@ -354,7 +357,10 @@ describe(QualificationsController, () => {
         request,
       );
 
-      expect(checkCanViewProfession).toHaveBeenCalledWith(request, profession);
+      expect(checkCanChangeProfession).toHaveBeenCalledWith(
+        request,
+        profession,
+      );
     });
   });
 

--- a/src/professions/admin/qualifications.controller.ts
+++ b/src/professions/admin/qualifications.controller.ts
@@ -26,7 +26,7 @@ import { isUK } from '../../helpers/nations.helper';
 import { ProfessionVersion } from '../profession-version.entity';
 import { Profession } from '../profession.entity';
 import { RequestWithAppSession } from '../../common/interfaces/request-with-app-session.interface';
-import { checkCanViewProfession } from '../../users/helpers/check-can-view-profession';
+import { checkCanChangeProfession } from '../../users/helpers/check-can-change-profession';
 import { OtherCountriesRecognitionRoutesRadioButtonsPresenter } from './presenters/other-countries-recognition-routes-radio-buttons-presenter';
 
 @UseGuards(AuthenticationGuard)
@@ -53,7 +53,7 @@ export class QualificationsController {
       professionId,
     );
 
-    checkCanViewProfession(request, profession);
+    checkCanChangeProfession(request, profession);
 
     const version = await this.professionVersionsService.findWithProfession(
       versionId,
@@ -78,7 +78,7 @@ export class QualificationsController {
       professionId,
     );
 
-    checkCanViewProfession(request, profession);
+    checkCanChangeProfession(request, profession);
 
     const validator = await Validator.validate(
       QualificationsDto,

--- a/src/professions/admin/registration.controller.spec.ts
+++ b/src/professions/admin/registration.controller.spec.ts
@@ -16,9 +16,9 @@ import { ProfessionsService } from '../professions.service';
 
 import { translationOf } from '../../testutils/translation-of';
 import { createDefaultMockRequest } from '../../testutils/factories/create-default-mock-request';
-import { checkCanViewProfession } from '../../users/helpers/check-can-view-profession';
+import { checkCanChangeProfession } from '../../users/helpers/check-can-change-profession';
 
-jest.mock('../../users/helpers/check-can-view-profession');
+jest.mock('../../users/helpers/check-can-change-profession');
 
 describe(RegistrationController, () => {
   let controller: RegistrationController;
@@ -119,7 +119,10 @@ describe(RegistrationController, () => {
 
       await controller.edit(response, 'profession-id', 'version-id', request);
 
-      expect(checkCanViewProfession).toHaveBeenCalledWith(request, profession);
+      expect(checkCanChangeProfession).toHaveBeenCalledWith(
+        request,
+        profession,
+      );
     });
   });
 
@@ -267,7 +270,10 @@ describe(RegistrationController, () => {
         request,
       );
 
-      expect(checkCanViewProfession).toHaveBeenCalledWith(request, profession);
+      expect(checkCanChangeProfession).toHaveBeenCalledWith(
+        request,
+        profession,
+      );
     });
   });
 

--- a/src/professions/admin/registration.controller.ts
+++ b/src/professions/admin/registration.controller.ts
@@ -34,7 +34,7 @@ import { RegistrationTemplate } from './interfaces/registration.template';
 import ViewUtils from './viewUtils';
 import { Profession } from '../profession.entity';
 import { RequestWithAppSession } from '../../common/interfaces/request-with-app-session.interface';
-import { checkCanViewProfession } from '../../users/helpers/check-can-view-profession';
+import { checkCanChangeProfession } from '../../users/helpers/check-can-change-profession';
 
 @UseGuards(AuthenticationGuard)
 @Controller('admin/professions')
@@ -60,7 +60,7 @@ export class RegistrationController {
       professionId,
     );
 
-    checkCanViewProfession(req, profession);
+    checkCanChangeProfession(req, profession);
 
     const version = await this.professionVersionsService.findWithProfession(
       versionId,
@@ -84,7 +84,7 @@ export class RegistrationController {
     const profession = await this.professionsService.findWithVersions(
       professionId,
     );
-    checkCanViewProfession(req, profession);
+    checkCanChangeProfession(req, profession);
 
     const validator = await Validator.validate(
       RegistrationDto,

--- a/src/professions/admin/regulated-activities.controller.spec.ts
+++ b/src/professions/admin/regulated-activities.controller.spec.ts
@@ -16,9 +16,9 @@ import { RegulatedActivitiesController } from './regulated-activities.controller
 import { RegulationTypeRadioButtonsPresenter } from './presenters/regulation-type-radio-buttons.presenter';
 import userFactory from '../../testutils/factories/user';
 import { createDefaultMockRequest } from '../../testutils/factories/create-default-mock-request';
-import { checkCanViewProfession } from '../../users/helpers/check-can-view-profession';
+import { checkCanChangeProfession } from '../../users/helpers/check-can-change-profession';
 
-jest.mock('../../users/helpers/check-can-view-profession');
+jest.mock('../../users/helpers/check-can-change-profession');
 
 describe(RegulatedActivitiesController, () => {
   let controller: RegulatedActivitiesController;
@@ -115,7 +115,10 @@ describe(RegulatedActivitiesController, () => {
 
       await controller.edit(response, 'profession-id', 'version-id', request);
 
-      expect(checkCanViewProfession).toHaveBeenCalledWith(request, profession);
+      expect(checkCanChangeProfession).toHaveBeenCalledWith(
+        request,
+        profession,
+      );
     });
   });
 
@@ -311,7 +314,10 @@ describe(RegulatedActivitiesController, () => {
         request,
       );
 
-      expect(checkCanViewProfession).toHaveBeenCalledWith(request, profession);
+      expect(checkCanChangeProfession).toHaveBeenCalledWith(
+        request,
+        profession,
+      );
     });
   });
 

--- a/src/professions/admin/regulated-activities.controller.ts
+++ b/src/professions/admin/regulated-activities.controller.ts
@@ -29,7 +29,7 @@ import { Profession } from '../profession.entity';
 import { I18nService } from 'nestjs-i18n';
 import { RegulationTypeRadioButtonsPresenter } from './presenters/regulation-type-radio-buttons.presenter';
 import { RequestWithAppSession } from '../../common/interfaces/request-with-app-session.interface';
-import { checkCanViewProfession } from '../../users/helpers/check-can-view-profession';
+import { checkCanChangeProfession } from '../../users/helpers/check-can-change-profession';
 
 @UseGuards(AuthenticationGuard)
 @Controller('admin/professions')
@@ -55,7 +55,7 @@ export class RegulatedActivitiesController {
       professionId,
     );
 
-    checkCanViewProfession(req, profession);
+    checkCanChangeProfession(req, profession);
 
     const version = await this.professionVersionsService.findWithProfession(
       versionId,
@@ -88,7 +88,7 @@ export class RegulatedActivitiesController {
       professionId,
     );
 
-    checkCanViewProfession(req, profession);
+    checkCanChangeProfession(req, profession);
 
     const validator = await Validator.validate(
       RegulatedActivitiesDto,

--- a/src/professions/admin/scope.controller.spec.ts
+++ b/src/professions/admin/scope.controller.spec.ts
@@ -14,9 +14,9 @@ import { ProfessionVersionsService } from '../profession-versions.service';
 import professionVersionFactory from '../../testutils/factories/profession-version';
 import { createDefaultMockRequest } from '../../testutils/factories/create-default-mock-request';
 import userFactory from '../../testutils/factories/user';
-import { checkCanViewProfession } from '../../users/helpers/check-can-view-profession';
+import { checkCanChangeProfession } from '../../users/helpers/check-can-change-profession';
 
-jest.mock('../../users/helpers/check-can-view-profession');
+jest.mock('../../users/helpers/check-can-change-profession');
 
 describe('ScopeController', () => {
   let controller: ScopeController;
@@ -268,7 +268,10 @@ describe('ScopeController', () => {
 
       await controller.edit(response, 'profession-id', 'version-id', request);
 
-      expect(checkCanViewProfession).toHaveBeenCalledWith(request, profession);
+      expect(checkCanChangeProfession).toHaveBeenCalledWith(
+        request,
+        profession,
+      );
     });
   });
 
@@ -428,7 +431,10 @@ describe('ScopeController', () => {
         request,
       );
 
-      expect(checkCanViewProfession).toHaveBeenCalledWith(request, profession);
+      expect(checkCanChangeProfession).toHaveBeenCalledWith(
+        request,
+        profession,
+      );
     });
   });
 

--- a/src/professions/admin/scope.controller.ts
+++ b/src/professions/admin/scope.controller.ts
@@ -30,7 +30,7 @@ import { ProfessionVersion } from '../profession-version.entity';
 import { allNations, isUK } from '../../helpers/nations.helper';
 import { ScopeDto } from './dto/scope.dto';
 import { Profession } from '../profession.entity';
-import { checkCanViewProfession } from '../../users/helpers/check-can-view-profession';
+import { checkCanChangeProfession } from '../../users/helpers/check-can-change-profession';
 import { RequestWithAppSession } from '../../common/interfaces/request-with-app-session.interface';
 
 @UseGuards(AuthenticationGuard)
@@ -59,7 +59,7 @@ export class ScopeController {
       professionId,
     );
 
-    checkCanViewProfession(req, profession);
+    checkCanChangeProfession(req, profession);
 
     const version = await this.professionVersionsService.findWithProfession(
       versionId,
@@ -100,7 +100,7 @@ export class ScopeController {
       professionId,
     );
 
-    checkCanViewProfession(req, profession);
+    checkCanChangeProfession(req, profession);
 
     const version = await this.professionVersionsService.findWithProfession(
       versionId,

--- a/src/professions/admin/top-level-information.controller.spec.ts
+++ b/src/professions/admin/top-level-information.controller.spec.ts
@@ -11,9 +11,9 @@ import { translationOf } from '../../testutils/translation-of';
 import { OrganisationVersionsService } from '../../organisations/organisation-versions.service';
 import { createDefaultMockRequest } from '../../testutils/factories/create-default-mock-request';
 import userFactory from '../../testutils/factories/user';
-import { checkCanViewProfession } from '../../users/helpers/check-can-view-profession';
+import { checkCanChangeProfession } from '../../users/helpers/check-can-change-profession';
 
-jest.mock('../../users/helpers/check-can-view-profession');
+jest.mock('../../users/helpers/check-can-change-profession');
 
 describe('TopLevelInformationController', () => {
   let controller: TopLevelInformationController;
@@ -108,7 +108,7 @@ describe('TopLevelInformationController', () => {
 
         await controller.edit(response, 'profession-id', 'false', request);
 
-        expect(checkCanViewProfession).toHaveBeenCalledWith(
+        expect(checkCanChangeProfession).toHaveBeenCalledWith(
           request,
           profession,
         );
@@ -208,7 +208,10 @@ describe('TopLevelInformationController', () => {
         request,
       );
 
-      expect(checkCanViewProfession).toHaveBeenCalledWith(request, profession);
+      expect(checkCanChangeProfession).toHaveBeenCalledWith(
+        request,
+        profession,
+      );
     });
   });
 

--- a/src/professions/admin/top-level-information.controller.ts
+++ b/src/professions/admin/top-level-information.controller.ts
@@ -25,7 +25,7 @@ import ViewUtils from './viewUtils';
 import { OrganisationsService } from '../../organisations/organisations.service';
 import { I18nService } from 'nestjs-i18n';
 import { OrganisationVersionsService } from '../../organisations/organisation-versions.service';
-import { checkCanViewProfession } from '../../users/helpers/check-can-view-profession';
+import { checkCanChangeProfession } from '../../users/helpers/check-can-change-profession';
 import { RequestWithAppSession } from '../../common/interfaces/request-with-app-session.interface';
 @UseGuards(AuthenticationGuard)
 @Controller('admin/professions')
@@ -55,7 +55,7 @@ export class TopLevelInformationController {
       professionId,
     );
 
-    checkCanViewProfession(req, profession);
+    checkCanChangeProfession(req, profession);
 
     return this.renderForm(
       res,
@@ -84,7 +84,7 @@ export class TopLevelInformationController {
       professionId,
     );
 
-    checkCanViewProfession(req, profession);
+    checkCanChangeProfession(req, profession);
 
     const validator = await Validator.validate(
       TopLevelDetailsDto,

--- a/src/users/helpers/can-change-profession.spec.ts
+++ b/src/users/helpers/can-change-profession.spec.ts
@@ -1,0 +1,133 @@
+import professionFactory from '../../testutils/factories/profession';
+import { canChangeProfession } from './can-change-profession';
+import userFactory from '../../testutils/factories/user';
+import * as getActingUserModule from './get-acting-user.helper';
+import * as getTierOneOrganisationsFromProfessionModule from '../../professions/helpers/get-tier-one-organisations-from-profession.helper';
+import organisationFactory from '../../testutils/factories/organisation';
+
+describe('canChangeProfession', () => {
+  describe('when called as a service owner user', () => {
+    it('returns true', () => {
+      const getActingUserSpy = jest.spyOn(getActingUserModule, 'getActingUser');
+      const getTierOneOrganisationsFromProfessionSpy = jest.spyOn(
+        getTierOneOrganisationsFromProfessionModule,
+        'getTierOneOrganisationsFromProfession',
+      );
+
+      const user = userFactory.build({ serviceOwner: true });
+      const profession = professionFactory.build();
+
+      getActingUserSpy.mockReturnValue(user);
+
+      expect(canChangeProfession(user, profession)).toBeTruthy();
+
+      expect(getTierOneOrganisationsFromProfessionSpy).not.toBeCalled();
+    });
+  });
+
+  describe('when called as a non-service owner user', () => {
+    describe('the profession has no tier-one organisations', () => {
+      it('returns false', () => {
+        const getTierOneOrganisationsFromProfessionSpy = jest.spyOn(
+          getTierOneOrganisationsFromProfessionModule,
+          'getTierOneOrganisationsFromProfession',
+        );
+
+        const user = userFactory.build({
+          serviceOwner: false,
+          organisation: organisationFactory.build(),
+        });
+        const profession = professionFactory.build();
+
+        getTierOneOrganisationsFromProfessionSpy.mockReturnValue([]);
+
+        expect(canChangeProfession(user, profession)).toBeFalsy();
+
+        expect(getTierOneOrganisationsFromProfessionSpy).toBeCalledWith(
+          profession,
+        );
+      });
+    });
+
+    describe("the profession has one tier-one organisation, which matches the user's", () => {
+      it('returns true', () => {
+        const getTierOneOrganisationsFromProfessionSpy = jest.spyOn(
+          getTierOneOrganisationsFromProfessionModule,
+          'getTierOneOrganisationsFromProfession',
+        );
+
+        const user = userFactory.build({
+          serviceOwner: false,
+          organisation: organisationFactory.build(),
+        });
+        const profession = professionFactory.build();
+
+        getTierOneOrganisationsFromProfessionSpy.mockReturnValue([
+          user.organisation,
+        ]);
+
+        expect(canChangeProfession(user, profession)).toBeTruthy();
+
+        expect(getTierOneOrganisationsFromProfessionSpy).toBeCalledWith(
+          profession,
+        );
+      });
+    });
+
+    describe("the profession has one tier-one organisation, which does not match the user's", () => {
+      it('returns false', () => {
+        const getTierOneOrganisationsFromProfessionSpy = jest.spyOn(
+          getTierOneOrganisationsFromProfessionModule,
+          'getTierOneOrganisationsFromProfession',
+        );
+
+        const user = userFactory.build({
+          serviceOwner: false,
+          organisation: organisationFactory.build(),
+        });
+        const profession = professionFactory.build();
+
+        getTierOneOrganisationsFromProfessionSpy.mockReturnValue([
+          organisationFactory.build(),
+        ]);
+
+        expect(canChangeProfession(user, profession)).toBeFalsy();
+
+        expect(getTierOneOrganisationsFromProfessionSpy).toBeCalledWith(
+          profession,
+        );
+      });
+    });
+
+    describe("the profession has one tier-one organisation, which matches the user's, and another tier-one organisation, which does not", () => {
+      it('returns true', () => {
+        const getTierOneOrganisationsFromProfessionSpy = jest.spyOn(
+          getTierOneOrganisationsFromProfessionModule,
+          'getTierOneOrganisationsFromProfession',
+        );
+
+        const user = userFactory.build({
+          serviceOwner: false,
+          organisation: organisationFactory.build(),
+        });
+
+        const profession = professionFactory.build();
+
+        getTierOneOrganisationsFromProfessionSpy.mockReturnValue([
+          user.organisation,
+          organisationFactory.build(),
+        ]);
+
+        expect(canChangeProfession(user, profession)).toBeTruthy();
+
+        expect(getTierOneOrganisationsFromProfessionSpy).toBeCalledWith(
+          profession,
+        );
+      });
+    });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+});

--- a/src/users/helpers/can-change-profession.ts
+++ b/src/users/helpers/can-change-profession.ts
@@ -1,0 +1,16 @@
+import { Profession } from '../../professions/profession.entity';
+import { getTierOneOrganisationsFromProfession } from '../../professions/helpers/get-tier-one-organisations-from-profession.helper';
+import { User } from '../../users/user.entity';
+
+export function canChangeProfession(
+  actingUser: User,
+  profession: Profession,
+): boolean {
+  if (actingUser.serviceOwner) {
+    return true;
+  }
+
+  return getTierOneOrganisationsFromProfession(profession).some(
+    (organisation) => organisation.id === actingUser.organisation.id,
+  );
+}

--- a/src/users/helpers/check-can-change-profession.spec.ts
+++ b/src/users/helpers/check-can-change-profession.spec.ts
@@ -1,13 +1,13 @@
 import { createDefaultMockRequest } from '../../testutils/factories/create-default-mock-request';
 import professionFactory from '../../testutils/factories/profession';
-import { checkCanViewProfession } from './check-can-view-profession';
+import { checkCanChangeProfession } from './check-can-change-profession';
 import userFactory from '../../testutils/factories/user';
 import * as getActingUserModule from './get-acting-user.helper';
 import * as getTierOneOrganisationsFromProfessionModule from '../../professions/helpers/get-tier-one-organisations-from-profession.helper';
 import organisationFactory from '../../testutils/factories/organisation';
 import { UnauthorizedException } from '@nestjs/common';
 
-describe('checkCanViewProfession', () => {
+describe('checkCanChangeProfession', () => {
   describe('when called as a service owner user', () => {
     it('returns without throwing an Error', () => {
       const getActingUserSpy = jest.spyOn(getActingUserModule, 'getActingUser');
@@ -24,7 +24,7 @@ describe('checkCanViewProfession', () => {
       const request = createDefaultMockRequest({ user });
 
       expect(() => {
-        checkCanViewProfession(request, profession);
+        checkCanChangeProfession(request, profession);
       }).not.toThrowError();
 
       expect(getActingUserSpy).toBeCalledWith(request);
@@ -56,7 +56,7 @@ describe('checkCanViewProfession', () => {
         const request = createDefaultMockRequest({ user });
 
         expect(() => {
-          checkCanViewProfession(request, profession);
+          checkCanChangeProfession(request, profession);
         }).toThrowError(UnauthorizedException);
 
         expect(getActingUserSpy).toBeCalledWith(request);
@@ -91,7 +91,7 @@ describe('checkCanViewProfession', () => {
         const request = createDefaultMockRequest({ user });
 
         expect(() => {
-          checkCanViewProfession(request, profession);
+          checkCanChangeProfession(request, profession);
         }).not.toThrowError();
 
         expect(getActingUserSpy).toBeCalledWith(request);

--- a/src/users/helpers/check-can-change-profession.ts
+++ b/src/users/helpers/check-can-change-profession.ts
@@ -4,7 +4,7 @@ import { getActingUser } from './get-acting-user.helper';
 import { getTierOneOrganisationsFromProfession } from '../../professions/helpers/get-tier-one-organisations-from-profession.helper';
 import { UnauthorizedException } from '@nestjs/common';
 
-export function checkCanViewProfession(
+export function checkCanChangeProfession(
   request: RequestWithAppSession,
   profession: Profession,
 ) {

--- a/src/users/helpers/check-can-change-profession.ts
+++ b/src/users/helpers/check-can-change-profession.ts
@@ -1,8 +1,8 @@
 import { RequestWithAppSession } from '../../common/interfaces/request-with-app-session.interface';
 import { Profession } from '../../professions/profession.entity';
 import { getActingUser } from './get-acting-user.helper';
-import { getTierOneOrganisationsFromProfession } from '../../professions/helpers/get-tier-one-organisations-from-profession.helper';
 import { UnauthorizedException } from '@nestjs/common';
+import { canChangeProfession } from './can-change-profession';
 
 export function checkCanChangeProfession(
   request: RequestWithAppSession,
@@ -10,15 +10,7 @@ export function checkCanChangeProfession(
 ) {
   const actingUser = getActingUser(request);
 
-  if (actingUser.serviceOwner) {
-    return;
-  }
-
-  const belongsToTierOneOrganisation = getTierOneOrganisationsFromProfession(
-    profession,
-  ).some((organisation) => organisation.id === actingUser.organisation.id);
-
-  if (!belongsToTierOneOrganisation) {
+  if (!canChangeProfession(actingUser, profession)) {
     throw new UnauthorizedException();
   }
 }

--- a/views/admin/professions/_actions.njk
+++ b/views/admin/professions/_actions.njk
@@ -1,0 +1,47 @@
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% if profession.status !== 'archived' and canChangeProfession(profession) %}
+  <nav role="navigation" data-cy="actions">
+    <ul class="govuk-list">
+      {% if 'editProfession' in permissions %}
+      <li>
+          <form method="post" action="/admin/professions/{{ profession.id }}/versions">
+            {{
+              govukButton({
+                id: "submit-button",
+                type: "Submit",
+                classes: "govuk-button--secondary",
+                id: "edit-button",
+                text: (('professions.admin.button.edit.' + profession.status) | t)
+              })
+            }}
+          </form>
+      </li>
+      {% endif %}
+      {% if profession.status === 'draft' and 'publishProfession' in permissions and canChangeProfession(profession) %}
+        <li>
+          {{
+            govukButton({
+              text: ('professions.form.button.publish' | t),
+              attributes: { "data-cy": "publish-button" },
+              href: "/admin/professions/" + profession.id + "/versions/" + profession.versionId + "/publish",
+              disabled: publicationBlockers.length
+            })
+          }}
+        </li>
+      {% endif %}
+      {% if 'deleteProfession' in permissions and canChangeProfession(profession) %}
+      <li>
+          {{
+            govukButton({
+              text: ("professions.admin.button.archive" | t),
+              href: "/admin/professions/" + profession.id + "/versions/" + profession.versionId + "/archive",
+              classes: "govuk-button--warning"
+            })
+          }}
+      </li>
+      {% endif %}
+    </ul>
+  </nav>
+  {% include '../../shared/_publication-blockers.njk' %}
+{% endif %}

--- a/views/admin/professions/_actions.njk.spec.ts
+++ b/views/admin/professions/_actions.njk.spec.ts
@@ -1,0 +1,82 @@
+import { JSDOM } from 'jsdom';
+import * as nunjucks from 'nunjucks';
+import { translationOf } from '../../../src/testutils/translation-of';
+import professionVersionFactory from '../../../src/testutils/factories/profession-version';
+import professionFactory from '../../../src/testutils/factories/profession';
+
+import { ProfessionVersionStatus } from '../../../src/professions/profession-version.entity';
+import { Profession } from '../../../src/professions/profession.entity';
+
+import { nunjucksEnvironment } from '../../testutils/nunjucksEnvironment';
+
+describe('_actions.njk', () => {
+  beforeAll(async () => {
+    await nunjucksEnvironment();
+  });
+
+  describe('when a user can change a profession', () => {
+    it('should show the edit, publish and delete buttons', () => {
+      const canChangeProfession = () => true;
+      const professionVersion = professionVersionFactory.build({
+        status: ProfessionVersionStatus.Draft,
+      });
+      const profession = Profession.withVersion(
+        professionFactory.build(),
+        professionVersion,
+      );
+      const permissions = [
+        'publishProfession',
+        'editProfession',
+        'deleteProfession',
+      ];
+
+      nunjucks.render(
+        'admin/professions/_actions.njk',
+        { canChangeProfession, profession, permissions },
+        function (_err, res) {
+          expect(res).toMatch(
+            translationOf('professions.admin.button.edit.draft'),
+          );
+          expect(res).toMatch(translationOf('professions.form.button.publish'));
+          expect(res).toMatch(
+            translationOf('professions.admin.button.archive'),
+          );
+        },
+      );
+    });
+  });
+
+  describe("when a user can't change a profession", () => {
+    it('should hide the edit, publish and delete buttons', () => {
+      const canChangeProfession = () => false;
+      const professionVersion = professionVersionFactory.build({
+        status: ProfessionVersionStatus.Draft,
+      });
+      const profession = Profession.withVersion(
+        professionFactory.build(),
+        professionVersion,
+      );
+      const permissions = [
+        'publishProfession',
+        'editProfession',
+        'deleteProfession',
+      ];
+
+      nunjucks.render(
+        'admin/professions/_actions.njk',
+        { canChangeProfession, profession, permissions },
+        function (_err, res) {
+          expect(res).not.toMatch(
+            translationOf('professions.admin.button.edit.draft'),
+          );
+          expect(res).not.toMatch(
+            translationOf('professions.form.button.publish'),
+          );
+          expect(res).not.toMatch(
+            translationOf('professions.admin.button.archive'),
+          );
+        },
+      );
+    });
+  });
+});

--- a/views/admin/professions/show.njk
+++ b/views/admin/professions/show.njk
@@ -1,8 +1,6 @@
 {% set bodyClasses = "rpr-internal__page rpr-details__page" %}
 {% extends "admin/base.njk" %}
 
-{% from "govuk/components/button/macro.njk" import govukButton %}
-
 {% set title = profession.name %}
 
 {% block content %}
@@ -39,51 +37,7 @@
           </h2>
         {% endif %}
 
-        {% if profession.status !== 'archived' %}
-          <nav role="navigation" data-cy="actions">
-            <ul class="govuk-list">
-              {% if 'editProfession' in permissions %}
-              <li>
-                  <form method="post" action="/admin/professions/{{ profession.id }}/versions">
-                    {{
-                      govukButton({
-                        id: "submit-button",
-                        type: "Submit",
-                        classes: "govuk-button--secondary",
-                        id: "edit-button",
-                        text: (('professions.admin.button.edit.' + profession.status) | t)
-                      })
-                    }}
-                  </form>
-              </li>
-              {% endif %}
-              {% if profession.status === 'draft' and 'publishProfession' in permissions %}
-                <li>
-                  {{
-                    govukButton({
-                      text: ('professions.form.button.publish' | t),
-                      attributes: { "data-cy": "publish-button" },
-                      href: "/admin/professions/" + profession.id + "/versions/" + profession.versionId + "/publish",
-                      disabled: publicationBlockers.length
-                    })
-                  }}
-                </li>
-              {% endif %}
-              {% if 'deleteProfession' in permissions %}
-              <li>
-                  {{
-                    govukButton({
-                      text: ("professions.admin.button.archive" | t),
-                      href: "/admin/professions/" + profession.id + "/versions/" + profession.versionId + "/archive",
-                      classes: "govuk-button--warning"
-                    })
-                  }}
-              </li>
-              {% endif %}
-            </ul>
-          </nav>
-          {% include '../../shared/_publication-blockers.njk' %}
-        {% endif %}
+        {% include './_actions.njk' %}
       </aside>
     </div>
   </div>


### PR DESCRIPTION
This allows users who belong to a regulator who is not a tier 1 regulator for a profession (i.e. an enforcement body or awarding body) to view a profession, but removes the buttons to delete/edit/publish a profession (which wouldn't work anyway).

### Screenshots

![image](https://user-images.githubusercontent.com/109774/162981423-d82993e1-6280-4bb7-afad-79243df111db.png)