### PR TITLE
Pin `webpack-encore` package to 1.8.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@nestjs/platform-express": "^8.4.4",
         "@nestjs/typeorm": "^8.0.3",
         "@opensearch-project/opensearch": "^1.1.0",
-        "@symfony/webpack-encore": "^1.8.2",
+        "@symfony/webpack-encore": "1.8.2",
         "@types/auth0": "^2.34.19",
         "@types/connect-flash": "^0.0.37",
         "@types/express-session": "^1.17.4",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@nestjs/platform-express": "^8.4.4",
     "@nestjs/typeorm": "^8.0.3",
     "@opensearch-project/opensearch": "^1.1.0",
-    "@symfony/webpack-encore": "^1.8.2",
+    "@symfony/webpack-encore": "1.8.2",
     "@types/auth0": "^2.34.19",
     "@types/connect-flash": "^0.0.37",
     "@types/express-session": "^1.17.4",


### PR DESCRIPTION
The current latest `webpack-encore` depeneds on `webpack` 5.72.0, but `@nestjs/cli` depends on 5.71.0 and these version appear to clash. This can be resolved my manually including the latest `webpack` directly in our `package.json`, though this produces warnings from `webpack-encore`.

Latest `webpack-encore` also produces warning on our stylesheet and latest GDS stylesheets