### PR TITLE
(2360) Display confirmation flash message when publishing or saving decision data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - "Total" column on internal decision data tables
 - Add bulk decision data download link
+- Display confirmation banner when saving or publishing decision data
 
 ### Changed
 

--- a/cypress/integration/admin/decisions/edit.spec.ts
+++ b/cypress/integration/admin/decisions/edit.spec.ts
@@ -158,6 +158,12 @@ describe('Editing a decision dataset', () => {
 
       cy.checkAccessibility();
 
+      cy.translate('decisions.admin.saveAsDraft.confirmation.heading').then(
+        (confirmationHeading) => {
+          cy.get('body').should('contain', confirmationHeading);
+        },
+      );
+
       cy.get('table caption')
         .contains('International Route')
         .parent()
@@ -223,6 +229,14 @@ describe('Editing a decision dataset', () => {
       cy.translate('decisions.admin.buttons.publish').then((publish) => {
         cy.get('button').contains(publish).click();
       });
+
+      cy.checkAccessibility();
+
+      cy.translate('decisions.admin.publication.confirmation.heading').then(
+        (confirmationHeading) => {
+          cy.get('body').should('contain', confirmationHeading);
+        },
+      );
 
       cy.visitAndCheckAccessibility('/admin/decisions');
 

--- a/cypress/integration/admin/decisions/publish.spec.ts
+++ b/cypress/integration/admin/decisions/publish.spec.ts
@@ -46,6 +46,12 @@ describe('Publishing a decision dataset', () => {
         cy.get('body').should('contain', heading);
       });
 
+      cy.translate('decisions.admin.publication.confirmation.heading').then(
+        (confirmationHeading) => {
+          cy.get('body').should('contain', confirmationHeading);
+        },
+      );
+
       // Temporary check until we display the status on the "show" page
       cy.visitAndCheckAccessibility('/admin/decisions');
 

--- a/src/decisions/admin/edit.controller.spec.ts
+++ b/src/decisions/admin/edit.controller.spec.ts
@@ -26,8 +26,11 @@ import { DecisionDatasetEditPresenter } from './presenters/decision-dataset-edit
 import * as checkCanChangeDatasetModule from './helpers/check-can-change-dataset.helper';
 import * as checkCanPublishDatasetModule from './helpers/check-can-publish-dataset.helper';
 import { EditController } from './edit.controller';
+import { flashMessage } from '../../common/flash-message';
+import { translationOf } from '../../testutils/translation-of';
 
 jest.mock('./presenters/decision-dataset-edit.presenter');
+jest.mock('../../common/flash-message');
 
 const mockRouteTemplates: RouteTemplate[] = [
   {
@@ -313,6 +316,8 @@ describe('EditController', () => {
 
         const request = createDefaultMockRequest();
         const response = createMock<Response>();
+        const flashMock = flashMessage as jest.Mock;
+        flashMock.mockImplementation(() => 'STUB_FLASH_MESSAGE');
 
         await controller.update(
           'example-profession-id',
@@ -324,6 +329,11 @@ describe('EditController', () => {
         );
 
         expect(checkCanPublishDatasetSpy).toHaveBeenCalledWith(request);
+
+        expect(flashMock).toHaveBeenCalledWith(
+          translationOf('decisions.admin.publication.confirmation.heading'),
+          translationOf('decisions.admin.publication.confirmation.body'),
+        );
 
         expect(response.redirect).toHaveBeenCalledWith(
           '/admin/decisions/example-profession-id/example-organisation-id/2016',
@@ -425,6 +435,9 @@ describe('EditController', () => {
         const request = createDefaultMockRequest();
         const response = createMock<Response>();
 
+        const flashMock = flashMessage as jest.Mock;
+        flashMock.mockImplementation(() => 'STUB_FLASH_MESSAGE');
+
         await controller.update(
           'example-profession-id',
           'example-organisation-id',
@@ -432,6 +445,11 @@ describe('EditController', () => {
           editDto,
           request,
           response,
+        );
+
+        expect(flashMock).toHaveBeenCalledWith(
+          translationOf('decisions.admin.saveAsDraft.confirmation.heading'),
+          translationOf('decisions.admin.saveAsDraft.confirmation.body'),
         );
 
         expect(response.redirect).toHaveBeenCalledWith(

--- a/src/decisions/admin/edit.controller.ts
+++ b/src/decisions/admin/edit.controller.ts
@@ -32,6 +32,7 @@ import { parseEditDtoDecisionRoutes } from './helpers/parse-edit-dto-decision-ro
 import { modifyDecisionRoutes } from './helpers/modify-decision-routes.helper';
 import { checkCanChangeDataset } from './helpers/check-can-change-dataset.helper';
 import { checkCanPublishDataset } from './helpers/check-can-publish-dataset.helper';
+import { flashMessage } from '../../common/flash-message';
 
 const emptyCountry = {
   code: null,
@@ -153,6 +154,21 @@ export class EditController {
       };
 
       await this.decisionDatasetsService.save(newDataset);
+
+      const localisationId =
+        action === 'publish' ? 'publication' : 'saveAsDraft';
+
+      const messageTitle = await this.i18nService.translate(
+        `decisions.admin.${localisationId}.confirmation.heading`,
+      );
+
+      const messageBody = await this.i18nService.translate(
+        `decisions.admin.${localisationId}.confirmation.body`,
+      );
+
+      const flashType = action === 'publish' ? 'success' : 'info';
+
+      request.flash(flashType, flashMessage(messageTitle, messageBody));
 
       response.redirect(
         `/admin/decisions/${profession.id}/${organisation.id}/${year}`,

--- a/src/decisions/admin/publication.controller.spec.ts
+++ b/src/decisions/admin/publication.controller.spec.ts
@@ -1,13 +1,19 @@
 import { createMock, DeepMocked } from '@golevelup/ts-jest';
 import { Test, TestingModule } from '@nestjs/testing';
-import { Response } from 'express';
+import { Request, Response } from 'express';
+import { I18nService } from 'nestjs-i18n';
+import { flashMessage } from '../../common/flash-message';
 import { OrganisationsService } from '../../organisations/organisations.service';
 import { ProfessionsService } from '../../professions/professions.service';
+import { createMockI18nService } from '../../testutils/create-mock-i18n-service';
 import decisionDatasetFactory from '../../testutils/factories/decision-dataset';
 import organisationFactory from '../../testutils/factories/organisation';
 import professionFactory from '../../testutils/factories/profession';
+import { translationOf } from '../../testutils/translation-of';
 import { DecisionDatasetsService } from '../decision-datasets.service';
 import { PublicationController } from './publication.controller';
+
+jest.mock('../../common/flash-message');
 
 describe('PublicationController', () => {
   let controller: PublicationController;
@@ -15,11 +21,13 @@ describe('PublicationController', () => {
   let decisionDatasetsService: DeepMocked<DecisionDatasetsService>;
   let professionsService: DeepMocked<ProfessionsService>;
   let organisationsService: DeepMocked<OrganisationsService>;
+  let i18nService: DeepMocked<I18nService>;
 
   beforeEach(async () => {
     decisionDatasetsService = createMock<DecisionDatasetsService>();
     professionsService = createMock<ProfessionsService>();
     organisationsService = createMock<OrganisationsService>();
+    i18nService = createMockI18nService();
 
     const module: TestingModule = await Test.createTestingModule({
       controllers: [PublicationController],
@@ -35,6 +43,10 @@ describe('PublicationController', () => {
         {
           provide: OrganisationsService,
           useValue: organisationsService,
+        },
+        {
+          provide: I18nService,
+          useValue: i18nService,
         },
       ],
     }).compile();
@@ -86,6 +98,10 @@ describe('PublicationController', () => {
     describe('when the user is a service owner', () => {
       it('saves the given dataset with the published status', async () => {
         const response = createMock<Response>();
+        const request = createMock<Request>();
+
+        const flashMock = flashMessage as jest.Mock;
+        flashMock.mockImplementation(() => 'STUB_FLASH_MESSAGE');
 
         const profession = professionFactory.build({
           id: 'example-profession-id',
@@ -106,6 +122,7 @@ describe('PublicationController', () => {
           'example-organisation-id',
           2016,
           response,
+          request,
         );
 
         expect(decisionDatasetsService.find).toHaveBeenCalledWith(
@@ -115,6 +132,12 @@ describe('PublicationController', () => {
         );
 
         expect(decisionDatasetsService.publish).toHaveBeenCalledWith(dataset);
+
+        expect(flashMock).toHaveBeenCalledWith(
+          translationOf('decisions.admin.publication.confirmation.heading'),
+          translationOf('decisions.admin.publication.confirmation.body'),
+        );
+
         expect(response.redirect).toHaveBeenCalledWith(
           '/admin/decisions/example-profession-id/example-organisation-id/2016',
         );

--- a/src/i18n/en/decisions.json
+++ b/src/i18n/en/decisions.json
@@ -29,6 +29,10 @@
         "organisation": "Regulator: ",
         "profession": "Profession: ",
         "year": "Year: "
+      },
+      "confirmation": {
+        "heading": "This recognition decision dataset has been published.",
+        "body": "<a href='/admin/decisions' class='govuk-link'>Back to recognition decision data listing page</a>."
       }
     },
     "new": {

--- a/src/i18n/en/decisions.json
+++ b/src/i18n/en/decisions.json
@@ -35,6 +35,12 @@
         "body": "<a href='/admin/decisions' class='govuk-link'>Back to recognition decision data listing page</a>."
       }
     },
+    "saveAsDraft": {
+      "confirmation": {
+        "heading": "This recognition decision dataset has been saved.",
+        "body": "<p class='govuk-body-m'>The changes have not been published yet.</p><a href='/admin/decisions' class='govuk-link'>Back to recognition decision data listing page</a>."
+      }
+    },
     "new": {
       "heading": "Recognition decision data",
       "caption": "Adding new recognition decision data",


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR

Adds confirmation banner to pages after saving or publishing decision data. I've tweaked the content slightly from the designs to be a bit clearer.

## Screenshots of UI changes

### Save as draft

<img width="1000" alt="image" src="https://user-images.githubusercontent.com/19826940/165347155-1db299fe-b363-439a-b3c1-8e8fc643353e.png">

### Publication

<img width="996" alt="image" src="https://user-images.githubusercontent.com/19826940/165347183-a525bf7f-b65c-44b0-81cf-704c05622959.png">

