### PR TITLE
(2311) Add download data button for an individual profession for internal users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 - Add confirmation page when publishing decision data from the editing page
+- Add single decision dataset download link to internal dataset pages
 
 ### Changed
 

--- a/assets/stylesheets/application.scss
+++ b/assets/stylesheets/application.scss
@@ -217,6 +217,15 @@ $small-screen: 768px;
         margin-bottom: 0;
       }
     }
+
+    &-file-download-link {
+      display: block;
+      background-image: url(/assets/images/icon-file-download.svg);
+      background-repeat: no-repeat;
+      background-size: 40px 40px;
+      min-height: 2.5em;
+      padding: 8px 0 0 50px;
+    }
   }
 
   &__buttons-container {

--- a/cypress/integration/admin/decisions/show.spec.ts
+++ b/cypress/integration/admin/decisions/show.spec.ts
@@ -148,5 +148,34 @@ describe('Showing a decision dataset', () => {
         },
       );
     });
+
+    it('I can download a decision dataset', () => {
+      cy.get('tr')
+        .contains(
+          'Secondary School Teacher in State maintained schools (England)',
+        )
+        .parent()
+        .within(() => {
+          cy.get('a').contains('View details').click();
+        });
+
+      cy.translate('decisions.admin.show.download', {
+        profession:
+          'Secondary School Teacher in State maintained schools (England)',
+      }).then((download) => {
+        cy.checkCsvDownload(
+          download,
+          'decisions-secondary-school-teacher-in-state-maintained-schools-england-department-for-education-2019',
+          (dataset) => {
+            return (
+              dataset.profession ===
+                'Secondary School Teacher in State maintained schools (England)' &&
+              dataset.organisation === 'Department for Education' &&
+              dataset.year === 2019
+            );
+          },
+        );
+      });
+    });
   });
 });

--- a/cypress/support/index.ts
+++ b/cypress/support/index.ts
@@ -24,6 +24,16 @@ export interface AxeRules {
 }
 
 declare global {
+  type SeedDecisionDataset = {
+    profession: string;
+    organisation: string;
+    year: number;
+    status: string;
+    routes: {
+      countries: [];
+    }[];
+  };
+
   // eslint-disable-next-line @typescript-eslint/no-namespace
   namespace Cypress {
     interface Chainable {
@@ -75,6 +85,12 @@ declare global {
       visitInternalDashboard(): void;
       clickFilterButtonAndCheckAccessibility(): void;
       expandFilters(prefix: string): void;
+      getDisplayedDatasets(): Chainable<SeedDecisionDataset[]>;
+      checkCsvDownload(
+        downloadText: string,
+        filename: string,
+        filter: (dataset: SeedDecisionDataset) => boolean,
+      ): void;
     }
   }
 }

--- a/src/decisions/admin/decisions.controller.ts
+++ b/src/decisions/admin/decisions.controller.ts
@@ -99,11 +99,7 @@ export class DecisionsController {
   }
 
   @Get('export')
-  @Permissions(
-    UserPermission.UploadDecisionData,
-    UserPermission.DownloadDecisionData,
-    UserPermission.ViewDecisionData,
-  )
+  @Permissions(UserPermission.DownloadDecisionData)
   async export(
     @Req() request: RequestWithAppSession,
     @Res() response: Response,

--- a/src/decisions/admin/show.controller.spec.ts
+++ b/src/decisions/admin/show.controller.spec.ts
@@ -1,0 +1,155 @@
+import { createMock, DeepMocked } from '@golevelup/ts-jest';
+import { Test, TestingModule } from '@nestjs/testing';
+import { I18nService } from 'nestjs-i18n';
+import { ProfessionsService } from '../../professions/professions.service';
+import { createMockI18nService } from '../../testutils/create-mock-i18n-service';
+import { createDefaultMockRequest } from '../../testutils/factories/create-default-mock-request';
+import decisionDatasetFactory from '../../testutils/factories/decision-dataset';
+import organisationFactory from '../../testutils/factories/organisation';
+import professionFactory from '../../testutils/factories/profession';
+import { DecisionDatasetsService } from '../decision-datasets.service';
+import * as checkCanChangeDatasetModule from './helpers/check-can-change-dataset.helper';
+import { DecisionDatasetStatus } from '../decision-dataset.entity';
+import { ShowController } from './show.controller';
+import { DecisionDatasetPresenter } from '../presenters/decision-dataset.presenter';
+import { Table } from '../../common/interfaces/table';
+import { ShowTemplate } from './interfaces/show-template.interface';
+
+jest.mock('../presenters/decision-dataset.presenter');
+
+const mockTables: Table[] = [
+  {
+    caption: 'Example route',
+    head: [],
+    rows: [],
+  },
+];
+
+describe('ShowController', () => {
+  let controller: ShowController;
+
+  let decisionDatasetsService: DeepMocked<DecisionDatasetsService>;
+  let professionsService: DeepMocked<ProfessionsService>;
+  let i18nService: DeepMocked<I18nService>;
+
+  beforeEach(async () => {
+    decisionDatasetsService = createMock<DecisionDatasetsService>();
+    professionsService = createMock<ProfessionsService>();
+    i18nService = createMockI18nService();
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [ShowController],
+      providers: [
+        {
+          provide: DecisionDatasetsService,
+          useValue: decisionDatasetsService,
+        },
+        {
+          provide: ProfessionsService,
+          useValue: professionsService,
+        },
+        {
+          provide: I18nService,
+          useValue: i18nService,
+        },
+      ],
+    }).compile();
+
+    controller = module.get<ShowController>(ShowController);
+  });
+
+  describe('show', () => {
+    it('presents the specified decision dataset', async () => {
+      const profession = professionFactory.build({
+        id: 'example-profession-id',
+      });
+      const organisation = organisationFactory.build({
+        id: 'example-organisation-id',
+      });
+
+      const dataset = decisionDatasetFactory.build({
+        profession: profession,
+        organisation: organisation,
+        year: 2017,
+        status: DecisionDatasetStatus.Live,
+      });
+
+      const request = createDefaultMockRequest();
+
+      const checkCanChangeDatasetSpy = jest
+        .spyOn(checkCanChangeDatasetModule, 'checkCanChangeDataset')
+        .mockImplementation();
+
+      professionsService.findWithVersions.mockResolvedValueOnce(profession);
+      decisionDatasetsService.find.mockResolvedValue(dataset);
+
+      (DecisionDatasetPresenter.prototype.tables as jest.Mock).mockReturnValue(
+        mockTables,
+      );
+
+      Object.defineProperties(DecisionDatasetPresenter.prototype, {
+        changedBy: {
+          get() {
+            return {
+              name: 'name',
+              email: 'email',
+            };
+          },
+        },
+        lastModified: {
+          get() {
+            return '29 Apr 2022';
+          },
+        },
+      });
+
+      const expected: ShowTemplate = {
+        profession,
+        organisation,
+        changedBy: { name: 'name', email: 'email' },
+        lastModified: '29 Apr 2022',
+        tables: mockTables,
+        year: 2017,
+        isPublished: true,
+        datasetStatus: DecisionDatasetStatus.Live,
+      };
+
+      const result = await controller.show(
+        'example-profession-id',
+        'example-organisation-id',
+        2017,
+        request,
+      );
+
+      expect(result).toEqual(expected);
+
+      expect(checkCanChangeDatasetSpy).toHaveBeenCalledWith(
+        request,
+        profession,
+        organisation,
+        2017,
+        true,
+      );
+
+      expect(professionsService.findWithVersions).toHaveBeenCalledWith(
+        'example-profession-id',
+      );
+      expect(decisionDatasetsService.find).toHaveBeenCalledWith(
+        'example-profession-id',
+        'example-organisation-id',
+        2017,
+      );
+
+      expect(DecisionDatasetPresenter).toHaveBeenCalledWith(
+        dataset,
+        i18nService,
+      );
+      expect(DecisionDatasetPresenter.prototype.tables).toHaveBeenCalled();
+    });
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+    jest.restoreAllMocks();
+  });
+});

--- a/src/decisions/admin/show.controller.ts
+++ b/src/decisions/admin/show.controller.ts
@@ -1,0 +1,73 @@
+import {
+  Controller,
+  Get,
+  Param,
+  ParseIntPipe,
+  Render,
+  Req,
+  UseGuards,
+} from '@nestjs/common';
+import { I18nService } from 'nestjs-i18n';
+import { AuthenticationGuard } from '../../common/authentication.guard';
+import { RequestWithAppSession } from '../../common/interfaces/request-with-app-session.interface';
+import { UserPermission } from '../../users/user-permission';
+import { Permissions } from '../../common/permissions.decorator';
+import { DecisionDatasetsService } from '../decision-datasets.service';
+import { ProfessionsService } from '../../professions/professions.service';
+import { checkCanChangeDataset } from './helpers/check-can-change-dataset.helper';
+import { BackLink } from '../../common/decorators/back-link.decorator';
+import { ShowTemplate } from './interfaces/show-template.interface';
+import { DecisionDatasetStatus } from '../decision-dataset.entity';
+import { DecisionDatasetPresenter } from '../presenters/decision-dataset.presenter';
+
+@UseGuards(AuthenticationGuard)
+@Controller('admin/decisions')
+export class ShowController {
+  constructor(
+    private readonly decisionDatasetsService: DecisionDatasetsService,
+    private readonly professionsService: ProfessionsService,
+    private readonly i18nService: I18nService,
+  ) {}
+
+  @Get(':professionId/:organisationId/:year')
+  @Permissions(
+    UserPermission.UploadDecisionData,
+    UserPermission.DownloadDecisionData,
+    UserPermission.ViewDecisionData,
+  )
+  @Render('admin/decisions/show')
+  @BackLink('/admin/decisions')
+  async show(
+    @Param('professionId') professionId: string,
+    @Param('organisationId') organisationId: string,
+    @Param('year', ParseIntPipe) year: number,
+    @Req() request: RequestWithAppSession,
+  ): Promise<ShowTemplate> {
+    const profession = await this.professionsService.findWithVersions(
+      professionId,
+    );
+
+    const dataset = await this.decisionDatasetsService.find(
+      professionId,
+      organisationId,
+      year,
+    );
+
+    const organisation = dataset.organisation;
+
+    checkCanChangeDataset(request, profession, organisation, year, true);
+
+    const presenter = new DecisionDatasetPresenter(dataset, this.i18nService);
+
+    return {
+      profession,
+      organisation,
+      year,
+      tables: presenter.tables(),
+      datasetStatus: dataset.status,
+      isPublished: dataset.status === DecisionDatasetStatus.Live,
+      changedBy: presenter.changedBy,
+      lastModified: presenter.lastModified,
+    };
+  }
+}

--- a/src/decisions/decisions.module.ts
+++ b/src/decisions/decisions.module.ts
@@ -18,6 +18,7 @@ import { NewController } from './admin/new.controller';
 import { EditController } from './admin/edit.controller';
 import { PublicationController } from './admin/publication.controller';
 import { SubmissionController } from './admin/submission.controller';
+import { ShowController } from './admin/show.controller';
 
 @Module({
   imports: [
@@ -39,6 +40,7 @@ import { SubmissionController } from './admin/submission.controller';
   ],
   controllers: [
     DecisionsController,
+    ShowController,
     NewController,
     EditController,
     PublicationController,

--- a/src/i18n/en/decisions.json
+++ b/src/i18n/en/decisions.json
@@ -50,7 +50,8 @@
       "label": "Public facing link"
     },
     "show": {
-      "edit": "Edit"
+      "edit": "Edit",
+      "download": "Download dataset for {profession} (CSV)"
     },
     "confirmation": {
       "labels": {

--- a/views/admin/decisions/index.njk
+++ b/views/admin/decisions/index.njk
@@ -42,17 +42,17 @@
     </div>
   </div>
 
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-full">
-      <div class="rpr-internal-listing__file-download-link-container">
-        <div class="rpr-internal-listing__file-download-link-container-right">
-          <a class="govuk-link rpr-internal-listing__file-download-link" href="/admin/decisions/export{{('?' + filterQuery) if filterQuery else '' }}">{{"decisions.admin.dashboard.download" | t}}</a>
+  {% if 'downloadDecisionData' in permissions %}
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-full">
+        <div class="rpr-internal-listing__file-download-link-container">
+          <div class="rpr-internal-listing__file-download-link-container-right">
+            <a class="govuk-link rpr-internal-listing__file-download-link" href="/admin/decisions/export{{('?' + filterQuery) if filterQuery else '' }}">{{"decisions.admin.dashboard.download" | t}}</a>
+          </div>
         </div>
       </div>
     </div>
-  </div>
-
-  <div class="govuk-grid-row">
+  {% endif %}
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">

--- a/views/admin/decisions/show.njk
+++ b/views/admin/decisions/show.njk
@@ -73,6 +73,13 @@
               }}
             </li>
           {% endif %}
+          {% if 'downloadDecisionData' in permissions %}
+            <li>
+              <span class="govuk-body-s">
+                <a href="/admin/decisions/{{profession.id}}/{{organisation.id}}/{{year}}/export" class="govuk-link rpr-internal__details-page-file-download-link">{{ "decisions.admin.show.download" | t({profession: profession.name}) }}</a>
+              </span>
+            </li>
+          {% endif %}
         </ul>
       </nav>
     </aside>


### PR DESCRIPTION
# Changes in this PR

## Screenshots of UI changes

- Add single decision dataset download link to internal dataset pages

### Before
![localhost_3000_admin_decisions_e172db1f-b179-4d28-b09a-36bea19662da_ee096e43-a2b7-475a-a28d-9369e1cf3485_2021](https://user-images.githubusercontent.com/94137563/166682204-0502c361-8c8d-4e93-a211-dfb6df2cac88.png)

### After
![localhost_3000_admin_decisions_94d17b7c-bffd-4603-bb6e-74a9e3a18816_ad5903c1-2e32-49e6-bddc-96bd78a8bb1b_2021](https://user-images.githubusercontent.com/94137563/166682226-85703c8a-c515-42dd-9b4f-a16b75afff29.png)

