### PR TITLE
2331 allow up to 25 regulators to be selected on a profession

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [unreleased]
 
+### Changed
+
+- Allow Professions to have up to 25 regulators (previously 5)
+
 ### Added
 
 - Hide edit and delete buttons for non Tier 1 users

--- a/assets/javascripts/regulatory-authority-select.js
+++ b/assets/javascripts/regulatory-authority-select.js
@@ -10,18 +10,19 @@ function showRegulator(event) {
 
   const latestRegulator = items[0];
 
-  showElement(latestRegulator);
+  if (latestRegulator) {
+    showElement(latestRegulator);
 
-  const regulatoryAuthoritySelect = latestRegulator.querySelector(
-    'select.organisation',
-  );
-  const roleSelect = latestRegulator.querySelector('select.role');
+    const regulatoryAuthoritySelect = latestRegulator.querySelector(
+      'select.organisation',
+    );
+    const roleSelect = latestRegulator.querySelector('select.role');
 
-  regulatoryAuthoritySelect.removeAttribute('tabindex');
-  roleSelect.removeAttribute('tabindex');
+    regulatoryAuthoritySelect.removeAttribute('tabindex');
+    roleSelect.removeAttribute('tabindex');
 
-  addRemoveButton(latestRegulator);
-
+    addRemoveButton(latestRegulator);
+  }
   // If there are no more hidden containers left, hide the button.
   if (
     document.querySelectorAll(hiddenRegulatoryAuthorityContainerSelector)

--- a/assets/javascripts/regulatory-authority-select.js
+++ b/assets/javascripts/regulatory-authority-select.js
@@ -7,6 +7,7 @@ function showRegulator(event) {
   const items = document.querySelectorAll(
     hiddenRegulatoryAuthorityContainerSelector,
   );
+  const addRegulatorButton = document.querySelector('#add-regulator');
 
   const latestRegulator = items[0];
 
@@ -28,7 +29,8 @@ function showRegulator(event) {
     document.querySelectorAll(hiddenRegulatoryAuthorityContainerSelector)
       .length == 0
   ) {
-    hideElement(addButton);
+    addRegulatorButton.classList.add('rpr-hidden-element');
+    addRegulatorButton.setAttribute('aria-hidden', true);
   }
 
   event.preventDefault();
@@ -69,14 +71,18 @@ function initialize(items) {
 function removeRegulator(event) {
   const button = event.target;
   const container = button.parentElement;
-
-  hideElement(container);
+  const addRegulatorButton = document.querySelector('#add-regulator');
 
   container.querySelector('select.organisation').value = '';
   container.querySelector('select.role').value = '';
 
   button.remove();
-
+  container.classList.add('rpr-hidden-element');
+  container.setAttribute('aria-hidden', true);
+  if (addRegulatorButton.classList.contains('rpr-hidden-element')) {
+    addRegulatorButton.classList.remove('rpr-hidden-element');
+    addRegulatorButton.setAttribute('aria-hidden', false);
+  }
   event.preventDefault();
 }
 

--- a/assets/stylesheets/application.scss
+++ b/assets/stylesheets/application.scss
@@ -10,6 +10,10 @@ $small-screen: 768px;
   padding-top: 10px;
 }
 
+.rpr-hidden-element {
+  display: none;
+}
+
 .rpr-details {
   &__sub-group {
     padding: 1em 0 0 0;

--- a/cypress/integration/admin/professions/new.spec.ts
+++ b/cypress/integration/admin/professions/new.spec.ts
@@ -420,5 +420,40 @@ describe('Adding a new profession', () => {
         format(new Date(), 'd MMM yyyy'),
       );
     });
+    it("hides 'Add a Regulator' button when the maximum number of regulators (25) is reached ", () => {
+      cy.visit('/admin/professions');
+
+      cy.translate('professions.admin.addButtonLabel').then((buttonText) => {
+        cy.get('button').contains(buttonText).click();
+      });
+
+      cy.get('input[name="name"]').type('Example Profession');
+
+      cy.translate('app.continue').then((buttonText) => {
+        cy.get('button').contains(buttonText).click();
+      });
+
+      cy.clickSummaryListRowChangeLink(
+        'professions.form.label.organisations.name',
+      );
+
+      cy.get('select[id="regulatoryBodies_1"]').select(
+        'Department for Education',
+      );
+
+      for (let i = 0; i < 24; i++) {
+        cy.translate('professions.form.button.addRegulator').then((label) => {
+          cy.get('a').contains(label).click();
+        });
+      }
+      cy.checkAccessibility();
+
+      cy.get('#add-regulator').should('not.be.visible');
+
+      cy.get('[data-purpose="removeRegulator"]').first().click();
+      cy.get('#add-regulator').should('be.visible');
+
+      cy.checkAccessibility();
+    });
   });
 });

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "prebuild": "rimraf dist",
     "build": "nest build",
     "build:assets": "encore dev",
+    "build:assets:watch": "encore dev --watch",
     "build:assets:prod": "encore production",
     "console": "ts-node --transpile-only ./src/console.ts",
     "heroku-postbuild": "npm run build && npm run build:assets:prod",

--- a/src/professions/admin/organisations.controller.spec.ts
+++ b/src/professions/admin/organisations.controller.spec.ts
@@ -19,6 +19,7 @@ import {
   ProfessionToOrganisation,
   OrganisationRole,
 } from '../profession-to-organisation.entity';
+import { AuthorityAndRoleArgs } from './interfaces/authority-and-role-args';
 
 jest.mock('../../users/helpers/check-can-change-profession');
 jest.mock('./presenters/regulated-authorities-select-presenter');
@@ -67,17 +68,17 @@ describe('OrganisationsController', () => {
         const organisations = organisationFactory.buildList(2);
         organisationVersionsService.allLive.mockResolvedValue(organisations);
 
-        const regulatedAuthoritiesSelectPresenter =
-          new RegulatedAuthoritiesSelectPresenter(organisations, null);
-        const authoritiesAndRoles =
-          regulatedAuthoritiesSelectPresenter.authoritiesAndRoles(i18nService);
+        const authoritiesAndRoles: AuthorityAndRoleArgs = {
+          authorities: [],
+          roles: [],
+        };
 
         jest
           .spyOn(
             RegulatedAuthoritiesSelectPresenter.prototype,
             'authoritiesAndRoles',
           )
-          .mockImplementation(() => authoritiesAndRoles);
+          .mockImplementation(async () => authoritiesAndRoles);
 
         const request = createDefaultMockRequest({
           user: userFactory.build(),

--- a/src/professions/admin/organisations.controller.spec.ts
+++ b/src/professions/admin/organisations.controller.spec.ts
@@ -89,13 +89,10 @@ describe('OrganisationsController', () => {
         expect(response.render).toHaveBeenCalledWith(
           'admin/professions/organisations',
           expect.objectContaining({
-            selectArgsArray: [
-              authoritiesAndRoles,
-              authoritiesAndRoles,
-              authoritiesAndRoles,
-              authoritiesAndRoles,
-              authoritiesAndRoles,
-            ],
+            selectArgsArray: Array.from({ length: 25 }, () => ({
+              ...authoritiesAndRoles,
+            })),
+
             captionText: translationOf('professions.form.captions.add'),
           }),
         );
@@ -169,14 +166,10 @@ describe('OrganisationsController', () => {
               regulatedAuthoritiesSelectPresenterWithSelectedAdditionalOrganisation.authoritiesAndRoles(
                 i18nService,
               ),
-              regulatedAuthoritiesSelectPresenter.authoritiesAndRoles(
-                i18nService,
-              ),
-              regulatedAuthoritiesSelectPresenter.authoritiesAndRoles(
-                i18nService,
-              ),
-              regulatedAuthoritiesSelectPresenter.authoritiesAndRoles(
-                i18nService,
+              ...Array.from({ length: 23 }, () =>
+                regulatedAuthoritiesSelectPresenter.authoritiesAndRoles(
+                  i18nService,
+                ),
               ),
             ],
             captionText: translationOf('professions.form.captions.edit'),

--- a/src/professions/admin/organisations.controller.ts
+++ b/src/professions/admin/organisations.controller.ts
@@ -155,7 +155,7 @@ export class OrganisationsController {
     const selectArgsArray = await Promise.all(
       Array.from({
         ...professionToOrganisations,
-        length: 5,
+        length: 25,
       }).map(async (professionToOrganisation) => {
         const presenter = new RegulatedAuthoritiesSelectPresenter(
           regulatedAuthorities,


### PR DESCRIPTION
# Changes in this PR
This change allows a profession to have up to 25 regulators. 
Whilst updating the clientside Javascript I also fixed a bug where the 'Add another regulator' button still showed even though the limit had been reached.
The clientside Javascript is responsible for showing and hiding each regulator as the 'Add another regulator' or 'Remove regulator' button is pressed. For users that have Javascript disabled this means that they will presented with a full list of 25 regulators that they can add details for when they load the page. This was judged to be an edge case so we are ok to have a stylistically degraded experience for users without javascript.


## Screenshots of UI changes

### Before
This screenshot erroneously shows the 'Add another regulator' button even though the limit is 5 due to a bug
![image](https://user-images.githubusercontent.com/44123869/163983179-44e83306-90c8-4b7f-be42-6e280386530c.png)

### After
![image](https://user-images.githubusercontent.com/44123869/163983477-89ae0a96-8ea5-4601-b332-b03319eb4c09.png)
