### PR TITLE
(2356) Allow users to be created with a duplicate email address if the other user is archived

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Improve text on internal links to public pages
 - Change "View" buttons to "View details" links on user listing page
 - Prevent organisation's nation from erroneously being shown as 'N/A'
+- A new user with the same email address as a previously archived user can be created
+- Archived users can no longer login to the service if Auth0 account deletion fails
 
 ## [release-021] - 2022-05-11
 

--- a/src/db/migrate/1652355295227-ModifyUserExternalIdentifierUniquenessConstraint.ts
+++ b/src/db/migrate/1652355295227-ModifyUserExternalIdentifierUniquenessConstraint.ts
@@ -1,0 +1,31 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class ModifyUserExternalIdentifierUniquenessConstraint1652355295227
+  implements MigrationInterface
+{
+  name = 'ModifyUserExternalIdentifierUniquenessConstraint1652355295227';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_cc73de2c9b07b9926fcb5158b9"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "decision-datasets" ALTER COLUMN "status" SET DEFAULT 'unconfirmed'`,
+    );
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX "IDX_5b423e3ddcccabc257a997b9f1" ON "users" ("externalIdentifier") WHERE "externalIdentifier" IS NOT NULL AND "archived" = false AND "confirmed" = true`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_5b423e3ddcccabc257a997b9f1"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "decision-datasets" ALTER COLUMN "status" SET DEFAULT 'unconfirmed'-datasets_status_enum"`,
+    );
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX "IDX_cc73de2c9b07b9926fcb5158b9" ON "users" ("externalIdentifier") WHERE ("externalIdentifier" IS NOT NULL)`,
+    );
+  }
+}

--- a/src/users/user.entity.ts
+++ b/src/users/user.entity.ts
@@ -25,7 +25,11 @@ export class User {
   @Column()
   name: string;
 
-  @Index({ unique: true, where: '"externalIdentifier" IS NOT NULL' })
+  @Index({
+    unique: true,
+    where:
+      '"externalIdentifier" IS NOT NULL AND "archived" = false AND "confirmed" = true',
+  })
   @Column({ nullable: true })
   externalIdentifier: string;
 

--- a/src/users/users-archive.controller.spec.ts
+++ b/src/users/users-archive.controller.spec.ts
@@ -70,12 +70,14 @@ describe('UsersArchiveController', () => {
   });
 
   describe('delete', () => {
-    it('should add an archived flag to a user', async () => {
+    it('should add an archived flag to a user and remove their externalIdentifier', async () => {
       const flashMock = flashMessage as jest.Mock;
 
       flashMock.mockImplementation(() => 'Stub Archive Message');
 
-      const user = userFactory.build();
+      const user = userFactory.build({
+        externalIdentifier: 'external-identifier',
+      });
 
       auth0Service.deleteUser.mockReturnValue({
         performNow: async () => {
@@ -104,6 +106,7 @@ describe('UsersArchiveController', () => {
 
       expect(usersService.save).toHaveBeenCalledWith({
         ...user,
+        externalIdentifier: null,
         archived: true,
       });
     });

--- a/src/users/users-archive.controller.ts
+++ b/src/users/users-archive.controller.ts
@@ -46,11 +46,14 @@ export class UsersArchiveController {
       'users.archive.confirmation.body',
     );
     const user = await this.usersService.find(id);
-    user.archived = true;
 
     await this.auth0Service.deleteUser(user.externalIdentifier).performLater();
 
-    await this.usersService.save(user);
+    await this.usersService.save({
+      ...user,
+      archived: true,
+      externalIdentifier: null,
+    });
 
     const successMessage = flashMessage(messageTitle);
 

--- a/src/users/users.service.spec.ts
+++ b/src/users/users.service.spec.ts
@@ -75,9 +75,10 @@ describe('UsersService', () => {
 
       await service.allConfirmed();
 
-      expect(queryBuilder.where).toHaveBeenCalledWith(
-        'user.confirmed = true AND user.archived = false',
-      );
+      expect(queryBuilder.where).toHaveBeenCalledWith({
+        confirmed: true,
+        archived: false,
+      });
       expect(queryBuilder.orderBy).toHaveBeenCalledWith('LOWER(user.name)');
       expect(queryBuilder.getMany).toHaveBeenCalled();
     });
@@ -102,9 +103,10 @@ describe('UsersService', () => {
 
       await service.allConfirmedForOrganisation(organisation);
 
-      expect(queryBuilder.where).toHaveBeenCalledWith(
-        'user.confirmed = true AND user.archived = false',
-      );
+      expect(queryBuilder.where).toHaveBeenCalledWith({
+        confirmed: true,
+        archived: false,
+      });
       expect(queryBuilder.andWhere).toHaveBeenCalledWith(
         'organisation.id = :organisationId',
         {
@@ -135,7 +137,11 @@ describe('UsersService', () => {
 
       expect(post).toEqual(user);
       expect(repoSpy).toHaveBeenCalledWith({
-        where: { externalIdentifier: 'external-identifier' },
+        where: {
+          externalIdentifier: 'external-identifier',
+          confirmed: true,
+          archived: false,
+        },
       });
     });
   });
@@ -177,6 +183,8 @@ describe('UsersService', () => {
 
         expect(findSpy).toHaveBeenCalledWith(User, {
           externalIdentifier: user.externalIdentifier,
+          confirmed: true,
+          archived: false,
         });
         expect(saveSpy).toHaveBeenCalledWith(User, user);
 
@@ -200,6 +208,8 @@ describe('UsersService', () => {
 
         expect(findSpy).toHaveBeenCalledWith(User, {
           externalIdentifier: user.externalIdentifier,
+          confirmed: true,
+          archived: false,
         });
         expect(saveSpy).not.toBeCalled();
 
@@ -222,6 +232,8 @@ describe('UsersService', () => {
 
       expect(findSpy).toHaveBeenCalledWith(User, {
         externalIdentifier: user.externalIdentifier,
+        confirmed: true,
+        archived: false,
       });
       expect(saveSpy).not.toBeCalled();
 

--- a/src/users/users.service.spec.ts
+++ b/src/users/users.service.spec.ts
@@ -58,16 +58,6 @@ describe('UsersService', () => {
     repo = module.get<Repository<User>>(getRepositoryToken(User));
   });
 
-  describe('all', () => {
-    it('should return all users', async () => {
-      const repoSpy = jest.spyOn(repo, 'find');
-      const posts = await service.all();
-
-      expect(posts).toEqual(userArray);
-      expect(repoSpy).toHaveBeenCalled();
-    });
-  });
-
   describe('allConfirmed', () => {
     it('should return all confirmed users', async () => {
       const users = userFactory.buildList(2);
@@ -156,33 +146,6 @@ describe('UsersService', () => {
       await service.save(user);
 
       expect(repoSpy).toHaveBeenCalledWith(user);
-    });
-  });
-
-  describe('delete', () => {
-    it('should delete a user', async () => {
-      await service.delete('some-uuid');
-
-      jest.spyOn(queryBuilder.delete(), 'from');
-      jest.spyOn(queryBuilder.delete().from(expect.anything()), 'where');
-      jest.spyOn(
-        queryBuilder
-          .delete()
-          .from(User)
-          .where(expect.anything(), expect.anything()),
-        'execute',
-      );
-
-      expect(queryBuilder.delete().from).toHaveBeenCalledWith(User);
-      expect(
-        queryBuilder.delete().from(expect.anything()).where,
-      ).toHaveBeenCalledWith('id = :id', { id: 'some-uuid' });
-      expect(
-        queryBuilder
-          .delete()
-          .from(expect.anything())
-          .where(expect.anything(), expect.anything()).execute,
-      ).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -16,7 +16,7 @@ export class UsersService {
   async allConfirmed(): Promise<User[]> {
     return this.repository
       .createQueryBuilder('user')
-      .where('user.confirmed = true AND user.archived = false')
+      .where({ confirmed: true, archived: false })
       .orderBy('LOWER(user.name)')
       .getMany();
   }
@@ -24,7 +24,7 @@ export class UsersService {
   allConfirmedForOrganisation(organisation: Organisation): Promise<User[]> {
     return this.repository
       .createQueryBuilder('user')
-      .where('user.confirmed = true AND user.archived = false')
+      .where({ confirmed: true, archived: false })
       .leftJoinAndSelect('user.organisation', 'organisation')
       .andWhere('organisation.id = :organisationId', {
         organisationId: organisation.id,
@@ -39,7 +39,7 @@ export class UsersService {
 
   findByEmail(email: string): Promise<User> {
     return this.repository.findOne({
-      where: { email },
+      where: { email, confirmed: true, archived: false },
     });
   }
 
@@ -49,7 +49,7 @@ export class UsersService {
 
   findByExternalIdentifier(externalIdentifier: string): Promise<User> {
     return this.repository.findOne({
-      where: { externalIdentifier },
+      where: { externalIdentifier, confirmed: true, archived: false },
     });
   }
 
@@ -65,6 +65,8 @@ export class UsersService {
     try {
       const foundUser = await queryRunner.manager.findOne(User, {
         externalIdentifier: user.externalIdentifier,
+        confirmed: true,
+        archived: false,
       });
 
       if (!foundUser) {

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -1,4 +1,4 @@
-import { Connection, Repository, DeleteResult } from 'typeorm';
+import { Connection, Repository } from 'typeorm';
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 
@@ -12,10 +12,6 @@ export class UsersService {
     private repository: Repository<User>,
     private connection: Connection,
   ) {}
-
-  all(): Promise<User[]> {
-    return this.repository.find();
-  }
 
   async allConfirmed(): Promise<User[]> {
     return this.repository
@@ -49,15 +45,6 @@ export class UsersService {
 
   async save(user: User): Promise<User> {
     return await this.repository.save(user);
-  }
-
-  async delete(id: string): Promise<DeleteResult> {
-    return this.repository
-      .createQueryBuilder()
-      .delete()
-      .from(User)
-      .where('id = :id', { id: id })
-      .execute();
   }
 
   findByExternalIdentifier(externalIdentifier: string): Promise<User> {


### PR DESCRIPTION
# Changes in this PR

- A new user with the same email address as a previously archived user can be created
- Archived users can no longer login to the service if Auth0 account deletion fails