### PR TITLE
Properly seed Legislations with an index

### DIFF
--- a/src/legislations/legislation.entity.ts
+++ b/src/legislations/legislation.entity.ts
@@ -43,8 +43,9 @@ export class Legislation {
   })
   updated_at: Date;
 
-  constructor(name?: string, url?: string) {
+  constructor(name?: string, url?: string, index?: number) {
     this.name = name || '';
     this.url = url || '';
+    this.index = index || 0;
   }
 }

--- a/src/legislations/legislations.seeder.ts
+++ b/src/legislations/legislations.seeder.ts
@@ -24,7 +24,7 @@ export class LegislationsSeeder implements Seeder {
 
   async seed(): Promise<any> {
     const legislations = this.data.map((legislation) => {
-      return new Legislation(legislation.name, legislation.url);
+      return new Legislation(legislation.name, legislation.url, -1);
     });
 
     return this.legislationsRepository.save(legislations);

--- a/src/professions/professions.seeder.ts
+++ b/src/professions/professions.seeder.ts
@@ -179,10 +179,12 @@ export class ProfessionsSeeder implements Seeder {
           );
         }
 
+        // We use the index -1 to get a legislation seeded by our legislation
+        // seeder that is unattached to a profession version
         let legislations: Legislation[] =
           version.legislations &&
           (await this.legislationsRepository.find({
-            where: { name: In(version.legislations) },
+            where: { name: In(version.legislations), index: -1 },
           }));
 
         if (legislations && legislations.length > 0) {
@@ -191,7 +193,7 @@ export class ProfessionsSeeder implements Seeder {
           // each time. We need to fix this, but in the interests of getting
           // seed data in, we'll just create a new entry each time
           const newLegislations = legislations.map(
-            (leg) => new Legislation(leg.name, leg.url),
+            (leg, index) => new Legislation(leg.name, leg.url, index),
           );
           legislations = await this.legislationsRepository.save(
             newLegislations,


### PR DESCRIPTION
# Changes in this PR

- Properly seed Legislations with an index

Previously, legislations were being seeded without an index, so ordering was non-deterministic. Also, we were wrongly attaching multiple identical legislations to a profession version