### PR TITLE
Revert sass-loader to 12.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,7 @@
         "rollbar": "^2.25.0",
         "rxjs": "^7.5.5",
         "sass": "^1.52.1",
-        "sass-loader": "^13.0.0",
+        "sass-loader": "^12.6.0",
         "slugify": "^1.6.5",
         "ts-node": "^10.8.0",
         "typeorm": "^0.2.45"
@@ -19106,15 +19106,15 @@
       }
     },
     "node_modules/sass-loader": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-13.0.0.tgz",
-      "integrity": "sha512-IHCFecI+rbPvXE2zO/mqdVFe8MU7ElGrwga9hh2H65Ru4iaBJAMRteum1c4Gsxi9Cq1FOtTEDd6+/AEYuQDM4Q==",
+      "version": "12.6.0",
+      "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-12.6.0.tgz",
+      "integrity": "sha512-oLTaH0YCtX4cfnJZxKSLAyglED0naiYfNG1iXfU5w1LNZ+ukoA5DtyDIN5zmKVZwYNJP4KRc5Y3hkWga+7tYfA==",
       "dependencies": {
         "klona": "^2.0.4",
         "neo-async": "^2.6.2"
       },
       "engines": {
-        "node": ">= 14.15.0"
+        "node": ">= 12.13.0"
       },
       "funding": {
         "type": "opencollective",
@@ -36800,9 +36800,9 @@
       }
     },
     "sass-loader": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-13.0.0.tgz",
-      "integrity": "sha512-IHCFecI+rbPvXE2zO/mqdVFe8MU7ElGrwga9hh2H65Ru4iaBJAMRteum1c4Gsxi9Cq1FOtTEDd6+/AEYuQDM4Q==",
+      "version": "12.6.0",
+      "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-12.6.0.tgz",
+      "integrity": "sha512-oLTaH0YCtX4cfnJZxKSLAyglED0naiYfNG1iXfU5w1LNZ+ukoA5DtyDIN5zmKVZwYNJP4KRc5Y3hkWga+7tYfA==",
       "requires": {
         "klona": "^2.0.4",
         "neo-async": "^2.6.2"

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "rollbar": "^2.25.0",
     "rxjs": "^7.5.5",
     "sass": "^1.52.1",
-    "sass-loader": "^13.0.0",
+    "sass-loader": "^12.6.0",
     "slugify": "^1.6.5",
     "ts-node": "^10.8.0",
     "typeorm": "^0.2.45"


### PR DESCRIPTION
sass-loader 13.0.0 is incompatible with @symfony/webpack-encore 2.1.0 and shows errors in the console when building assets.
I assumed, incorrectly, that the errors would be fixed when we upgraded @symfony/webpack-encore from 1.8.2 to 2.1.0.
Although this doesn't *seem* to cause issues at the moment it may do in the future therefore I think it is safer to revert
