### PR TITLE
(2394) Remove 'new' from the publishing success message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Use production session store
 - Regulators for professions now show on new lines if there is more than one in the admin professions view
 - In public search, show drop shadows within scrollable filter selections to indicate further content
+- Fix already-published professions and regulatory authorities being referred to as "new" when an updated version is published
 
 ## [release-022] - 2022-05-17
 

--- a/cypress/integration/admin/organisations/publish.spec.ts
+++ b/cypress/integration/admin/organisations/publish.spec.ts
@@ -72,6 +72,12 @@ describe('Publishing organisations', () => {
         },
       );
 
+      cy.translate('organisations.admin.publish.confirmation.body', {
+        name: 'Draft Organisation',
+      }).then((confirmationBody) => {
+        cy.get('html').should('contain.html', confirmationBody);
+      });
+
       cy.translate('organisations.admin.button.edit.live').then(
         (editButton) => {
           cy.get('html').should('contain', editButton);
@@ -207,6 +213,12 @@ describe('Publishing organisations', () => {
         },
       );
 
+      cy.translate('organisations.admin.publish.confirmation.body', {
+        name: 'Draft Organisation',
+      }).then((confirmationBody) => {
+        cy.get('html').should('contain.html', confirmationBody);
+      });
+
       cy.translate('organisations.admin.button.edit.live').then(
         (editButton) => {
           cy.get('html').should('contain', editButton);
@@ -329,7 +341,7 @@ describe('Publishing organisations', () => {
           },
         );
 
-        cy.translate('organisations.admin.publish.confirmation.body', {
+        cy.translate('organisations.admin.publish.confirmation.bodyNew', {
           name: 'New Organisation',
         }).then((confirmationBody) => {
           cy.get('html').should('contain.html', confirmationBody);

--- a/cypress/integration/admin/professions/publish.spec.ts
+++ b/cypress/integration/admin/professions/publish.spec.ts
@@ -66,6 +66,12 @@ describe('Publishing professions', () => {
         },
       );
 
+      cy.translate('professions.admin.publish.confirmation.body', {
+        name: 'Gas Safe Engineer',
+      }).then((confirmation) => {
+        cy.get('html').should('contain.html', confirmation);
+      });
+
       cy.translate('professions.admin.button.edit.live').then((buttonText) => {
         cy.get('html').should('contain', buttonText);
       });
@@ -209,6 +215,12 @@ describe('Publishing professions', () => {
           cy.get('html').should('contain', confirmation);
         },
       );
+
+      cy.translate('professions.admin.publish.confirmation.body', {
+        name: 'Orthodontic Therapist',
+      }).then((confirmation) => {
+        cy.get('html').should('contain.html', confirmation);
+      });
 
       cy.translate('professions.admin.button.edit.live').then((buttonText) => {
         cy.get('html').should('contain', buttonText);
@@ -571,6 +583,12 @@ describe('Publishing professions', () => {
           cy.get('html').should('contain', confirmation);
         },
       );
+
+      cy.translate('professions.admin.publish.confirmation.bodyNew', {
+        name: 'Example Profession',
+      }).then((confirmation) => {
+        cy.get('html').should('contain.html', confirmation);
+      });
 
       cy.get('[data-cy=changed-by-user-name]').should('contain', 'Registrar');
       cy.get('[data-cy=changed-by-user-email]').should(

--- a/src/i18n/en/organisations.json
+++ b/src/i18n/en/organisations.json
@@ -57,7 +57,8 @@
       "caption": "Publishing an organisation",
       "confirmation": {
         "heading": "Regulatory authority published",
-        "body": "The new regulator <strong>{name}</strong> has been published.",
+        "body": "The regulator <strong>{name}</strong> has been published.",
+        "bodyNew": "The new regulator <strong>{name}</strong> has been published.",
         "next": "What happens next?",
         "backToDashboard": "Back to the dashboard"
       }

--- a/src/i18n/en/professions.json
+++ b/src/i18n/en/professions.json
@@ -329,7 +329,8 @@
     "publish": {
       "confirmation": {
         "heading": "Regulated profession published",
-        "body": "The new profession <strong>{name}</strong> has been published.",
+        "body": "The profession <strong>{name}</strong> has been published.",
+        "bodyNew": "The new profession <strong>{name}</strong> has been published.",
         "next": "What happens next?",
         "backToDashboard": "Back to the dashboard"
       },

--- a/src/organisations/admin/organisation-publication.controller.spec.ts
+++ b/src/organisations/admin/organisation-publication.controller.spec.ts
@@ -162,7 +162,7 @@ describe('OrganisationPublicationController', () => {
 
         expect(flashMock).toHaveBeenCalledWith(
           translationOf('organisations.admin.publish.confirmation.heading'),
-          translationOf('organisations.admin.publish.confirmation.body'),
+          translationOf('organisations.admin.publish.confirmation.bodyNew'),
         );
 
         expect(escape).toHaveBeenCalledWith(brandNewOrganisation.name);

--- a/src/organisations/admin/organisation-publication.controller.ts
+++ b/src/organisations/admin/organisation-publication.controller.ts
@@ -74,7 +74,9 @@ export class OrganisationPublicationController {
       getActingUser(req),
     );
 
-    if (!isConfirmed(organisation)) {
+    const confirmed = isConfirmed(organisation);
+
+    if (!confirmed) {
       await this.organisationsService.setSlug(organisation);
     }
 
@@ -85,7 +87,9 @@ export class OrganisationPublicationController {
     );
 
     const messageBody = await this.i18nService.translate(
-      'organisations.admin.publish.confirmation.body',
+      confirmed
+        ? 'organisations.admin.publish.confirmation.body'
+        : 'organisations.admin.publish.confirmation.bodyNew',
       { args: { name: escape(version.organisation.name) } },
     );
 

--- a/src/professions/admin/profession-publication.controller.spec.ts
+++ b/src/professions/admin/profession-publication.controller.spec.ts
@@ -166,7 +166,7 @@ describe('ProfessionPublicationController', () => {
 
         expect(flashMock).toHaveBeenCalledWith(
           translationOf('professions.admin.publish.confirmation.heading'),
-          translationOf('professions.admin.publish.confirmation.body'),
+          translationOf('professions.admin.publish.confirmation.bodyNew'),
         );
 
         expect(escape).toHaveBeenCalledWith(brandNewProfession.name);

--- a/src/professions/admin/profession-publication.controller.ts
+++ b/src/professions/admin/profession-publication.controller.ts
@@ -83,7 +83,9 @@ export class ProfessionPublicationController {
       getActingUser(req),
     );
 
-    if (!isConfirmed(profession)) {
+    const confirmed = isConfirmed(profession);
+
+    if (!confirmed) {
       await this.professionsService.setSlug(profession);
     }
 
@@ -94,7 +96,9 @@ export class ProfessionPublicationController {
     );
 
     const messageBody = await this.i18nService.translate(
-      'professions.admin.publish.confirmation.body',
+      confirmed
+        ? 'professions.admin.publish.confirmation.body'
+        : 'professions.admin.publish.confirmation.bodyNew',
       { args: { name: escape(version.profession.name) } },
     );
 


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR

- Fix already-published professions and regulatory authorities being referred to as "new" when an updated version is published


## Screenshots of UI changes

### Before
![localhost_3000_admin_professions_63ecf11a-592d-4f13-96b8-03d99e0d7896_versions_b9f7f7a3-6193-45a7-8b49-b3d3447527a3](https://user-images.githubusercontent.com/94137563/169063621-40fc53e3-b961-4fd7-b430-2511b092d42a.png)

### After
![localhost_3000_admin_professions_63ecf11a-592d-4f13-96b8-03d99e0d7896_versions_c6e87607-35cf-45ca-a106-1a166c8c8499](https://user-images.githubusercontent.com/94137563/169063640-48715fa7-4d3a-43cf-8038-b7b60352cde6.png)

