### PR TITLE
(2405) Show drop shadows within scrollable filter selections to indicate further content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Move public search result count further up screen for screen readers
 - Use production session store
 - Regulators for professions now show on new lines if there is more than one in the admin professions view
+- In public search, show drop shadows within scrollable filter selections to indicate further content
 
 ## [release-022] - 2022-05-17
 

--- a/assets/stylesheets/application.scss
+++ b/assets/stylesheets/application.scss
@@ -36,6 +36,39 @@ $small-screen: 768px;
     background-color: govuk-colour('white');
     height: 180px;
     overflow-y: auto;
+    // From https://stackoverflow.com/questions/44793453/how-do-i-add-a-top-and-bottom-shadow-while-scrolling-but-only-when-needed
+    background: linear-gradient(white 30%, rgba(255, 255, 255, 0)),
+      linear-gradient(rgba(255, 255, 255, 0), white 70%) 0 100%,
+      radial-gradient(
+        50% 0,
+        farthest-side,
+        rgba(0, 0, 0, 0.2),
+        rgba(0, 0, 0, 0)
+      ),
+      radial-gradient(
+          50% 100%,
+          farthest-side,
+          rgba(0, 0, 0, 0.2),
+          rgba(0, 0, 0, 0)
+        )
+        0 100%;
+    background: linear-gradient(white 30%, rgba(255, 255, 255, 0)),
+      linear-gradient(rgba(255, 255, 255, 0), white 70%) 0 100%,
+      radial-gradient(
+        farthest-side at 50% 0,
+        rgba(0, 0, 0, 0.2),
+        rgba(0, 0, 0, 0)
+      ),
+      radial-gradient(
+          farthest-side at 50% 100%,
+          rgba(0, 0, 0, 0.2),
+          rgba(0, 0, 0, 0)
+        )
+        0 100%;
+    background-repeat: no-repeat;
+    background-color: white;
+    background-size: 100% 40px, 100% 40px, 100% 14px, 100% 14px;
+    background-attachment: local, local, scroll, scroll;
   }
 
   &__filters-details-summary {

--- a/views/shared/_horizontal-filter.njk
+++ b/views/shared/_horizontal-filter.njk
@@ -1,4 +1,4 @@
-{% set filterCheckboxClasses = 'govuk-checkboxes--small rpr-listing__filter'%}
+{% set filterCheckboxClasses = 'govuk-checkboxes--small rpr-internal-listing__filter'%}
 {% set filterButtonClasses = 'govuk-button--secondary rpr-internal-listing__filter-button'%}
 {% set filterRowClass = 'govuk-grid-row' %}
 {% set filterButtonColumnClass = 'govuk-grid-column-full' %}


### PR DESCRIPTION
# Changes in this PR

- In public search, show drop shadows within scrollable filter selections to indicate further content

## Screenshots of UI changes

### Before

![localhost_3000_professions_search (3)](https://user-images.githubusercontent.com/94137563/169280736-bdc4c453-7ef3-4045-b9e0-1c5363b3a72a.png)


### After

![localhost_3000_professions_search (2)](https://user-images.githubusercontent.com/94137563/169280753-82f163d9-4632-4fc6-9139-0d158a949d38.png)

