### PR TITLE
2264 archiving a regulator shouldn't archive their professions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- Prevent Organisation from being archived if they have related Professions - Regulator must have Professions removed before it can be archived
 - Allow Professions to have up to 25 regulators (previously 5)
 - Show full list of countries when editing/adding decision data
 - Fix bug where publish button could still be clicked despite being disabled

--- a/cypress/integration/admin/organisations/archive.spec.ts
+++ b/cypress/integration/admin/organisations/archive.spec.ts
@@ -7,187 +7,286 @@ describe('Archiving organisations', () => {
       cy.visitInternalDashboard();
     });
 
-    it('Allows me to archive a draft organisation', () => {
-      cy.get('a').contains('Regulatory authorities').click();
-      cy.checkAccessibility();
+    describe('Draft organisations', () => {
+      it('Allows me to archive a draft organisation with no associated professions', () => {
+        cy.get('a').contains('Regulatory authorities').click();
+        cy.checkAccessibility();
 
-      cy.contains('Department for Education')
-        .parent('tr')
-        .within(() => {
-          cy.get('a').contains('View details').click();
-        });
-
-      cy.translate('app.status.draft').then((status) => {
-        cy.get('h2[data-status]').should('contain', status);
-      });
-
-      cy.translate('organisations.admin.button.archive').then(
-        (archiveButton) => {
-          cy.get('a').contains(archiveButton).click();
-        },
-      );
-
-      cy.checkAccessibility();
-
-      cy.translate('organisations.admin.archive.caption').then(
-        (archiveCaption) => {
-          cy.get('body').contains(archiveCaption);
-        },
-      );
-
-      cy.translate('organisations.admin.archive.heading', {
-        organisationName: 'Department for Education',
-      }).then((heading) => {
-        cy.contains(heading);
-      });
-
-      cy.translate('organisations.admin.button.archive').then((buttonText) => {
-        cy.get('button').contains(buttonText).click();
-      });
-
-      cy.checkAccessibility();
-
-      cy.translate('organisations.admin.archive.confirmation.heading').then(
-        (confirmation) => {
-          cy.get('html').should('contain', confirmation);
-        },
-      );
-
-      cy.get('[data-cy=actions]').should('not.exist');
-
-      cy.translate('app.status.archived').then((status) => {
-        cy.get('h2[data-status]').should('contain', status);
-      });
-      cy.get('[data-cy=changed-by-user-name]').should('contain', 'Registrar');
-      cy.get('[data-cy=changed-by-user-email]').should(
-        'contain',
-        'beis-rpr+registrar@dxw.com',
-      );
-      cy.get('[data-cy=last-modified]').should(
-        'contain',
-        format(new Date(), 'd MMM yyyy'),
-      );
-
-      cy.visitAndCheckAccessibility('/admin/organisations');
-
-      cy.get('tr')
-        .contains('Department for Education')
-        .then(($header) => {
-          const $row = $header.parent();
-
-          cy.translate(`app.status.archived`).then((status) => {
-            cy.wrap($row).should('contain', status);
+        cy.contains('Draft Organisation with no professions')
+          .parent('tr')
+          .within(() => {
+            cy.get('a').contains('View details').click();
           });
+
+        cy.translate('app.status.draft').then((status) => {
+          cy.get('h2[data-status]').should('contain', status);
         });
 
-      cy.visitAndCheckAccessibility('/regulatory-authorities/search');
+        cy.translate('organisations.admin.button.archive').then(
+          (archiveButton) => {
+            cy.get('a').contains(archiveButton).click();
+          },
+        );
 
-      cy.get('body').should('not.contain', 'Department for Education');
+        cy.checkAccessibility();
+
+        cy.translate('organisations.admin.archive.caption').then(
+          (archiveCaption) => {
+            cy.get('body').contains(archiveCaption);
+          },
+        );
+
+        cy.translate('organisations.admin.archive.heading', {
+          organisationName: 'Draft Organisation with no professions',
+        }).then((heading) => {
+          cy.contains(heading);
+        });
+
+        cy.translate('organisations.admin.button.archive').then(
+          (buttonText) => {
+            cy.get('button').contains(buttonText).click();
+          },
+        );
+
+        cy.checkAccessibility();
+
+        cy.translate('organisations.admin.archive.confirmation.heading').then(
+          (confirmation) => {
+            cy.get('html').should('contain', confirmation);
+          },
+        );
+
+        cy.get('[data-cy=actions]').should('not.exist');
+
+        cy.translate('app.status.archived').then((status) => {
+          cy.get('h2[data-status]').should('contain', status);
+        });
+        cy.get('[data-cy=changed-by-user-name]').should('contain', 'Registrar');
+        cy.get('[data-cy=changed-by-user-email]').should(
+          'contain',
+          'beis-rpr+registrar@dxw.com',
+        );
+        cy.get('[data-cy=last-modified]').should(
+          'contain',
+          format(new Date(), 'd MMM yyyy'),
+        );
+
+        cy.visitAndCheckAccessibility('/admin/organisations');
+
+        cy.get('tr')
+          .contains('Draft Organisation with no professions')
+          .then(($header) => {
+            const $row = $header.parent();
+
+            cy.translate(`app.status.archived`).then((status) => {
+              cy.wrap($row).should('contain', status);
+            });
+          });
+
+        cy.visitAndCheckAccessibility('/regulatory-authorities/search');
+
+        cy.get('body').should(
+          'not.contain',
+          'Draft Organisation with no professions',
+        );
+      });
+
+      it('Shows blocking error when trying to archive a draft organisation with associated professions', () => {
+        cy.get('a').contains('Regulatory authorities').click();
+        cy.checkAccessibility();
+
+        cy.contains('Department for Education')
+          .parent('tr')
+          .within(() => {
+            cy.get('a').contains('View details').click();
+          });
+
+        cy.translate('app.status.draft').then((status) => {
+          cy.get('h2[data-status]').should('contain', status);
+        });
+
+        cy.translate('organisations.admin.button.archive').then(
+          (archiveButton) => {
+            cy.get('a').contains(archiveButton).click();
+          },
+        );
+
+        cy.checkAccessibility();
+
+        cy.translate('organisations.admin.archive.caption').then(
+          (archiveCaption) => {
+            cy.get('body').contains(archiveCaption);
+          },
+        );
+
+        cy.translate('organisations.admin.archive.heading', {
+          organisationName: 'Department for Education',
+        }).then((heading) => {
+          cy.contains(heading);
+        });
+
+        cy.translate('organisations.admin.archive.forbidden').then(
+          (message) => {
+            cy.contains(message);
+          },
+        );
+
+        cy.get('ul.govuk-list--bullet').within(() => {
+          cy.get('li')
+            .should('contain', 'Draft Profession')
+            .should('contain', 'Profession with two tier-one Organisations')
+            .should('contain', 'Secondary School Teacher');
+        });
+
+        cy.translate('organisations.admin.button.backToRegulator').then(
+          (buttonText) => {
+            cy.get('a').contains(buttonText).click();
+          },
+        );
+
+        cy.get('h1').should('contain', 'Department for Education');
+        cy.checkAccessibility();
+      });
     });
+    describe('Live organisations', () => {
+      it('Allows me to archive a live organisation with no associated professions', () => {
+        cy.get('a').contains('Regulatory authorities').click();
 
-    it('Allows me to archive a live organisation', () => {
-      cy.get('a').contains('Regulatory authorities').click();
+        cy.contains('Published organisation with no professions')
+          .parent('tr')
+          .within(() => {
+            cy.get('a').contains('View details').click();
+          });
 
-      cy.contains('Council of Registered Gas Installers')
-        .parent('tr')
-        .within(() => {
-          cy.get('a').contains('View details').click();
+        cy.translate('app.status.live').then((status) => {
+          cy.get('h2[data-status]').should('contain', status);
         });
 
-      cy.translate('app.status.live').then((status) => {
-        cy.get('h2[data-status]').should('contain', status);
-      });
+        cy.get('[data-cy=currently-published-version-text]').within(($h2) => {
+          cy.translate('organisations.admin.publicFacingLink.heading').then(
+            (publicFacingLinkHeading) => {
+              cy.wrap($h2).should('contain', publicFacingLinkHeading);
+            },
+          );
 
-      cy.get('[data-cy=currently-published-version-text]').within(($h2) => {
-        cy.translate('organisations.admin.publicFacingLink.heading').then(
-          (publicFacingLinkHeading) => {
-            cy.wrap($h2).should('contain', publicFacingLinkHeading);
+          cy.translate('organisations.admin.publicFacingLink.label').then(
+            (publicFacingLinkLabel) => {
+              cy.get('a').should('contain', publicFacingLinkLabel);
+            },
+          );
+
+          cy.get('a').click();
+        });
+        cy.get('body').should(
+          'contain',
+          'Published organisation with no professions',
+        );
+        cy.go('back');
+
+        cy.translate('organisations.admin.button.archive').then(
+          (archiveButton) => {
+            cy.get('a').contains(archiveButton).click();
           },
         );
 
-        cy.translate('organisations.admin.publicFacingLink.label').then(
-          (publicFacingLinkLabel) => {
-            cy.get('a').should('contain', publicFacingLinkLabel);
+        cy.translate('organisations.admin.button.archive').then(
+          (buttonText) => {
+            cy.get('button').contains(buttonText).click();
           },
         );
 
-        cy.get('a').click();
-      });
-      cy.get('body').should('contain', 'Council of Registered Gas Installers');
-      cy.go('back');
+        cy.translate('organisations.admin.archive.confirmation.heading').then(
+          (confirmation) => {
+            cy.get('html').should('contain', confirmation);
+          },
+        );
 
-      cy.translate('organisations.admin.button.archive').then(
-        (archiveButton) => {
-          cy.get('a').contains(archiveButton).click();
-        },
-      );
+        cy.get('[data-cy=actions]').should('not.exist');
 
-      cy.translate('organisations.admin.button.archive').then((buttonText) => {
-        cy.get('button').contains(buttonText).click();
-      });
+        cy.translate('app.status.archived').then((status) => {
+          cy.get('h2[data-status]').should('contain', status);
+        });
+        cy.get('[data-cy=changed-by-user-name]').should('contain', 'Registrar');
+        cy.get('[data-cy=changed-by-user-email]').should(
+          'contain',
+          'beis-rpr+registrar@dxw.com',
+        );
+        cy.get('[data-cy=last-modified]').should(
+          'contain',
+          format(new Date(), 'd MMM yyyy'),
+        );
+        cy.get('[data-cy=currently-published-version-text]').should(
+          'not.exist',
+        );
 
-      cy.translate('organisations.admin.archive.confirmation.heading').then(
-        (confirmation) => {
-          cy.get('html').should('contain', confirmation);
-        },
-      );
+        cy.visit('/admin/organisations');
 
-      cy.get('[data-cy=actions]').should('not.exist');
+        cy.get('tr')
+          .contains('Organisation with no professions')
+          .then(($header) => {
+            const $row = $header.parent();
 
-      cy.translate('app.status.archived').then((status) => {
-        cy.get('h2[data-status]').should('contain', status);
-      });
-      cy.get('[data-cy=changed-by-user-name]').should('contain', 'Registrar');
-      cy.get('[data-cy=changed-by-user-email]').should(
-        'contain',
-        'beis-rpr+registrar@dxw.com',
-      );
-      cy.get('[data-cy=last-modified]').should(
-        'contain',
-        format(new Date(), 'd MMM yyyy'),
-      );
-      cy.get('[data-cy=currently-published-version-text]').should('not.exist');
-
-      cy.visit('/admin/organisations');
-
-      cy.get('tr')
-        .contains('Council of Registered Gas Installers')
-        .then(($header) => {
-          const $row = $header.parent();
-
-          cy.translate(`app.status.archived`).then((status) => {
-            cy.wrap($row).should('contain', status);
+            cy.translate(`app.status.archived`).then((status) => {
+              cy.wrap($row).should('contain', status);
+            });
           });
+
+        cy.visit('/regulatory-authorities/search');
+
+        cy.get('body').should(
+          'not.contain',
+          'Organisation with no professions',
+        );
+
+        cy.visit('/admin/professions');
+      });
+      it('Shows blocking error when trying to archive a live organisation with associated professions', () => {
+        cy.get('a').contains('Regulatory authorities').click();
+
+        cy.contains('Council of Registered Gas Installers')
+          .parent('tr')
+          .within(() => {
+            cy.get('a').contains('View details').click();
+          });
+
+        cy.translate('app.status.live').then((status) => {
+          cy.get('h2[data-status]').should('contain', status);
         });
 
-      cy.visit('/regulatory-authorities/search');
+        cy.get('[data-cy=currently-published-version-text]').within(($h2) => {
+          cy.translate('organisations.admin.publicFacingLink.heading').then(
+            (publicFacingLinkHeading) => {
+              cy.wrap($h2).should('contain', publicFacingLinkHeading);
+            },
+          );
 
-      cy.get('body').should(
-        'not.contain',
-        'Council of Registered Gas Installers',
-      );
+          cy.translate('organisations.admin.publicFacingLink.label').then(
+            (publicFacingLinkLabel) => {
+              cy.get('a').should('contain', publicFacingLinkLabel);
+            },
+          );
 
-      cy.visit('/admin/professions');
-
-      cy.get('tr')
-        .contains('Gas Safe Engineer')
-        .then(($header) => {
-          const $row = $header.parent();
-
-          cy.translate('app.status.archived').then((status) => {
-            cy.wrap($row).should('contain', status);
-          });
+          cy.get('a').click();
         });
+        cy.get('body').should(
+          'contain',
+          'Council of Registered Gas Installers',
+        );
+        cy.go('back');
 
-      cy.get('tr')
-        .contains('Draft Profession')
-        .then(($header) => {
-          const $row = $header.parent();
-
-          cy.translate('app.status.archived').then((status) => {
-            cy.wrap($row).should('contain', status);
-          });
-        });
+        cy.translate('organisations.admin.button.archive').then(
+          (archiveButton) => {
+            cy.get('a').contains(archiveButton).click();
+          },
+        );
+        cy.translate('organisations.admin.button.backToRegulator').then(
+          (buttonText) => {
+            cy.get('a').contains(buttonText).click();
+          },
+        );
+        cy.get('h1').should('contain', 'Council of Registered Gas Installers');
+        cy.checkAccessibility();
+      });
     });
   });
 });

--- a/seeds/development/organisations.json
+++ b/seeds/development/organisations.json
@@ -109,5 +109,33 @@
         "status": "draft"
       }
     ]
+  },
+  {
+    "name": "Draft Organisation with no professions",
+    "slug": "draft-organisation-no-profs",
+    "versions": [
+      {
+        "alternateName": "",
+        "address": "789 Fake Street\nLondon\nEC1 1AB",
+        "url": "www.gmc.com",
+        "email": "gmc@example.com",
+        "telephone": "+44 0123 456789",
+        "status": "draft"
+      }
+    ]
+  },
+  {
+    "name": "Published organisation with no professions",
+    "slug": "Published organisation-no-profs",
+    "versions": [
+      {
+        "alternateName": "",
+        "address": "789 Fake Street\nLondon\nEC1 1AB",
+        "url": "www.gmc.com",
+        "email": "gmc@example.com",
+        "telephone": "+44 0123 456789",
+        "status": "live"
+      }
+    ]
   }
 ]

--- a/seeds/test/organisations.json
+++ b/seeds/test/organisations.json
@@ -111,5 +111,35 @@
         "status": "draft"
       }
     ]
+  },
+  {
+    "name": "Draft Organisation with no professions",
+    "slug": "draft-organisation-no-profs",
+    "versions": [
+      {
+        "alternateName": "",
+        "address": "789 Fake Street\nLondon\nEC1 1AB",
+        "url": "www.gmc.com",
+        "email": "gmc@example.com",
+        "telephone": "+44 0123 456789",
+        "status": "draft",
+        "created_at": "2022-01-01"
+      }
+    ]
+  },
+  {
+    "name": "Published organisation with no professions",
+    "slug": "Published organisation-no-profs",
+    "versions": [
+      {
+        "alternateName": "",
+        "address": "789 Fake Street\nLondon\nEC1 1AB",
+        "url": "www.gmc.com",
+        "email": "gmc@example.com",
+        "telephone": "+44 0123 456789",
+        "status": "live",
+        "created_at": "2022-01-01"
+      }
+    ]
   }
 ]

--- a/src/i18n/en/organisations.json
+++ b/src/i18n/en/organisations.json
@@ -69,7 +69,8 @@
       "confirmation": {
         "heading": "Regulatory authority archived",
         "body": "The regulator <strong>{name}</strong> has been archived."
-      }
+      },
+      "forbidden": "This organisation cannot be archived yet. Before you can archive, remove the regulator from the following professions:"
     },
     "tableHeading": {
       "name": "Name",
@@ -120,7 +121,8 @@
       },
       "archive": "Archive this regulatory authority",
       "saveAsDraft": "Save as draft",
-      "publish": "Publish to register"
+      "publish": "Publish to register",
+      "backToRegulator": "Back to regulator"
     },
     "publicFacingLink": {
       "heading": "Currently published version",

--- a/src/organisations/admin/organisation-archive.controller.spec.ts
+++ b/src/organisations/admin/organisation-archive.controller.spec.ts
@@ -156,7 +156,6 @@ describe('OrganisationArchiveController', () => {
 
       expect(organisationVersionsService.archive).toHaveBeenCalledWith(
         versionToArchive,
-        user,
       );
 
       expect(flashMock).toHaveBeenCalledWith(
@@ -195,6 +194,7 @@ describe('OrganisationArchiveController', () => {
 
       expect(checkCanViewOrganisation).toHaveBeenCalledWith(req, organisation);
     });
+
     it('throws BadRequestException when request is made to archive organisation with professions', async () => {
       const profession = professionFactory.build({
         name: 'profession',

--- a/src/organisations/admin/organisation-archive.controller.spec.ts
+++ b/src/organisations/admin/organisation-archive.controller.spec.ts
@@ -4,10 +4,12 @@ import { Response } from 'express';
 import { I18nService } from 'nestjs-i18n';
 import { flashMessage } from '../../common/flash-message';
 import { escape } from '../../helpers/escape.helper';
+import { ProfessionToOrganisation } from '../../professions/profession-to-organisation.entity';
 import { createMockI18nService } from '../../testutils/create-mock-i18n-service';
 import { createDefaultMockRequest } from '../../testutils/factories/create-default-mock-request';
 import organisationFactory from '../../testutils/factories/organisation';
 import organisationVersionFactory from '../../testutils/factories/organisation-version';
+import professionFactory from '../../testutils/factories/profession';
 import userFactory from '../../testutils/factories/user';
 import { translationOf } from '../../testutils/translation-of';
 import { checkCanViewOrganisation } from '../../users/helpers/check-can-view-organisation';
@@ -52,7 +54,14 @@ describe('OrganisationArchiveController', () => {
 
   describe('new', () => {
     it('fetches the Organisation to render on the page', async () => {
-      const organisation = organisationFactory.build();
+      const profession1 = professionFactory.build({ name: 'profession1' });
+      const profession2 = professionFactory.build({ name: 'profession2' });
+      const organisation = organisationFactory.build({
+        professionToOrganisations: [
+          { profession: profession1 },
+          { profession: profession2 },
+        ] as ProfessionToOrganisation[],
+      });
       const version = organisationVersionFactory.build({
         organisation,
       });
@@ -72,11 +81,17 @@ describe('OrganisationArchiveController', () => {
       ).toHaveBeenCalledWith(organisation.id, version.id);
       expect(result).toEqual({
         organisation: Organisation.withVersion(organisation, version),
+        professions: [profession1, profession2],
       });
     });
 
     it('checks the acting user has permission to archive the Organisation', async () => {
-      const organisation = organisationFactory.build();
+      const profession = professionFactory.build({ name: 'profession' });
+      const organisation = organisationFactory.build({
+        professionToOrganisations: [
+          { profession },
+        ] as ProfessionToOrganisation[],
+      });
       const version = organisationVersionFactory.build({
         organisation,
       });

--- a/src/organisations/admin/organisation-archive.controller.ts
+++ b/src/organisations/admin/organisation-archive.controller.ts
@@ -47,9 +47,13 @@ export class OrganisationArchiveController {
       version,
     );
 
+    const professions = organisation.professionToOrganisations.map(
+      (professionToOrganisation) => professionToOrganisation.profession,
+    );
+
     checkCanViewOrganisation(req, organisation);
 
-    return { organisation };
+    return { organisation, professions };
   }
 
   @Delete(':organisationId/versions/:versionId/archive')
@@ -65,7 +69,6 @@ export class OrganisationArchiveController {
         organisationId,
         versionId,
       );
-
     checkCanViewOrganisation(req, version.organisation);
 
     const user = getActingUser(req);

--- a/src/organisations/admin/organisation-archive.controller.ts
+++ b/src/organisations/admin/organisation-archive.controller.ts
@@ -6,6 +6,7 @@ import {
   Render,
   Req,
   Res,
+  BadRequestException,
 } from '@nestjs/common';
 import { Response } from 'express';
 import { I18nService } from 'nestjs-i18n';
@@ -69,6 +70,13 @@ export class OrganisationArchiveController {
         organisationId,
         versionId,
       );
+
+    const professions = version.organisation.professionToOrganisations?.find(
+      (professionToOrganisation) => !!professionToOrganisation.profession,
+    );
+
+    if (professions) throw new BadRequestException();
+
     checkCanViewOrganisation(req, version.organisation);
 
     const user = getActingUser(req);

--- a/src/organisations/admin/organisation-archive.controller.ts
+++ b/src/organisations/admin/organisation-archive.controller.ts
@@ -86,7 +86,7 @@ export class OrganisationArchiveController {
       user,
     );
 
-    await this.organisationVersionsService.archive(versionToArchive, user);
+    await this.organisationVersionsService.archive(versionToArchive);
 
     const messageTitle = await this.i18nService.translate(
       'organisations.admin.archive.confirmation.heading',

--- a/views/admin/organisations/archive/new.njk
+++ b/views/admin/organisations/archive/new.njk
@@ -2,6 +2,7 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
 {% set title = ("organisations.admin.archive.heading" | t) %}
+{% set canArchiveOrganisation = not professions.length %}
 
 {% block title %}
   {{ "organisations.admin.archive.heading" | t }}
@@ -13,15 +14,30 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
-      <p class="govuk-body">{{ 'organisations.admin.archive.details' | t }}</p>
+      {% if canArchiveOrganisation %}
+        <form action="/admin/organisations/{{ organisation.id }}/versions/{{ organisation.versionId }}/archive?_method=DELETE" method="post">
+          {{
+            govukButton({
+              text: ("organisations.admin.button.archive" | t)
+            })
+          }}
+        </form>
+      {% else %}
+        <h2 class="govuk-heading-m">{{ 'organisations.admin.archive.forbidden' | t }}</h2>
+        <ul class="govuk-list govuk-list--bullet">
+          {% for profession in professions %}
 
-      <form action="/admin/organisations/{{ organisation.id }}/versions/{{ organisation.versionId }}/archive?_method=DELETE" method="post">
+            <li class="govuk-body-m">{{profession.name}}</li>
+          {% endfor %}
+        </ul>
+
         {{
-          govukButton({
-            text: ("organisations.admin.button.archive" | t)
-          })
-        }}
-      </form>
+            govukButton({
+              text: ("organisations.admin.button.backToRegulator" | t),
+              href: backLink
+            })
+          }}
+      {% endif %}
     </div>
 
   </div>


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR

This PR prevents admins from archiving a organisations whilst it has professions attatched. 

We could have chosen to automatically remove professions from a regulator when it is being archived but the user may not expect this to happen so could have been confusing. It also may have meant for more complex logic in the controller which would have to be maintained.

Instead if a user attempts to archive an organisation with professions they are presented with a screen (screenshot below) showing them which professions should be removed from the organisation in order for them to archive it.


## Screenshots of UI changes

### Before

![image](https://user-images.githubusercontent.com/44123869/164239723-d4d853fc-9870-4f3d-b22d-3215d9694383.png)


### After
![image](https://user-images.githubusercontent.com/44123869/164239346-f20f3d4e-5956-474a-a32e-8039db5245d2.png)
