### PR TITLE
(2375) Increase expiry on emails to 30 days

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [unreleased]
 
+### Changed
+
+- Increase timeout on invitation emails to 30 days
+
 ## [release-018] - 2022-05-03
 
 ### Added

--- a/src/users/auth0.service.spec.ts
+++ b/src/users/auth0.service.spec.ts
@@ -63,7 +63,7 @@ describe('Auth0Service', () => {
           managementClient.createPasswordChangeTicket,
         ).toHaveBeenCalledWith({
           result_url: `${process.env['HOST_URL']}/admin`,
-          ttl_sec: 1209600,
+          ttl_sec: 2592000,
           user_id: 123,
         });
 

--- a/src/users/auth0.service.ts
+++ b/src/users/auth0.service.ts
@@ -61,7 +61,7 @@ export class Auth0Service {
     const passwordChangeTicket = await client.createPasswordChangeTicket({
       result_url: `${process.env['HOST_URL']}/admin`,
       user_id: user.user_id,
-      ttl_sec: 1209600,
+      ttl_sec: 2592000,
     });
 
     return {


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR

Increase expiry on emails to 30 days. We don't want them to be valid for a really long period of time, as that could be a risk to security, but this gives them a month to edit details. After this, we should prompt them to request a new link.

30 days was chosen from this stackexchange conversation: https://security.stackexchange.com/questions/229119/when-should-user-invite-links-tokens-expire

