### PR TITLE
(2404) Clarify the wording on the profession/org publishing order error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - Fix already-published professions and regulatory authorities being referred to as "new" when an updated version is published
+- When showing a list of reasons why a profession cannot be published, show any not-published associated regulators first
 
 ## [release-023] - 2022-05-19
 

--- a/src/i18n/en/professions.json
+++ b/src/i18n/en/professions.json
@@ -343,7 +343,7 @@
       "blocked": {
         "heading": "This page is not ready to publish. Before you can publish, check:",
         "incompleteSection": "{section} is complete",
-        "organisationNotLive": "{organisation} is published"
+        "organisationNotLive": "{organisation}'s page is published"
       }
     },
     "status": {

--- a/src/professions/helpers/get-publication-blockers.helper.spec.ts
+++ b/src/professions/helpers/get-publication-blockers.helper.spec.ts
@@ -55,6 +55,10 @@ describe('getPublicationBlockers', () => {
 
       expect(getPublicationBlockers(version)).toEqual([
         {
+          type: 'organisation-not-live',
+          organisation: organisation,
+        },
+        {
           type: 'incomplete-section',
           section: 'scope',
         },
@@ -69,10 +73,6 @@ describe('getPublicationBlockers', () => {
         {
           type: 'incomplete-section',
           section: 'legislation',
-        },
-        {
-          type: 'organisation-not-live',
-          organisation: organisation,
         },
       ] as PublicationBlocker[]);
     });

--- a/src/professions/helpers/get-publication-blockers.helper.ts
+++ b/src/professions/helpers/get-publication-blockers.helper.ts
@@ -28,6 +28,19 @@ export function getPublicationBlockers(
 ): PublicationBlocker[] {
   const blockers: PublicationBlocker[] = [];
 
+  const organisations = getOrganisationsFromProfession(version.profession);
+
+  if (organisations?.length) {
+    for (const organisation of organisations) {
+      if (!hasLiveVersion(organisation)) {
+        blockers.push({
+          type: 'organisation-not-live',
+          organisation: organisation,
+        });
+      }
+    }
+  }
+
   if (!version.industries?.length || !version.occupationLocations?.length) {
     blockers.push({ type: 'incomplete-section', section: 'scope' });
   }
@@ -52,19 +65,6 @@ export function getPublicationBlockers(
 
   if (!version.legislations?.[0]?.name) {
     blockers.push({ type: 'incomplete-section', section: 'legislation' });
-  }
-
-  const organisations = getOrganisationsFromProfession(version.profession);
-
-  if (organisations?.length) {
-    for (const organisation of organisations) {
-      if (!hasLiveVersion(organisation)) {
-        blockers.push({
-          type: 'organisation-not-live',
-          organisation: organisation,
-        });
-      }
-    }
   }
 
   return blockers;


### PR DESCRIPTION
# Changes in this PR

- When showing a list of reasons why a profession cannot be published, show any not-published associated regulators first

## Screenshots of UI changes

### Before

![localhost_3000_admin_professions_94be07f2-3548-4e24-b180-2bae31403a7a_versions_d5788bcf-6bc7-4c9d-805a-020feca4c663_check-your-answers (1)](https://user-images.githubusercontent.com/94137563/170301240-3fa7405b-c2ac-414a-9edf-5ea1df864e2a.png)


### After

![localhost_3000_admin_professions_94be07f2-3548-4e24-b180-2bae31403a7a_versions_d5788bcf-6bc7-4c9d-805a-020feca4c663_check-your-answers](https://user-images.githubusercontent.com/94137563/170301253-ddb9e91c-e349-42de-80ae-d176a0d1a85d.png)

