### PR TITLE
(2355) Copy missing for Select boxes error when adding a regulator to a profession

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - Prevent Organisation from being archived if they have related Professions - Regulator must have Professions removed before it can be archived
+- Correct missing error copy when clicking CTA whilst amending a profession without selecting regulator name **and** regulator role
 - Allow Professions to have up to 25 regulators (previously 5)
 - Show full list of countries when editing/adding decision data
 - Fix bug where publish button could still be clicked despite being disabled

--- a/src/professions/admin/dto/organisations.dto.ts
+++ b/src/professions/admin/dto/organisations.dto.ts
@@ -63,7 +63,7 @@ class ProfessionToOrganisationNotBlank implements ValidatorConstraintInterface {
 
 export class OrganisationsDto {
   @Validate(ProfessionToOrganisationNotBlank, {
-    message: 'professions.form.errors.professionToOrganisations.blank',
+    message: 'professions.form.errors.professionToOrganisations.empty',
   })
   @Validate(ProfessionToOrganisationMustHaveRole, {
     message: 'professions.form.errors.professionToOrganisations.missingRole',

--- a/src/professions/admin/organisations.controller.spec.ts
+++ b/src/professions/admin/organisations.controller.spec.ts
@@ -335,7 +335,7 @@ describe('OrganisationsController', () => {
           expect.objectContaining({
             errors: {
               professionToOrganisations: {
-                text: 'professions.form.errors.professionToOrganisations.blank',
+                text: 'professions.form.errors.professionToOrganisations.empty',
               },
             },
           }),


### PR DESCRIPTION
This copy fits the error so I am assuming that 'empty' was just confused for 'blank'

## Screenshots of UI changes

### Before
![image](https://user-images.githubusercontent.com/44123869/165068102-27dcf843-9e69-4119-867c-f2cad2b09f59.png)

### After
![image](https://user-images.githubusercontent.com/44123869/165067935-638f6639-3cd5-442c-8cdb-08023447ae7e.png)
