### PR TITLE
(2399) Left align the decision data download button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix back links around creating and editing users
 - Correct text on error pages
 - Fix legislations on professions with multiple legislations sometimes being displayed out of order
+- Left align the decision data download button
 
 ## [release-023] - 2022-05-19
 

--- a/assets/stylesheets/application.scss
+++ b/assets/stylesheets/application.scss
@@ -283,8 +283,8 @@ $small-screen: 768px;
       margin: 0;
     }
 
-    &__file-download-link-container-right {
-      float: right;
+    &__file-download-link-container-left {
+      float: left;
       @media screen and (max-width: $small-screen) {
         float: none;
       }

--- a/assets/stylesheets/application.scss
+++ b/assets/stylesheets/application.scss
@@ -285,6 +285,9 @@ $small-screen: 768px;
 
     &__file-download-link-container-left {
       float: left;
+      border: 1px solid govuk-colour('black');
+      padding: 0.5em 0.8em 0 0;
+      margin-bottom: 1.5em;
       @media screen and (max-width: $small-screen) {
         float: none;
       }
@@ -296,7 +299,8 @@ $small-screen: 768px;
       background-repeat: no-repeat;
       background-size: 40px 40px;
       min-height: 2.5em;
-      padding: 0 0 0 50px;
+      padding: 8px 0 0 50px;
+      margin-bottom: 0;
     }
 
     &__sort-container {

--- a/views/admin/decisions/index.njk
+++ b/views/admin/decisions/index.njk
@@ -55,8 +55,8 @@
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-full">
         <div class="rpr-internal-listing__file-download-link-container">
-          <div class="rpr-internal-listing__file-download-link-container-right">
-            <a class="govuk-link rpr-internal-listing__file-download-link" href="/admin/decisions/export{{('?' + filterQuery) if filterQuery else '' }}">{{"decisions.admin.dashboard.download" | t}}</a>
+          <div class="rpr-internal-listing__file-download-link-container-left">
+            <a class="govuk-link rpr-internal-listing__file-download-link govuk-body" href="/admin/decisions/export{{('?' + filterQuery) if filterQuery else '' }}">{{"decisions.admin.dashboard.download" | t}}</a>
           </div>
         </div>
       </div>


### PR DESCRIPTION
# Changes in this PR

Left align the decision data download button and add some padding beneath it so it isn't too close to the 'X Datasets found' heading

## Screenshots of UI changes

### Before
![image](https://user-images.githubusercontent.com/44123869/170519196-470c2567-d89e-4ef2-9706-0a64fe29f8f9.png)
### After
![image](https://user-images.githubusercontent.com/44123869/170962151-052d9d58-94be-43f7-adb9-139a7cd0f4e5.png)
