### PR TITLE
Refactor `formatStatus` as it's no longer async

### DIFF
--- a/src/config/nunjucks.config.ts
+++ b/src/config/nunjucks.config.ts
@@ -96,12 +96,12 @@ export const nunjucksConfig = async (
 
   env.addFilter(
     'status',
-    async (...args) => {
+    (...args) => {
       const callback = args.pop();
       const status = args[0];
       try {
         const result = new nunjucks.runtime.SafeString(
-          await formatStatus(status, i18nHelper.i18nService),
+          formatStatus(status, i18nHelper.i18nService),
         );
         callback(null, result);
       } catch (error) {

--- a/src/decisions/admin/presenters/list-entry.presenter.spec.ts
+++ b/src/decisions/admin/presenters/list-entry.presenter.spec.ts
@@ -14,7 +14,7 @@ describe('ListEntryPresenter', () => {
     it('returns a table row for the given DecisionDataset', async () => {
       const formatStatusSpy = jest
         .spyOn(formatStatusModule, 'formatStatus')
-        .mockImplementation(async (status) => statusOf(status));
+        .mockImplementation((status) => statusOf(status));
       const formatDateSpy = jest
         .spyOn(formatDateModule, 'formatDate')
         .mockImplementation(dateOf);
@@ -32,7 +32,7 @@ describe('ListEntryPresenter', () => {
         { text: 'Example Profession' },
         { text: '2013' },
         { text: dateOf(new Date(2022, 6, 12)) },
-        { html: await statusOf(DecisionDatasetStatus.Draft) },
+        { html: statusOf(DecisionDatasetStatus.Draft) },
         {
           html: `<a class="govuk-link" href="/admin/decisions/${
             dataset.profession.id
@@ -42,7 +42,7 @@ describe('ListEntryPresenter', () => {
         },
       ];
 
-      const result = await presenter.tableRow();
+      const result = presenter.tableRow();
 
       expect(result).toEqual(expected);
       expect(formatStatusSpy).toBeCalledWith(

--- a/src/decisions/admin/presenters/list-entry.presenter.ts
+++ b/src/decisions/admin/presenters/list-entry.presenter.ts
@@ -32,7 +32,7 @@ export class ListEntryPresenter {
     private readonly i18nService: I18nService,
   ) {}
 
-  async tableRow(): Promise<TableRow> {
+  tableRow(): TableRow {
     const viewDetails = `<a class="govuk-link" href="/admin/decisions/${
       this.dataset.profession.id
     }/${this.dataset.organisation.id}/${
@@ -53,7 +53,7 @@ export class ListEntryPresenter {
       year: { text: this.dataset.year.toString() },
       lastModified: { text: formatDate(this.dataset.updated_at) },
       status: {
-        html: await formatStatus(this.dataset.status, this.i18nService),
+        html: formatStatus(this.dataset.status, this.i18nService),
       },
       actions: { html: viewDetails },
     };

--- a/src/helpers/format-status.helper.spec.ts
+++ b/src/helpers/format-status.helper.spec.ts
@@ -6,20 +6,20 @@ import { formatStatus } from './format-status.helper';
 
 describe('formatStatus', () => {
   describe('when given `null`', () => {
-    it('returns an empty string', async () => {
+    it('returns an empty string', () => {
       const i18nService = createMockI18nService();
 
-      const result = await formatStatus(null, i18nService);
+      const result = formatStatus(null, i18nService);
 
       expect(result).toEqual('');
     });
   });
 
   describe('when given an unrecognised status', () => {
-    it('returns an empty string', async () => {
+    it('returns an empty string', () => {
       const i18nService = createMockI18nService();
 
-      const result = await formatStatus(
+      const result = formatStatus(
         'not a status' as ProfessionVersionStatus,
         i18nService,
       );
@@ -29,10 +29,10 @@ describe('formatStatus', () => {
   });
 
   describe('when given a "unconfirmed" status', () => {
-    it('returns an empty string', async () => {
+    it('returns an empty string', () => {
       const i18nService = createMockI18nService();
 
-      const result = await formatStatus(
+      const result = formatStatus(
         OrganisationVersionStatus.Unconfirmed,
         i18nService,
       );
@@ -42,10 +42,10 @@ describe('formatStatus', () => {
   });
 
   describe('when given a "archived" status', () => {
-    it('returns a grey tag', async () => {
+    it('returns a grey tag', () => {
       const i18nService = createMockI18nService();
 
-      const result = await formatStatus(
+      const result = formatStatus(
         ProfessionVersionStatus.Archived,
         i18nService,
       );
@@ -59,13 +59,10 @@ describe('formatStatus', () => {
   });
 
   describe('when given a "draft" status', () => {
-    it('returns a yellow tag', async () => {
+    it('returns a yellow tag', () => {
       const i18nService = createMockI18nService();
 
-      const result = await formatStatus(
-        OrganisationVersionStatus.Draft,
-        i18nService,
-      );
+      const result = formatStatus(OrganisationVersionStatus.Draft, i18nService);
 
       expect(result).toEqual(
         `<strong class="govuk-tag govuk-tag--yellow">${translationOf(
@@ -76,13 +73,10 @@ describe('formatStatus', () => {
   });
 
   describe('when given a "live" status', () => {
-    it('returns a turquoise tag', async () => {
+    it('returns a turquoise tag', () => {
       const i18nService = createMockI18nService();
 
-      const result = await formatStatus(
-        ProfessionVersionStatus.Live,
-        i18nService,
-      );
+      const result = formatStatus(ProfessionVersionStatus.Live, i18nService);
 
       expect(result).toEqual(
         `<strong class="govuk-tag govuk-tag--turquoise">${translationOf(

--- a/src/helpers/format-status.helper.ts
+++ b/src/helpers/format-status.helper.ts
@@ -3,13 +3,13 @@ import { DecisionDatasetStatus } from '../decisions/decision-dataset.entity';
 import { OrganisationVersionStatus } from '../organisations/organisation-version.entity';
 import { ProfessionVersionStatus } from '../professions/profession-version.entity';
 
-export async function formatStatus(
+export function formatStatus(
   status:
     | ProfessionVersionStatus
     | OrganisationVersionStatus
     | DecisionDatasetStatus,
   i18nSerice: I18nService,
-): Promise<string> {
+): string {
   let colourClass: string;
 
   if (
@@ -31,7 +31,7 @@ export async function formatStatus(
     return '';
   }
 
-  const text = await i18nSerice.translate(`app.status.${status}`);
+  const text = i18nSerice.translate(`app.status.${status}`);
 
   return `<strong class="govuk-tag ${colourClass}">${text}</strong>`;
 }

--- a/src/organisations/presenters/organisation.presenter.ts
+++ b/src/organisations/presenters/organisation.presenter.ts
@@ -49,7 +49,7 @@ export class OrganisationPresenter {
         },
       },
       {
-        html: await formatStatus(this.organisation.status, this.i18nService),
+        html: formatStatus(this.organisation.status, this.i18nService),
       },
       {
         html: `<a class="govuk-link" href="/admin/organisations/${

--- a/src/professions/presenters/profession.presenter.spec.ts
+++ b/src/professions/presenters/profession.presenter.spec.ts
@@ -119,11 +119,11 @@ describe('ProfessionPresenter', () => {
 
       const presenter = new ProfessionPresenter(profession, i18nService);
 
-      (formatStatus as jest.Mock).mockImplementation(async (status) =>
+      (formatStatus as jest.Mock).mockImplementation((status) =>
         statusOf(status),
       );
 
-      const result = await presenter.status;
+      const result = presenter.status;
 
       expect(result).toEqual(statusOf(ProfessionVersionStatus.Draft));
       expect(formatStatus).toBeCalledWith(

--- a/src/professions/presenters/profession.presenter.ts
+++ b/src/professions/presenters/profession.presenter.ts
@@ -55,7 +55,7 @@ export class ProfessionPresenter {
     return formatDate(this.profession.lastModified);
   }
 
-  get status(): Promise<string> {
+  get status(): string {
     return formatStatus(this.profession.status, this.i18nService);
   }
 


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR

Removes the `Promise` return from `formatStatus` since the new version of `nestjs-i18n`now returns a string.

I've done this now, as I'm updating code that touches `formatStatus` when editing the decision data dashboards and this felt like a good thing to squeeze in now, so we don't have to do a big bang approach later on.
