### PR TITLE
(2358) nations showing as ‘N/A’ on organisation search results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Consistent styling on links across service
 - Improve text on internal links to public pages
 - Change "View" buttons to "View details" links on user listing page
+- Prevent organisation's nation from erroneously being shown as 'N/A'
 
 ## [release-021] - 2022-05-11
 

--- a/cypress/integration/organisations/search/search.spec.ts
+++ b/cypress/integration/organisations/search/search.spec.ts
@@ -44,6 +44,10 @@ describe('Searching an organisation', () => {
       .should('contain', 'United Kingdom');
 
     cy.get('.rpr-listing__ra-container')
+      .contains('div', 'Department for Education')
+      .should('contain', 'England');
+
+    cy.get('.rpr-listing__ra-container')
       .contains('div', 'Law Society of England and Wales')
       .should('contain', 'England');
   });
@@ -100,7 +104,8 @@ describe('Searching an organisation', () => {
         (version) =>
           version.occupationLocations &&
           (version.occupationLocations.includes('GB-SCT') ||
-            version.occupationLocations.includes('GB-WLS')),
+            version.occupationLocations.includes('GB-WLS')) &&
+          version.status === 'live',
       ),
     ).then((liveOrganisations) => {
       cy.get('input[name="nations[]"][value="GB-SCT"]').check();

--- a/src/organisations/organisation-versions.service.spec.ts
+++ b/src/organisations/organisation-versions.service.spec.ts
@@ -655,7 +655,10 @@ describe('OrganisationVersionsService', () => {
 
       expect(result).toEqual(expectedOrgs);
 
-      expectJoinsToHaveBeenApplied(queryBuilder);
+      expectJoinsToHaveBeenApplied(
+        queryBuilder,
+        `professionVersions.status = '${ProfessionVersionStatus.Live}'`,
+      );
 
       expect(queryBuilder.distinctOn).toHaveBeenCalledWith([
         'organisation.name',

--- a/src/organisations/organisation-versions.service.ts
+++ b/src/organisations/organisation-versions.service.ts
@@ -96,7 +96,7 @@ export class OrganisationVersionsService {
   }
 
   async searchLive(filter: FilterInput): Promise<Organisation[]> {
-    const query = this.versionsWithJoins()
+    const query = this.versionsWithJoins([ProfessionVersionStatus.Live])
       .distinctOn(['organisation.name', 'organisation'])
       .orderBy('organisation.name, organisation')
       .where('organisationVersion.status = :status', {


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR
This seemed to be being caused by the `distinctOn` function in the `allLive` function that was initially added to prevent duplicate orgs showing. 

## Screenshots of UI changes

### Before
![image](https://user-images.githubusercontent.com/44123869/168055849-439fc950-3259-48f7-b6bf-293339e5be6a.png)

### After
![image](https://user-images.githubusercontent.com/44123869/168055905-76bae9aa-475a-4a0a-89a6-342c5fa0c100.png)
