### PR TITLE
(2412) Allow draft professions to be assigned to draft organisations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [unreleased]
 
+### Changed
+
+- Allow draft professions to be assigned to draft regulatory authorities
+
 ## [release-022] - 2022-05-17
 
 ### Added

--- a/src/organisations/organisation-versions.service.ts
+++ b/src/organisations/organisation-versions.service.ts
@@ -95,6 +95,23 @@ export class OrganisationVersionsService {
     );
   }
 
+  async allLiveOrDraft(): Promise<Organisation[]> {
+    const versions = await this.versionsWithJoins()
+      .distinctOn(['organisation.name', 'organisation'])
+      .where('organisationVersion.status IN(:...status)', {
+        status: [
+          OrganisationVersionStatus.Live,
+          OrganisationVersionStatus.Draft,
+        ],
+      })
+      .orderBy('organisation.name, organisation')
+      .getMany();
+
+    return versions.map((version) =>
+      Organisation.withVersion(version.organisation, version),
+    );
+  }
+
   async searchLive(filter: FilterInput): Promise<Organisation[]> {
     const query = this.versionsWithJoins([ProfessionVersionStatus.Live])
       .distinctOn(['organisation.name', 'organisation'])


### PR DESCRIPTION
# Changes in this PR

- Allow draft professions to be assigned to draft regulatory authorities

## Screenshots of UI changes

### Before

![image](https://user-images.githubusercontent.com/94137563/168818726-f49fb183-fd8a-49da-89ce-6b94f0aae613.png)

### After

![image](https://user-images.githubusercontent.com/94137563/168818739-c22027da-81fc-405b-8468-c155e9715104.png)

