### PR TITLE
(2383) Validate no duplicate countries per route in decision data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Left align the decision data download button
 - Use a multi-line text input for profession registration requirements
 - Enforce length limits on all input fields
+- Add validation to prevent empty and duplicate countries when entering decision data
 
 ## [release-024] - 2022-05-30
 

--- a/assets/stylesheets/application.scss
+++ b/assets/stylesheets/application.scss
@@ -171,6 +171,7 @@ $small-screen: 768px;
     th,
     td {
       width: calc(100% / 7);
+      vertical-align: bottom;
     }
 
     th:first-child,

--- a/src/helpers/decision-data-validator.spec.ts
+++ b/src/helpers/decision-data-validator.spec.ts
@@ -110,4 +110,30 @@ describe('DecisionDataValidator', () => {
       ]);
     });
   });
+
+  describe('when duplicate countries are submitted', () => {
+    it('returns an array of errors, with the duplicate countries highlighted', () => {
+      const editDto: EditDto = {
+        routes: ['Route 1', 'Route 2'],
+        countries: [['CA'], ['JP', 'JP']],
+        yeses: [['1'], ['1', '1']],
+        yesAfterComps: [['1', '1'], ['1']],
+        noes: [['1'], ['1', '1']],
+        noAfterComps: [['1'], ['1', '1']],
+        action: 'save',
+      };
+
+      const validated = DecisionDataValidator.validate(editDto);
+
+      expect(validated.valid()).toEqual(false);
+      expect(validated.errors).toEqual([
+        {
+          constraints: {
+            message: 'decisions.admin.edit.errors.countries.duplicate',
+          },
+          property: 'countries[2][2]',
+        },
+      ]);
+    });
+  });
 });

--- a/src/helpers/decision-data-validator.spec.ts
+++ b/src/helpers/decision-data-validator.spec.ts
@@ -1,103 +1,81 @@
+import { EditDto } from '../decisions/admin/dto/edit.dto';
 import { DecisionDataValidator } from './decision-data-validator';
 
 describe('DecisionDataValidator', () => {
-  describe('validating no empty routes', () => {
-    describe('when there are no empty routes submitted', () => {
-      it('returns an empty array of errors', () => {
-        const editDto = {
-          routes: ['Route 1', 'Route 2'],
-          countries: [['CA'], ['AR']],
-          yeses: [['1'], ['1']],
-          yesAfterComps: [['1'], ['1']],
-          noes: [['1'], ['1']],
-          noAfterComps: [['1'], ['1']],
-          action: 'save',
-        };
+  describe('valid data is submitted', () => {
+    it('returns an empty array of errors', () => {
+      const editDto: EditDto = {
+        routes: ['Route 1', 'Route 2'],
+        countries: [['CA'], ['AR']],
+        yeses: [['1'], ['1']],
+        yesAfterComps: [['1'], ['1']],
+        noes: [['1'], ['1']],
+        noAfterComps: [['1'], ['1']],
+        action: 'save',
+      };
 
-        const validated = DecisionDataValidator.validate(editDto);
+      const validated = DecisionDataValidator.validate(editDto);
 
-        expect(validated.valid()).toEqual(true);
-        expect(validated.errors).toEqual([]);
-      });
-    });
-
-    describe('when empty routes are submitted', () => {
-      it('returns an array of errors', () => {
-        const editDto = {
-          routes: ['', 'Route 2', ' '],
-          countries: [['CA'], ['AR'], ['JP']],
-          yeses: [['1'], ['1'], ['1']],
-          yesAfterComps: [['1'], ['1'], ['1']],
-          noes: [['1'], ['1'], ['1']],
-          noAfterComps: [['1'], ['1'], ['1']],
-          action: 'save',
-        };
-
-        const validated = DecisionDataValidator.validate(editDto);
-
-        expect(validated.valid()).toEqual(false);
-        expect(validated.errors).toEqual([
-          {
-            constraints: {
-              message: 'decisions.admin.edit.errors.routes.empty',
-            },
-            property: 'routes[1]',
-          },
-          {
-            constraints: {
-              message: 'decisions.admin.edit.errors.routes.empty',
-            },
-            property: 'routes[3]',
-          },
-        ]);
-      });
+      expect(validated.valid()).toEqual(true);
+      expect(validated.errors).toEqual([]);
     });
   });
 
-  describe('validating no duplicate routes', () => {
-    describe('when there are no duplicate routes submitted', () => {
-      it('returns an empty array of errors', () => {
-        const editDto = {
-          routes: ['Route 1', 'Route 2'],
-          countries: [['CA'], ['AR']],
-          yeses: [['1'], ['1']],
-          yesAfterComps: [['1'], ['1']],
-          noes: [['1'], ['1']],
-          noAfterComps: [['1'], ['1']],
-          action: 'save',
-        };
+  describe('when empty routes are submitted', () => {
+    it('returns an array of errors, with the empty routes highlighted', () => {
+      const editDto: EditDto = {
+        routes: ['', 'Route 2', ' '],
+        countries: [['CA'], ['AR'], ['JP']],
+        yeses: [['1'], ['1'], ['1']],
+        yesAfterComps: [['1'], ['1'], ['1']],
+        noes: [['1'], ['1'], ['1']],
+        noAfterComps: [['1'], ['1'], ['1']],
+        action: 'save',
+      };
 
-        const validated = DecisionDataValidator.validate(editDto);
+      const validated = DecisionDataValidator.validate(editDto);
 
-        expect(validated.valid()).toEqual(true);
-        expect(validated.errors).toEqual([]);
-      });
-    });
-
-    describe('when duplicate routes are submitted', () => {
-      it('returns an array of errors, with the duplicate route highlighted', () => {
-        const editDto = {
-          routes: ['Route 1', 'Route 2', 'Route 1'],
-          countries: [['CA'], ['AR'], ['JP']],
-          yeses: [['1'], ['1'], ['1']],
-          yesAfterComps: [['1'], ['1'], ['1']],
-          noes: [['1'], ['1'], ['1']],
-          noAfterComps: [['1'], ['1'], ['1']],
-          action: 'save',
-        };
-
-        const validated = DecisionDataValidator.validate(editDto);
-
-        expect(validated.valid()).toEqual(false);
-        expect(validated.errors).toEqual([
-          {
-            constraints: {
-              message: 'decisions.admin.edit.errors.routes.duplicate',
-            },
-            property: 'routes[3]',
+      expect(validated.valid()).toEqual(false);
+      expect(validated.errors).toEqual([
+        {
+          constraints: {
+            message: 'decisions.admin.edit.errors.routes.empty',
           },
-        ]);
-      });
+          property: 'routes[1]',
+        },
+        {
+          constraints: {
+            message: 'decisions.admin.edit.errors.routes.empty',
+          },
+          property: 'routes[3]',
+        },
+      ]);
+    });
+  });
+
+  describe('when duplicate routes are submitted', () => {
+    it('returns an array of errors, with the duplicate route highlighted', () => {
+      const editDto: EditDto = {
+        routes: ['Route 1', 'Route 2', 'Route 1'],
+        countries: [['CA'], ['AR'], ['JP']],
+        yeses: [['1'], ['1'], ['1']],
+        yesAfterComps: [['1'], ['1'], ['1']],
+        noes: [['1'], ['1'], ['1']],
+        noAfterComps: [['1'], ['1'], ['1']],
+        action: 'save',
+      };
+
+      const validated = DecisionDataValidator.validate(editDto);
+
+      expect(validated.valid()).toEqual(false);
+      expect(validated.errors).toEqual([
+        {
+          constraints: {
+            message: 'decisions.admin.edit.errors.routes.duplicate',
+          },
+          property: 'routes[3]',
+        },
+      ]);
     });
   });
 });

--- a/src/helpers/decision-data-validator.spec.ts
+++ b/src/helpers/decision-data-validator.spec.ts
@@ -78,4 +78,36 @@ describe('DecisionDataValidator', () => {
       ]);
     });
   });
+
+  describe('when empty countries are submitted', () => {
+    it('returns an array of errors, with the empty countries highlighted', () => {
+      const editDto: EditDto = {
+        routes: ['Route 1', 'Route 2'],
+        countries: [[''], ['', 'JP']],
+        yeses: [['1'], ['1', '1']],
+        yesAfterComps: [['1', '1'], ['1']],
+        noes: [['1'], ['1', '1']],
+        noAfterComps: [['1'], ['1', '1']],
+        action: 'save',
+      };
+
+      const validated = DecisionDataValidator.validate(editDto);
+
+      expect(validated.valid()).toEqual(false);
+      expect(validated.errors).toEqual([
+        {
+          constraints: {
+            message: 'decisions.admin.edit.errors.countries.empty',
+          },
+          property: 'countries[1][1]',
+        },
+        {
+          constraints: {
+            message: 'decisions.admin.edit.errors.countries.empty',
+          },
+          property: 'countries[2][1]',
+        },
+      ]);
+    });
+  });
 });

--- a/src/helpers/decision-data-validator.ts
+++ b/src/helpers/decision-data-validator.ts
@@ -11,6 +11,7 @@ export class DecisionDataValidator {
     const errors = [
       this.validateNoEmptyRoutes(obj),
       this.validateNoDuplicateRoutes(obj),
+      this.validateNoEmptyCountries(obj),
     ].flat();
 
     return new DecisionDataValidator(object, errors);
@@ -25,7 +26,7 @@ export class DecisionDataValidator {
     return this.errors.length == 0;
   }
 
-  public static validateNoEmptyRoutes(editDto: EditDto): ValidationError[] {
+  private static validateNoEmptyRoutes(editDto: EditDto): ValidationError[] {
     return editDto.routes
       .map((route, index) => {
         if (route.trim() === '') {
@@ -41,7 +42,9 @@ export class DecisionDataValidator {
       .filter((n) => n);
   }
 
-  public static validateNoDuplicateRoutes(editDto: EditDto): ValidationError[] {
+  private static validateNoDuplicateRoutes(
+    editDto: EditDto,
+  ): ValidationError[] {
     return editDto.routes
       .map((route, index) => {
         if (editDto.routes.indexOf(route) !== index && route !== '') {
@@ -54,5 +57,24 @@ export class DecisionDataValidator {
         }
       })
       .filter((n) => n);
+  }
+
+  private static validateNoEmptyCountries(editDto: EditDto): ValidationError[] {
+    return editDto.countries
+      .map((countries, routeIndex) => {
+        return countries
+          .map((country, countryIndex) => {
+            if (!country) {
+              return {
+                property: `countries[${routeIndex + 1}][${countryIndex + 1}]`,
+                constraints: {
+                  message: 'decisions.admin.edit.errors.countries.empty',
+                },
+              };
+            }
+          })
+          .filter((n) => n);
+      })
+      .flat();
   }
 }

--- a/src/helpers/decision-data-validator.ts
+++ b/src/helpers/decision-data-validator.ts
@@ -12,6 +12,7 @@ export class DecisionDataValidator {
       this.validateNoEmptyRoutes(obj),
       this.validateNoDuplicateRoutes(obj),
       this.validateNoEmptyCountries(obj),
+      this.validateNoDuplicateCountries(obj),
     ].flat();
 
     return new DecisionDataValidator(object, errors);
@@ -69,6 +70,27 @@ export class DecisionDataValidator {
                 property: `countries[${routeIndex + 1}][${countryIndex + 1}]`,
                 constraints: {
                   message: 'decisions.admin.edit.errors.countries.empty',
+                },
+              };
+            }
+          })
+          .filter((n) => n);
+      })
+      .flat();
+  }
+
+  private static validateNoDuplicateCountries(
+    editDto: EditDto,
+  ): ValidationError[] {
+    return editDto.countries
+      .map((countries, routeIndex) => {
+        return countries
+          .map((country, countryIndex) => {
+            if (countries.indexOf(country) !== countryIndex && country) {
+              return {
+                property: `countries[${routeIndex + 1}][${countryIndex + 1}]`,
+                constraints: {
+                  message: 'decisions.admin.edit.errors.countries.duplicate',
                 },
               };
             }

--- a/src/i18n/en/decisions.json
+++ b/src/i18n/en/decisions.json
@@ -139,7 +139,8 @@
           "duplicate": "It looks like you've already added a route with that name - enter a different one"
         },
         "countries": {
-          "empty": "Enter a country"
+          "empty": "Enter a country",
+          "duplicate": "It looks like you've already entered data for that country - enter data for a different one"
         }
       }
     },

--- a/src/i18n/en/decisions.json
+++ b/src/i18n/en/decisions.json
@@ -137,6 +137,9 @@
         "routes": {
           "empty": "Enter a route",
           "duplicate": "It looks like you've already added a route with that name - enter a different one"
+        },
+        "countries": {
+          "empty": "Enter a country"
         }
       }
     },

--- a/views/admin/decisions/edit.njk
+++ b/views/admin/decisions/edit.njk
@@ -86,7 +86,8 @@
                           },
                           name: "countries" + index,
                           id: "countries" + index,
-                          items: country.countriesSelectArgs
+                          items: country.countriesSelectArgs,
+                          errorMessage: (errors["countries" + index] | tError)
                         }) }}
                       </td>
                       <td class="govuk-table__cell">

--- a/views/admin/decisions/edit.njk
+++ b/views/admin/decisions/edit.njk
@@ -12,7 +12,7 @@
 {% block content %}
   {% include "../../_messages.njk" %}
   {% include "../../shared/_errors.njk" %}
-  <form action="/admin/decisions/{{ profession.id }}/{{ organisation.id }}/{{ year }}/edit" method="post">
+  <form action="/admin/decisions/{{ profession.id }}/{{ organisation.id }}/{{ year }}/edit" method="post" novalidate>
 
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-three-quarters">
@@ -98,7 +98,10 @@
                           },
                           name: "yeses" + index,
                           id: "yeses" + index,
-                          value: country.decisions.yes
+                          value: country.decisions.yes,
+                          inputmode: "numeric",
+                          pattern: "[0-9]*",
+                          spellcheck: false
                         }) }}
                       </td>
                       <td class="govuk-table__cell">
@@ -109,7 +112,10 @@
                           },
                           name: "yesAfterComps" + index,
                           id: "yesAfterComps" + index,
-                          value: country.decisions.yesAfterComp
+                          value: country.decisions.yesAfterComp,
+                          inputmode: "numeric",
+                          pattern: "[0-9]*",
+                          spellcheck: false
                         }) }}
                       </td>
                       <td class="govuk-table__cell">
@@ -120,7 +126,10 @@
                           },
                           name: "noes" + index,
                           id: "noes" + index,
-                          value: country.decisions.no
+                          value: country.decisions.no,
+                          inputmode: "numeric",
+                          pattern: "[0-9]*",
+                          spellcheck: false
                         }) }}
                       </td>
                       <td class="govuk-table__cell">
@@ -131,7 +140,10 @@
                           },
                           name: "noAfterComps" + index,
                           id: "noAfterComps" + index,
-                          value: country.decisions.noAfterComp
+                          value: country.decisions.noAfterComp,
+                          inputmode: "numeric",
+                          pattern: "[0-9]*",
+                          spellcheck: false
                         }) }}
                       </td>
                       <td class="govuk-table__cell">


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR

- Add validation to prevent empty and duplicate countries when entering decision data

## Screenshots of UI changes

### Before
![localhost_3000_admin_decisions_36715437-1496-49fe-919b-6e315d543600_36711100-f9ab-4f2c-9380-a3d60b38e6af_2020_edit_fromEdit=true](https://user-images.githubusercontent.com/94137563/171017501-e472e3a1-1219-4047-9367-94e71e54d7dc.png)

### After
![localhost_3000_admin_decisions_36715437-1496-49fe-919b-6e315d543600_36711100-f9ab-4f2c-9380-a3d60b38e6af_2020_edit](https://user-images.githubusercontent.com/94137563/171017508-b5620387-4f66-488d-a940-430044a2b04a.png)

