### PR TITLE
(2361) Add backlinks to decision data journey

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add confirmation page when editing decision data
 - Validations to ensure no duplicate or empty routes are entered in Decision data
 - Link to recognition decisions dashboard from admin dashboard and navigation bar
+- Add backlink from decision data edit page to the edit confirmation page
 
 ### Changed
 

--- a/cypress/integration/admin/decisions/edit.spec.ts
+++ b/cypress/integration/admin/decisions/edit.spec.ts
@@ -48,6 +48,12 @@ describe('Editing a decision dataset', () => {
         cy.get('a').contains(buttonText).click();
       });
 
+      cy.get('a').contains('Back').click().url().should('contain', 'new');
+
+      cy.translate('decisions.admin.buttons.edit').then((edit) => {
+        cy.get('a').contains(edit).click();
+      });
+
       cy.checkAccessibility();
 
       withinEditTableDiv('International Route', () => {

--- a/cypress/integration/admin/decisions/new.spec.ts
+++ b/cypress/integration/admin/decisions/new.spec.ts
@@ -60,6 +60,45 @@ describe('Creating a decision dataset', () => {
         cy.get('button').contains(continueLabel).click();
       });
 
+      cy.get('a').contains('Back').click().url().should('not.contain', '2021');
+
+      cy.translate('decisions.admin.new.labels.profession').then(
+        (profession) => {
+          cy.get('label')
+            .contains(profession)
+            .parent()
+            .within(() => {
+              cy.get('select').select(
+                'Profession with two tier-one Organisations',
+              );
+            });
+        },
+      );
+
+      cy.translate('decisions.admin.new.labels.organisation').then(
+        (profession) => {
+          cy.get('label')
+            .contains(profession)
+            .parent()
+            .within(() => {
+              cy.get('select').select('Organisation with no optional fields');
+            });
+        },
+      );
+
+      cy.translate('decisions.admin.new.labels.year').then((profession) => {
+        cy.get('label')
+          .contains(profession)
+          .parent()
+          .within(() => {
+            cy.get('select').select('2021');
+          });
+      });
+
+      cy.translate('app.continue').then((continueLabel) => {
+        cy.get('button').contains(continueLabel).click();
+      });
+
       cy.get('h1').should(
         'contain',
         'Profession with two tier-one Organisations',

--- a/src/decisions/admin/edit.controller.ts
+++ b/src/decisions/admin/edit.controller.ts
@@ -103,6 +103,11 @@ export class EditController {
     UserPermission.ViewDecisionData,
   )
   @Render('admin/decisions/edit')
+  @BackLink((request) =>
+    request.query.fromEdit
+      ? '/admin/decisions/:professionId/:organisationId/:year/new'
+      : '/admin/decisions/new',
+  )
   async edit(
     @Param('professionId') professionId: string,
     @Param('organisationId') organisationId: string,

--- a/views/admin/decisions/edit/new.njk
+++ b/views/admin/decisions/edit/new.njk
@@ -24,7 +24,7 @@
             text: "decisions.admin.buttons.edit" | t,
             classes: "govuk-button",
             id: 'publish-button',
-            href: "/admin/decisions/" + profession.id + "/" + organisation.id + "/" + year + "/edit"
+            href: "/admin/decisions/" + profession.id + "/" + organisation.id + "/" + year + "/edit?fromEdit=true"
           })
         }}
     </div>


### PR DESCRIPTION
# Changes in this PR

This PR adds a back link from the decision data edit page to the previous page - the edit confirmation page. 

I checked through the rest of the decision data journey and it doesn't appear that we are missing any other backlinks but please shout up if you think I've missed one.

As mentioned in the commit I wasn't sure whether this should link back to the confirmation page or to the page before that which displays the decision data. I've opted for the confirmation page as from my perspective this would be least confusing for the user. I would happily link it to the page before the confirmation page which just displays the data though if anyone thinks that is more appropriate. 

I also wasn't sure if this should be tested in the e2e tests or if we have full confidence in the BackLink decorator working but opted to be safer than sorry at the cost of a fair amount of back and forth in the e2e tests.

## Screenshots of UI changes

### Before
![image](https://user-images.githubusercontent.com/44123869/167416136-fbff608d-a9d0-4d92-b5e2-4a2ea876dc10.png)

### After
![image](https://user-images.githubusercontent.com/44123869/167416045-ccc98331-0ccf-4df3-9570-ce80d9fe1a7e.png)
