### PR TITLE
(2302) Primary legislation sometimes being shown as secondary legislation on legislation screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - When showing a list of reasons why a profession cannot be published, show any not-published associated regulators first
 - Fix back links around creating and editing users
 - Correct text on error pages
+- Fix legislations on professions with multiple legislations sometimes being displayed out of order
 
 ## [release-023] - 2022-05-19
 

--- a/cypress/integration/admin/professions/edit.spec.ts
+++ b/cypress/integration/admin/professions/edit.spec.ts
@@ -769,7 +769,7 @@ describe('Editing an existing profession', () => {
       cy.translate('professions.form.captions.edit', {
         professionName: 'Profession with two tier-one Organisation',
       }).then((editCaption) => {
-        cy.get('body').contains(editCaption);
+        cy.get('body').should('contain', editCaption);
       });
       cy.get('textarea[name="regulationSummary"]')
         .clear()
@@ -780,6 +780,33 @@ describe('Editing an existing profession', () => {
       cy.checkSummaryListRowValue(
         'professions.form.label.regulatedActivities.regulationSummary',
         'Updated regulation summary',
+      );
+
+      cy.clickSummaryListRowChangeLink(
+        'professions.form.label.legislation.nationalLegislation',
+      );
+      cy.checkAccessibility();
+      cy.translate('professions.form.captions.edit', {
+        professionName: 'Profession with two tier-one Organisation',
+      }).then((editCaption) => {
+        cy.get('body').should('contain', editCaption);
+      });
+      cy.get('textarea[name="secondNationalLegislation"]').clear();
+      cy.translate('app.continue').then((buttonText) => {
+        cy.get('button').contains(buttonText).click();
+      });
+      cy.clickSummaryListRowChangeLink(
+        'professions.form.label.legislation.nationalLegislation',
+      );
+      cy.get('textarea[name="secondNationalLegislation"]').type(
+        'Secondary legislation',
+      );
+      cy.translate('app.continue').then((buttonText) => {
+        cy.get('button').contains(buttonText).click();
+      });
+      cy.checkSummaryListRowValue(
+        'professions.form.label.legislation.secondNationalLegislation',
+        'Secondary legislation',
       );
 
       cy.translate('professions.form.button.saveAsDraft').then((buttonText) => {

--- a/src/config/nunjucks.config.ts
+++ b/src/config/nunjucks.config.ts
@@ -11,6 +11,7 @@ import { pad } from '../helpers/pad.helper';
 import { formatStatus } from '../helpers/format-status.helper';
 import { formatTelephone } from '../helpers/format-telephone.helper';
 import { getDomain } from '../helpers/get-domain.helper';
+import { sortLegislationsByIndex } from '../professions/helpers/sort-legislations-by-index.helper';
 
 export const nunjucksConfig = async (
   app: NestExpressApplication,
@@ -90,6 +91,10 @@ export const nunjucksConfig = async (
 
   env.addFilter('pad', (array, minimumLength) => {
     return pad(array, minimumLength);
+  });
+
+  env.addFilter('sortLegislations', (legislations) => {
+    return legislations ? sortLegislationsByIndex(legislations) : [];
   });
 
   env.addFilter(

--- a/src/db/migrate/1653495199991-AddIndexColumnToLegislations.ts
+++ b/src/db/migrate/1653495199991-AddIndexColumnToLegislations.ts
@@ -1,0 +1,23 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddIndexColumnToLegislations1653495199991
+  implements MigrationInterface
+{
+  name = 'AddIndexColumnToLegislations1653495199991';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "legislations" ADD "index" integer NOT NULL DEFAULT '0'`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "decision-datasets" ALTER COLUMN "status" SET DEFAULT 'unconfirmed'`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "decision-datasets" ALTER COLUMN "status" SET DEFAULT 'unconfirmed'-datasets_status_enum"`,
+    );
+    await queryRunner.query(`ALTER TABLE "legislations" DROP COLUMN "index"`);
+  }
+}

--- a/src/legislations/legislation.entity.ts
+++ b/src/legislations/legislation.entity.ts
@@ -19,6 +19,11 @@ export class Legislation {
   @Column()
   url: string;
 
+  @Column({
+    default: 0,
+  })
+  index: number;
+
   @ManyToOne(
     () => ProfessionVersion,
     (professionVersion) => professionVersion.legislations,

--- a/src/professions/admin/check-your-answers.controller.spec.ts
+++ b/src/professions/admin/check-your-answers.controller.spec.ts
@@ -22,6 +22,7 @@ import { Profession } from '../profession.entity';
 import { CheckYourAnswersController } from './check-your-answers.controller';
 import { ProfessionToOrganisation } from '../profession-to-organisation.entity';
 import { ProfessionToOrganisationsPresenter } from './presenters/profession-to-organisations.presenter';
+import * as sortLegislationsByIndexModule from '../helpers/sort-legislations-by-index.helper';
 
 jest.mock('../../users/helpers/check-can-change-profession');
 jest.mock('../../nations/presenters/nations-list.presenter');
@@ -106,6 +107,10 @@ describe('CheckYourAnswersController', () => {
         const getPublicationBlockersSpy = jest
           .spyOn(getPublicationBlockersModule, 'getPublicationBlockers')
           .mockReturnValue([]);
+        const sortLegislationsByIndexSpy = jest
+          .spyOn(sortLegislationsByIndexModule, 'sortLegislationsByIndex')
+          .mockImplementation((legislations) => legislations);
+
         const user = userFactory.build();
 
         const expectedSummaryList =
@@ -179,6 +184,9 @@ describe('CheckYourAnswersController', () => {
           professionVersionsService.findByIdWithProfession,
         ).toHaveBeenCalledWith('profession-id', 'version-id');
         expect(getPublicationBlockersSpy).toHaveBeenCalledWith(version);
+        expect(sortLegislationsByIndexSpy).toHaveBeenCalledWith(
+          version.legislations,
+        );
         expect(NationsListPresenter).toHaveBeenCalledWith(
           [Nation.find('GB-ENG')],
           i18nService,
@@ -220,6 +228,9 @@ describe('CheckYourAnswersController', () => {
               section: 'legislation',
             },
           ]);
+        const sortLegislationsByIndexSpy = jest
+          .spyOn(sortLegislationsByIndexModule, 'sortLegislationsByIndex')
+          .mockImplementation((legislations) => legislations);
 
         (
           NationsListPresenter.prototype.htmlList as jest.Mock
@@ -275,6 +286,9 @@ describe('CheckYourAnswersController', () => {
           professionVersionsService.findByIdWithProfession,
         ).toHaveBeenCalledWith('profession-id', 'version-id');
         expect(getPublicationBlockersSpy).toHaveBeenCalledWith(version);
+        expect(sortLegislationsByIndexSpy).toHaveBeenCalledWith(
+          version.legislations,
+        );
         expect(NationsListPresenter).toHaveBeenCalledWith([], i18nService);
       });
     });

--- a/src/professions/admin/check-your-answers.controller.ts
+++ b/src/professions/admin/check-your-answers.controller.ts
@@ -28,6 +28,7 @@ import { getPublicationBlockers } from '../helpers/get-publication-blockers.help
 import { Profession } from '../profession.entity';
 import { NationsListPresenter } from '../../nations/presenters/nations-list.presenter';
 import { getActingUser } from '../../users/helpers/get-acting-user.helper';
+import { sortLegislationsByIndex } from '../helpers/sort-legislations-by-index.helper';
 
 @UseGuards(AuthenticationGuard)
 @Controller('admin/professions')
@@ -96,7 +97,9 @@ export class CheckYourAnswersController {
       protectedTitles: version.protectedTitles,
       regulationUrl: version.regulationUrl,
       qualification,
-      legislations: version.legislations,
+      legislations: version.legislations
+        ? sortLegislationsByIndex(version.legislations)
+        : [],
       captionText: await ViewUtils.captionText(this.i18nService, profession),
       publicationBlockers: getPublicationBlockers(version),
       isUK: version.occupationLocations

--- a/src/professions/admin/legislation.controller.spec.ts
+++ b/src/professions/admin/legislation.controller.spec.ts
@@ -200,6 +200,7 @@ describe(LegislationController, () => {
               expect.objectContaining({
                 url: 'http://www.legal-legislation.com',
                 name: 'Legal Services Act 2008',
+                index: 0,
               }),
             ],
             profession: profession,
@@ -248,10 +249,12 @@ describe(LegislationController, () => {
               expect.objectContaining({
                 url: 'http://www.legal-legislation.com',
                 name: 'Legal Services Act 2008',
+                index: 0,
               }),
               expect.objectContaining({
                 url: 'http://www.another-legal-legislation.com',
                 name: 'Another Legal Services Act 2008',
+                index: 1,
               }),
             ],
             profession: profession,

--- a/src/professions/admin/legislation.controller.ts
+++ b/src/professions/admin/legislation.controller.ts
@@ -99,6 +99,7 @@ export class LegislationController {
         name: submittedValues.nationalLegislation,
         url: submittedValues.link,
       },
+      index: 0,
     };
 
     const updatedSecondLegislation: Legislation = {
@@ -107,6 +108,7 @@ export class LegislationController {
         name: submittedValues.secondNationalLegislation,
         url: submittedValues.secondLink,
       },
+      index: 1,
     };
 
     if (!validator.valid()) {

--- a/src/professions/admin/legislation.controller.ts
+++ b/src/professions/admin/legislation.controller.ts
@@ -25,6 +25,7 @@ import { I18nService } from 'nestjs-i18n';
 import { Profession } from '../profession.entity';
 import { RequestWithAppSession } from '../../common/interfaces/request-with-app-session.interface';
 import { checkCanChangeProfession } from '../../users/helpers/check-can-change-profession';
+import { sortLegislationsByIndex } from '../helpers/sort-legislations-by-index.helper';
 
 @UseGuards(AuthenticationGuard)
 @Controller('admin/professions')
@@ -56,12 +57,11 @@ export class LegislationController {
       versionId,
     );
 
-    return this.renderForm(
-      res,
-      version.legislations[0],
-      version.legislations[1],
-      profession,
-    );
+    const legislations = version.legislations
+      ? sortLegislationsByIndex(version.legislations)
+      : [];
+
+    return this.renderForm(res, legislations[0], legislations[1], profession);
   }
 
   @Post('/:professionId/versions/:versionId/legislation')
@@ -89,8 +89,12 @@ export class LegislationController {
       versionId,
     );
 
+    const legislations = version.legislations
+      ? sortLegislationsByIndex(version.legislations)
+      : [];
+
     const updatedLegislation: Legislation = {
-      ...version.legislations[0],
+      ...legislations[0],
       ...{
         name: submittedValues.nationalLegislation,
         url: submittedValues.link,
@@ -98,7 +102,7 @@ export class LegislationController {
     };
 
     const updatedSecondLegislation: Legislation = {
-      ...version.legislations[1],
+      ...legislations[1],
       ...{
         name: submittedValues.secondNationalLegislation,
         url: submittedValues.secondLink,

--- a/src/professions/helpers/sort-legislations-by-index.helper.spec.ts
+++ b/src/professions/helpers/sort-legislations-by-index.helper.spec.ts
@@ -1,0 +1,18 @@
+import legislationFactory from '../../testutils/factories/legislation';
+import { sortLegislationsByIndex } from './sort-legislations-by-index.helper';
+
+describe('sortLegislationsByIndex', () => {
+  it('returns legislations sorted by index', () => {
+    const legislation0 = legislationFactory.build({ index: 0 });
+    const legislation1 = legislationFactory.build({ index: 1 });
+    const legislation2 = legislationFactory.build({ index: 2 });
+
+    const result = sortLegislationsByIndex([
+      legislation2,
+      legislation0,
+      legislation1,
+    ]);
+
+    expect(result).toEqual([legislation0, legislation1, legislation2]);
+  });
+});

--- a/src/professions/helpers/sort-legislations-by-index.helper.ts
+++ b/src/professions/helpers/sort-legislations-by-index.helper.ts
@@ -1,0 +1,9 @@
+import { Legislation } from '../../legislations/legislation.entity';
+
+export function sortLegislationsByIndex(
+  legislations: Legislation[],
+): Legislation[] {
+  return legislations.sort((a, b) => {
+    return a.index - b.index;
+  });
+}

--- a/src/testutils/factories/legislation.ts
+++ b/src/testutils/factories/legislation.ts
@@ -5,6 +5,7 @@ export default Factory.define<Legislation>(({ sequence }) => ({
   id: sequence.toString(),
   name: 'Example legislation',
   url: 'https://www.legislation.example.com',
+  index: sequence,
   professionVersion: undefined,
   created_at: new Date(),
   updated_at: new Date(),

--- a/views/professions/_profession-details.njk
+++ b/views/professions/_profession-details.njk
@@ -260,7 +260,7 @@
 
 <h2 class="govuk-heading-l">{{ "professions.show.legislation.heading" | t}}</h2>
 
-{% for legislation in ((profession.legislations | pad(2)) if showEmptyProfessionDetails else profession.legislations) %}
+{% for legislation in ((profession.legislations | sortLegislations | pad(2)) if showEmptyProfessionDetails else profession.legislations) %}
   {% set legislationLocalisationId = "professions.show.legislation.secondNationalLegislation" if (showEmptyProfessionDetails and loop.index > 1) else "professions.show.legislation.nationalLegislation" %}
   {% set legislationLinkLocalisationId = "professions.show.legislation.secondLink" if (showEmptyProfessionDetails and loop.index > 1) else "professions.show.legislation.link" %}
 


### PR DESCRIPTION
# Changes in this PR

- Fix legislations on professions with multiple legislations sometimes being displayed out of order

Legislations are stored in their own DB table, and the order we received them was arbitrary, so we need additional work to enforce an order. In many places, Legislations are populated on the Profession automatically using `{eager: true}`, which doesn't allow us to specify an order, so we sort using a `sortLegislationsByIndex` helper function