### PR TITLE
(2391) - Put multiple regs on new lines in the edit professions list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Internal guidance pages require user to be logged in to view
 - Move public search result count further up screen for screen readers
 - Use production session store
+- Regulators for professions now show on new lines if there is more than one in the admin professions view
 
 ## [release-022] - 2022-05-17
 

--- a/src/professions/admin/presenters/list-entry.presenter.spec.ts
+++ b/src/professions/admin/presenters/list-entry.presenter.spec.ts
@@ -62,7 +62,15 @@ describe('ListEntryPresenter', () => {
 
         const expected: TableRow = [
           { text: 'Example Profession' },
-          { text: 'Example Organisation, Additional Example Organisation' },
+          {
+            html: `<ul class="govuk-list">
+        <li>
+              Example Organisation,
+            </li><li>
+              Additional Example Organisation
+            </li>
+          </ul>`,
+          },
           {
             text: `${translationOf('nations.scotland')}, ${translationOf(
               'nations.northernIreland',

--- a/src/professions/admin/presenters/list-entry.presenter.ts
+++ b/src/professions/admin/presenters/list-entry.presenter.ts
@@ -91,9 +91,24 @@ export class ListEntryPresenter {
       { args: { name: escape(this.profession.name) } },
     )}</a>`;
 
-    const organisations = getOrganisationsFromProfession(this.profession)
-      .map((organisation) => organisation.name)
-      .join(', ');
+    const organisationsList = () => {
+      const organisations = getOrganisationsFromProfession(this.profession);
+
+      if (organisations.length > 1) {
+        return `<ul class="govuk-list">
+        ${organisations
+          .map(
+            (organisation, i) =>
+              `<li>
+              ${organisation.name}${i < organisations.length - 1 ? ',' : ''}
+            </li>`,
+          )
+          .join('')}
+          </ul>`;
+      } else {
+        return organisations[0].name;
+      }
+    };
 
     const entries: { [K in Field]: TableCell } = {
       profession: { text: this.profession.name },
@@ -101,7 +116,7 @@ export class ListEntryPresenter {
       lastModified: { text: presenter.lastModified },
       changedBy: { text: presenter.changedBy?.name },
       organisation: {
-        text: organisations,
+        html: organisationsList(),
       },
       industry: { text: industries },
       status: { html: await presenter.status },


### PR DESCRIPTION
# Changes in this PR
If a profession has mutltiple organisations in the `/admin/professions` view they will now be comma seperated *and* on a new line

## Screenshots of UI changes

### Before
![image](https://user-images.githubusercontent.com/44123869/169047604-c6a8f39c-86bd-4a31-bda6-33c2633b5949.png)

### After
![image](https://user-images.githubusercontent.com/44123869/169047553-f31ce93f-e308-40ef-a59b-6097e4dcee45.png)
