### PR TITLE
(2332) Decision data route validations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Public view of decision data, linked to from public profession pages
 - Add confirmation page when editing decision data
+- Validations to ensure no duplicate or empty routes are entered in Decision data
 
 ### Changed
 

--- a/cypress/integration/admin/decisions/new.spec.ts
+++ b/cypress/integration/admin/decisions/new.spec.ts
@@ -101,6 +101,103 @@ describe('Creating a decision dataset', () => {
           });
         });
     });
+
+    it('displays validation errors when entering invalid data', () => {
+      cy.get('tbody').should(
+        'not.contain',
+        'Profession with no optional fields',
+      );
+
+      cy.translate('decisions.admin.dashboard.addButtonLabel').then((add) => {
+        cy.get('a').contains(add).click();
+      });
+
+      cy.checkAccessibility();
+
+      cy.translate('decisions.admin.new.labels.profession').then(
+        (profession) => {
+          cy.get('label')
+            .contains(profession)
+            .parent()
+            .within(() => {
+              cy.get('select').select('Profession with no optional fields');
+            });
+        },
+      );
+
+      cy.translate('decisions.admin.new.labels.organisation').then(
+        (profession) => {
+          cy.get('label')
+            .contains(profession)
+            .parent()
+            .within(() => {
+              cy.get('select').select('Organisation with no optional fields');
+            });
+        },
+      );
+
+      cy.translate('decisions.admin.new.labels.year').then((profession) => {
+        cy.get('label')
+          .contains(profession)
+          .parent()
+          .within(() => {
+            cy.get('select').select('2021');
+          });
+      });
+
+      cy.translate('app.continue').then((continueLabel) => {
+        cy.get('button').contains(continueLabel).click();
+      });
+
+      cy.get('h1').should('contain', 'Profession with no optional fields');
+
+      cy.checkSummaryListRowValue(
+        'decisions.admin.edit.regulator',
+        'Organisation with no optional fields',
+      );
+      cy.checkSummaryListRowValue('decisions.admin.edit.year', '2021');
+
+      cy.get('input[name="routes[1]"]').type('Duplicate Route');
+      cy.get('select[name="countries[1][1]"]').select('Japan');
+      cy.get('input[name="yeses[1][1]"]').type('3');
+      cy.get('input[name="noes[1][1]"]').type('9');
+      cy.get('input[name="yesAfterComps[1][1]"]').type('8');
+      cy.get('input[name="noAfterComps[1][1]"]').type('4');
+
+      cy.translate('decisions.admin.buttons.addRoute').then((addRoute) => {
+        cy.get('button').contains(addRoute).click();
+      });
+
+      cy.get('input[name="routes[2]"]').type('Duplicate Route');
+      cy.get('select[name="countries[2][1]"]').select('Japan');
+      cy.get('input[name="yeses[2][1]"]').type('3');
+      cy.get('input[name="noes[2][1]"]').type('9');
+      cy.get('input[name="yesAfterComps[2][1]"]').type('8');
+      cy.get('input[name="noAfterComps[2][1]"]').type('4');
+
+      cy.translate('decisions.admin.buttons.addRoute').then((addRoute) => {
+        cy.get('button').contains(addRoute).click();
+      });
+
+      cy.get('select[name="countries[3][1]"]').select('Japan');
+      cy.get('input[name="yeses[3][1]"]').type('3');
+      cy.get('input[name="noes[3][1]"]').type('9');
+      cy.get('input[name="yesAfterComps[3][1]"]').type('8');
+      cy.get('input[name="noAfterComps[3][1]"]').type('4');
+
+      cy.translate('decisions.admin.buttons.saveAsDraft').then((save) => {
+        cy.get('button').contains(save).click();
+      });
+
+      cy.translate('decisions.admin.edit.errors.routes.duplicate').then(
+        (error) => {
+          cy.get('body').should('contain', error);
+        },
+      );
+      cy.translate('decisions.admin.edit.errors.routes.empty').then((error) => {
+        cy.get('body').should('contain', error);
+      });
+    });
   });
 
   context('When I am logged in as an organisation editor', () => {

--- a/src/decisions/admin/edit.controller.spec.ts
+++ b/src/decisions/admin/edit.controller.spec.ts
@@ -376,458 +376,594 @@ describe('EditController', () => {
   });
 
   describe('update', () => {
-    describe('when the `action` is "publish"', () => {
-      it('saves the given dataset as draft and redirects to the publication confirmation page', async () => {
-        const editDto: EditDto = {
-          routes: ['Example route'],
-          countries: [['Brazil']],
-          yeses: [['1']],
-          noes: [['5']],
-          yesAfterComps: [['4']],
-          noAfterComps: [['7']],
-          action: 'publish',
-        };
+    describe('when submitting valid data', () => {
+      describe('when the `action` is "publish"', () => {
+        it('saves the given dataset as draft and redirects to the publication confirmation page', async () => {
+          const editDto: EditDto = {
+            routes: ['Example route'],
+            countries: [['Brazil']],
+            yeses: [['1']],
+            noes: [['5']],
+            yesAfterComps: [['4']],
+            noAfterComps: [['7']],
+            action: 'publish',
+          };
 
-        const decisionRoutes: DecisionRoute[] = [
-          {
-            name: 'Example route',
-            countries: [
-              {
-                code: 'BR',
-                decisions: {
-                  yes: 1,
-                  no: 5,
-                  yesAfterComp: 5,
-                  noAfterComp: 7,
+          const decisionRoutes: DecisionRoute[] = [
+            {
+              name: 'Example route',
+              countries: [
+                {
+                  code: 'BR',
+                  decisions: {
+                    yes: 1,
+                    no: 5,
+                    yesAfterComp: 5,
+                    noAfterComp: 7,
+                  },
                 },
-              },
-            ],
-          },
-        ];
+              ],
+            },
+          ];
 
-        const profession = professionFactory.build({
-          id: 'example-profession-id',
+          const profession = professionFactory.build({
+            id: 'example-profession-id',
+          });
+
+          const organisation = organisationFactory.build({
+            id: 'example-organisation-id',
+          });
+
+          const user = userFactory.build();
+
+          professionsService.findWithVersions.mockResolvedValue(profession);
+          organisationsService.find.mockResolvedValue(organisation);
+          decisionDatasetsService.find.mockResolvedValue(undefined);
+
+          const checkCanChangeDatasetSpy = jest
+            .spyOn(checkCanChangeDatasetModule, 'checkCanChangeDataset')
+            .mockImplementation();
+
+          const getActingUserSpy = jest
+            .spyOn(getActingUserModule, 'getActingUser')
+            .mockReturnValue(user);
+
+          const parseEditDtoDecisionRoutesSpy = jest
+            .spyOn(
+              parseEditDtoDecisionRoutesModule,
+              'parseEditDtoDecisionRoutes',
+            )
+            .mockReturnValue(decisionRoutes);
+          const modifyDecisionRoutesSpy = jest.spyOn(
+            modifyDecisionRoutesModule,
+            'modifyDecisionRoutes',
+          );
+          const checkCanPublishDatasetSpy = jest
+            .spyOn(checkCanPublishDatasetModule, 'checkCanPublishDataset')
+            .mockReturnValue(undefined);
+
+          const request = createDefaultMockRequest();
+          const response = createMock<Response>();
+          const flashMock = flashMessage as jest.Mock;
+          flashMock.mockImplementation(() => 'STUB_FLASH_MESSAGE');
+
+          await controller.update(
+            'example-profession-id',
+            'example-organisation-id',
+            2016,
+            editDto,
+            request,
+            response,
+          );
+
+          expect(checkCanPublishDatasetSpy).toHaveBeenCalledWith(request);
+
+          expect(response.redirect).toHaveBeenCalledWith(
+            '/admin/decisions/example-profession-id/example-organisation-id/2016/publish?fromEdit=true',
+          );
+
+          expect(professionsService.findWithVersions).toHaveBeenCalledWith(
+            'example-profession-id',
+          );
+          expect(organisationsService.find).toHaveBeenCalledWith(
+            'example-organisation-id',
+          );
+          expect(decisionDatasetsService.find).toHaveBeenCalledWith(
+            'example-profession-id',
+            'example-organisation-id',
+            2016,
+          );
+
+          expect(decisionDatasetsService.save).toHaveBeenCalledWith({
+            profession,
+            organisation,
+            year: 2016,
+            user,
+            status: DecisionDatasetStatus.Draft,
+            routes: decisionRoutes,
+          } as DecisionDataset);
+
+          expect(checkCanChangeDatasetSpy).toHaveBeenCalledWith(
+            request,
+            profession,
+            organisation,
+            2016,
+            false,
+          );
+          expect(getActingUserSpy).toHaveBeenCalledWith(request);
+          expect(parseEditDtoDecisionRoutesSpy).toHaveBeenCalledWith(editDto);
+          expect(modifyDecisionRoutesSpy).not.toHaveBeenCalled();
         });
+      });
 
-        const organisation = organisationFactory.build({
-          id: 'example-organisation-id',
+      describe('when the `action` is "submit"', () => {
+        it('saves the given dataset as draft and redirects to the submission confirmation page', async () => {
+          const editDto: EditDto = {
+            routes: ['Example route'],
+            countries: [['Brazil']],
+            yeses: [['1']],
+            noes: [['5']],
+            yesAfterComps: [['4']],
+            noAfterComps: [['7']],
+            action: 'submit',
+          };
+
+          const decisionRoutes: DecisionRoute[] = [
+            {
+              name: 'Example route',
+              countries: [
+                {
+                  code: 'BR',
+                  decisions: {
+                    yes: 1,
+                    no: 5,
+                    yesAfterComp: 5,
+                    noAfterComp: 7,
+                  },
+                },
+              ],
+            },
+          ];
+
+          const profession = professionFactory.build({
+            id: 'example-profession-id',
+          });
+
+          const organisation = organisationFactory.build({
+            id: 'example-organisation-id',
+          });
+
+          const user = userFactory.build();
+
+          professionsService.findWithVersions.mockResolvedValue(profession);
+          organisationsService.find.mockResolvedValue(organisation);
+          decisionDatasetsService.find.mockResolvedValue(undefined);
+
+          const checkCanChangeDatasetSpy = jest
+            .spyOn(checkCanChangeDatasetModule, 'checkCanChangeDataset')
+            .mockImplementation();
+
+          const getActingUserSpy = jest
+            .spyOn(getActingUserModule, 'getActingUser')
+            .mockReturnValue(user);
+
+          const parseEditDtoDecisionRoutesSpy = jest
+            .spyOn(
+              parseEditDtoDecisionRoutesModule,
+              'parseEditDtoDecisionRoutes',
+            )
+            .mockReturnValue(decisionRoutes);
+          const modifyDecisionRoutesSpy = jest.spyOn(
+            modifyDecisionRoutesModule,
+            'modifyDecisionRoutes',
+          );
+
+          const request = createDefaultMockRequest();
+          const response = createMock<Response>();
+          const flashMock = flashMessage as jest.Mock;
+          flashMock.mockImplementation(() => 'STUB_FLASH_MESSAGE');
+
+          await controller.update(
+            'example-profession-id',
+            'example-organisation-id',
+            2016,
+            editDto,
+            request,
+            response,
+          );
+
+          expect(response.redirect).toHaveBeenCalledWith(
+            '/admin/decisions/example-profession-id/example-organisation-id/2016/submit?fromEdit=true',
+          );
+
+          expect(professionsService.findWithVersions).toHaveBeenCalledWith(
+            'example-profession-id',
+          );
+          expect(organisationsService.find).toHaveBeenCalledWith(
+            'example-organisation-id',
+          );
+          expect(decisionDatasetsService.find).toHaveBeenCalledWith(
+            'example-profession-id',
+            'example-organisation-id',
+            2016,
+          );
+
+          expect(decisionDatasetsService.save).toHaveBeenCalledWith({
+            profession,
+            organisation,
+            year: 2016,
+            user,
+            status: DecisionDatasetStatus.Draft,
+            routes: decisionRoutes,
+          } as DecisionDataset);
+
+          expect(checkCanChangeDatasetSpy).toHaveBeenCalledWith(
+            request,
+            profession,
+            organisation,
+            2016,
+            false,
+          );
+          expect(getActingUserSpy).toHaveBeenCalledWith(request);
+          expect(parseEditDtoDecisionRoutesSpy).toHaveBeenCalledWith(editDto);
+          expect(modifyDecisionRoutesSpy).not.toHaveBeenCalled();
         });
+      });
 
-        const user = userFactory.build();
+      describe('when the `action` is "save"', () => {
+        it('saves the given dataset with the draft status', async () => {
+          const editDto: EditDto = {
+            routes: ['Example route'],
+            countries: [['Germany']],
+            yeses: [['1']],
+            noes: [['8']],
+            yesAfterComps: [['1']],
+            noAfterComps: [['2']],
+            action: 'save',
+          };
 
-        professionsService.findWithVersions.mockResolvedValue(profession);
-        organisationsService.find.mockResolvedValue(organisation);
-        decisionDatasetsService.find.mockResolvedValue(undefined);
+          const decisionRoutes: DecisionRoute[] = [
+            {
+              name: 'Example route',
+              countries: [
+                {
+                  code: 'DE',
+                  decisions: {
+                    yes: 1,
+                    no: 8,
+                    yesAfterComp: 1,
+                    noAfterComp: 2,
+                  },
+                },
+              ],
+            },
+          ];
 
-        const checkCanChangeDatasetSpy = jest
-          .spyOn(checkCanChangeDatasetModule, 'checkCanChangeDataset')
-          .mockImplementation();
+          const profession = professionFactory.build({
+            id: 'example-profession-id',
+          });
 
-        const getActingUserSpy = jest
-          .spyOn(getActingUserModule, 'getActingUser')
-          .mockReturnValue(user);
+          const organisation = organisationFactory.build({
+            id: 'example-organisation-id',
+          });
 
-        const parseEditDtoDecisionRoutesSpy = jest
-          .spyOn(parseEditDtoDecisionRoutesModule, 'parseEditDtoDecisionRoutes')
-          .mockReturnValue(decisionRoutes);
-        const modifyDecisionRoutesSpy = jest.spyOn(
-          modifyDecisionRoutesModule,
-          'modifyDecisionRoutes',
-        );
-        const checkCanPublishDatasetSpy = jest
-          .spyOn(checkCanPublishDatasetModule, 'checkCanPublishDataset')
-          .mockReturnValue(undefined);
+          const user = userFactory.build();
 
-        const request = createDefaultMockRequest();
-        const response = createMock<Response>();
-        const flashMock = flashMessage as jest.Mock;
-        flashMock.mockImplementation(() => 'STUB_FLASH_MESSAGE');
+          professionsService.findWithVersions.mockResolvedValue(profession);
+          organisationsService.find.mockResolvedValue(organisation);
+          decisionDatasetsService.find.mockResolvedValue(undefined);
 
-        await controller.update(
-          'example-profession-id',
-          'example-organisation-id',
-          2016,
-          editDto,
-          request,
-          response,
-        );
+          const checkCanChangeDatasetSpy = jest
+            .spyOn(checkCanChangeDatasetModule, 'checkCanChangeDataset')
+            .mockImplementation();
 
-        expect(checkCanPublishDatasetSpy).toHaveBeenCalledWith(request);
+          const getActingUserSpy = jest
+            .spyOn(getActingUserModule, 'getActingUser')
+            .mockReturnValue(user);
 
-        expect(response.redirect).toHaveBeenCalledWith(
-          '/admin/decisions/example-profession-id/example-organisation-id/2016/publish?fromEdit=true',
-        );
+          const parseEditDtoDecisionRoutesSpy = jest
+            .spyOn(
+              parseEditDtoDecisionRoutesModule,
+              'parseEditDtoDecisionRoutes',
+            )
+            .mockReturnValue(decisionRoutes);
+          const modifyDecisionRoutesSpy = jest.spyOn(
+            modifyDecisionRoutesModule,
+            'modifyDecisionRoutes',
+          );
 
-        expect(professionsService.findWithVersions).toHaveBeenCalledWith(
-          'example-profession-id',
-        );
-        expect(organisationsService.find).toHaveBeenCalledWith(
-          'example-organisation-id',
-        );
-        expect(decisionDatasetsService.find).toHaveBeenCalledWith(
-          'example-profession-id',
-          'example-organisation-id',
-          2016,
-        );
+          const request = createDefaultMockRequest();
+          const response = createMock<Response>();
 
-        expect(decisionDatasetsService.save).toHaveBeenCalledWith({
-          profession,
-          organisation,
-          year: 2016,
-          user,
-          status: DecisionDatasetStatus.Draft,
-          routes: decisionRoutes,
-        } as DecisionDataset);
+          const flashMock = flashMessage as jest.Mock;
+          flashMock.mockImplementation(() => 'STUB_FLASH_MESSAGE');
 
-        expect(checkCanChangeDatasetSpy).toHaveBeenCalledWith(
-          request,
-          profession,
-          organisation,
-          2016,
-          false,
-        );
-        expect(getActingUserSpy).toHaveBeenCalledWith(request);
-        expect(parseEditDtoDecisionRoutesSpy).toHaveBeenCalledWith(editDto);
-        expect(modifyDecisionRoutesSpy).not.toHaveBeenCalled();
+          await controller.update(
+            'example-profession-id',
+            'example-organisation-id',
+            2016,
+            editDto,
+            request,
+            response,
+          );
+
+          expect(flashMock).toHaveBeenCalledWith(
+            translationOf('decisions.admin.saveAsDraft.confirmation.heading'),
+            translationOf('decisions.admin.saveAsDraft.confirmation.body'),
+          );
+
+          expect(response.redirect).toHaveBeenCalledWith(
+            '/admin/decisions/example-profession-id/example-organisation-id/2016',
+          );
+
+          expect(professionsService.findWithVersions).toHaveBeenCalledWith(
+            'example-profession-id',
+          );
+          expect(organisationsService.find).toHaveBeenCalledWith(
+            'example-organisation-id',
+          );
+          expect(decisionDatasetsService.find).toHaveBeenCalledWith(
+            'example-profession-id',
+            'example-organisation-id',
+            2016,
+          );
+
+          expect(decisionDatasetsService.save).toHaveBeenCalledWith({
+            profession,
+            organisation,
+            year: 2016,
+            user,
+            status: DecisionDatasetStatus.Draft,
+            routes: decisionRoutes,
+          } as DecisionDataset);
+
+          expect(checkCanChangeDatasetSpy).toHaveBeenCalledWith(
+            request,
+            profession,
+            organisation,
+            2016,
+            false,
+          );
+          expect(getActingUserSpy).toHaveBeenCalledWith(request);
+          expect(parseEditDtoDecisionRoutesSpy).toHaveBeenCalledWith(editDto);
+          expect(modifyDecisionRoutesSpy).not.toHaveBeenCalled();
+        });
+      });
+
+      describe('when the `action` is a modification command', () => {
+        it('does not validate the data, but modifies the dataset', async () => {
+          const editDto: EditDto = {
+            routes: ['Example route'],
+            countries: [['Japan']],
+            yeses: [['4']],
+            noes: [['5']],
+            yesAfterComps: [['']],
+            noAfterComps: [['9']],
+            action: 'addCountry:1',
+          };
+
+          const decisionRoutes: DecisionRoute[] = [
+            {
+              name: 'Example route',
+              countries: [
+                {
+                  code: 'JP',
+                  decisions: {
+                    yes: 4,
+                    no: 5,
+                    yesAfterComp: null,
+                    noAfterComp: 9,
+                  },
+                },
+              ],
+            },
+          ];
+
+          const profession = professionFactory.build({
+            id: 'example-profession-id',
+          });
+
+          const organisation = organisationFactory.build({
+            id: 'example-organisation-id',
+          });
+
+          professionsService.findWithVersions.mockResolvedValue(profession);
+          organisationsService.find.mockResolvedValue(organisation);
+          decisionDatasetsService.find.mockResolvedValue(undefined);
+
+          (
+            DecisionDatasetEditPresenter.prototype.present as jest.Mock
+          ).mockReturnValue(mockRouteTemplates);
+
+          const checkCanChangeDatasetSpy = jest
+            .spyOn(checkCanChangeDatasetModule, 'checkCanChangeDataset')
+            .mockImplementation();
+
+          const parseEditDtoDecisionRoutesSpy = jest
+            .spyOn(
+              parseEditDtoDecisionRoutesModule,
+              'parseEditDtoDecisionRoutes',
+            )
+            .mockReturnValue(decisionRoutes);
+          const modifyDecisionRoutesSpy = jest
+            .spyOn(modifyDecisionRoutesModule, 'modifyDecisionRoutes')
+            .mockImplementation();
+
+          const request = createDefaultMockRequest();
+          const response = createMock<Response>();
+
+          await controller.update(
+            'example-profession-id',
+            'example-organisation-id',
+            2017,
+            editDto,
+            request,
+            response,
+          );
+
+          expect(response.render).toHaveBeenCalledWith('admin/decisions/edit', {
+            profession,
+            organisation,
+            year: 2017,
+            routes: mockRouteTemplates,
+          } as EditTemplate);
+
+          expect(professionsService.findWithVersions).toHaveBeenCalledWith(
+            'example-profession-id',
+          );
+          expect(organisationsService.find).toHaveBeenCalledWith(
+            'example-organisation-id',
+          );
+          expect(decisionDatasetsService.find).toHaveBeenCalledWith(
+            'example-profession-id',
+            'example-organisation-id',
+            2017,
+          );
+
+          expect(DecisionDatasetEditPresenter).toHaveBeenCalledWith(
+            decisionRoutes,
+            i18nService,
+          );
+          expect(
+            DecisionDatasetEditPresenter.prototype.present,
+          ).toHaveBeenCalled();
+
+          expect(checkCanChangeDatasetSpy).toHaveBeenCalledWith(
+            request,
+            profession,
+            organisation,
+            2017,
+            false,
+          );
+          expect(parseEditDtoDecisionRoutesSpy).toHaveBeenCalledWith(editDto);
+          expect(modifyDecisionRoutesSpy).toHaveBeenCalledWith(
+            decisionRoutes,
+            'addCountry:1',
+          );
+        });
       });
     });
 
-    describe('when the `action` is "submit"', () => {
-      it('saves the given dataset as draft and redirects to the submission confirmation page', async () => {
-        const editDto: EditDto = {
-          routes: ['Example route'],
-          countries: [['Brazil']],
-          yeses: [['1']],
-          noes: [['5']],
-          yesAfterComps: [['4']],
-          noAfterComps: [['7']],
-          action: 'submit',
-        };
+    describe('when submitting invalid data', () => {
+      describe.each(['publish', 'save', 'submit'])(
+        'when the action is %s',
+        (action) => {
+          it('re-renders the view with errors, not saving the entry', async () => {
+            const editDtoWithEmptyRoutes: EditDto = {
+              routes: ['', 'Route 2', ''],
+              countries: [['CA'], ['AR'], ['JP']],
+              yeses: [['1'], ['1'], ['1']],
+              yesAfterComps: [['1'], ['1'], ['1']],
+              noes: [['1'], ['1'], ['1']],
+              noAfterComps: [['1'], ['1'], ['1']],
+              action,
+            };
 
-        const decisionRoutes: DecisionRoute[] = [
-          {
-            name: 'Example route',
-            countries: [
+            const decisionRoutes: DecisionRoute[] = [
               {
-                code: 'BR',
-                decisions: {
-                  yes: 1,
-                  no: 5,
-                  yesAfterComp: 5,
-                  noAfterComp: 7,
-                },
+                name: 'Example route',
+                countries: [
+                  {
+                    code: 'JP',
+                    decisions: {
+                      yes: 4,
+                      no: 5,
+                      yesAfterComp: null,
+                      noAfterComp: 9,
+                    },
+                  },
+                ],
               },
-            ],
-          },
-        ];
+            ];
 
-        const profession = professionFactory.build({
-          id: 'example-profession-id',
-        });
+            const profession = professionFactory.build({
+              id: 'example-profession-id',
+            });
 
-        const organisation = organisationFactory.build({
-          id: 'example-organisation-id',
-        });
+            const organisation = organisationFactory.build({
+              id: 'example-organisation-id',
+            });
 
-        const user = userFactory.build();
+            professionsService.findWithVersions.mockResolvedValue(profession);
+            organisationsService.find.mockResolvedValue(organisation);
+            decisionDatasetsService.find.mockResolvedValue(undefined);
 
-        professionsService.findWithVersions.mockResolvedValue(profession);
-        organisationsService.find.mockResolvedValue(organisation);
-        decisionDatasetsService.find.mockResolvedValue(undefined);
+            (
+              DecisionDatasetEditPresenter.prototype.present as jest.Mock
+            ).mockReturnValue(mockRouteTemplates);
 
-        const checkCanChangeDatasetSpy = jest
-          .spyOn(checkCanChangeDatasetModule, 'checkCanChangeDataset')
-          .mockImplementation();
+            const checkCanChangeDatasetSpy = jest
+              .spyOn(checkCanChangeDatasetModule, 'checkCanChangeDataset')
+              .mockImplementation();
 
-        const getActingUserSpy = jest
-          .spyOn(getActingUserModule, 'getActingUser')
-          .mockReturnValue(user);
+            const parseEditDtoDecisionRoutesSpy = jest
+              .spyOn(
+                parseEditDtoDecisionRoutesModule,
+                'parseEditDtoDecisionRoutes',
+              )
+              .mockReturnValue(decisionRoutes);
 
-        const parseEditDtoDecisionRoutesSpy = jest
-          .spyOn(parseEditDtoDecisionRoutesModule, 'parseEditDtoDecisionRoutes')
-          .mockReturnValue(decisionRoutes);
-        const modifyDecisionRoutesSpy = jest.spyOn(
-          modifyDecisionRoutesModule,
-          'modifyDecisionRoutes',
-        );
+            jest
+              .spyOn(checkCanPublishDatasetModule, 'checkCanPublishDataset')
+              .mockReturnValue(undefined);
 
-        const request = createDefaultMockRequest();
-        const response = createMock<Response>();
-        const flashMock = flashMessage as jest.Mock;
-        flashMock.mockImplementation(() => 'STUB_FLASH_MESSAGE');
+            const request = createDefaultMockRequest();
+            const response = createMock<Response>();
 
-        await controller.update(
-          'example-profession-id',
-          'example-organisation-id',
-          2016,
-          editDto,
-          request,
-          response,
-        );
+            await controller.update(
+              'example-profession-id',
+              'example-organisation-id',
+              2017,
+              editDtoWithEmptyRoutes,
+              request,
+              response,
+            );
 
-        expect(response.redirect).toHaveBeenCalledWith(
-          '/admin/decisions/example-profession-id/example-organisation-id/2016/submit?fromEdit=true',
-        );
-
-        expect(professionsService.findWithVersions).toHaveBeenCalledWith(
-          'example-profession-id',
-        );
-        expect(organisationsService.find).toHaveBeenCalledWith(
-          'example-organisation-id',
-        );
-        expect(decisionDatasetsService.find).toHaveBeenCalledWith(
-          'example-profession-id',
-          'example-organisation-id',
-          2016,
-        );
-
-        expect(decisionDatasetsService.save).toHaveBeenCalledWith({
-          profession,
-          organisation,
-          year: 2016,
-          user,
-          status: DecisionDatasetStatus.Draft,
-          routes: decisionRoutes,
-        } as DecisionDataset);
-
-        expect(checkCanChangeDatasetSpy).toHaveBeenCalledWith(
-          request,
-          profession,
-          organisation,
-          2016,
-          false,
-        );
-        expect(getActingUserSpy).toHaveBeenCalledWith(request);
-        expect(parseEditDtoDecisionRoutesSpy).toHaveBeenCalledWith(editDto);
-        expect(modifyDecisionRoutesSpy).not.toHaveBeenCalled();
-      });
-    });
-
-    describe('when the `action` is "save"', () => {
-      it('saves the given dataset with the draft status', async () => {
-        const editDto: EditDto = {
-          routes: ['Example route'],
-          countries: [['Germany']],
-          yeses: [['1']],
-          noes: [['8']],
-          yesAfterComps: [['1']],
-          noAfterComps: [['2']],
-          action: 'save',
-        };
-
-        const decisionRoutes: DecisionRoute[] = [
-          {
-            name: 'Example route',
-            countries: [
+            expect(response.render).toHaveBeenCalledWith(
+              'admin/decisions/edit',
               {
-                code: 'DE',
-                decisions: {
-                  yes: 1,
-                  no: 8,
-                  yesAfterComp: 1,
-                  noAfterComp: 2,
+                profession,
+                organisation,
+                year: 2017,
+                routes: mockRouteTemplates,
+                errors: {
+                  'routes[1]': {
+                    text: 'decisions.admin.edit.errors.routes.empty',
+                  },
+                  'routes[3]': {
+                    text: 'decisions.admin.edit.errors.routes.empty',
+                  },
                 },
-              },
-            ],
-          },
-        ];
+              } as EditTemplate,
+            );
 
-        const profession = professionFactory.build({
-          id: 'example-profession-id',
-        });
+            expect(professionsService.findWithVersions).toHaveBeenCalledWith(
+              'example-profession-id',
+            );
+            expect(organisationsService.find).toHaveBeenCalledWith(
+              'example-organisation-id',
+            );
+            expect(decisionDatasetsService.find).toHaveBeenCalledWith(
+              'example-profession-id',
+              'example-organisation-id',
+              2017,
+            );
 
-        const organisation = organisationFactory.build({
-          id: 'example-organisation-id',
-        });
+            expect(checkCanChangeDatasetSpy).toHaveBeenCalledWith(
+              request,
+              profession,
+              organisation,
+              2017,
+              false,
+            );
+            expect(parseEditDtoDecisionRoutesSpy).toHaveBeenCalledWith(
+              editDtoWithEmptyRoutes,
+            );
 
-        const user = userFactory.build();
-
-        professionsService.findWithVersions.mockResolvedValue(profession);
-        organisationsService.find.mockResolvedValue(organisation);
-        decisionDatasetsService.find.mockResolvedValue(undefined);
-
-        const checkCanChangeDatasetSpy = jest
-          .spyOn(checkCanChangeDatasetModule, 'checkCanChangeDataset')
-          .mockImplementation();
-
-        const getActingUserSpy = jest
-          .spyOn(getActingUserModule, 'getActingUser')
-          .mockReturnValue(user);
-
-        const parseEditDtoDecisionRoutesSpy = jest
-          .spyOn(parseEditDtoDecisionRoutesModule, 'parseEditDtoDecisionRoutes')
-          .mockReturnValue(decisionRoutes);
-        const modifyDecisionRoutesSpy = jest.spyOn(
-          modifyDecisionRoutesModule,
-          'modifyDecisionRoutes',
-        );
-
-        const request = createDefaultMockRequest();
-        const response = createMock<Response>();
-
-        const flashMock = flashMessage as jest.Mock;
-        flashMock.mockImplementation(() => 'STUB_FLASH_MESSAGE');
-
-        await controller.update(
-          'example-profession-id',
-          'example-organisation-id',
-          2016,
-          editDto,
-          request,
-          response,
-        );
-
-        expect(flashMock).toHaveBeenCalledWith(
-          translationOf('decisions.admin.saveAsDraft.confirmation.heading'),
-          translationOf('decisions.admin.saveAsDraft.confirmation.body'),
-        );
-
-        expect(response.redirect).toHaveBeenCalledWith(
-          '/admin/decisions/example-profession-id/example-organisation-id/2016',
-        );
-
-        expect(professionsService.findWithVersions).toHaveBeenCalledWith(
-          'example-profession-id',
-        );
-        expect(organisationsService.find).toHaveBeenCalledWith(
-          'example-organisation-id',
-        );
-        expect(decisionDatasetsService.find).toHaveBeenCalledWith(
-          'example-profession-id',
-          'example-organisation-id',
-          2016,
-        );
-
-        expect(decisionDatasetsService.save).toHaveBeenCalledWith({
-          profession,
-          organisation,
-          year: 2016,
-          user,
-          status: DecisionDatasetStatus.Draft,
-          routes: decisionRoutes,
-        } as DecisionDataset);
-
-        expect(checkCanChangeDatasetSpy).toHaveBeenCalledWith(
-          request,
-          profession,
-          organisation,
-          2016,
-          false,
-        );
-        expect(getActingUserSpy).toHaveBeenCalledWith(request);
-        expect(parseEditDtoDecisionRoutesSpy).toHaveBeenCalledWith(editDto);
-        expect(modifyDecisionRoutesSpy).not.toHaveBeenCalled();
-      });
-    });
-
-    describe('when the `action` is a modification command', () => {
-      it('modifies the dataset', async () => {
-        const editDto: EditDto = {
-          routes: ['Example route'],
-          countries: [['Japan']],
-          yeses: [['4']],
-          noes: [['5']],
-          yesAfterComps: [['']],
-          noAfterComps: [['9']],
-          action: 'addCountry:1',
-        };
-
-        const decisionRoutes: DecisionRoute[] = [
-          {
-            name: 'Example route',
-            countries: [
-              {
-                code: 'JP',
-                decisions: {
-                  yes: 4,
-                  no: 5,
-                  yesAfterComp: null,
-                  noAfterComp: 9,
-                },
-              },
-            ],
-          },
-        ];
-
-        const profession = professionFactory.build({
-          id: 'example-profession-id',
-        });
-
-        const organisation = organisationFactory.build({
-          id: 'example-organisation-id',
-        });
-
-        professionsService.findWithVersions.mockResolvedValue(profession);
-        organisationsService.find.mockResolvedValue(organisation);
-        decisionDatasetsService.find.mockResolvedValue(undefined);
-
-        (
-          DecisionDatasetEditPresenter.prototype.present as jest.Mock
-        ).mockReturnValue(mockRouteTemplates);
-
-        const checkCanChangeDatasetSpy = jest
-          .spyOn(checkCanChangeDatasetModule, 'checkCanChangeDataset')
-          .mockImplementation();
-
-        const parseEditDtoDecisionRoutesSpy = jest
-          .spyOn(parseEditDtoDecisionRoutesModule, 'parseEditDtoDecisionRoutes')
-          .mockReturnValue(decisionRoutes);
-        const modifyDecisionRoutesSpy = jest
-          .spyOn(modifyDecisionRoutesModule, 'modifyDecisionRoutes')
-          .mockImplementation();
-
-        const request = createDefaultMockRequest();
-        const response = createMock<Response>();
-
-        await controller.update(
-          'example-profession-id',
-          'example-organisation-id',
-          2017,
-          editDto,
-          request,
-          response,
-        );
-
-        expect(response.render).toHaveBeenCalledWith('admin/decisions/edit', {
-          profession,
-          organisation,
-          year: 2017,
-          routes: mockRouteTemplates,
-        } as EditTemplate);
-
-        expect(professionsService.findWithVersions).toHaveBeenCalledWith(
-          'example-profession-id',
-        );
-        expect(organisationsService.find).toHaveBeenCalledWith(
-          'example-organisation-id',
-        );
-        expect(decisionDatasetsService.find).toHaveBeenCalledWith(
-          'example-profession-id',
-          'example-organisation-id',
-          2017,
-        );
-
-        expect(DecisionDatasetEditPresenter).toHaveBeenCalledWith(
-          decisionRoutes,
-          i18nService,
-        );
-        expect(
-          DecisionDatasetEditPresenter.prototype.present,
-        ).toHaveBeenCalled();
-
-        expect(checkCanChangeDatasetSpy).toHaveBeenCalledWith(
-          request,
-          profession,
-          organisation,
-          2017,
-          false,
-        );
-        expect(parseEditDtoDecisionRoutesSpy).toHaveBeenCalledWith(editDto);
-        expect(modifyDecisionRoutesSpy).toHaveBeenCalledWith(
-          decisionRoutes,
-          'addCountry:1',
-        );
-      });
+            expect(decisionDatasetsService.save).not.toHaveBeenCalled();
+          });
+        },
+      );
     });
   });
 

--- a/src/helpers/decision-data-validator.spec.ts
+++ b/src/helpers/decision-data-validator.spec.ts
@@ -53,4 +53,51 @@ describe('DecisionDataValidator', () => {
       });
     });
   });
+
+  describe('validating no duplicate routes', () => {
+    describe('when there are no duplicate routes submitted', () => {
+      it('returns an empty array of errors', () => {
+        const editDto = {
+          routes: ['Route 1', 'Route 2'],
+          countries: [['CA'], ['AR']],
+          yeses: [['1'], ['1']],
+          yesAfterComps: [['1'], ['1']],
+          noes: [['1'], ['1']],
+          noAfterComps: [['1'], ['1']],
+          action: 'save',
+        };
+
+        const validated = DecisionDataValidator.validate(editDto);
+
+        expect(validated.valid()).toEqual(true);
+        expect(validated.errors).toEqual([]);
+      });
+    });
+
+    describe('when duplicate routes are submitted', () => {
+      it('returns an array of errors, with the duplicate route highlighted', () => {
+        const editDto = {
+          routes: ['Route 1', 'Route 2', 'Route 1'],
+          countries: [['CA'], ['AR'], ['JP']],
+          yeses: [['1'], ['1'], ['1']],
+          yesAfterComps: [['1'], ['1'], ['1']],
+          noes: [['1'], ['1'], ['1']],
+          noAfterComps: [['1'], ['1'], ['1']],
+          action: 'save',
+        };
+
+        const validated = DecisionDataValidator.validate(editDto);
+
+        expect(validated.valid()).toEqual(false);
+        expect(validated.errors).toEqual([
+          {
+            constraints: {
+              message: 'decisions.admin.edit.errors.routes.duplicate',
+            },
+            property: 'routes[3]',
+          },
+        ]);
+      });
+    });
+  });
 });

--- a/src/helpers/decision-data-validator.spec.ts
+++ b/src/helpers/decision-data-validator.spec.ts
@@ -1,0 +1,56 @@
+import { DecisionDataValidator } from './decision-data-validator';
+
+describe('DecisionDataValidator', () => {
+  describe('validating no empty routes', () => {
+    describe('when there are no empty routes submitted', () => {
+      it('returns an empty array of errors', () => {
+        const editDto = {
+          routes: ['Route 1', 'Route 2'],
+          countries: [['CA'], ['AR']],
+          yeses: [['1'], ['1']],
+          yesAfterComps: [['1'], ['1']],
+          noes: [['1'], ['1']],
+          noAfterComps: [['1'], ['1']],
+          action: 'save',
+        };
+
+        const validated = DecisionDataValidator.validate(editDto);
+
+        expect(validated.valid()).toEqual(true);
+        expect(validated.errors).toEqual([]);
+      });
+    });
+
+    describe('when empty routes are submitted', () => {
+      it('returns an array of errors', () => {
+        const editDto = {
+          routes: ['', 'Route 2', ' '],
+          countries: [['CA'], ['AR'], ['JP']],
+          yeses: [['1'], ['1'], ['1']],
+          yesAfterComps: [['1'], ['1'], ['1']],
+          noes: [['1'], ['1'], ['1']],
+          noAfterComps: [['1'], ['1'], ['1']],
+          action: 'save',
+        };
+
+        const validated = DecisionDataValidator.validate(editDto);
+
+        expect(validated.valid()).toEqual(false);
+        expect(validated.errors).toEqual([
+          {
+            constraints: {
+              message: 'decisions.admin.edit.errors.routes.empty',
+            },
+            property: 'routes[1]',
+          },
+          {
+            constraints: {
+              message: 'decisions.admin.edit.errors.routes.empty',
+            },
+            property: 'routes[3]',
+          },
+        ]);
+      });
+    });
+  });
+});

--- a/src/helpers/decision-data-validator.ts
+++ b/src/helpers/decision-data-validator.ts
@@ -8,7 +8,10 @@ export class DecisionDataValidator {
 
   public static validate(obj: EditDto) {
     const object: EditDto = plainToClass(EditDto, obj);
-    const errors = this.validateNoEmptyRoutes(obj);
+    const errors = [
+      this.validateNoEmptyRoutes(obj),
+      this.validateNoDuplicateRoutes(obj),
+    ].flat();
 
     return new DecisionDataValidator(object, errors);
   }
@@ -31,6 +34,21 @@ export class DecisionDataValidator {
             property: `routes[${index + 1}]`,
             constraints: {
               message: 'decisions.admin.edit.errors.routes.empty',
+            },
+          };
+        }
+      })
+      .filter((n) => n);
+  }
+
+  public static validateNoDuplicateRoutes(editDto: EditDto): ValidationError[] {
+    return editDto.routes
+      .map((route, index) => {
+        if (editDto.routes.indexOf(route) !== index && route !== '') {
+          return {
+            property: `routes[${index + 1}]`,
+            constraints: {
+              message: 'decisions.admin.edit.errors.routes.duplicate',
             },
           };
         }

--- a/src/helpers/decision-data-validator.ts
+++ b/src/helpers/decision-data-validator.ts
@@ -1,0 +1,40 @@
+import { ValidationError } from 'class-validator';
+import { plainToClass } from 'class-transformer';
+import { EditDto } from '../decisions/admin/dto/edit.dto';
+
+export class DecisionDataValidator {
+  obj: EditDto;
+  errors: ValidationError[];
+
+  public static validate(obj: EditDto) {
+    const object: EditDto = plainToClass(EditDto, obj);
+    const errors = this.validateNoEmptyRoutes(obj);
+
+    return new DecisionDataValidator(object, errors);
+  }
+
+  constructor(obj: EditDto, errors: ValidationError[]) {
+    this.obj = obj;
+    this.errors = errors;
+  }
+
+  public valid?() {
+    return this.errors.length == 0;
+  }
+
+  public static validateNoEmptyRoutes(editDto: EditDto): ValidationError[] {
+    return editDto.routes
+      .map((route, index) => {
+        if (route.trim() === '') {
+          return {
+            // indexes in the template are not zero indexed, so we add 1 here
+            property: `routes[${index + 1}]`,
+            constraints: {
+              message: 'decisions.admin.edit.errors.routes.empty',
+            },
+          };
+        }
+      })
+      .filter((n) => n);
+  }
+}

--- a/src/i18n/en/decisions.json
+++ b/src/i18n/en/decisions.json
@@ -128,6 +128,11 @@
         "caption": "Editing decision data",
         "bodyUnpublish": "Editing this dataset will unpublish any existing decision data for this profession. Are you sure you want to do this?<br/>There will be no data available on this profession until the new draft is published.",
         "bodyUnsubmit": "Editing this dataset will unsubmit any existing decision data for this profession. Are you sure you want to do this?<br/>There will be no data available on this profession until the new draft is published."
+      },
+      "errors": {
+        "routes": {
+          "empty": "Enter a route"
+        }
       }
     },
     "buttons": {

--- a/src/i18n/en/decisions.json
+++ b/src/i18n/en/decisions.json
@@ -131,7 +131,8 @@
       },
       "errors": {
         "routes": {
-          "empty": "Enter a route"
+          "empty": "Enter a route",
+          "duplicate": "It looks like you've already added a route with that name - enter a different one"
         }
       }
     },

--- a/views/admin/decisions/edit.njk
+++ b/views/admin/decisions/edit.njk
@@ -11,6 +11,7 @@
 
 {% block content %}
   {% include "../../_messages.njk" %}
+  {% include "../../shared/_errors.njk" %}
   <form action="/admin/decisions/{{ profession.id }}/{{ organisation.id }}/{{ year }}/edit" method="post">
 
     <div class="govuk-grid-row">
@@ -58,7 +59,8 @@
                     },
                     name: "routes[" + loop.index + "]",
                     id: "routes[" + loop.index + "]",
-                    value: route.name
+                    value: route.name,
+                    errorMessage: (errors["routes" + "[" + loop.index + "]"] | tError)
                   }) }}
                 </caption>
                 <thead class="govuk-table__head">


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR

Adds validations to display error messages to users when they try to save or submit duplicate or empty routes in decision data.

We can't use the standard validation mechanism here where we use the`@Validate` decorator in the DTO itself due to the shape of the data structure with nested arrays, which make it near-impossible to select the invalid field and highlight it in the table. This adds a custom `DecisionDataValidator` class that wrangles things into the right shape so we can use the existing `ValidationFailedError` class. We highlight the missing fields in the table.

For the controller tests here, I've opted not to mock the error classes for a few reasons:

- We're using other controller methods to test validator logic (even if that's the only way possible using decorator methods)
- I don't want to have loads of slow end to end tests to test this logic
- In an alternative universe, our controller tests would be more integration-style request specs ([see what these look like in Rails](https://relishapp.com/rspec/rspec-rails/docs/request-specs/request-spec) that actually test integrations between the different classes here. Nest calls these "end to end" tests. We've taken to a bit of a hybrid approach here as we've gone with the Nest JS documentation which suggests controllers should be tested as individual units, but I think integration tests would be safer overall.

## Screenshots of UI changes

### After

![image](https://user-images.githubusercontent.com/19826940/167395735-ae54f5f1-00ed-4b4e-81ce-4a2b23cef9b9.png)

