### PR TITLE
(2403) Add feedback link on start page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 - Add page explaining regulation types, with a link from the regulation types filter in the public searches
+- Add link for technical feedback on the start page
 
 ### Changed
 

--- a/src/i18n/en/app.json
+++ b/src/i18n/en/app.json
@@ -59,7 +59,8 @@
       },
       "help": {
         "heading": "Get help checking a regulated profession",
-        "body": "If you cannot find the information you need on the RPR, you may wish to <a class='govuk-link' href='https://cpq.ecctis.com/'>contact the UK Centre for Professional Qualifications (UK CPQ)</a>. The UK CPQ can also help you understand how to get your professional qualifications recognised outside the UK."
+        "body": "If you cannot find the information you need on the RPR, you may wish to <a class='govuk-link' href='https://cpq.ecctis.com/'>contact the UK Centre for Professional Qualifications (UK CPQ)</a>. The UK CPQ can also help you understand how to get your professional qualifications recognised outside the UK.",
+        "feedback": "If you have a technical issue, please <a class='govuk-link' target='_blank' href='{feedbackFormUrl}'>provide feedback</a>."
       }
     },
     "selectService": {

--- a/views/index.njk
+++ b/views/index.njk
@@ -1,6 +1,7 @@
 {% extends "base.njk" %}
 
 {% set title = ("app.pages.index.heading" | t) %}
+{% set feedbackFormUrl = "https://forms.office.com/Pages/ResponsePage.aspx?id=BXCsy8EC60O0l-ZJLRst2Hs7TwXbV7BKiF_b_DtnqB1UNFQxV0gxNEhMMzhVNDJVTVpLNzIzWlk5UCQlQCN0PWcu" %}
 
 {% block content %}
 <div class="govuk-grid-row">
@@ -42,6 +43,7 @@
 
       <p class="govuk-body">{{ "app.pages.index.help.body" | t | safe }}</p>
 
+      <p class="govuk-body">{{ "app.pages.index.help.feedback" | t({feedbackFormUrl: feedbackFormUrl}) | safe }}</p>
     </div>
   </div>
 {% endblock %}


### PR DESCRIPTION
# Changes in this PR
Adds a link for technical feedback on the start page of the service

## Screenshots of UI changes

### Before
![image](https://user-images.githubusercontent.com/44123869/169065730-07661881-67d8-4ca8-8398-7525876d71d3.png)

### After
![image](https://user-images.githubusercontent.com/44123869/169065673-76bf15e2-2c71-4237-aa89-1eed2a66c2c2.png)

