### PR TITLE
(Fix) Track multiple query params in Plausible

### DIFF
--- a/views/base.njk
+++ b/views/base.njk
@@ -39,8 +39,8 @@
       const queryParams = new URLSearchParams(location.search)
       let customUrl = url.protocol + "//" + url.hostname + url.pathname
       for (const paramName of params) {
-        const paramValue = queryParams.get(paramName)
-        if (paramValue) customUrl = customUrl + '/' + paramName + '=' + paramValue
+        const paramValues = queryParams.getAll(paramName)
+        if (paramValues && paramValues.length > 0 && paramValues[0]) customUrl = customUrl + '/' + paramName + '=' + paramValues.join("&")
       }
       return customUrl
     }


### PR DESCRIPTION
# Changes in this PR

Append multiple query params to the logged url in Plausible when a user searches for more than one nation/sector etc.

Before this change, we only logged the first value for each query param.

## Screenshots of UI changes

### After

![image](https://user-images.githubusercontent.com/19826940/166940770-8ac7b5ad-31a6-48f8-89d9-028297954dad.png)

