### PR TITLE
(2307) Add Regulator column to decision data table for admin users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Hide edit and delete buttons for non Tier 1 users
 - Placeholder page for editing decision data
 - Placeholder page for adding decision data
+- Add Regulator column to decision data table for central admin users
 
 ## [release-016] - 2022-04-11
 

--- a/cypress/integration/admin/decisions/index.spec.ts
+++ b/cypress/integration/admin/decisions/index.spec.ts
@@ -14,7 +14,7 @@ describe('Listing decision datasets', () => {
       cy.visitAndCheckAccessibility('/admin/decisions');
     });
 
-    it('Lists all decision datasets', () => {
+    it('Lists all decision datasets with their organisation', () => {
       cy.readFile('./seeds/test/decision-datasets.json').then(
         (datasets: SeedDecisionDataset[]) => {
           const datasetsToShow = getDisplayedDatasets(datasets);
@@ -30,6 +30,7 @@ describe('Listing decision datasets', () => {
               .eq(index)
               .then(($row) => {
                 cy.wrap($row).should('contain', dataset.profession);
+                cy.wrap($row).should('contain', dataset.organisation);
                 cy.wrap($row).should('contain', dataset.year.toString());
 
                 cy.get('[data-cy=changed-by-text]').should('not.exist');
@@ -72,6 +73,7 @@ describe('Listing decision datasets', () => {
               .eq(index)
               .then(($row) => {
                 cy.wrap($row).should('contain', dataset.profession);
+                cy.wrap($row).should('not.contain', dataset.organisation);
                 cy.wrap($row).should('contain', dataset.year.toString());
 
                 cy.get('[data-cy=changed-by-text]').should('not.exist');

--- a/src/decisions/admin/decisions.controller.ts
+++ b/src/decisions/admin/decisions.controller.ts
@@ -22,7 +22,10 @@ import { ShowTemplate } from './interfaces/show-template.interface';
 import { ProfessionsService } from '../../professions/professions.service';
 import { checkCanChangeProfession } from '../../users/helpers/check-can-change-profession';
 import { checkCanViewOrganisation } from '../../users/helpers/check-can-view-organisation';
-import { DecisionDatasetsPresenter } from './presenters/decision-datasets.presenter';
+import {
+  DecisionDatasetsPresenter,
+  DecisionDatasetsPresenterView,
+} from './presenters/decision-datasets.presenter';
 import { DecisionDatasetPresenter } from '../presenters/decision-dataset.presenter';
 import { Response } from 'express';
 import { OrganisationsService } from '../../organisations/organisations.service';
@@ -350,6 +353,10 @@ export class DecisionsController {
 
     const userOrganisation = showAllOrgs ? null : actingUser.organisation;
 
+    const view: DecisionDatasetsPresenterView = showAllOrgs
+      ? 'overview'
+      : 'single-organisation';
+
     const allDecisionDatasets = await (showAllOrgs
       ? this.decisionDatasetsService.all()
       : this.decisionDatasetsService.allForOrganisation(userOrganisation));
@@ -358,7 +365,7 @@ export class DecisionsController {
       userOrganisation,
       allDecisionDatasets,
       this.i18nService,
-    ).present();
+    ).present(view);
   }
 
   private async renderNew(

--- a/src/decisions/admin/presenters/decision-datasets.presenter.spec.ts
+++ b/src/decisions/admin/presenters/decision-datasets.presenter.spec.ts
@@ -22,9 +22,9 @@ const mockTableHeadingRow: TableRow = [
 ];
 
 describe('DecisionDatasetsPresenter', () => {
-  describe('table', () => {
-    describe('when given a user organisation', () => {
-      it('returns a populated IndexTemplate', () => {
+  describe('present', () => {
+    describe('when called with `single-organisation`', () => {
+      it("returns a populated IndexTemplate with the user's organisation listed", async () => {
         const i18nService = createMockI18nService();
 
         const organisation = organisationFactory.build();
@@ -56,16 +56,16 @@ describe('DecisionDatasetsPresenter', () => {
           },
         };
 
-        const result = presenter.present();
+        const result = presenter.present('single-organisation');
 
         expect(result).toEqual(expected);
-        expect(ListEntryPresenter.headings).toBeCalled();
+        expect(ListEntryPresenter.headings).toBeCalledWith(false, i18nService);
         expect(ListEntryPresenter.prototype.tableRow).toBeCalledTimes(3);
       });
     });
 
-    describe('when given no user organisation', () => {
-      it('returns a populated IndexTemplate', () => {
+    describe('when called with `overview`', () => {
+      it('returns a populated IndexTemplate with the BEIS organisation listed', async () => {
         const i18nService = createMockI18nService();
 
         const datasets = decisionDatasetFactory.buildList(3);
@@ -96,10 +96,10 @@ describe('DecisionDatasetsPresenter', () => {
           },
         };
 
-        const result = presenter.present();
+        const result = presenter.present('overview');
 
         expect(result).toEqual(expected);
-        expect(ListEntryPresenter.headings).toBeCalled();
+        expect(ListEntryPresenter.headings).toBeCalledWith(true, i18nService);
         expect(ListEntryPresenter.prototype.tableRow).toBeCalledTimes(3);
       });
     });

--- a/src/decisions/admin/presenters/decision-datasets.presenter.spec.ts
+++ b/src/decisions/admin/presenters/decision-datasets.presenter.spec.ts
@@ -24,7 +24,7 @@ const mockTableHeadingRow: TableRow = [
 describe('DecisionDatasetsPresenter', () => {
   describe('table', () => {
     describe('when given a user organisation', () => {
-      it('returns a populated IndexTemplate', async () => {
+      it('returns a populated IndexTemplate', () => {
         const i18nService = createMockI18nService();
 
         const organisation = organisationFactory.build();
@@ -39,7 +39,7 @@ describe('DecisionDatasetsPresenter', () => {
         (ListEntryPresenter.headings as jest.Mock).mockReturnValue(
           mockTableHeadingRow,
         );
-        (ListEntryPresenter.prototype.tableRow as jest.Mock).mockResolvedValue(
+        (ListEntryPresenter.prototype.tableRow as jest.Mock).mockReturnValue(
           mockTableRow,
         );
 
@@ -56,7 +56,7 @@ describe('DecisionDatasetsPresenter', () => {
           },
         };
 
-        const result = await presenter.present();
+        const result = presenter.present();
 
         expect(result).toEqual(expected);
         expect(ListEntryPresenter.headings).toBeCalled();
@@ -65,7 +65,7 @@ describe('DecisionDatasetsPresenter', () => {
     });
 
     describe('when given no user organisation', () => {
-      it('returns a populated IndexTemplate', async () => {
+      it('returns a populated IndexTemplate', () => {
         const i18nService = createMockI18nService();
 
         const datasets = decisionDatasetFactory.buildList(3);
@@ -79,7 +79,7 @@ describe('DecisionDatasetsPresenter', () => {
         (ListEntryPresenter.headings as jest.Mock).mockReturnValue(
           mockTableHeadingRow,
         );
-        (ListEntryPresenter.prototype.tableRow as jest.Mock).mockResolvedValue(
+        (ListEntryPresenter.prototype.tableRow as jest.Mock).mockReturnValue(
           mockTableRow,
         );
 
@@ -96,7 +96,7 @@ describe('DecisionDatasetsPresenter', () => {
           },
         };
 
-        const result = await presenter.present();
+        const result = presenter.present();
 
         expect(result).toEqual(expected);
         expect(ListEntryPresenter.headings).toBeCalled();

--- a/src/decisions/admin/presenters/decision-datasets.presenter.ts
+++ b/src/decisions/admin/presenters/decision-datasets.presenter.ts
@@ -5,6 +5,8 @@ import { Organisation } from '../../../organisations/organisation.entity';
 import { Table } from '../../../common/interfaces/table';
 import { DecisionDataset } from '../../decision-dataset.entity';
 
+export type DecisionDatasetsPresenterView = 'overview' | 'single-organisation';
+
 export class DecisionDatasetsPresenter {
   constructor(
     private readonly userOrganisation: Organisation | null,
@@ -12,22 +14,23 @@ export class DecisionDatasetsPresenter {
     private readonly i18nService: I18nService,
   ) {}
 
-  present(): IndexTemplate {
-    const organisation = !this.userOrganisation
-      ? this.i18nService.translate('app.beis')
-      : this.userOrganisation.name;
+  present(view: DecisionDatasetsPresenterView): IndexTemplate {
+    const organisation =
+      view === 'overview'
+        ? this.i18nService.translate('app.beis')
+        : this.userOrganisation.name;
 
     return {
       organisation,
-      decisionDatasetsTable: this.table(),
+      decisionDatasetsTable: this.table(view),
     };
   }
 
-  private table(): Table {
-    const headings = ListEntryPresenter.headings(this.i18nService);
+  private table(view: DecisionDatasetsPresenterView): Table {
+    const headings = ListEntryPresenter.headings(this.i18nService, view);
 
     const rows = this.decisionDatasets.map((dataset) =>
-      new ListEntryPresenter(dataset, this.i18nService).tableRow(),
+      new ListEntryPresenter(dataset, this.i18nService).tableRow(view),
     );
 
     const numberOfResults = rows.length;

--- a/src/decisions/admin/presenters/decision-datasets.presenter.ts
+++ b/src/decisions/admin/presenters/decision-datasets.presenter.ts
@@ -12,24 +12,22 @@ export class DecisionDatasetsPresenter {
     private readonly i18nService: I18nService,
   ) {}
 
-  async present(): Promise<IndexTemplate> {
+  present(): IndexTemplate {
     const organisation = !this.userOrganisation
       ? this.i18nService.translate('app.beis')
       : this.userOrganisation.name;
 
     return {
       organisation,
-      decisionDatasetsTable: await this.table(),
+      decisionDatasetsTable: this.table(),
     };
   }
 
-  private async table(): Promise<Table> {
+  private table(): Table {
     const headings = ListEntryPresenter.headings(this.i18nService);
 
-    const rows = await Promise.all(
-      this.decisionDatasets.map(async (dataset) =>
-        new ListEntryPresenter(dataset, this.i18nService).tableRow(),
-      ),
+    const rows = this.decisionDatasets.map((dataset) =>
+      new ListEntryPresenter(dataset, this.i18nService).tableRow(),
     );
 
     const numberOfResults = rows.length;

--- a/src/decisions/admin/presenters/list-entry.presenter.spec.ts
+++ b/src/decisions/admin/presenters/list-entry.presenter.spec.ts
@@ -1,9 +1,10 @@
-import { TableRow } from '../../../common/interfaces/table-row';
 import * as formatDateModule from '../../../common/utils';
 import * as formatStatusModule from '../../../helpers/format-status.helper';
 import { createMockI18nService } from '../../../testutils/create-mock-i18n-service';
 import { dateOf } from '../../../testutils/date-of';
 import decisionDatasetFactory from '../../../testutils/factories/decision-dataset';
+import organisationFactory from '../../../testutils/factories/organisation';
+import professionFactory from '../../../testutils/factories/profession';
 import { statusOf } from '../../../testutils/status-of';
 import { translationOf } from '../../../testutils/translation-of';
 import { DecisionDatasetStatus } from '../../decision-dataset.entity';
@@ -11,73 +12,166 @@ import { ListEntryPresenter } from './list-entry.presenter';
 
 describe('ListEntryPresenter', () => {
   describe('tableRow', () => {
-    it('returns a table row for the given DecisionDataset', async () => {
-      const formatStatusSpy = jest
-        .spyOn(formatStatusModule, 'formatStatus')
-        .mockImplementation((status) => statusOf(status));
-      const formatDateSpy = jest
-        .spyOn(formatDateModule, 'formatDate')
-        .mockImplementation(dateOf);
+    describe('when called with `overview`', () => {
+      it('returns a table row for the given DecisionDataset with the overview columns', async () => {
+        const formatStatusSpy = jest
+          .spyOn(formatStatusModule, 'formatStatus')
+          .mockImplementation((status) => statusOf(status));
+        const formatDateSpy = jest
+          .spyOn(formatDateModule, 'formatDate')
+          .mockImplementation(dateOf);
 
-      const i18nService = createMockI18nService();
-      const dataset = decisionDatasetFactory.build({
-        year: 2013,
-        status: DecisionDatasetStatus.Draft,
-        updated_at: new Date(2022, 6, 12),
+        const i18nService = createMockI18nService();
+        const dataset = decisionDatasetFactory.build({
+          organisation: organisationFactory.build({
+            name: 'Example Organisation',
+          }),
+          profession: professionFactory.build({ name: 'Example Profession' }),
+          year: 2013,
+          status: DecisionDatasetStatus.Draft,
+          updated_at: new Date(2022, 6, 12),
+        });
+
+        const presenter = new ListEntryPresenter(dataset, i18nService);
+
+        expect(presenter.tableRow('overview')).toEqual([
+          { text: 'Example Profession' },
+          { text: 'Example Organisation' },
+          { text: '2013' },
+          { text: dateOf(new Date(2022, 6, 12)) },
+          { html: statusOf(DecisionDatasetStatus.Draft) },
+          {
+            html: `<a class="govuk-link" href="/admin/decisions/${
+              dataset.profession.id
+            }/${dataset.organisation.id}/2013">${translationOf(
+              'decisions.admin.dashboard.viewDetails',
+            )}</a>`,
+          },
+        ]);
+
+        expect(formatStatusSpy).toBeCalledWith(
+          DecisionDatasetStatus.Draft,
+          i18nService,
+        );
+        expect(formatDateSpy).toBeCalledWith(new Date(2022, 6, 12));
       });
+    });
 
-      const presenter = new ListEntryPresenter(dataset, i18nService);
+    describe('when called with `single-organisation`', () => {
+      it('returns a table row for the given DecisionDataset with the columns for a single organisation', async () => {
+        const formatStatusSpy = jest
+          .spyOn(formatStatusModule, 'formatStatus')
+          .mockImplementation((status) => statusOf(status));
+        const formatDateSpy = jest
+          .spyOn(formatDateModule, 'formatDate')
+          .mockImplementation(dateOf);
 
-      const expected: TableRow = [
-        { text: 'Example Profession' },
-        { text: '2013' },
-        { text: dateOf(new Date(2022, 6, 12)) },
-        { html: statusOf(DecisionDatasetStatus.Draft) },
-        {
-          html: `<a class="govuk-link" href="/admin/decisions/${
-            dataset.profession.id
-          }/${dataset.organisation.id}/2013">${translationOf(
-            'decisions.admin.dashboard.viewDetails',
-          )}</a>`,
-        },
-      ];
+        const i18nService = createMockI18nService();
+        const dataset = decisionDatasetFactory.build({
+          profession: professionFactory.build({ name: 'Example Profession' }),
+          year: 2013,
+          status: DecisionDatasetStatus.Draft,
+          updated_at: new Date(2022, 6, 12),
+        });
 
-      const result = presenter.tableRow();
+        const presenter = new ListEntryPresenter(dataset, i18nService);
 
-      expect(result).toEqual(expected);
-      expect(formatStatusSpy).toBeCalledWith(
-        DecisionDatasetStatus.Draft,
-        i18nService,
-      );
-      expect(formatDateSpy).toBeCalledWith(new Date(2022, 6, 12));
+        const result = presenter.tableRow('single-organisation');
+
+        expect(result).toEqual([
+          { text: 'Example Profession' },
+          { text: '2013' },
+          { text: dateOf(new Date(2022, 6, 12)) },
+          { html: statusOf(DecisionDatasetStatus.Draft) },
+          {
+            html: `<a class="govuk-link" href="/admin/decisions/${
+              dataset.profession.id
+            }/${dataset.organisation.id}/2013">${translationOf(
+              'decisions.admin.dashboard.viewDetails',
+            )}</a>`,
+          },
+        ]);
+
+        expect(formatStatusSpy).toBeCalledWith(
+          DecisionDatasetStatus.Draft,
+          i18nService,
+        );
+        expect(formatDateSpy).toBeCalledWith(new Date(2022, 6, 12));
+      });
     });
   });
 
   describe('headers', () => {
-    it('returns a table row of headings', () => {
-      const expected: TableRow = [
-        {
-          text: translationOf(
-            'decisions.admin.dashboard.tableHeading.profession',
-          ),
-        },
-        { text: translationOf('decisions.admin.dashboard.tableHeading.year') },
-        {
-          text: translationOf(
-            'decisions.admin.dashboard.tableHeading.lastModified',
-          ),
-        },
-        {
-          text: translationOf('decisions.admin.dashboard.tableHeading.status'),
-        },
-        {
-          text: translationOf('decisions.admin.dashboard.tableHeading.actions'),
-        },
-      ];
+    describe('when called with `overview`', () => {
+      it('returns a table row of headings including the overview headings', () => {
+        expect(
+          ListEntryPresenter.headings(createMockI18nService(), 'overview'),
+        ).toEqual([
+          {
+            text: translationOf(
+              'decisions.admin.dashboard.tableHeading.profession',
+            ),
+          },
+          {
+            text: translationOf(
+              'decisions.admin.dashboard.tableHeading.regulator',
+            ),
+          },
+          {
+            text: translationOf('decisions.admin.dashboard.tableHeading.year'),
+          },
+          {
+            text: translationOf(
+              'decisions.admin.dashboard.tableHeading.lastModified',
+            ),
+          },
+          {
+            text: translationOf(
+              'decisions.admin.dashboard.tableHeading.status',
+            ),
+          },
+          {
+            text: translationOf(
+              'decisions.admin.dashboard.tableHeading.actions',
+            ),
+          },
+        ]);
+      });
+    });
 
-      expect(ListEntryPresenter.headings(createMockI18nService())).toEqual(
-        expected,
-      );
+    describe('when called with `single-organisation`', () => {
+      it('returns a table row of headings including the headings for a single organisation', () => {
+        expect(
+          ListEntryPresenter.headings(
+            createMockI18nService(),
+            'single-organisation',
+          ),
+        ).toEqual([
+          {
+            text: translationOf(
+              'decisions.admin.dashboard.tableHeading.profession',
+            ),
+          },
+          {
+            text: translationOf('decisions.admin.dashboard.tableHeading.year'),
+          },
+          {
+            text: translationOf(
+              'decisions.admin.dashboard.tableHeading.lastModified',
+            ),
+          },
+          {
+            text: translationOf(
+              'decisions.admin.dashboard.tableHeading.status',
+            ),
+          },
+          {
+            text: translationOf(
+              'decisions.admin.dashboard.tableHeading.actions',
+            ),
+          },
+        ]);
+      });
     });
   });
 

--- a/src/decisions/admin/presenters/list-entry.presenter.ts
+++ b/src/decisions/admin/presenters/list-entry.presenter.ts
@@ -5,20 +5,41 @@ import { escape } from '../../../helpers/escape.helper';
 import { DecisionDataset } from '../../decision-dataset.entity';
 import { formatDate } from '../../../common/utils';
 import { formatStatus } from '../../../helpers/format-status.helper';
+import { DecisionDatasetsPresenterView } from './decision-datasets.presenter';
+import { ProfessionsPresenterView } from '../../../professions/admin/presenters/professions.presenter';
 
-type Field = 'profession' | 'year' | 'lastModified' | 'status' | 'actions';
+type Field =
+  | 'profession'
+  | 'year'
+  | 'lastModified'
+  | 'status'
+  | 'actions'
+  | 'regulator';
 
-const fields: Field[] = [
-  'profession',
-  'year',
-  'lastModified',
-  'status',
-  'actions',
-];
+const fields = {
+  overview: [
+    'profession',
+    'regulator',
+    'year',
+    'lastModified',
+    'status',
+    'actions',
+  ],
+  'single-organisation': [
+    'profession',
+    'year',
+    'lastModified',
+    'status',
+    'actions',
+  ],
+} as { [K in DecisionDatasetsPresenterView]: Field[] };
 
 export class ListEntryPresenter {
-  static headings(i18nService: I18nService): TableRow {
-    return fields
+  static headings(
+    i18nService: I18nService,
+    contents: DecisionDatasetsPresenterView,
+  ): TableRow {
+    return fields[contents]
       .map((field) =>
         i18nService.translate<string>(
           `decisions.admin.dashboard.tableHeading.${field}`,
@@ -32,7 +53,7 @@ export class ListEntryPresenter {
     private readonly i18nService: I18nService,
   ) {}
 
-  tableRow(): TableRow {
+  tableRow(contents: ProfessionsPresenterView): TableRow {
     const viewDetails = `<a class="govuk-link" href="/admin/decisions/${
       this.dataset.profession.id
     }/${this.dataset.organisation.id}/${
@@ -50,6 +71,7 @@ export class ListEntryPresenter {
 
     const entries: { [K in Field]: TableCell } = {
       profession: { text: this.dataset.profession.name },
+      regulator: { text: this.dataset.organisation.name },
       year: { text: this.dataset.year.toString() },
       lastModified: { text: formatDate(this.dataset.updated_at) },
       status: {
@@ -58,6 +80,6 @@ export class ListEntryPresenter {
       actions: { html: viewDetails },
     };
 
-    return fields.map((field) => entries[field]);
+    return fields[contents].map((field) => entries[field]);
   }
 }

--- a/src/i18n/en/decisions.json
+++ b/src/i18n/en/decisions.json
@@ -7,6 +7,7 @@
       "viewDetails": "View details <span class='govuk-visually-hidden'>about {year} {organisaition} {profession} decision data</span>",
       "tableHeading": {
         "profession": "Profession",
+        "regulator": "Regulator",
         "year": "Year",
         "lastModified": "Last updated",
         "status": "Status",


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR

Adds "Regulator" column to the table on the decision data index page for Central Admin users.

## Screenshots of UI changes

### After

#### Regulator user

![image](https://user-images.githubusercontent.com/19826940/163418107-6cd2bd84-4ee7-467e-ad58-049bed9075fb.png)


#### Central admin user

![image](https://user-images.githubusercontent.com/19826940/163418087-efcade73-824a-4801-bc90-0829147c28b0.png)



