### PR TITLE
(2348) Don't display duplicate organisations on public listing and when selecting an organisation for a profession

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Allow Professions to have up to 25 regulators (previously 5)
 - Show full list of countries when editing/adding decision data
 - Fix bug where publish button could still be clicked despite being disabled
+- Fix bug where duplicate regulators were being displayed publicly
 
 ### Added
 

--- a/src/organisations/organisation-versions.service.spec.ts
+++ b/src/organisations/organisation-versions.service.spec.ts
@@ -272,52 +272,6 @@ describe('OrganisationVersionsService', () => {
     });
   });
 
-  describe('allLiveAndDraft', () => {
-    it('fetches all of the live and draft organisations', async () => {
-      const versions = organisationVersionFactory.buildList(5);
-      const queryBuilder = createMock<SelectQueryBuilder<OrganisationVersion>>({
-        leftJoinAndSelect: () => queryBuilder,
-        distinctOn: () => queryBuilder,
-        where: () => queryBuilder,
-        orderBy: () => queryBuilder,
-        getMany: async () => versions,
-      });
-
-      jest
-        .spyOn(repo, 'createQueryBuilder')
-        .mockImplementation(() => queryBuilder);
-
-      const result = await service.allLiveAndDraft();
-
-      const expectedOrganisations = versions.map((version) =>
-        Organisation.withVersion(version.organisation, version),
-      );
-
-      expect(result).toEqual(expectedOrganisations);
-
-      expectJoinsToHaveBeenApplied(queryBuilder);
-
-      expect(queryBuilder.distinctOn).toHaveBeenCalledWith([
-        'organisation.name',
-        'organisation',
-      ]);
-
-      expect(queryBuilder.where).toHaveBeenCalledWith(
-        'organisationVersion.status IN(:...status)',
-        {
-          status: [
-            OrganisationVersionStatus.Live,
-            OrganisationVersionStatus.Draft,
-          ],
-        },
-      );
-
-      expect(queryBuilder.orderBy).toHaveBeenCalledWith(
-        'organisation.name, organisation',
-      );
-    });
-  });
-
   describe('allWithLatestVersion', () => {
     it('gets all organisations and their latest draft or live version with draft or live Professions', async () => {
       const versions = organisationVersionFactory.buildList(5);

--- a/src/organisations/organisation-versions.service.spec.ts
+++ b/src/organisations/organisation-versions.service.spec.ts
@@ -747,6 +747,7 @@ describe('OrganisationVersionsService', () => {
     const versions = organisationVersionFactory.buildList(5);
     const queryBuilder = createMock<SelectQueryBuilder<OrganisationVersion>>({
       leftJoinAndSelect: () => queryBuilder,
+      distinctOn: () => queryBuilder,
       where: () => queryBuilder,
       orderBy: () => queryBuilder,
       andWhere: () => queryBuilder,
@@ -775,6 +776,11 @@ describe('OrganisationVersionsService', () => {
       expect(result).toEqual(expectedOrgs);
 
       expectJoinsToHaveBeenApplied(queryBuilder);
+
+      expect(queryBuilder.distinctOn).toHaveBeenCalledWith([
+        'organisation.name',
+        'organisation',
+      ]);
 
       expect(queryBuilder.where).toHaveBeenCalledWith(
         'organisationVersion.status = :status',

--- a/src/organisations/organisation-versions.service.spec.ts
+++ b/src/organisations/organisation-versions.service.spec.ts
@@ -230,11 +230,12 @@ describe('OrganisationVersionsService', () => {
   });
 
   describe('allLive', () => {
-    it('fetches all of currently live organisations', async () => {
+    it('fetches all currently live organisations', async () => {
       const versions = organisationVersionFactory.buildList(5);
       const queryBuilder = createMock<SelectQueryBuilder<OrganisationVersion>>({
         leftJoinAndSelect: () => queryBuilder,
         where: () => queryBuilder,
+        distinctOn: () => queryBuilder,
         orderBy: () => queryBuilder,
         getMany: async () => versions,
       });
@@ -260,7 +261,14 @@ describe('OrganisationVersionsService', () => {
         },
       );
 
-      expect(queryBuilder.orderBy).toHaveBeenCalledWith('organisation.name');
+      expect(queryBuilder.distinctOn).toHaveBeenCalledWith([
+        'organisation.name',
+        'organisation',
+      ]);
+
+      expect(queryBuilder.orderBy).toHaveBeenCalledWith(
+        'organisation.name, organisation',
+      );
     });
   });
 

--- a/src/organisations/organisation-versions.service.ts
+++ b/src/organisations/organisation-versions.service.ts
@@ -101,23 +101,6 @@ export class OrganisationVersionsService {
     return await this.filter(query, filter);
   }
 
-  async allLiveAndDraft(): Promise<Organisation[]> {
-    const versions = await this.versionsWithJoins()
-      .distinctOn(['organisation.name', 'organisation'])
-      .where('organisationVersion.status IN(:...status)', {
-        status: [
-          OrganisationVersionStatus.Live,
-          OrganisationVersionStatus.Draft,
-        ],
-      })
-      .orderBy('organisation.name, organisation')
-      .getMany();
-
-    return versions.map((version) =>
-      Organisation.withVersion(version.organisation, version),
-    );
-  }
-
   async searchWithLatestVersion(filter: FilterInput): Promise<Organisation[]> {
     const query = this.versionsWithJoins()
       .distinctOn([

--- a/src/organisations/organisation-versions.service.ts
+++ b/src/organisations/organisation-versions.service.ts
@@ -91,7 +91,8 @@ export class OrganisationVersionsService {
 
   async searchLive(filter: FilterInput): Promise<Organisation[]> {
     const query = this.versionsWithJoins()
-      .orderBy('organisation.name')
+      .distinctOn(['organisation.name', 'organisation'])
+      .orderBy('organisation.name, organisation')
       .where('organisationVersion.status = :status', {
         status: OrganisationVersionStatus.Live,
       });

--- a/src/organisations/organisation-versions.service.ts
+++ b/src/organisations/organisation-versions.service.ts
@@ -78,10 +78,11 @@ export class OrganisationVersionsService {
 
   async allLive(): Promise<Organisation[]> {
     const versions = await this.versionsWithJoins()
+      .distinctOn(['organisation.name', 'organisation'])
       .where('organisationVersion.status = :status', {
         status: OrganisationVersionStatus.Live,
       })
-      .orderBy('organisation.name')
+      .orderBy('organisation.name, organisation')
       .getMany();
 
     return versions.map((version) =>


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR

Adds a `distinctOn` clause to `OrganisationVersionsService` functions to filter out where we were displaying multiple versions on the public index of Regulators, as well as on the internal list of regulators selected for an Organisation.

## Screenshots of UI changes

### Before

![image](https://user-images.githubusercontent.com/19826940/165041317-f00de59e-196a-40ef-b8ec-b7fd9d721962.png)

### After

I can't actually replicate this locally.
