### PR TITLE
Remove `secure` attribute from cookie settings

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -64,7 +64,6 @@ async function bootstrap() {
       resave: false,
       saveUninitialized: false,
       cookie: {
-        secure: process.env['NODE_ENV'] === 'production',
         httpOnly: true,
         maxAge: 30 * 24 * 60 * 60 * 1000,
         domain: getDomain(process.env['HOST_URL']),


### PR DESCRIPTION
# Changes in this PR

Remove `secure` attribute from cookie settings. This is the primary culprit for session issues on staging, so we remove until we can investigate further