### PR TITLE
(2354) Add link to decisions dashboard from main admin dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Public view of decision data, linked to from public profession pages
 - Add confirmation page when editing decision data
 - Validations to ensure no duplicate or empty routes are entered in Decision data
+- Link to recognition decisions dashboard from admin dashboard and navigation bar
 
 ### Changed
 

--- a/cypress/integration/admin/decisions/edit.spec.ts
+++ b/cypress/integration/admin/decisions/edit.spec.ts
@@ -2,7 +2,13 @@ describe('Editing a decision dataset', () => {
   context('When I am logged in as editor', () => {
     beforeEach(() => {
       cy.loginAuth0('editor');
-      cy.visitAndCheckAccessibility('/admin/decisions');
+      cy.visitInternalDashboard();
+      cy.translate(
+        'app.pages.admin.dashboard.editDecisionDataCentralAdmin',
+      ).then((link) => {
+        cy.get('a').contains(link).click();
+        cy.checkAccessibility();
+      });
     });
 
     it('I can edit a decision dataset', () => {
@@ -328,7 +334,13 @@ describe('Editing a decision dataset', () => {
   context('When I am logged in as an org user', () => {
     beforeEach(() => {
       cy.loginAuth0('orgadmin');
-      cy.visitAndCheckAccessibility('/admin/decisions');
+      cy.visitInternalDashboard();
+      cy.translate('app.pages.admin.dashboard.editDecisionDataRegulators').then(
+        (link) => {
+          cy.get('a').contains(link).click();
+          cy.checkAccessibility();
+        },
+      );
     });
 
     it('I cannot publish decision data', () => {

--- a/cypress/integration/admin/decisions/index.spec.ts
+++ b/cypress/integration/admin/decisions/index.spec.ts
@@ -4,7 +4,13 @@ describe('Listing decision datasets', () => {
   context('When I am logged in as editor', () => {
     beforeEach(() => {
       cy.loginAuth0('editor');
-      cy.visitAndCheckAccessibility('/admin/decisions');
+      cy.visitInternalDashboard();
+      cy.translate(
+        'app.pages.admin.dashboard.editDecisionDataCentralAdmin',
+      ).then((link) => {
+        cy.get('a').contains(link).click();
+        cy.checkAccessibility();
+      });
     });
 
     it('Lists all decision datasets', () => {
@@ -196,7 +202,13 @@ describe('Listing decision datasets', () => {
   context('When I am logged in as organisation editor', () => {
     beforeEach(() => {
       cy.loginAuth0('orgeditor');
-      cy.visitAndCheckAccessibility('/admin/decisions');
+      cy.visitInternalDashboard();
+      cy.translate('app.pages.admin.dashboard.editDecisionDataRegulators').then(
+        (link) => {
+          cy.get('a').contains(link).click();
+          cy.checkAccessibility();
+        },
+      );
     });
 
     it('Lists decision datasets for my organisation', () => {

--- a/cypress/integration/admin/decisions/new.spec.ts
+++ b/cypress/integration/admin/decisions/new.spec.ts
@@ -2,7 +2,13 @@ describe('Creating a decision dataset', () => {
   context('When I am logged in as editor', () => {
     beforeEach(() => {
       cy.loginAuth0('editor');
-      cy.visitAndCheckAccessibility('/admin/decisions');
+      cy.visitInternalDashboard();
+      cy.translate(
+        'app.pages.admin.dashboard.editDecisionDataCentralAdmin',
+      ).then((link) => {
+        cy.get('a').contains(link).click();
+        cy.checkAccessibility();
+      });
     });
 
     it('I can create a decision dataset for a chosen organisation', () => {
@@ -203,7 +209,13 @@ describe('Creating a decision dataset', () => {
   context('When I am logged in as an organisation editor', () => {
     beforeEach(() => {
       cy.loginAuth0('orgeditor');
-      cy.visitAndCheckAccessibility('/admin/decisions');
+      cy.visitInternalDashboard();
+      cy.translate('app.pages.admin.dashboard.editDecisionDataRegulators').then(
+        (link) => {
+          cy.get('a').contains(link).click();
+          cy.checkAccessibility();
+        },
+      );
     });
 
     it('I can create a decision dataset for my organisation', () => {

--- a/cypress/integration/admin/decisions/publish.spec.ts
+++ b/cypress/integration/admin/decisions/publish.spec.ts
@@ -2,7 +2,13 @@ describe('Publishing a decision dataset', () => {
   context('When I am logged in as an admin', () => {
     beforeEach(() => {
       cy.loginAuth0('admin');
-      cy.visitAndCheckAccessibility('/admin/decisions');
+      cy.visitInternalDashboard();
+      cy.translate(
+        'app.pages.admin.dashboard.editDecisionDataCentralAdmin',
+      ).then((link) => {
+        cy.get('a').contains(link).click();
+        cy.checkAccessibility();
+      });
     });
 
     it('I can publish a draft decision dataset', () => {

--- a/cypress/integration/admin/decisions/show.spec.ts
+++ b/cypress/integration/admin/decisions/show.spec.ts
@@ -4,7 +4,13 @@ describe('Showing a decision dataset', () => {
   context('When I am logged in as editor', () => {
     beforeEach(() => {
       cy.loginAuth0('editor');
-      cy.visitAndCheckAccessibility('/admin/decisions');
+      cy.visitInternalDashboard();
+      cy.translate(
+        'app.pages.admin.dashboard.editDecisionDataCentralAdmin',
+      ).then((link) => {
+        cy.get('a').contains(link).click();
+        cy.checkAccessibility();
+      });
     });
 
     it('I can view a decision dataset', () => {

--- a/cypress/integration/admin/decisions/submit.spec.ts
+++ b/cypress/integration/admin/decisions/submit.spec.ts
@@ -2,7 +2,13 @@ describe('Submiting a decision dataset', () => {
   context('When I am logged in as an organisation-level user', () => {
     beforeEach(() => {
       cy.loginAuth0('orgeditor');
-      cy.visitAndCheckAccessibility('/admin/decisions');
+      cy.visitInternalDashboard();
+      cy.translate('app.pages.admin.dashboard.editDecisionDataRegulators').then(
+        (link) => {
+          cy.get('a').contains(link).click();
+          cy.checkAccessibility();
+        },
+      );
     });
 
     it('I can submit a draft decision dataset', () => {
@@ -80,7 +86,13 @@ describe('Submiting a decision dataset', () => {
   context('When I am logged in as a central admin user', () => {
     beforeEach(() => {
       cy.loginAuth0('editor');
-      cy.visitAndCheckAccessibility('/admin/decisions');
+      cy.visitInternalDashboard();
+      cy.translate(
+        'app.pages.admin.dashboard.editDecisionDataCentralAdmin',
+      ).then((link) => {
+        cy.get('a').contains(link).click();
+        cy.checkAccessibility();
+      });
     });
 
     it('I cannot submit a draft decision dataset', () => {

--- a/src/i18n/en/app.json
+++ b/src/i18n/en/app.json
@@ -78,6 +78,8 @@
         "editProfessionsRegulators": "Edit information about the professions you regulate",
         "editRegulatorsCentralAdmin": "Edit information about regulators",
         "editRegulatorsRegulators": "Edit information about your regulator",
+        "editDecisionDataCentralAdmin": "Review and publish decision data",
+        "editDecisionDataRegulators": "Submit recognition decision data for professions you regulate",
         "manageAccessCentralAdmin": "Manage who uses this service",
         "manageAccessRegulators": "Manage who uses this service",
         "guidance": "Read how to use this service"

--- a/src/i18n/en/decisions.json
+++ b/src/i18n/en/decisions.json
@@ -1,5 +1,6 @@
 {
   "admin": {
+    "heading": "Recognition decisions",
     "dashboard": {
       "heading": "Recognition decision data",
       "addButtonLabel": "Add decision data",

--- a/src/users/helpers/get-permissions-from-user.helper.ts
+++ b/src/users/helpers/get-permissions-from-user.helper.ts
@@ -57,7 +57,6 @@ const permissions = {
       UserPermission.PublishProfession,
       UserPermission.UploadDecisionData,
       UserPermission.DownloadDecisionData,
-      UserPermission.ViewDecisionData,
       UserPermission.UploadDecisionData,
       UserPermission.SubmitDecisionData,
       UserPermission.DownloadDecisionData,

--- a/views/admin/base.njk
+++ b/views/admin/base.njk
@@ -24,6 +24,10 @@
           text: ("organisations.admin.heading" | t )
         } if 'editOrganisation' in permissions else undefined,
         {
+          href: "/admin/decisions",
+          text: ("decisions.admin.heading" | t )
+        } if 'viewDecisionData' in permissions else undefined,
+        {
           href: "/admin/users",
           text: ("users.headings.index" | t)
         } if 'editUser' in permissions else undefined,

--- a/views/admin/dashboard.njk
+++ b/views/admin/dashboard.njk
@@ -34,6 +34,16 @@
         </li>
       {% endif %}
 
+      {% if 'viewDecisionData' in permissions %}
+        <li>
+          {% if (user.serviceOwner) %}
+            <a class="govuk-link" href="/admin/decisions">{{ "app.pages.admin.dashboard.editDecisionDataCentralAdmin" | t }}</a>
+          {% else %}
+            <a class="govuk-link" href="/admin/decisions">{{ "app.pages.admin.dashboard.editDecisionDataRegulators" | t }}</a>
+          {% endif %}
+        </li>
+      {% endif %}
+
       {% if 'editUser' in permissions %}
         <li>
           {% if (user.serviceOwner) %}


### PR DESCRIPTION
# Changes in this PR

- Link to recognition decisions dashboard from admin dashboard and navigation bar

To be merged once we've had thumbs up to do so

## Screenshots of UI changes

### Before
![localhost_3000_admin_dashboard (2)](https://user-images.githubusercontent.com/94137563/167405483-8b7476e8-094e-485a-be22-b0a422738e47.png)


![localhost_3000_admin_dashboard (3)](https://user-images.githubusercontent.com/94137563/167405479-6e92b2f7-f2cb-4a05-9bfa-a76852c0ae6e.png)

### After

![localhost_3000_admin_dashboard (1)](https://user-images.githubusercontent.com/94137563/167405288-1a464f27-73c3-47ab-9cfe-96e73c23102b.png)
![localhost_3000_admin_dashboard](https://user-images.githubusercontent.com/94137563/167405291-7e923b36-687b-4629-8236-d79ff7f7c5a3.png)

