### PR TITLE
2319 add sidebar to admin decision data page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Display confirmation banner when saving or publishing decision data
 - Filters on decision data dashboard, applying to displayed data and exported CSV data
 - "Submitted" status for decision datasets to make it clear that they're ready for publishing
+- Add sidebar to admin decision data page
 
 ### Changed
 

--- a/cypress/integration/admin/decisions/show.spec.ts
+++ b/cypress/integration/admin/decisions/show.spec.ts
@@ -1,3 +1,5 @@
+import { format } from 'date-fns';
+
 describe('Showing a decision dataset', () => {
   context('When I am logged in as editor', () => {
     beforeEach(() => {
@@ -76,6 +78,75 @@ describe('Showing a decision dataset', () => {
             ],
           );
         });
+    });
+
+    it('the sidebar shows the correct data', () => {
+      cy.get('tr')
+        .contains('Registered Trademark Attorney')
+        .parent()
+        .within(() => {
+          cy.get('a').contains('View details').click();
+        });
+
+      cy.get('h2')
+        .contains('Status')
+        .get('.govuk-tag--yellow')
+        .contains('Draft');
+
+      cy.get('h2')
+        .contains('Last modified')
+        .get('[data-cy=last-modified]')
+        .should('contain', format(new Date(), 'd MMM yyyy'));
+
+      cy.get('h2')
+        .contains('Changed by')
+        .get('[data-cy=changed-by-text]')
+        .should('contain', 'Organisation Admin')
+        .should('contain', 'beis-rpr+orgadmin@dxw.com');
+
+      cy.get('nav').find('ul').should('have.length', 2);
+    });
+
+    it('I can edit the data by clicking the edit button', () => {
+      cy.get('tr')
+        .contains('Registered Trademark Attorney')
+        .parent()
+        .within(() => {
+          cy.get('a').contains('View details').click();
+        });
+      cy.translate('decisions.admin.buttons.edit').then((editButtonText) => {
+        cy.get('a')
+          .contains(editButtonText)
+          .click()
+          .url()
+          .should('contain', 'edit');
+      });
+    });
+
+    it('I can view the "Currently published version" by clicking the link button', () => {
+      cy.get('tr')
+        .contains('Registered Trademark Attorney')
+        .parent()
+        .within(() => {
+          cy.get('a').contains('View details').click();
+        });
+      cy.translate('decisions.admin.publicFacingLink.label').then(
+        (publicFacingLinkButtonText) => {
+          cy.get('[data-cy="currently-published-version-text"]').contains(
+            publicFacingLinkButtonText,
+          );
+        },
+      );
+      cy.translate('decisions.admin.publicFacingLink.heading').then(
+        (publicFacingLinkButtonText) => {
+          cy.get('[data-cy="currently-published-version-text"]')
+            .contains(publicFacingLinkButtonText)
+            .contains('a')
+            .click()
+            .url()
+            .should('contain', '');
+        },
+      );
     });
   });
 });

--- a/seeds/development/decision-datasets.json
+++ b/seeds/development/decision-datasets.json
@@ -4,6 +4,9 @@
     "organisation": "Law Society of England and Wales",
     "year": 2020,
     "status": "live",
+    "user": {
+      "email": "beis-rpr@dxw.com"
+    },
     "routes": [
       {
         "name": "Degree",
@@ -35,6 +38,9 @@
     "organisation": "Law Society of England and Wales",
     "year": 2021,
     "status": "live",
+    "user": {
+      "email": "beis-rpr+orgeditor@dxw.com"
+    },
     "routes": [
       {
         "name": "EEA Route",
@@ -66,6 +72,9 @@
     "organisation": "Alternative Law Society",
     "year": 2020,
     "status": "draft",
+    "user": {
+      "email": "beis-rpr+orgadmin@dxw.com"
+    },
     "routes": [
       {
         "name": "Other qualification",
@@ -97,6 +106,9 @@
     "organisation": "Department for Education",
     "year": 2019,
     "status": "draft",
+    "user": {
+      "email": "beis-rpr@dxw.com"
+    },
     "routes": [
       {
         "name": "EEA Route",
@@ -151,6 +163,9 @@
     "organisation": "Department for Education",
     "year": 2018,
     "status": "live",
+    "user": {
+      "email": "beis-rpr@dxw.com"
+    },
     "routes": [
       {
         "name": "Other qualification",

--- a/seeds/test/decision-datasets.json
+++ b/seeds/test/decision-datasets.json
@@ -4,6 +4,9 @@
     "organisation": "Law Society of England and Wales",
     "year": 2020,
     "status": "live",
+    "user": {
+      "email": "beis-rpr@dxw.com"
+    },
     "routes": [
       {
         "name": "Degree",
@@ -35,6 +38,9 @@
     "organisation": "Law Society of England and Wales",
     "year": 2021,
     "status": "live",
+    "user": {
+      "email": "beis-rpr+orgeditor@dxw.com"
+    },
     "routes": [
       {
         "name": "EEA Route",
@@ -66,6 +72,9 @@
     "organisation": "Alternative Law Society",
     "year": 2020,
     "status": "draft",
+    "user": {
+      "email": "beis-rpr+orgadmin@dxw.com"
+    },
     "routes": [
       {
         "name": "Other qualification",
@@ -97,6 +106,9 @@
     "organisation": "Department for Education",
     "year": 2019,
     "status": "draft",
+    "user": {
+      "email": "beis-rpr@dxw.com"
+    },
     "routes": [
       {
         "name": "EEA Route",
@@ -151,6 +163,9 @@
     "organisation": "Department for Education",
     "year": 2018,
     "status": "live",
+    "user": {
+      "email": "beis-rpr@dxw.com"
+    },
     "routes": [
       {
         "name": "Other qualification",

--- a/src/decisions/admin/decisions.controller.spec.ts
+++ b/src/decisions/admin/decisions.controller.spec.ts
@@ -433,11 +433,30 @@ describe('DecisionsController', () => {
         mockTables,
       );
 
+      Object.defineProperties(DecisionDatasetPresenter.prototype, {
+        changedBy: {
+          get() {
+            return {
+              name: 'name',
+              email: 'email',
+            };
+          },
+        },
+        lastModified: {
+          get() {
+            return '29 Apr 2022';
+          },
+        },
+      });
+
       const expected: ShowTemplate = {
         profession,
         organisation,
+        changedBy: { name: 'name', email: 'email' },
+        lastModified: '29 Apr 2022',
         tables: mockTables,
         year: 2017,
+        isPublished: true,
         datasetStatus: DecisionDatasetStatus.Live,
       };
 
@@ -468,7 +487,7 @@ describe('DecisionsController', () => {
       );
 
       expect(DecisionDatasetPresenter).toHaveBeenCalledWith(
-        dataset.routes,
+        dataset,
         i18nService,
       );
       expect(DecisionDatasetPresenter.prototype.tables).toHaveBeenCalled();

--- a/src/decisions/admin/decisions.controller.ts
+++ b/src/decisions/admin/decisions.controller.ts
@@ -34,6 +34,7 @@ import { Response } from 'express';
 import { OrganisationVersionsService } from '../../organisations/organisation-versions.service';
 import { getQueryString } from './helpers/get-query-string.helper';
 import { getExportTimestamp } from './helpers/get-export-timestamp.helper';
+import { DecisionDatasetStatus } from '../decision-dataset.entity';
 
 @UseGuards(AuthenticationGuard)
 @Controller('admin/decisions')
@@ -164,18 +165,16 @@ export class DecisionsController {
     const organisation = dataset.organisation;
 
     checkCanChangeDataset(request, profession, organisation, year, true);
-
-    const presenter = new DecisionDatasetPresenter(
-      dataset.routes,
-      this.i18nService,
-    );
-
+    const presenter = new DecisionDatasetPresenter(dataset, this.i18nService);
     return {
       profession,
       organisation,
       year,
       tables: presenter.tables(),
       datasetStatus: dataset.status,
+      isPublished: dataset.status === DecisionDatasetStatus.Live,
+      changedBy: presenter.changedBy,
+      lastModified: presenter.lastModified,
     };
   }
 }

--- a/src/decisions/admin/interfaces/show-template.interface.ts
+++ b/src/decisions/admin/interfaces/show-template.interface.ts
@@ -7,6 +7,9 @@ export interface ShowTemplate {
   profession: Profession;
   organisation: Organisation;
   year: number;
-  tables: Table[];
   datasetStatus: DecisionDatasetStatus;
+  isPublished: boolean;
+  tables: Table[];
+  changedBy: { name: string; email: string };
+  lastModified: string;
 }

--- a/src/decisions/decision-dataset.seeder.ts
+++ b/src/decisions/decision-dataset.seeder.ts
@@ -3,6 +3,7 @@ import { Repository } from 'typeorm';
 import { Seeder } from 'nestjs-seeder';
 import { InjectRepository } from '@nestjs/typeorm';
 import { InjectData } from '../common/decorators/seeds.decorator';
+import { User } from '../users/user.entity';
 import { Organisation } from '../organisations/organisation.entity';
 import {
   DecisionDataset,
@@ -17,6 +18,7 @@ type SeedDecisionDataset = {
   year: number;
   status: DecisionDatasetStatus;
   routes: DecisionRoute[];
+  user: User;
 };
 
 @Injectable()
@@ -31,6 +33,8 @@ export class DecisionDatasetsSeeder implements Seeder {
     private readonly professionsRepository: Repository<Profession>,
     @InjectRepository(Organisation)
     private readonly organisationRepository: Repository<Organisation>,
+    @InjectRepository(User)
+    private readonly userRepository: Repository<User>,
   ) {}
 
   async seed(): Promise<void> {
@@ -44,13 +48,17 @@ export class DecisionDatasetsSeeder implements Seeder {
           where: { name: seedDataset.organisation },
         });
 
+        const user = await this.userRepository.findOne({
+          where: { email: seedDataset.user.email },
+        });
+
         const dataset: DecisionDataset = {
           profession,
           organisation,
+          user,
           year: seedDataset.year,
           status: seedDataset.status,
           routes: seedDataset.routes,
-          user: null,
           created_at: undefined,
           updated_at: undefined,
         };

--- a/src/decisions/presenters/decision-dataset.presenter.spec.ts
+++ b/src/decisions/presenters/decision-dataset.presenter.spec.ts
@@ -4,8 +4,9 @@ import { Country } from '../../countries/country';
 import { createMockI18nService } from '../../testutils/create-mock-i18n-service';
 import { translationOf } from '../../testutils/translation-of';
 import * as decisionValueToStringModule from '../admin/helpers/decision-value-to-string.helper';
-import { DecisionRoute } from '../interfaces/decision-route.interface';
 import { DecisionDatasetPresenter } from './decision-dataset.presenter';
+import userFactory from '../../testutils/factories/user';
+import decisionDatasetFactory from '../../testutils/factories/decision-dataset';
 
 jest.mock('../../countries/country');
 
@@ -22,53 +23,54 @@ describe('DecisionDatasetPresenter', () => {
 
       const spotCheckCountryCode = 'CY';
       const spotCheckValue = 8;
-
-      const routes: DecisionRoute[] = [
-        {
-          name: 'Example route 1',
-          countries: [
-            {
-              code: spotCheckCountryCode,
-              decisions: {
-                yes: 4,
-                no: 5,
-                yesAfterComp: 6,
-                noAfterComp: 7,
+      const dataset = decisionDatasetFactory.build({
+        routes: [
+          {
+            name: 'Example route 1',
+            countries: [
+              {
+                code: spotCheckCountryCode,
+                decisions: {
+                  yes: 4,
+                  no: 5,
+                  yesAfterComp: 6,
+                  noAfterComp: 7,
+                },
               },
-            },
-            {
-              code: 'FR',
-              decisions: {
-                yes: 5,
-                no: spotCheckValue,
-                yesAfterComp: 0,
-                noAfterComp: 4,
+              {
+                code: 'FR',
+                decisions: {
+                  yes: 5,
+                  no: spotCheckValue,
+                  yesAfterComp: 0,
+                  noAfterComp: 4,
+                },
               },
-            },
-          ],
-        },
-        {
-          name: 'Example route 2',
-          countries: [
-            {
-              code: 'JP',
-              decisions: {
-                yes: 1,
-                no: 3,
-                yesAfterComp: 11,
-                noAfterComp: 2,
+            ],
+          },
+          {
+            name: 'Example route 2',
+            countries: [
+              {
+                code: 'JP',
+                decisions: {
+                  yes: 1,
+                  no: 3,
+                  yesAfterComp: 11,
+                  noAfterComp: 2,
+                },
               },
-            },
-          ],
-        },
-      ];
+            ],
+          },
+        ],
+      });
 
       const decisionValueToStringSpy = jest.spyOn(
         decisionValueToStringModule,
         'decisionValueToString',
       );
 
-      const presenter = new DecisionDatasetPresenter(routes, i18nService);
+      const presenter = new DecisionDatasetPresenter(dataset, i18nService);
 
       const expectedHead: TableRow = [
         {
@@ -179,6 +181,33 @@ describe('DecisionDatasetPresenter', () => {
 
       expect(decisionValueToStringSpy).toHaveBeenCalledTimes(12);
       expect(decisionValueToStringSpy).nthCalledWith(7, spotCheckValue);
+    });
+
+    describe('changedBy', () => {
+      it('if the dataset has a user it returns their name and email address', () => {
+        const user = userFactory.build({
+          name: 'example',
+          email: 'test@test.com',
+        });
+        const dataset = decisionDatasetFactory.build({ user });
+        const i18nService = createMockI18nService();
+
+        const presenter = new DecisionDatasetPresenter(dataset, i18nService);
+
+        expect(presenter.changedBy).toEqual({
+          name: 'example',
+          email: 'test@test.com',
+        });
+      });
+
+      it("if the dataset doesn't have a user it returns null", () => {
+        const dataset = decisionDatasetFactory.build({ user: undefined });
+        const i18nService = createMockI18nService();
+
+        const presenter = new DecisionDatasetPresenter(dataset, i18nService);
+
+        expect(presenter.changedBy).toEqual(null);
+      });
     });
   });
 

--- a/src/decisions/presenters/decision-dataset.presenter.ts
+++ b/src/decisions/presenters/decision-dataset.presenter.ts
@@ -3,11 +3,15 @@ import { Table } from '../../common/interfaces/table';
 import { TableRow } from '../../common/interfaces/table-row';
 import { Country } from '../../countries/country';
 import { decisionValueToString } from '../admin/helpers/decision-value-to-string.helper';
-import { DecisionRoute } from '../interfaces/decision-route.interface';
+import { formatDate } from '../../common/utils';
+import {
+  DecisionDataset,
+  DecisionDatasetStatus,
+} from '../decision-dataset.entity';
 
 export class DecisionDatasetPresenter {
   constructor(
-    private readonly routes: DecisionRoute[],
+    private readonly dataset: DecisionDataset,
     private readonly i18nService: I18nService,
   ) {}
 
@@ -45,7 +49,7 @@ export class DecisionDatasetPresenter {
       },
     ];
 
-    return this.routes.map((route) => {
+    return this.dataset.routes.map((route) => {
       const table: Table = {
         classes: 'rpr-decision-data__table-container',
         captionClasses: 'govuk-table__caption--l',
@@ -79,6 +83,23 @@ export class DecisionDatasetPresenter {
 
       return table;
     });
+  }
+  get changedBy(): { name: string; email: string } {
+    const user = this.dataset.user;
+    return user
+      ? {
+          name: user.name,
+          email: user.email,
+        }
+      : null;
+  }
+
+  get lastModified(): string {
+    return formatDate(this.dataset.updated_at);
+  }
+
+  get status(): DecisionDatasetStatus {
+    return this.dataset.status;
   }
 
   private computeTotal(decisions: {

--- a/src/i18n/en/decisions.json
+++ b/src/i18n/en/decisions.json
@@ -34,15 +34,20 @@
         "profession": "Profession",
         "regulator": "Regulator",
         "year": "Year",
-        "lastModified": "Last updated",
+        "lastModified": "Last modified",
         "status": "Status",
-        "actions": "Actions"
+        "actions": "Actions",
+        "changedBy": "Changed by"
       },
       "search": {
         "foundSingular": "{count} decision dataset found",
         "foundPlural": "{count} decision datasets found"
       },
       "download": "Download datasets"
+    },
+    "publicFacingLink": {
+      "heading": "Currently published version",
+      "label": "Public facing link"
     },
     "show": {
       "edit": "Edit"

--- a/views/admin/decisions/show.njk
+++ b/views/admin/decisions/show.njk
@@ -11,7 +11,32 @@
     <div class="govuk-grid-column-three-quarters">
       {% include "../../decisions/_decision-tables.njk" %}
     </div>
-    <div class="govuk-grid-column-one-quarter">
+    <aside class="govuk-grid-column-one-quarter">
+
+      <h2 class="govuk-heading-s" data-status>
+        {{ "decisions.admin.dashboard.tableHeading.status" | t }}<br>
+        {{ datasetStatus | status }}
+      </h2>
+
+      <h2 class="govuk-heading-s" data-cy="last-modified-text">
+        {{ "decisions.admin.dashboard.tableHeading.lastModified" | t }}<br>
+        <span class="govuk-body" data-cy="last-modified">{{ lastModified }}</span>
+      </h2>
+
+      {% if changedBy %}
+        <h2 class="govuk-heading-s" data-cy="changed-by-text">
+          {{ "decisions.admin.dashboard.tableHeading.changedBy" | t }}<br>
+          <span class="govuk-body" data-cy="changed-by-user-name">{{ changedBy.name }}</span><br>
+          <span class="govuk-body" data-cy="changed-by-user-email">{{ changedBy.email | email }}</span>
+        </h2>
+      {% endif %}
+      <h2 class="govuk-heading-s" data-cy="currently-published-version-text">
+        {{ "decisions.admin.publicFacingLink.heading" | t }}<br>
+        <span class="govuk-body" data-cy="currently-published-version">
+          <a href="">{{ "decisions.admin.publicFacingLink.label" | t }}</a>
+        </span>
+      </h2>
+
       <nav role="navigation" data-cy="actions">
         <ul class="govuk-list">
           {% if 'uploadDecisionData' in permissions %}
@@ -50,7 +75,10 @@
           {% endif %}
         </ul>
       </nav>
-    </div>
-  </div>
+    </aside>
+  </aside>
+</div>
+
+</div>
 
 {% endblock %}


### PR DESCRIPTION
# Changes in this PR
This PR adds a sidebar to the admin decision data page which contains:

- The status of the decision data (published/draft/submitted)
- The date that the data was last changed
- The user that last changed the data
- A publicly facing link for the data (currently intentionally blank until functionality has been developed)
- A button to edit the data

A button to download the dataset will be added in a subsequent PR

## Screenshots of UI changes

### Before
![image](https://user-images.githubusercontent.com/44123869/165963950-2d624597-b32e-4d66-9311-f822d11f6aa1.png)

### After
![image](https://user-images.githubusercontent.com/44123869/165962886-a1841658-9332-490b-9222-b13aa0622126.png)

