### PR TITLE
(2320) Be able to view decision data for each year as member of the public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [unreleased]
 
+### Added
+
+- Public view of decision data, linked to from public profession pages
+
 ### Changed
 
 - Exported CSV files now include both the country name and the country code
@@ -16,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Add confirmation page when publishing decision data from the editing page
 - Add single decision dataset download link to internal dataset pages
+- Public view of decision data, linked to from public profession pages
 
 ### Changed
 

--- a/assets/stylesheets/application.scss
+++ b/assets/stylesheets/application.scss
@@ -97,6 +97,21 @@ $small-screen: 768px;
   &__table-container {
     overflow-x: auto;
   }
+
+  &__public-table-container {
+    overflow-x: auto;
+    table-layout: fixed;
+
+    th,
+    td {
+      border: 1px solid govuk-colour('mid-grey');
+      padding: 0.4em;
+    }
+
+    td:nth-child(2) {
+      width: 20%;
+    }
+  }
 }
 
 .rpr-internal {

--- a/cypress/integration/admin/decisions/edit.spec.ts
+++ b/cypress/integration/admin/decisions/edit.spec.ts
@@ -169,7 +169,7 @@ describe('Editing a decision dataset', () => {
         .parent()
         .parent()
         .within(() => {
-          cy.checkTable(
+          cy.checkVerticalTable(
             [
               'decisions.show.tableHeading.country',
               'decisions.show.tableHeading.yes',
@@ -189,7 +189,7 @@ describe('Editing a decision dataset', () => {
         .parent()
         .parent()
         .within(() => {
-          cy.checkTable(
+          cy.checkVerticalTable(
             [
               'decisions.show.tableHeading.country',
               'decisions.show.tableHeading.yes',

--- a/cypress/integration/admin/decisions/new.spec.ts
+++ b/cypress/integration/admin/decisions/new.spec.ts
@@ -78,7 +78,7 @@ describe('Creating a decision dataset', () => {
 
       cy.get('caption').should('contain', 'New route');
 
-      cy.checkTable(
+      cy.checkVerticalTable(
         [
           'decisions.show.tableHeading.country',
           'decisions.show.tableHeading.yes',
@@ -168,7 +168,7 @@ describe('Creating a decision dataset', () => {
 
       cy.get('caption').should('contain', 'New route');
 
-      cy.checkTable(
+      cy.checkVerticalTable(
         [
           'decisions.show.tableHeading.country',
           'decisions.show.tableHeading.yes',

--- a/cypress/integration/admin/decisions/show.spec.ts
+++ b/cypress/integration/admin/decisions/show.spec.ts
@@ -41,7 +41,7 @@ describe('Showing a decision dataset', () => {
         .parent()
         .parent()
         .within(() => {
-          cy.checkTable(
+          cy.checkVerticalTable(
             [
               'decisions.show.tableHeading.country',
               'decisions.show.tableHeading.yes',
@@ -63,7 +63,7 @@ describe('Showing a decision dataset', () => {
         .parent()
         .parent()
         .within(() => {
-          cy.checkTable(
+          cy.checkVerticalTable(
             [
               'decisions.show.tableHeading.country',
               'decisions.show.tableHeading.yes',

--- a/cypress/integration/admin/decisions/show.spec.ts
+++ b/cypress/integration/admin/decisions/show.spec.ts
@@ -105,6 +105,12 @@ describe('Showing a decision dataset', () => {
         .should('contain', 'beis-rpr+orgadmin@dxw.com');
 
       cy.get('nav').find('ul').should('have.length', 2);
+
+      cy.translate('decisions.admin.publicFacingLink.label').then(
+        (publicFacingLinkButtonText) => {
+          cy.get('body').should('not.contain', publicFacingLinkButtonText);
+        },
+      );
     });
 
     it('I can edit the data by clicking the edit button', () => {
@@ -124,12 +130,14 @@ describe('Showing a decision dataset', () => {
     });
 
     it('I can view the "Currently published version" by clicking the link button', () => {
-      cy.get('tr')
-        .contains('Registered Trademark Attorney')
-        .parent()
-        .within(() => {
-          cy.get('a').contains('View details').click();
-        });
+      cy.translate('app.status.live').then((live) => {
+        cy.get('tr')
+          .contains(new RegExp(`Registered Trademark Attorney.*2021.*${live}`))
+          .within(() => {
+            cy.get('a').contains('View details').click();
+          });
+      });
+
       cy.translate('decisions.admin.publicFacingLink.label').then(
         (publicFacingLinkButtonText) => {
           cy.get('[data-cy="currently-published-version-text"]').contains(
@@ -137,16 +145,30 @@ describe('Showing a decision dataset', () => {
           );
         },
       );
-      cy.translate('decisions.admin.publicFacingLink.heading').then(
-        (publicFacingLinkButtonText) => {
-          cy.get('[data-cy="currently-published-version-text"]')
-            .contains(publicFacingLinkButtonText)
-            .contains('a')
+
+      cy.url().then((internalUrl) => {
+        cy.translate('decisions.admin.publicFacingLink.heading').then(
+          (publicFacingLinkButtonText) => {
+            cy.get('[data-cy="currently-published-version-text"]')
+              .contains(publicFacingLinkButtonText)
+              .contains('a')
+              .click()
+              .url()
+              .should(
+                'contain',
+                '/decisions/registered-trademark-attorney/2021',
+              );
+          },
+        );
+
+        cy.translate('app.back').then((back) => {
+          cy.get('a')
+            .contains(back)
             .click()
             .url()
-            .should('contain', '');
-        },
-      );
+            .should('contain', internalUrl);
+        });
+      });
     });
 
     it('I can download a decision dataset', () => {

--- a/cypress/integration/admin/professions/show.spec.ts
+++ b/cypress/integration/admin/professions/show.spec.ts
@@ -227,6 +227,10 @@ describe('Showing a profession', () => {
       cy.translate('professions.show.legislation.secondLink').then((label) => {
         cy.get('body').should('contain', label);
       });
+
+      cy.translate('professions.show.decisions.heading').then((heading) => {
+        cy.get('h2').should('not.contain', heading);
+      });
     });
 
     it('I can view a profession with the bare minimum fields', () => {
@@ -448,6 +452,10 @@ describe('Showing a profession', () => {
       });
       cy.translate('professions.show.legislation.secondLink').then((label) => {
         cy.get('body').should('contain', label);
+      });
+
+      cy.translate('professions.show.decisions.heading').then((heading) => {
+        cy.get('h2').should('not.contain', heading);
       });
     });
   });

--- a/cypress/integration/decisions/show.spec.ts
+++ b/cypress/integration/decisions/show.spec.ts
@@ -1,0 +1,41 @@
+describe("Showing a profession's decision data", () => {
+  it("I can view a profession's decision data", () => {
+    cy.visitAndCheckAccessibility('/professions/search');
+    cy.get('a').contains('Registered Trademark Attorney').click();
+
+    cy.translate('professions.show.decisions.heading').then((heading) => {
+      cy.get('h2')
+        .contains(heading)
+        .next()
+        .within(() => {
+          cy.get('a').contains('2021').click();
+        });
+    });
+
+    cy.checkAccessibility();
+
+    cy.translate('decisions.public.heading').then((heading) => {
+      cy.get('h1').should('contain', heading);
+    });
+    cy.get('body').should('contain', 'Registered Trademark Attorney');
+    cy.get('h2').should('contain', '2021');
+    cy.get('h3').should('contain', 'Law Society of England and Wales');
+    cy.get('table caption').should('contain', 'EEA Route');
+
+    cy.checkHorizontalTable(
+      [
+        'decisions.public.tableHeading.yes',
+        'decisions.public.tableHeading.yesAfterComp',
+        'decisions.public.tableHeading.no',
+        'decisions.public.tableHeading.noAfterComp',
+        'decisions.public.tableHeading.total',
+      ],
+      [['15', '4', '13', '4', '36']],
+    );
+
+    cy.translate('app.back').then((back) => {
+      cy.get('a').contains(back).click();
+    });
+    cy.url().should('contain', '/professions/registered-trademark-attorney');
+  });
+});

--- a/cypress/integration/professions/show.spec.ts
+++ b/cypress/integration/professions/show.spec.ts
@@ -8,10 +8,10 @@ describe('Showing a profession', () => {
       cy.get('body').should('contain', backLink);
     });
 
-    cy.get('body').should('contain', 'Registered Trademark Attorney');
+    cy.get('h1').should('contain', 'Registered Trademark Attorney');
 
     cy.translate('professions.show.bodies.heading').then((heading) => {
-      cy.get('body').should('contain', heading);
+      cy.get('h2').should('contain', heading);
     });
 
     cy.translate('app.unitedKingdom').then((uk) => {
@@ -201,7 +201,7 @@ describe('Showing a profession', () => {
     });
 
     cy.translate('professions.show.registration.heading').then((heading) => {
-      cy.get('body').should('contain', heading);
+      cy.get('h2').should('contain', heading);
     });
     cy.checkSummaryListRowValue(
       'professions.show.registration.registrationRequirements',
@@ -213,25 +213,41 @@ describe('Showing a profession', () => {
     );
 
     cy.translate('professions.show.legislation.heading').then((heading) => {
-      cy.get('body').should('contain', heading);
+      cy.get('h2').should('contain', heading);
     });
     cy.checkSummaryListRowValue(
       'professions.show.legislation.nationalLegislation',
       'The Trade Marks Act 1994',
     );
+
+    cy.translate('professions.show.decisions.heading').then((heading) => {
+      cy.get('h2').should('contain', heading);
+      cy.get('h2')
+        .contains(heading)
+        .next()
+        .within(() => {
+          cy.translate('decisions.show.year').then((year) => {
+            cy.get('dt').eq(0).should('contain', year);
+            cy.get('dd').eq(0).should('contain', '2021');
+
+            cy.get('dt').eq(1).should('contain', year);
+            cy.get('dd').eq(1).should('contain', '2020');
+          });
+        });
+    });
   });
 
   it('I can view a profession with the bare minimum fields', () => {
     cy.visitAndCheckAccessibility('/professions/no-optional-fields');
 
-    cy.get('body').should('contain', 'Profession with no optional fields');
+    cy.get('h1').should('contain', 'Profession with no optional fields');
 
     cy.translate('professions.show.bodies.heading').then((heading) => {
-      cy.get('body').should('contain', heading);
+      cy.get('h2').should('contain', heading);
     });
 
     cy.translate('professions.show.bodies.heading').then((heading) => {
-      cy.get('body').should('contain', heading);
+      cy.get('h2').should('contain', heading);
     });
 
     cy.translate('nations.england').then((england) => {
@@ -425,15 +441,19 @@ describe('Showing a profession', () => {
     });
 
     cy.translate('professions.show.registration.heading').then((heading) => {
-      cy.get('body').should('not.contain', heading);
+      cy.get('h2').should('not.contain', heading);
     });
 
     cy.translate('professions.show.legislation.heading').then((heading) => {
-      cy.get('body').should('contain', heading);
+      cy.get('h2').should('contain', heading);
     });
     cy.checkSummaryListRowValue(
       'professions.show.legislation.nationalLegislation',
       "The Education (School Teachers' Qualifications) (England) Regulations 2003/1662 (as amended)",
     );
+
+    cy.translate('professions.show.decisions.heading').then((heading) => {
+      cy.get('h2').should('not.contain', heading);
+    });
   });
 });

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -313,25 +313,53 @@ Cypress.Commands.add('checkPublishNotBlocked', () => {
     });
 });
 
-Cypress.Commands.add('checkTable', (headings: string[], rows: string[][]) => {
-  headings.forEach((heading, index) => {
-    cy.translate(heading).then((translatedHeading) => {
-      cy.get('table thead tr th')
-        .eq(index)
-        .should('contain', translatedHeading);
-    });
-  });
-
-  rows.forEach((row, rowIndex) => {
-    cy.get('table tbody tr')
-      .eq(rowIndex)
-      .within(() => {
-        row.forEach((cell, cellIndex) => {
-          cy.get('td').eq(cellIndex).should('contain', cell);
-        });
+Cypress.Commands.add(
+  'checkVerticalTable',
+  (headings: string[], rows: string[][]) => {
+    headings.forEach((heading, index) => {
+      cy.translate(heading).then((translatedHeading) => {
+        cy.get('table thead tr th')
+          .eq(index)
+          .should('contain', translatedHeading);
       });
-  });
-});
+    });
+
+    rows.forEach((row, rowIndex) => {
+      cy.get('table tbody tr')
+        .eq(rowIndex)
+        .within(() => {
+          row.forEach((cell, cellIndex) => {
+            cy.get('td').eq(cellIndex).should('contain', cell);
+          });
+        });
+    });
+  },
+);
+
+Cypress.Commands.add(
+  'checkHorizontalTable',
+  (headings: string[], columns: string[][]) => {
+    headings.forEach((heading, index) => {
+      cy.translate(heading).then((translatedHeading) => {
+        cy.get('table tr')
+          .eq(index)
+          .within(() => {
+            cy.get('th').should('contain', translatedHeading);
+          });
+      });
+    });
+
+    columns.forEach((column, columnIndex) => {
+      column.forEach((cell, cellIndex) => {
+        cy.get('table tbody tr')
+          .eq(cellIndex)
+          .within(() => {
+            cy.get('td').eq(columnIndex).should('contain', cell);
+          });
+      });
+    });
+  },
+);
 
 Cypress.Commands.add('visitAndCheckAccessibility', (url: string) => {
   cy.visit(url);

--- a/cypress/support/index.ts
+++ b/cypress/support/index.ts
@@ -79,7 +79,8 @@ declare global {
         shouldHaveButton?: boolean,
       ): Chainable<string>;
       checkPublishNotBlocked(): Chainable<string>;
-      checkTable(headings: string[], rows: string[][]): void;
+      checkVerticalTable(headings: string[], rows: string[][]): void;
+      checkHorizontalTable(headings: string[], coulmns: string[][]): void;
       visitAndCheckAccessibility(url: string): void;
       checkAccessibility(rules?: AxeRules): void;
       visitInternalDashboard(): void;

--- a/src/decisions/decision-datasets.service.spec.ts
+++ b/src/decisions/decision-datasets.service.spec.ts
@@ -4,6 +4,7 @@ import { getRepositoryToken } from '@nestjs/typeorm';
 import { Repository, SelectQueryBuilder } from 'typeorm';
 import decisionDatasetFactory from '../testutils/factories/decision-dataset';
 import organisationFactory from '../testutils/factories/organisation';
+import professionFactory from '../testutils/factories/profession';
 import {
   DecisionDataset,
   DecisionDatasetStatus,
@@ -560,6 +561,47 @@ describe('DecisionDatasetsService', () => {
         });
         expect(queryBuilder.getMany).toBeCalledWith();
       });
+    });
+  });
+
+  describe('allLiveForProfessionAndYear', () => {
+    it('returns all live DecisionDatasets for the give Profession and year', async () => {
+      const queryResultDatasets = decisionDatasetFactory.buildList(3);
+
+      const queryBuilder = createMock<SelectQueryBuilder<DecisionDataset>>({
+        leftJoinAndSelect: () => queryBuilder,
+        where: () => queryBuilder,
+        orderBy: () => queryBuilder,
+        getMany: async () => queryResultDatasets,
+      });
+
+      jest
+        .spyOn(repo, 'createQueryBuilder')
+        .mockImplementation(() => queryBuilder);
+
+      const queryProfession = professionFactory.build();
+      const queryYear = 2024;
+
+      const result = await service.allLiveForProfessionAndYear(
+        queryProfession,
+        queryYear,
+      );
+
+      expect(result).toEqual(queryResultDatasets);
+      expect(queryBuilder).toHaveJoined([
+        'decisionDataset.profession',
+        'decisionDataset.organisation',
+        'decisionDataset.user',
+      ]);
+      expect(queryBuilder.where).toBeCalledWith({
+        profession: { id: queryProfession.id },
+        year: queryYear,
+        status: DecisionDatasetStatus.Live,
+      });
+      expect(queryBuilder.orderBy).toBeCalledWith({
+        'organisation.name': 'ASC',
+      });
+      expect(queryBuilder.getMany).toBeCalledWith();
     });
   });
 

--- a/src/decisions/decision-datasets.service.spec.ts
+++ b/src/decisions/decision-datasets.service.spec.ts
@@ -605,6 +605,46 @@ describe('DecisionDatasetsService', () => {
     });
   });
 
+  describe('allLiveYearsForProfession', () => {
+    it('returns all live DecisionDataset years for the give Profession', async () => {
+      const findResultDatasets = [
+        decisionDatasetFactory.build({
+          year: 2025,
+        }),
+        decisionDatasetFactory.build({
+          year: 2024,
+        }),
+        decisionDatasetFactory.build({
+          year: 2022,
+        }),
+        decisionDatasetFactory.build({
+          year: 2021,
+        }),
+      ];
+
+      const queryProfession = professionFactory.build({
+        id: 'profession-uuid',
+      });
+
+      const repoSpy = jest
+        .spyOn(repo, 'find')
+        .mockResolvedValue(findResultDatasets);
+      const result = await service.allLiveYearsForProfession(queryProfession);
+
+      expect(result).toEqual([2025, 2024, 2022, 2021]);
+      expect(repoSpy).toBeCalledWith({
+        where: {
+          profession: { id: 'profession-uuid' },
+          status: DecisionDatasetStatus.Live,
+        },
+        order: {
+          year: 'DESC',
+        },
+        select: ['year'],
+      });
+    });
+  });
+
   describe('save', () => {
     it('saves the DecisionDataset', async () => {
       const dataset = decisionDatasetFactory.build();

--- a/src/decisions/decision-datasets.service.ts
+++ b/src/decisions/decision-datasets.service.ts
@@ -92,6 +92,21 @@ export class DecisionDatasetsService {
       .getMany();
   }
 
+  async allLiveYearsForProfession(profession: Profession): Promise<number[]> {
+    return (
+      await this.repository.find({
+        where: {
+          profession: { id: profession.id },
+          status: DecisionDatasetStatus.Live,
+        },
+        order: {
+          year: 'DESC',
+        },
+        select: ['year'],
+      })
+    ).map((dataset) => dataset.year);
+  }
+
   async save(dataset: DecisionDataset): Promise<DecisionDataset> {
     return this.repository.save(dataset);
   }

--- a/src/decisions/decision-datasets.service.ts
+++ b/src/decisions/decision-datasets.service.ts
@@ -3,6 +3,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository, SelectQueryBuilder } from 'typeorm';
 import { FilterInput } from '../common/interfaces/filter-input.interface';
 import { Organisation } from '../organisations/organisation.entity';
+import { Profession } from '../professions/profession.entity';
 import {
   DecisionDataset,
   DecisionDatasetStatus,
@@ -71,6 +72,22 @@ export class DecisionDatasetsService {
         'profession.name': 'ASC',
         'organisation.name': 'ASC',
         year: 'DESC',
+      })
+      .getMany();
+  }
+
+  async allLiveForProfessionAndYear(
+    profession: Profession,
+    year: number,
+  ): Promise<DecisionDataset[]> {
+    return this.datasetsWithJoins()
+      .where({
+        profession: { id: profession.id },
+        year,
+        status: DecisionDatasetStatus.Live,
+      })
+      .orderBy({
+        'organisation.name': 'ASC',
       })
       .getMany();
   }

--- a/src/decisions/decisions.controller.spec.ts
+++ b/src/decisions/decisions.controller.spec.ts
@@ -1,0 +1,123 @@
+import { createMock, DeepMocked } from '@golevelup/ts-jest';
+import { NotFoundException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { I18nService } from 'nestjs-i18n';
+import { createMockI18nService } from '../testutils/create-mock-i18n-service';
+import professionFactory from '../testutils/factories/profession';
+import decisionDatasetFactory from '../testutils/factories/decision-dataset';
+import { DecisionDatasetsPresenter } from '../decisions/presenters/decision-datasets.presenter';
+import { DecisionDatasetsService } from '../decisions/decision-datasets.service';
+import { DecisionsController } from './decisions.controller';
+import { ProfessionVersionsService } from '../professions/profession-versions.service';
+import { ShowTemplate } from './interfaces/show-template.interface';
+
+jest.mock('../decisions/presenters/decision-datasets.presenter');
+
+describe('DecisionsController', () => {
+  let controller: DecisionsController;
+  let professionVersionsService: DeepMocked<ProfessionVersionsService>;
+  let decisionDatasetsService: DeepMocked<DecisionDatasetsService>;
+  let i18nService: DeepMocked<I18nService>;
+
+  beforeEach(async () => {
+    professionVersionsService = createMock<ProfessionVersionsService>();
+    decisionDatasetsService = createMock<DecisionDatasetsService>();
+    i18nService = createMockI18nService();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        {
+          provide: ProfessionVersionsService,
+          useValue: professionVersionsService,
+        },
+        {
+          provide: DecisionDatasetsService,
+          useValue: decisionDatasetsService,
+        },
+        { provide: I18nService, useValue: i18nService },
+      ],
+      controllers: [DecisionsController],
+    }).compile();
+
+    controller = module.get<DecisionsController>(DecisionsController);
+  });
+
+  describe('show', () => {
+    describe('when the slug does not match a profession', () => {
+      it('throws an error', async () => {
+        professionVersionsService.findLiveBySlug.mockResolvedValue(null);
+
+        await expect(async () => {
+          await controller.show('example-invalid-slug', 2022);
+        }).rejects.toThrowError(NotFoundException);
+      });
+    });
+
+    describe('when the year does not match any dataset for the profession', () => {
+      it('throws an error when the year does not match any dataset for the profession', async () => {
+        const profession = professionFactory.build();
+
+        professionVersionsService.findLiveBySlug.mockResolvedValue(profession);
+        decisionDatasetsService.allLiveForProfessionAndYear.mockResolvedValue(
+          [],
+        );
+
+        await expect(async () => {
+          await controller.show('example-slug', 2022);
+        }).rejects.toThrowError(NotFoundException);
+      });
+    });
+
+    describe('when datasets exist for the given year and profession', () => {
+      it('returns a populated ShowTemplate', async () => {
+        const profession = professionFactory.build();
+        const datasets = decisionDatasetFactory.buildList(3);
+
+        const mockShowTemplate: ShowTemplate = {
+          profession: 'Secondary School Teacher',
+          nations: 'England, Wales',
+          year: 2025,
+          organisations: [
+            {
+              organisation: 'Department for Education',
+              routes: [],
+            },
+          ],
+        };
+
+        professionVersionsService.findLiveBySlug.mockResolvedValue(profession);
+        decisionDatasetsService.allLiveForProfessionAndYear.mockResolvedValue(
+          datasets,
+        );
+
+        (
+          DecisionDatasetsPresenter.prototype.present as jest.Mock
+        ).mockReturnValue(mockShowTemplate);
+
+        const result = await controller.show('example-slug', 2022);
+
+        expect(result).toEqual(mockShowTemplate);
+
+        expect(professionVersionsService.findLiveBySlug).toHaveBeenCalledWith(
+          'example-slug',
+        );
+        expect(
+          decisionDatasetsService.allLiveForProfessionAndYear,
+        ).toHaveBeenCalledWith(profession, 2022);
+
+        expect(DecisionDatasetsPresenter).toHaveBeenCalledWith(
+          profession,
+          2022,
+          datasets,
+          i18nService,
+        );
+        expect(DecisionDatasetsPresenter.prototype.present).toHaveBeenCalled();
+      });
+    });
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+    jest.restoreAllMocks();
+  });
+});

--- a/src/decisions/decisions.controller.ts
+++ b/src/decisions/decisions.controller.ts
@@ -6,6 +6,7 @@ import {
   ParseIntPipe,
   Render,
 } from '@nestjs/common';
+import { Request } from 'express';
 import { I18nService } from 'nestjs-i18n';
 import { BackLink } from '../common/decorators/back-link.decorator';
 import { DecisionDatasetsService } from '../decisions/decision-datasets.service';
@@ -23,7 +24,15 @@ export class DecisionsController {
 
   @Get('/decisions/:slug/:year')
   @Render('decisions/show')
-  @BackLink('/professions/:slug')
+  @BackLink((request: Request) => {
+    const fromInternalPage = request.query.fromInternalPage as string;
+    if (fromInternalPage) {
+      const [professionId, organisationId] = fromInternalPage.split(':');
+      return `/admin/decisions/${professionId}/${organisationId}/:year`;
+    } else {
+      return '/professions/:slug';
+    }
+  })
   async show(
     @Param('slug') slug: string,
     @Param('year', ParseIntPipe) year,

--- a/src/decisions/decisions.controller.ts
+++ b/src/decisions/decisions.controller.ts
@@ -1,0 +1,60 @@
+import {
+  Controller,
+  Get,
+  NotFoundException,
+  Param,
+  ParseIntPipe,
+  Render,
+} from '@nestjs/common';
+import { I18nService } from 'nestjs-i18n';
+import { BackLink } from '../common/decorators/back-link.decorator';
+import { DecisionDatasetsService } from '../decisions/decision-datasets.service';
+import { DecisionDatasetsPresenter } from '../decisions/presenters/decision-datasets.presenter';
+import { ShowTemplate } from './interfaces/show-template.interface';
+import { ProfessionVersionsService } from '../professions/profession-versions.service';
+
+@Controller()
+export class DecisionsController {
+  constructor(
+    private readonly professionVersionsService: ProfessionVersionsService,
+    private readonly decisionDatasetsService: DecisionDatasetsService,
+    private readonly i18nService: I18nService,
+  ) {}
+
+  @Get('/decisions/:slug/:year')
+  @Render('decisions/show')
+  @BackLink('/professions/:slug')
+  async show(
+    @Param('slug') slug: string,
+    @Param('year', ParseIntPipe) year,
+  ): Promise<ShowTemplate> {
+    const profession = await this.professionVersionsService.findLiveBySlug(
+      slug,
+    );
+
+    if (!profession) {
+      throw new NotFoundException(
+        `A profession with ID ${slug} could not be found`,
+      );
+    }
+
+    const datasets =
+      await this.decisionDatasetsService.allLiveForProfessionAndYear(
+        profession,
+        year,
+      );
+
+    if (!datasets.length) {
+      throw new NotFoundException(
+        `No datasets for profession ${slug} and year ${year} could be found`,
+      );
+    }
+
+    return new DecisionDatasetsPresenter(
+      profession,
+      year,
+      datasets,
+      this.i18nService,
+    ).present();
+  }
+}

--- a/src/decisions/decisions.module.ts
+++ b/src/decisions/decisions.module.ts
@@ -1,6 +1,6 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
-import { DecisionsController } from './admin/decisions.controller';
+import { DecisionsController as AdminDecisionsController } from './admin/decisions.controller';
 import { DecisionDatasetsService } from './decision-datasets.service';
 import { DecisionDataset } from './decision-dataset.entity';
 import { Profession } from '../professions/profession.entity';
@@ -19,6 +19,7 @@ import { EditController } from './admin/edit.controller';
 import { PublicationController } from './admin/publication.controller';
 import { SubmissionController } from './admin/submission.controller';
 import { ShowController } from './admin/show.controller';
+import { DecisionsController } from './decisions.controller';
 
 @Module({
   imports: [
@@ -40,6 +41,7 @@ import { ShowController } from './admin/show.controller';
   ],
   controllers: [
     DecisionsController,
+    AdminDecisionsController,
     ShowController,
     NewController,
     EditController,

--- a/src/decisions/interfaces/show-template.interface.ts
+++ b/src/decisions/interfaces/show-template.interface.ts
@@ -1,0 +1,16 @@
+export interface ShowTemplate {
+  profession: string;
+  nations: string;
+  year: number;
+  organisations: {
+    organisation: string;
+    routes: {
+      route: string;
+      yes: number;
+      no: number;
+      yesAfterComp: number;
+      noAfterComp: number;
+      total: number;
+    }[];
+  }[];
+}

--- a/src/decisions/presenters/decision-datasets.presenter.spec.ts
+++ b/src/decisions/presenters/decision-datasets.presenter.spec.ts
@@ -1,0 +1,176 @@
+import { Nation } from '../../nations/nation';
+import { NationsListPresenter } from '../../nations/presenters/nations-list.presenter';
+import { ShowTemplate } from '../interfaces/show-template.interface';
+import { createMockI18nService } from '../../testutils/create-mock-i18n-service';
+import decisionDatasetFactory from '../../testutils/factories/decision-dataset';
+import organisationFactory from '../../testutils/factories/organisation';
+import professionFactory from '../../testutils/factories/profession';
+import { DecisionDatasetsPresenter } from './decision-datasets.presenter';
+
+jest.mock('../../nations/presenters/nations-list.presenter');
+
+describe('DecisionDatasetsPresenter', () => {
+  describe('present', () => {
+    it('returns a ShowTemplate for the given Profession, year, and DecisionDatasets', async () => {
+      const profession = professionFactory.build({
+        name: 'Example Profession',
+        occupationLocations: ['GB-ENG', 'GB-SCT'],
+      });
+
+      const organisation1 = organisationFactory.build({
+        name: 'Example Organisation 1',
+      });
+
+      const organisation2 = organisationFactory.build({
+        name: 'Example Organisation 2',
+      });
+
+      const year = 2025;
+
+      const dataset1 = decisionDatasetFactory.build({
+        profession,
+        organisation: organisation1,
+        routes: [
+          {
+            name: 'Example route 1',
+            countries: [
+              {
+                code: 'DE',
+                decisions: {
+                  yes: 7,
+                  no: 4,
+                  yesAfterComp: null,
+                  noAfterComp: 11,
+                },
+              },
+              {
+                code: 'PL',
+                decisions: {
+                  yes: 3,
+                  no: 5,
+                  yesAfterComp: 9,
+                  noAfterComp: 8,
+                },
+              },
+            ],
+          },
+          {
+            name: 'Example route 2',
+            countries: [
+              {
+                code: 'FR',
+                decisions: {
+                  yes: 2,
+                  no: null,
+                  yesAfterComp: 12,
+                  noAfterComp: 5,
+                },
+              },
+              {
+                code: 'BE',
+                decisions: {
+                  yes: 2,
+                  no: 3,
+                  yesAfterComp: 8,
+                  noAfterComp: 1,
+                },
+              },
+            ],
+          },
+        ],
+      });
+
+      const dataset2 = decisionDatasetFactory.build({
+        profession,
+        organisation: organisation2,
+        routes: [
+          {
+            name: 'Example route 3',
+            countries: [
+              {
+                code: 'MA',
+                decisions: {
+                  yes: 1,
+                  no: 3,
+                  yesAfterComp: 3,
+                  noAfterComp: 4,
+                },
+              },
+              {
+                code: 'JP',
+                decisions: {
+                  yes: 1,
+                  no: 4,
+                  yesAfterComp: 5,
+                  noAfterComp: 8,
+                },
+              },
+            ],
+          },
+        ],
+      });
+
+      const i18nService = createMockI18nService();
+
+      (NationsListPresenter.prototype.textList as jest.Mock).mockReturnValue(
+        'Nation 1, Nation 2',
+      );
+
+      const presenter = new DecisionDatasetsPresenter(
+        profession,
+        year,
+        [dataset1, dataset2],
+        i18nService,
+      );
+      const result = await presenter.present();
+
+      expect(result).toEqual({
+        profession: 'Example Profession',
+        nations: 'Nation 1, Nation 2',
+        year,
+        organisations: [
+          {
+            organisation: 'Example Organisation 1',
+            routes: [
+              {
+                route: 'Example route 1',
+                yes: 10,
+                no: 9,
+                yesAfterComp: 9,
+                noAfterComp: 19,
+                total: 47,
+              },
+              {
+                route: 'Example route 2',
+                yes: 4,
+                no: 3,
+                yesAfterComp: 20,
+                noAfterComp: 6,
+                total: 33,
+              },
+            ],
+          },
+          {
+            organisation: 'Example Organisation 2',
+            routes: [
+              {
+                route: 'Example route 3',
+                yes: 2,
+                no: 7,
+                yesAfterComp: 8,
+                noAfterComp: 12,
+                total: 29,
+              },
+            ],
+          },
+        ],
+      } as ShowTemplate);
+
+      expect(NationsListPresenter).toHaveBeenCalledWith(
+        [Nation.find('GB-ENG'), Nation.find('GB-SCT')],
+        i18nService,
+      );
+      expect(NationsListPresenter.prototype.textList).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/decisions/presenters/decision-datasets.presenter.ts
+++ b/src/decisions/presenters/decision-datasets.presenter.ts
@@ -1,0 +1,60 @@
+import { I18nService } from 'nestjs-i18n';
+import { Nation } from '../../nations/nation';
+import { NationsListPresenter } from '../../nations/presenters/nations-list.presenter';
+import { ShowTemplate } from '../interfaces/show-template.interface';
+import { Profession } from '../../professions/profession.entity';
+import { DecisionDataset } from '../decision-dataset.entity';
+import { DecisionRoute } from '../interfaces/decision-route.interface';
+
+export class DecisionDatasetsPresenter {
+  constructor(
+    private readonly profession: Profession,
+    private readonly year: number,
+    private readonly datasets: DecisionDataset[],
+    private readonly i18nService: I18nService,
+  ) {}
+
+  async present(): Promise<ShowTemplate> {
+    const nations = new NationsListPresenter(
+      (this.profession.occupationLocations || []).map((code) =>
+        Nation.find(code),
+      ),
+      this.i18nService,
+    );
+
+    return {
+      profession: this.profession.name,
+      nations: await nations.textList(),
+      year: this.year,
+      organisations: this.datasets.map((dataset) => ({
+        organisation: dataset.organisation.name,
+        routes: dataset.routes.map((route) => {
+          const yes = this.computeTotal(route, 'yes');
+          const no = this.computeTotal(route, 'no');
+          const yesAfterComp = this.computeTotal(route, 'yesAfterComp');
+          const noAfterComp = this.computeTotal(route, 'noAfterComp');
+          const total = yes + no + yesAfterComp + noAfterComp;
+
+          return {
+            route: route.name,
+            yes,
+            no,
+            yesAfterComp,
+            noAfterComp,
+            total,
+          };
+        }),
+      })),
+    };
+  }
+
+  private computeTotal(
+    route: DecisionRoute,
+    key: keyof DecisionRoute['countries'][0]['decisions'],
+  ): number {
+    return route.countries.reduce((total, country) => {
+      const value = country.decisions[key];
+      return total + (typeof value === 'number' ? value : 0);
+    }, 0);
+  }
+}

--- a/src/i18n/en/decisions.json
+++ b/src/i18n/en/decisions.json
@@ -141,10 +141,10 @@
     "year": "Year",
     "tableHeading": {
       "country": "Country of qualification",
-      "yes": "Yes",
-      "no": "No",
-      "yesAfterComp": "Yes (after compensatory measure)",
-      "noAfterComp": "No (after compensatory measure)",
+      "yes": "Accepted - qualifications recognised",
+      "no": "Not accepted - qualifications not recognised",
+      "yesAfterComp": "Accepted - additional conditions met",
+      "noAfterComp": "Not accepted - additional conditions not met",
       "total": "Total"
     }
   },
@@ -157,10 +157,10 @@
       "route": "Route",
       "countryName": "Country of qualification",
       "countryCode": "Country code",
-      "yes": "Yes",
-      "no": "No",
-      "yesAfterComp": "Yes (after compensatory measure)",
-      "noAfterComp": "No (after compensatory measure)"
+      "yes": "Accepted - qualifications recognised",
+      "no": "Not accepted - qualifications not recognised",
+      "yesAfterComp": "Accepted - additional conditions met",
+      "noAfterComp": "Not accepted - additional conditions not met"
     },
     "status": {
       "live": "Published",

--- a/src/i18n/en/decisions.json
+++ b/src/i18n/en/decisions.json
@@ -148,6 +148,16 @@
       "total": "Total"
     }
   },
+  "public": {
+    "heading": "Recognition decision data",
+    "tableHeading": {
+      "yes": "Accepted - qualifications recognised",
+      "no": "Not accepted - qualifications not recognised",
+      "yesAfterComp": "Accepted - additional conditions met",
+      "noAfterComp": "Not accepted - additional conditions not met",
+      "total": "Total"
+    }
+  },
   "csv": {
     "heading": {
       "profession": "Profession",

--- a/src/i18n/en/professions.json
+++ b/src/i18n/en/professions.json
@@ -249,6 +249,10 @@
       "link": "Website link to legislation",
       "secondNationalLegislation": "Title of other act or charter",
       "secondLink": "Website link to other legislation"
+    },
+    "decisions": {
+      "heading": "Recognition decision data",
+      "year": "Year"
     }
   },
   "admin": {

--- a/src/professions/interfaces/show-template.interface.ts
+++ b/src/professions/interfaces/show-template.interface.ts
@@ -15,4 +15,5 @@ export interface ShowTemplate {
   industries: string[];
   organisations: GroupedTierOneOrganisations;
   enforcementBodies: string;
+  decisionYears?: SummaryList;
 }

--- a/src/professions/presenters/decision-dataset-years.presenter.spec.ts
+++ b/src/professions/presenters/decision-dataset-years.presenter.spec.ts
@@ -1,0 +1,57 @@
+import { SummaryList } from '../../common/interfaces/summary-list';
+import { createMockI18nService } from '../../testutils/create-mock-i18n-service';
+import professionFactory from '../../testutils/factories/profession';
+import { translationOf } from '../../testutils/translation-of';
+import { DecisionDatasetYearsPresenter } from './decision-dataset-years.presenter';
+
+describe('DecisionDatasetYearsPresenter', () => {
+  describe('summaryList', () => {
+    it('returns a SummaryList of the given years', () => {
+      const years = [2025, 2022, 2021];
+
+      const profession = professionFactory.build({
+        slug: 'example-slug',
+      });
+
+      const i18nService = createMockI18nService();
+
+      const presenter = new DecisionDatasetYearsPresenter(
+        years,
+        profession,
+        i18nService,
+      );
+
+      const result = presenter.summaryList();
+
+      expect(result).toEqual({
+        classes: 'govuk-summary-list--no-border',
+        rows: [
+          {
+            key: {
+              text: translationOf('professions.show.decisions.year'),
+            },
+            value: {
+              html: '<a href="/decisions/example-slug/2025" class="govuk-link">2025</a>',
+            },
+          },
+          {
+            key: {
+              text: translationOf('professions.show.decisions.year'),
+            },
+            value: {
+              html: '<a href="/decisions/example-slug/2022" class="govuk-link">2022</a>',
+            },
+          },
+          {
+            key: {
+              text: translationOf('professions.show.decisions.year'),
+            },
+            value: {
+              html: '<a href="/decisions/example-slug/2021" class="govuk-link">2021</a>',
+            },
+          },
+        ],
+      } as SummaryList);
+    });
+  });
+});

--- a/src/professions/presenters/decision-dataset-years.presenter.ts
+++ b/src/professions/presenters/decision-dataset-years.presenter.ts
@@ -1,0 +1,33 @@
+import { I18nService } from 'nestjs-i18n';
+import { SummaryList } from '../../common/interfaces/summary-list';
+import { Profession } from '../profession.entity';
+
+export class DecisionDatasetYearsPresenter {
+  constructor(
+    private readonly years: number[],
+    private readonly profession: Profession,
+    private readonly i18nService: I18nService,
+  ) {}
+
+  summaryList(): SummaryList {
+    const key = {
+      text: this.i18nService.translate<string>(
+        'professions.show.decisions.year',
+      ),
+    };
+
+    return {
+      classes: 'govuk-summary-list--no-border',
+      rows: this.years.map((year) => ({
+        key,
+        value: {
+          html: `<a href="${this.link(year)}" class="govuk-link">${year}</a>`,
+        },
+      })),
+    };
+  }
+
+  link(year: number): string {
+    return `/decisions/${this.profession.slug}/${year}`;
+  }
+}

--- a/src/professions/professions.controller.ts
+++ b/src/professions/professions.controller.ts
@@ -17,12 +17,15 @@ import { getOrganisationsFromProfessionByRole } from './helpers/get-organisation
 import { isUK } from '../helpers/nations.helper';
 import { NationsListPresenter } from '../nations/presenters/nations-list.presenter';
 import { organisationList } from './presenters/organisation-list';
-
+import { DecisionDatasetYearsPresenter } from './presenters/decision-dataset-years.presenter';
+import { DecisionDatasetsService } from '../decisions/decision-datasets.service';
 import { OrganisationRole } from './profession-to-organisation.entity';
+
 @Controller()
 export class ProfessionsController {
   constructor(
-    private professionVersionsService: ProfessionVersionsService,
+    private readonly professionVersionsService: ProfessionVersionsService,
+    private readonly decisionDatasetsService: DecisionDatasetsService,
     private readonly i18nService: I18nService,
   ) {}
 
@@ -36,6 +39,9 @@ export class ProfessionsController {
     const profession = await this.professionVersionsService.findLiveBySlug(
       slug,
     );
+
+    const decisionYears =
+      await this.decisionDatasetsService.allLiveYearsForProfession(profession);
 
     if (!profession) {
       throw new NotFoundException(
@@ -77,6 +83,14 @@ export class ProfessionsController {
         )
       : null;
 
+    const decisionYearsPresenter = decisionYears.length
+      ? new DecisionDatasetYearsPresenter(
+          decisionYears,
+          profession,
+          this.i18nService,
+        )
+      : null;
+
     return {
       profession,
       qualifications: qualification
@@ -91,6 +105,7 @@ export class ProfessionsController {
       industries,
       enforcementBodies: organisationList(enforcementBodies),
       organisations: tierOneOrganisations,
+      decisionYears: decisionYearsPresenter?.summaryList(),
     };
   }
 }

--- a/src/professions/professions.module.ts
+++ b/src/professions/professions.module.ts
@@ -29,6 +29,8 @@ import { OrganisationVersion } from '../organisations/organisation-version.entit
 import { ProfessionsSearchService } from './professions-search.service';
 import { OrganisationsSearchService } from '../organisations/organisations-search.service';
 import { SearchModule } from '../search/search.module';
+import { DecisionDatasetsService } from '../decisions/decision-datasets.service';
+import { DecisionDataset } from '../decisions/decision-dataset.entity';
 
 @Module({
   imports: [
@@ -38,6 +40,7 @@ import { SearchModule } from '../search/search.module';
     TypeOrmModule.forFeature([Organisation]),
     TypeOrmModule.forFeature([OrganisationVersion]),
     TypeOrmModule.forFeature([ProfessionToOrganisation]),
+    TypeOrmModule.forFeature([DecisionDataset]),
     SearchModule.register(),
   ],
   providers: [
@@ -48,6 +51,7 @@ import { SearchModule } from '../search/search.module';
     ProfessionsSearchService,
     OrganisationsSearchService,
     ProfessionVersionsService,
+    DecisionDatasetsService,
   ],
   controllers: [
     SearchController,

--- a/views/admin/decisions/show.njk
+++ b/views/admin/decisions/show.njk
@@ -30,12 +30,14 @@
           <span class="govuk-body" data-cy="changed-by-user-email">{{ changedBy.email | email }}</span>
         </h2>
       {% endif %}
-      <h2 class="govuk-heading-s" data-cy="currently-published-version-text">
-        {{ "decisions.admin.publicFacingLink.heading" | t }}<br>
-        <span class="govuk-body" data-cy="currently-published-version">
-          <a href="">{{ "decisions.admin.publicFacingLink.label" | t }}</a>
-        </span>
-      </h2>
+      {% if datasetStatus === 'live' %}
+        <h2 class="govuk-heading-s" data-cy="currently-published-version-text">
+          {{ "decisions.admin.publicFacingLink.heading" | t }}<br>
+          <span class="govuk-body" data-cy="currently-published-version">
+            <a class="govuk-link" href="/decisions/{{profession.slug}}/{{year}}/?fromInternalPage={{profession.id}}:{{organisation.id}}">{{ "decisions.admin.publicFacingLink.label" | t }}</a>
+          </span>
+        </h2>
+      {% endif %}
 
       <nav role="navigation" data-cy="actions">
         <ul class="govuk-list">

--- a/views/decisions/show.njk
+++ b/views/decisions/show.njk
@@ -1,0 +1,60 @@
+{% set bodyClasses = "rpr-details__page" %}
+{% extends "base.njk" %}
+
+{% set title = profession.name %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+
+    <div class="govuk-grid-column-full">
+
+      <h1 class="govuk-heading-xl">
+        {{ "decisions.public.heading" | t }}
+        <span class="govuk-caption-l">{{ profession }} - {{ nations }}</span>
+      </h1>
+
+      <h2 class="govuk-heading-l">{{ year }}</h2>
+
+      {% for organisation in organisations %}
+        <h3 class="govuk-heading-m">{{ organisation.organisation }}</h3>
+
+        {% for route in organisation.routes %}
+            <table class="govuk-table rpr-decision-data__public-table-container">
+                <caption class="govuk-table__caption govuk-table__caption--m">{{ route.route }}</caption>
+                <tbody class="govuk-table__head">
+                <tr class="govuk-table__row">
+                    <th scope="row" class="govuk-table__header">{{ "decisions.public.tableHeading.yes" | t }}</th>
+                    <td class="govuk-table__cell">{{ route.yes }}</td>
+                </tr>
+                <tr class="govuk-table__row">
+                    <th scope="row" class="govuk-table__header">{{ "decisions.public.tableHeading.yesAfterComp" | t }}</th>
+                    <td class="govuk-table__cell">{{ route.yesAfterComp }}</td>
+                </tr>
+                <tr class="govuk-table__row">
+                    <th scope="row" class="govuk-table__header">{{ "decisions.public.tableHeading.no" | t }}</th>
+                    <td class="govuk-table__cell">{{ route.no }}</td>
+                </tr>
+                <tr class="govuk-table__row">
+                    <th scope="row" class="govuk-table__header">{{ "decisions.public.tableHeading.noAfterComp" | t }}</th>
+                    <td class="govuk-table__cell">{{ route.noAfterComp }}</td>
+                </tr>
+                <tr class="govuk-table__row">
+                    <th scope="row" class="govuk-table__header">{{ "decisions.public.tableHeading.total" | t }}</th>
+                    <td class="govuk-table__cell"><strong>{{ route.total }}</strong></td>
+                </tr>
+                </tbody>
+            </table>
+        {% endfor %}
+
+        {% if not loop.last %}
+            <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
+        {% endif %}
+
+      {% endfor %}
+
+    </div>
+  </div>
+
+
+{% endblock %}

--- a/views/professions/_profession-details.njk
+++ b/views/professions/_profession-details.njk
@@ -286,5 +286,12 @@
     ]
   }) }}
 {% endfor %}
+{% endif %}
 
+{% if decisionYears %}
+
+  <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+  <h2 class="govuk-heading-l">{{ "professions.show.decisions.heading" | t}}</h2>
+  
+  {{ govukSummaryList(decisionYears) }}
 {% endif %}


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR

- Public view of decision data, linked to from public profession pages

## Screenshots of UI changes

### Before
![localhost_3000_professions_registered-trademark-attorney](https://user-images.githubusercontent.com/94137563/167147897-aa733999-c302-4f84-ac7e-f760b937b853.png)

### After
![localhost_3000_professions_registered-trademark-attorney (1)](https://user-images.githubusercontent.com/94137563/167147861-1f14220f-0002-4d6e-b5bc-0f8d5af7b4e9.png)

![localhost_3000_decisions_registered-trademark-attorney_2020](https://user-images.githubusercontent.com/94137563/167147845-dc46fb6d-2ad0-496a-956f-37abefb84ba4.png)



