### PR TITLE
(2378) Track search query params and outbound link clicks in Plausible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - Allow organisation users to submit decision data directly from the editing page
+- Track search parameters and outbound links in Plausible
 
 ## [release-019] - 2022-05-04
 

--- a/assets/javascripts/application.js
+++ b/assets/javascripts/application.js
@@ -1,11 +1,7 @@
 import { initAll } from 'govuk-frontend';
-import Plausible from 'plausible-tracker';
 import { regulatoryAuthoritySelect } from './regulatory-authority-select';
 
-const { enableAutoPageviews } = Plausible();
-
 initAll();
-enableAutoPageviews();
 regulatoryAuthoritySelect();
 
 const detailsHeaderElements = document.getElementsByClassName(

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,6 @@
         "notifications-node-client": "^5.1.1",
         "nunjucks": "^3.2.3",
         "pg": "^8.7.3",
-        "plausible-tracker": "^0.3.5",
         "reflect-metadata": "^0.1.13",
         "rimraf": "^3.0.2",
         "rollbar": "^2.25.0",
@@ -17782,14 +17781,6 @@
       "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/plausible-tracker": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/plausible-tracker/-/plausible-tracker-0.3.5.tgz",
-      "integrity": "sha512-6c6VPdPtI9KmIsfr8zLBViIDMt369eeaNA1J8JrAmAtrpSkeJWvjwcJ+cLn7gVJn5AtQWC8NgSEee2d/5RNytA==",
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/pluralize": {
@@ -36609,11 +36600,6 @@
           "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
         }
       }
-    },
-    "plausible-tracker": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/plausible-tracker/-/plausible-tracker-0.3.5.tgz",
-      "integrity": "sha512-6c6VPdPtI9KmIsfr8zLBViIDMt369eeaNA1J8JrAmAtrpSkeJWvjwcJ+cLn7gVJn5AtQWC8NgSEee2d/5RNytA=="
     },
     "pluralize": {
       "version": "8.0.0",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,6 @@
     "notifications-node-client": "^5.1.1",
     "nunjucks": "^3.2.3",
     "pg": "^8.7.3",
-    "plausible-tracker": "^0.3.5",
     "reflect-metadata": "^0.1.13",
     "rimraf": "^3.0.2",
     "rollbar": "^2.25.0",

--- a/views/base.njk
+++ b/views/base.njk
@@ -25,6 +25,28 @@
 {% block head %}
   {{ encore_entry_link_tags }}
 
+  {% if environment === 'production' %}
+    <script defer data-domain="{{ site_domain }}" src="https://plausible.io/js/script.manual.js"></script>
+  {% endif %}
+
+  <!-- define the `plausible` function to manually trigger events -->
+  <script>window.plausible = window.plausible || function() { (window.plausible.q = window.plausible.q || []).push(arguments) }</script>
+
+  <!-- trigger pageview -->
+  <script>
+    function prepareUrl(params) {
+      const url = new URL(location.href)
+      const queryParams = new URLSearchParams(location.search)
+      let customUrl = url.protocol + "//" + url.hostname + url.pathname
+      for (const paramName of params) {
+        const paramValue = queryParams.get(paramName)
+        if (paramValue) customUrl = customUrl + '/' + paramName + '=' + paramValue
+      }
+      return customUrl
+    }
+    plausible('pageview', { u: prepareUrl(["keywords", "industries[]", "nations[]", "regulationTypes[]", "years[]", "statuses[]"]) })
+  </script>
+
   {# For Internet Explorer 8, you need to compile specific stylesheet #}
   {# see https://frontend.design-system.service.gov.uk/supporting-ie8/#support-internet-explorer-8 #}
   <!--[if IE 8]>

--- a/views/base.njk
+++ b/views/base.njk
@@ -26,7 +26,7 @@
   {{ encore_entry_link_tags }}
 
   {% if environment === 'production' %}
-    <script defer data-domain="{{ site_domain }}" src="https://plausible.io/js/script.manual.js"></script>
+    <script defer data-domain="{{ site_domain }}" src="https://plausible.io/js/script.manual.outbound-links.js"></script>
   {% endif %}
 
   <!-- define the `plausible` function to manually trigger events -->


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR

Tracks search query params and outbound link clicks in Plausible, so we can get metrics on how effective our search is.

We've had to rollback our change to use the Plausible npm library here to get this working - it may be possible to use the library for this, but time was of the essence.

This isn't the prettiest - industries are logged with their uuid, so we'll need to look these up, but it at least gives us visibility over what users are searching for.

## Screenshots of UI changes

### After

#### Query params showing in Plausible

![image](https://user-images.githubusercontent.com/19826940/166919288-a1c7e237-24c2-444c-b209-4f9fc866c3fb.png)


#### Outbound links being tracked

![image](https://user-images.githubusercontent.com/19826940/166917967-39661e0a-869a-4787-a39c-ab3ccc77ea49.png)

