### PR TITLE
(2324) Everywhere we use `translate` no longer needs to return a promise

### DIFF
--- a/src/decisions/admin/edit.controller.ts
+++ b/src/decisions/admin/edit.controller.ts
@@ -228,11 +228,11 @@ export class EditController {
         );
       }
 
-      const messageTitle = await this.i18nService.translate(
+      const messageTitle = this.i18nService.translate<string>(
         `decisions.admin.saveAsDraft.confirmation.heading`,
       );
 
-      const messageBody = await this.i18nService.translate(
+      const messageBody = this.i18nService.translate<string>(
         `decisions.admin.saveAsDraft.confirmation.body`,
       );
 

--- a/src/decisions/admin/presenters/decision-datasets.presenter.ts
+++ b/src/decisions/admin/presenters/decision-datasets.presenter.ts
@@ -30,7 +30,7 @@ export class DecisionDatasetsPresenter {
   ): Omit<IndexTemplate, 'filterQuery'> {
     const organisation =
       view === 'overview'
-        ? this.i18nService.translate('app.beis')
+        ? this.i18nService.translate<string>('app.beis')
         : this.userOrganisation.name;
 
     const organisationsCheckboxItems = new OrganisationsCheckboxPresenter(

--- a/src/decisions/admin/publication.controller.ts
+++ b/src/decisions/admin/publication.controller.ts
@@ -84,11 +84,11 @@ export class PublicationController {
 
     await this.decisionDatasetsService.publish(dataset);
 
-    const messageTitle = await this.i18nService.translate(
+    const messageTitle = this.i18nService.translate<string>(
       'decisions.admin.publication.confirmation.heading',
     );
 
-    const messageBody = await this.i18nService.translate(
+    const messageBody = this.i18nService.translate<string>(
       'decisions.admin.publication.confirmation.body',
     );
 

--- a/src/decisions/admin/submission.controller.ts
+++ b/src/decisions/admin/submission.controller.ts
@@ -97,11 +97,11 @@ export class SubmissionController {
 
     await this.decisionDatasetsService.submit(dataset);
 
-    const messageTitle = await this.i18nService.translate(
+    const messageTitle = this.i18nService.translate<string>(
       'decisions.admin.submission.confirmation.heading',
     );
 
-    const messageBody = await this.i18nService.translate(
+    const messageBody = this.i18nService.translate<string>(
       'decisions.admin.submission.confirmation.body',
     );
 

--- a/src/decisions/presenters/decision-datasets.presenter.spec.ts
+++ b/src/decisions/presenters/decision-datasets.presenter.spec.ts
@@ -11,7 +11,7 @@ jest.mock('../../nations/presenters/nations-list.presenter');
 
 describe('DecisionDatasetsPresenter', () => {
   describe('present', () => {
-    it('returns a ShowTemplate for the given Profession, year, and DecisionDatasets', async () => {
+    it('returns a ShowTemplate for the given Profession, year, and DecisionDatasets', () => {
       const profession = professionFactory.build({
         name: 'Example Profession',
         occupationLocations: ['GB-ENG', 'GB-SCT'],
@@ -122,7 +122,7 @@ describe('DecisionDatasetsPresenter', () => {
         [dataset1, dataset2],
         i18nService,
       );
-      const result = await presenter.present();
+      const result = presenter.present();
 
       expect(result).toEqual({
         profession: 'Example Profession',

--- a/src/decisions/presenters/decision-datasets.presenter.ts
+++ b/src/decisions/presenters/decision-datasets.presenter.ts
@@ -14,7 +14,7 @@ export class DecisionDatasetsPresenter {
     private readonly i18nService: I18nService,
   ) {}
 
-  async present(): Promise<ShowTemplate> {
+  present(): ShowTemplate {
     const nations = new NationsListPresenter(
       (this.profession.occupationLocations || []).map((code) =>
         Nation.find(code),
@@ -24,7 +24,7 @@ export class DecisionDatasetsPresenter {
 
     return {
       profession: this.profession.name,
-      nations: await nations.textList(),
+      nations: nations.textList(),
       year: this.year,
       organisations: this.datasets.map((dataset) => ({
         organisation: dataset.organisation.name,

--- a/src/helpers/format-status.helper.ts
+++ b/src/helpers/format-status.helper.ts
@@ -35,7 +35,7 @@ export function formatStatus(
     return '';
   }
 
-  const text = i18nSerice.translate(`app.status.${status}`);
+  const text = i18nSerice.translate<string>(`app.status.${status}`);
 
   return `<strong class="govuk-tag ${colourClass}">${text}</strong>`;
 }

--- a/src/helpers/i18n.helper.spec.ts
+++ b/src/helpers/i18n.helper.spec.ts
@@ -16,14 +16,14 @@ describe('AssetsHelper', () => {
     helper = new I18nHelper(app);
   });
 
-  it('returns a translated string', async () => {
-    await helper.translate('hello world');
+  it('returns a translated string', () => {
+    helper.translate('hello world');
 
     expect(service.translate).toHaveBeenCalledWith('hello world', { args: {} });
   });
 
-  it('accepts optional personalisation options', async () => {
-    await helper.translate('hello world', { foo: 'bar' });
+  it('accepts optional personalisation options', () => {
+    helper.translate('hello world', { foo: 'bar' });
     expect(service.translate).toHaveBeenCalledWith('hello world', {
       args: { foo: 'bar' },
     });

--- a/src/helpers/i18n.helper.ts
+++ b/src/helpers/i18n.helper.ts
@@ -25,10 +25,7 @@ export class I18nHelper {
    * @param {any} - Any personalisations that need to be passed tho the translation
    * @returns {string} - The translated string (e.g `Hello world!`)
    */
-  public async translate(
-    text: string,
-    personalisation: any = {},
-  ): Promise<string> {
-    return await this.i18nService.translate(text, { args: personalisation });
+  public translate(text: string, personalisation: any = {}): string {
+    return this.i18nService.translate(text, { args: personalisation });
   }
 }

--- a/src/helpers/nations.helper.spec.ts
+++ b/src/helpers/nations.helper.spec.ts
@@ -32,7 +32,7 @@ describe('nations.helper', () => {
   });
 
   describe('getNationsFromProfession', () => {
-    it('joins the nations on the given professions', async () => {
+    it('joins the nations on the given professions', () => {
       const i18nService = createMockI18nService();
       const profession1NationCodes = ['GB-ENG', 'GB-WLS'];
       const profession2NationCodes = ['GB-SCT'];
@@ -52,11 +52,11 @@ describe('nations.helper', () => {
         }),
       ];
 
-      (NationsListPresenter.prototype.textList as jest.Mock).mockResolvedValue(
+      (NationsListPresenter.prototype.textList as jest.Mock).mockReturnValue(
         'England, Wales',
       );
 
-      expect(await getNationsFromProfessions(professions, i18nService)).toEqual(
+      expect(getNationsFromProfessions(professions, i18nService)).toEqual(
         'England, Wales',
       );
 
@@ -66,7 +66,7 @@ describe('nations.helper', () => {
       );
     });
 
-    it('removes duplicate nations', async () => {
+    it('removes duplicate nations', () => {
       const i18nService = createMockI18nService();
       const profession1NationCodes = ['GB-ENG', 'GB-WLS'];
       const profession2NationCodes = ['GB-SCT', 'GB-ENG'];
@@ -86,11 +86,11 @@ describe('nations.helper', () => {
         }),
       ];
 
-      (NationsListPresenter.prototype.textList as jest.Mock).mockResolvedValue(
+      (NationsListPresenter.prototype.textList as jest.Mock).mockReturnValue(
         'England, Wales',
       );
 
-      expect(await getNationsFromProfessions(professions, i18nService)).toEqual(
+      expect(getNationsFromProfessions(professions, i18nService)).toEqual(
         'England, Wales',
       );
 

--- a/src/helpers/nations.helper.ts
+++ b/src/helpers/nations.helper.ts
@@ -16,10 +16,10 @@ export function isUK(nationCodes: string[]) {
   );
 }
 
-export async function getNationsFromProfessions(
+export function getNationsFromProfessions(
   professions: Profession[],
   i18nService: I18nService,
-): Promise<string> {
+): string {
   const nationCodes = professions
     .map((profession) => profession.occupationLocations || [])
     .flat();

--- a/src/industries/industries-checkbox.presenter.spec.ts
+++ b/src/industries/industries-checkbox.presenter.spec.ts
@@ -5,7 +5,7 @@ import { IndustriesCheckboxPresenter } from './industries-checkbox.presenter';
 
 describe('IndustriesCheckboxPresenter', () => {
   describe('checkboxItems', () => {
-    it('should return unchecked checkbox arguments when called with an empty list of checked Industries', async () => {
+    it('should return unchecked checkbox arguments when called with an empty list of checked Industries', () => {
       const exampleIndustry1 = industry.build({
         name: 'industries.example1',
         id: 'example-industry-1',
@@ -27,7 +27,7 @@ describe('IndustriesCheckboxPresenter', () => {
         createMockI18nService(),
       );
 
-      await expect(presenter.checkboxItems()).resolves.toEqual([
+      expect(presenter.checkboxItems()).toEqual([
         {
           text: translationOf('industries.example1'),
           value: 'example-industry-1',
@@ -46,7 +46,7 @@ describe('IndustriesCheckboxPresenter', () => {
       ]);
     });
 
-    it('should return some checked checkbox arguments when called with a non-empty list of checked Industries', async () => {
+    it('should return some checked checkbox arguments when called with a non-empty list of checked Industries', () => {
       const exampleIndustry1 = industry.build({
         name: 'industries.example1',
         id: 'example-industry-1',
@@ -68,7 +68,7 @@ describe('IndustriesCheckboxPresenter', () => {
         createMockI18nService(),
       );
 
-      await expect(presenter.checkboxItems()).resolves.toEqual([
+      expect(presenter.checkboxItems()).toEqual([
         {
           text: translationOf('industries.example1'),
           value: 'example-industry-1',
@@ -88,7 +88,7 @@ describe('IndustriesCheckboxPresenter', () => {
     });
 
     describe('if there is an  "other" industry', () => {
-      it('should be placed at the end of the list', async () => {
+      it('should be placed at the end of the list', () => {
         const exampleIndustry1 = industry.build({
           name: 'industries.example1',
           id: 'example-industry-1',
@@ -110,7 +110,7 @@ describe('IndustriesCheckboxPresenter', () => {
           createMockI18nService(),
         );
 
-        await expect(presenter.checkboxItems()).resolves.toEqual([
+        expect(presenter.checkboxItems()).toEqual([
           {
             text: translationOf('industries.example1'),
             value: 'example-industry-1',

--- a/src/industries/industries-checkbox.presenter.ts
+++ b/src/industries/industries-checkbox.presenter.ts
@@ -8,7 +8,7 @@ export class IndustriesCheckboxPresenter {
     private readonly checkedIndustries: Industry[],
     private readonly i18nService: I18nService,
   ) {}
-  async checkboxItems(): Promise<CheckboxItems[]> {
+  checkboxItems(): CheckboxItems[] {
     let industries: Industry[];
 
     const other = this.allIndustries.find(
@@ -25,14 +25,12 @@ export class IndustriesCheckboxPresenter {
       industries = standardIndustries;
     }
 
-    return Promise.all(
-      industries.map(async (industry) => ({
-        text: await this.i18nService.translate(industry.name),
-        value: industry.id,
-        checked: !!this.checkedIndustries.find(
-          (checkedIndustry) => checkedIndustry.id === industry.id,
-        ),
-      })),
-    );
+    return industries.map((industry) => ({
+      text: this.i18nService.translate<string>(industry.name),
+      value: industry.id,
+      checked: !!this.checkedIndustries.find(
+        (checkedIndustry) => checkedIndustry.id === industry.id,
+      ),
+    }));
   }
 }

--- a/src/nations/nation.spec.ts
+++ b/src/nations/nation.spec.ts
@@ -33,11 +33,11 @@ describe(Nation, () => {
   });
 
   describe('translatedName', () => {
-    it('calls the translation service to return a translated version of the name', async () => {
+    it('calls the translation service to return a translated version of the name', () => {
       const nation = new Nation('nations.england', 'GB-ENG');
       const i18nService = createMockI18nService();
 
-      await expect(nation.translatedName(i18nService)).resolves.toEqual(
+      expect(nation.translatedName(i18nService)).toEqual(
         translationOf('nations.england'),
       );
       expect(i18nService.translate).toHaveBeenCalledWith('nations.england');

--- a/src/nations/nation.ts
+++ b/src/nations/nation.ts
@@ -9,8 +9,8 @@ export class Nation {
     this.code = code;
   }
 
-  async translatedName(i18nService: I18nService): Promise<string> {
-    return i18nService.translate(this.name);
+  translatedName(i18nService: I18nService): string {
+    return i18nService.translate<string>(this.name);
   }
 
   static all(): Nation[] {

--- a/src/nations/nations-checkbox.presenter.spec.ts
+++ b/src/nations/nations-checkbox.presenter.spec.ts
@@ -83,14 +83,14 @@ describe('NationsCheckboxPresenter', () => {
   });
 
   describe('checkboxArgs', () => {
-    it('should return arguments for a group of checkboxes', async () => {
+    it('should return arguments for a group of checkboxes', () => {
       const presenter = new NationsCheckboxPresenter(
         Nation.all(),
         [],
         i18nService,
       );
 
-      expect(await presenter.checkboxArgs('foo', 'foo[]', 'abc.123')).toEqual({
+      expect(presenter.checkboxArgs('foo', 'foo[]', 'abc.123')).toEqual({
         name: 'foo[]',
         hint: {
           text: translationOf('abc.123'),

--- a/src/nations/nations-checkbox.presenter.spec.ts
+++ b/src/nations/nations-checkbox.presenter.spec.ts
@@ -18,14 +18,14 @@ describe('NationsCheckboxPresenter', () => {
   });
 
   describe('checkboxItems', () => {
-    it('should return unchecked checkbox arguments when called with an empty list of Nations', async () => {
+    it('should return unchecked checkbox arguments when called with an empty list of Nations', () => {
       const presenter = new NationsCheckboxPresenter(
         Nation.all(),
         [],
         i18nService,
       );
 
-      await expect(presenter.checkboxItems()).resolves.toEqual([
+      expect(presenter.checkboxItems()).toEqual([
         {
           text: 'England',
           value: 'GB-ENG',
@@ -49,7 +49,7 @@ describe('NationsCheckboxPresenter', () => {
       ]);
     });
 
-    it('should return some checked checkbox arguments when called with a non-empty list of Nations', async () => {
+    it('should return some checked checkbox arguments when called with a non-empty list of Nations', () => {
       const nations = Nation.all();
       const presenter = new NationsCheckboxPresenter(
         nations,
@@ -57,7 +57,7 @@ describe('NationsCheckboxPresenter', () => {
         i18nService,
       );
 
-      await expect(presenter.checkboxItems()).resolves.toEqual([
+      expect(presenter.checkboxItems()).toEqual([
         {
           text: 'England',
           value: 'GB-ENG',

--- a/src/nations/nations-checkbox.presenter.ts
+++ b/src/nations/nations-checkbox.presenter.ts
@@ -13,24 +13,24 @@ export class NationsCheckboxPresenter {
 
   checkboxItems(): CheckboxItems[] {
     return this.allNations.map((nation) => ({
-        text: nation.translatedName(this.i18nService),
-        value: nation.code,
-        checked: !!this.checkedNations.find(
-          (checkedNation) => checkedNation.code === nation.code,
-        ),
-      }))
+      text: nation.translatedName(this.i18nService),
+      value: nation.code,
+      checked: !!this.checkedNations.find(
+        (checkedNation) => checkedNation.code === nation.code,
+      ),
+    }));
   }
 
-  async checkboxArgs(
+  checkboxArgs(
     idPrefix: string,
     name: string,
     hintTranslation: string,
-  ): Promise<CheckboxArgs> {
+  ): CheckboxArgs {
     return {
       idPrefix: idPrefix,
       name: name,
       hint: {
-        text: await this.i18nService.translate(hintTranslation),
+        text: this.i18nService.translate<string>(hintTranslation),
       },
       items: this.checkboxItems(),
     };

--- a/src/nations/nations-checkbox.presenter.ts
+++ b/src/nations/nations-checkbox.presenter.ts
@@ -11,16 +11,14 @@ export class NationsCheckboxPresenter {
     private readonly i18nService: I18nService,
   ) {}
 
-  async checkboxItems(): Promise<CheckboxItems[]> {
-    return Promise.all(
-      this.allNations.map(async (nation) => ({
-        text: await nation.translatedName(this.i18nService),
+  checkboxItems(): CheckboxItems[] {
+    return this.allNations.map((nation) => ({
+        text: nation.translatedName(this.i18nService),
         value: nation.code,
         checked: !!this.checkedNations.find(
           (checkedNation) => checkedNation.code === nation.code,
         ),
-      })),
-    );
+      }))
   }
 
   async checkboxArgs(
@@ -34,7 +32,7 @@ export class NationsCheckboxPresenter {
       hint: {
         text: await this.i18nService.translate(hintTranslation),
       },
-      items: await this.checkboxItems(),
+      items: this.checkboxItems(),
     };
   }
 }

--- a/src/nations/presenters/nations-list.presenter.spec.ts
+++ b/src/nations/presenters/nations-list.presenter.spec.ts
@@ -5,35 +5,35 @@ import { NationsListPresenter } from './nations-list.presenter';
 
 describe('NationsListPresenter', () => {
   describe('textList', () => {
-    it('outputs an empty string when given an empty list of nations', async () => {
+    it('outputs an empty string when given an empty list of nations', () => {
       const i18nService = createMockI18nService();
       const nationsListPresenter = new NationsListPresenter([], i18nService);
 
-      await expect(nationsListPresenter.textList()).resolves.toEqual('');
+      expect(nationsListPresenter.textList()).toEqual('');
     });
 
-    it('translates a single nation', async () => {
+    it('translates a single nation', () => {
       const i18nService = createMockI18nService();
       const nationsListPresenter = new NationsListPresenter(
         [Nation.find('GB-SCT')],
         i18nService,
       );
 
-      await expect(nationsListPresenter.textList()).resolves.toEqual(
+      expect(nationsListPresenter.textList()).toEqual(
         translationOf('nations.scotland'),
       );
 
       expect(i18nService.translate).toHaveBeenCalledWith('nations.scotland');
     });
 
-    it('concatenates multiple nations into a comma separated list', async () => {
+    it('concatenates multiple nations into a comma separated list', () => {
       const i18nService = createMockI18nService();
       const nationsListPresenter = new NationsListPresenter(
         [Nation.find('GB-ENG'), Nation.find('GB-WLS')],
         i18nService,
       );
 
-      await expect(nationsListPresenter.textList()).resolves.toEqual(
+      expect(nationsListPresenter.textList()).toEqual(
         `${translationOf('nations.england')}, ${translationOf(
           'nations.wales',
         )}`,
@@ -43,14 +43,14 @@ describe('NationsListPresenter', () => {
       expect(i18nService.translate).toHaveBeenCalledWith('nations.wales');
     });
 
-    it('collapses multiple nations to "United Kingdom"', async () => {
+    it('collapses multiple nations to "United Kingdom"', () => {
       const i18nService = createMockI18nService();
       const nationsListPresenter = new NationsListPresenter(
         Nation.all(),
         i18nService,
       );
 
-      await expect(nationsListPresenter.textList()).resolves.toEqual(
+      expect(nationsListPresenter.textList()).toEqual(
         translationOf('app.unitedKingdom'),
       );
 
@@ -60,21 +60,21 @@ describe('NationsListPresenter', () => {
   });
 
   describe('htmlList', () => {
-    it('outputs an empty string when given an empty list of nations', async () => {
+    it('outputs an empty string when given an empty list of nations', () => {
       const i18nService = createMockI18nService();
       const nationsListPresenter = new NationsListPresenter([], i18nService);
 
-      await expect(nationsListPresenter.htmlList()).resolves.toEqual('');
+      expect(nationsListPresenter.htmlList()).toEqual('');
     });
 
-    it('translates a single nation', async () => {
+    it('translates a single nation', () => {
       const i18nService = createMockI18nService();
       const nationsListPresenter = new NationsListPresenter(
         [Nation.find('GB-SCT')],
         i18nService,
       );
 
-      await expect(nationsListPresenter.htmlList()).resolves.toEqual(
+      expect(nationsListPresenter.htmlList()).toEqual(
         `<ul class="govuk-list"><li>${translationOf(
           'nations.scotland',
         )}</li></ul>`,
@@ -83,14 +83,14 @@ describe('NationsListPresenter', () => {
       expect(i18nService.translate).toHaveBeenCalledWith('nations.scotland');
     });
 
-    it('concatenates multiple nations a HTML list', async () => {
+    it('concatenates multiple nations a HTML list', () => {
       const i18nService = createMockI18nService();
       const nationsListPresenter = new NationsListPresenter(
         [Nation.find('GB-ENG'), Nation.find('GB-WLS')],
         i18nService,
       );
 
-      await expect(nationsListPresenter.htmlList()).resolves.toEqual(
+      expect(nationsListPresenter.htmlList()).toEqual(
         `<ul class="govuk-list"><li>${translationOf(
           'nations.england',
         )}</li><li>${translationOf('nations.wales')}</li></ul>`,
@@ -100,14 +100,14 @@ describe('NationsListPresenter', () => {
       expect(i18nService.translate).toHaveBeenCalledWith('nations.wales');
     });
 
-    it('collapses multiple nations to "United Kingdom"', async () => {
+    it('collapses multiple nations to "United Kingdom"', () => {
       const i18nService = createMockI18nService();
       const nationsListPresenter = new NationsListPresenter(
         Nation.all(),
         i18nService,
       );
 
-      await expect(nationsListPresenter.htmlList()).resolves.toEqual(
+      expect(nationsListPresenter.htmlList()).toEqual(
         translationOf('app.unitedKingdom'),
       );
 

--- a/src/nations/presenters/nations-list.presenter.ts
+++ b/src/nations/presenters/nations-list.presenter.ts
@@ -11,7 +11,7 @@ export class NationsListPresenter {
     if (this.all()) {
       return this.i18nService.translate('app.unitedKingdom');
     } else {
-      const translatedNations = await this.translatedNations();
+      const translatedNations = this.translatedNations();
 
       return translatedNations.length > 0
         ? `<ul class="govuk-list"><li>${translatedNations.join(
@@ -25,14 +25,12 @@ export class NationsListPresenter {
     if (this.all()) {
       return this.i18nService.translate('app.unitedKingdom');
     } else {
-      return (await this.translatedNations()).join(', ');
+      return this.translatedNations().join(', ');
     }
   }
 
-  private async translatedNations(): Promise<string[]> {
-    return Promise.all(
-      this.nations.map((nation) => nation.translatedName(this.i18nService)),
-    );
+  private translatedNations(): string[] {
+    return this.nations.map((nation) => nation.translatedName(this.i18nService));
   }
 
   private all(): boolean {

--- a/src/nations/presenters/nations-list.presenter.ts
+++ b/src/nations/presenters/nations-list.presenter.ts
@@ -7,9 +7,9 @@ export class NationsListPresenter {
     private readonly i18nService: I18nService,
   ) {}
 
-  async htmlList(): Promise<string> {
+  htmlList(): string {
     if (this.all()) {
-      return this.i18nService.translate('app.unitedKingdom');
+      return this.i18nService.translate<string>('app.unitedKingdom');
     } else {
       const translatedNations = this.translatedNations();
 
@@ -21,9 +21,9 @@ export class NationsListPresenter {
     }
   }
 
-  async textList(): Promise<string> {
+  textList(): string {
     if (this.all()) {
-      return this.i18nService.translate('app.unitedKingdom');
+      return this.i18nService.translate<string>('app.unitedKingdom');
     } else {
       return this.translatedNations().join(', ');
     }

--- a/src/nations/presenters/nations-list.presenter.ts
+++ b/src/nations/presenters/nations-list.presenter.ts
@@ -30,7 +30,9 @@ export class NationsListPresenter {
   }
 
   private translatedNations(): string[] {
-    return this.nations.map((nation) => nation.translatedName(this.i18nService));
+    return this.nations.map((nation) =>
+      nation.translatedName(this.i18nService),
+    );
   }
 
   private all(): boolean {

--- a/src/organisations/admin/organisation-archive.controller.ts
+++ b/src/organisations/admin/organisation-archive.controller.ts
@@ -85,11 +85,11 @@ export class OrganisationArchiveController {
 
     await this.organisationVersionsService.archive(versionToArchive);
 
-    const messageTitle = await this.i18nService.translate(
+    const messageTitle = this.i18nService.translate<string>(
       'organisations.admin.archive.confirmation.heading',
     );
 
-    const messageBody = await this.i18nService.translate(
+    const messageBody = this.i18nService.translate<string>(
       'organisations.admin.archive.confirmation.body',
       { args: { name: escape(version.organisation.name) } },
     );

--- a/src/organisations/admin/organisation-publication.controller.ts
+++ b/src/organisations/admin/organisation-publication.controller.ts
@@ -82,11 +82,11 @@ export class OrganisationPublicationController {
 
     await this.organisationVersionsService.publish(newVersion);
 
-    const messageTitle = await this.i18nService.translate(
+    const messageTitle = this.i18nService.translate<string>(
       'organisations.admin.publish.confirmation.heading',
     );
 
-    const messageBody = await this.i18nService.translate(
+    const messageBody = this.i18nService.translate<string>(
       confirmed
         ? 'organisations.admin.publish.confirmation.body'
         : 'organisations.admin.publish.confirmation.bodyNew',

--- a/src/organisations/admin/organisation-versions.controller.spec.ts
+++ b/src/organisations/admin/organisation-versions.controller.spec.ts
@@ -169,7 +169,7 @@ describe('OrganisationVersionsController', () => {
 
       (
         OrganisationSummaryPresenter.prototype as DeepMocked<OrganisationSummaryPresenter>
-      ).present.mockResolvedValue(showTemplate);
+      ).present.mockReturnValue(showTemplate);
 
       expect(
         await controller.show('org-uuid', 'version-uuid', request),

--- a/src/organisations/admin/organisation-versions.controller.ts
+++ b/src/organisations/admin/organisation-versions.controller.ts
@@ -104,7 +104,7 @@ export class OrganisationVersionsController {
     );
 
     return {
-      ...(await organisationSummaryPresenter.present(true)),
+      ...organisationSummaryPresenter.present(true),
       hasLiveVersion,
     };
   }

--- a/src/organisations/admin/organisations.controller.spec.ts
+++ b/src/organisations/admin/organisations.controller.spec.ts
@@ -121,7 +121,7 @@ describe('OrganisationsController', () => {
 
           (
             OrganisationsPresenter.prototype as DeepMocked<OrganisationsPresenter>
-          ).present.mockResolvedValue(templateParams);
+          ).present.mockReturnValue(templateParams);
 
           expect(await controller.index(request)).toEqual(templateParams);
 
@@ -189,7 +189,7 @@ describe('OrganisationsController', () => {
 
           (
             OrganisationsPresenter.prototype as DeepMocked<OrganisationsPresenter>
-          ).present.mockResolvedValue(templateParams);
+          ).present.mockReturnValue(templateParams);
 
           expect(
             await controller.index(request, {
@@ -270,7 +270,7 @@ describe('OrganisationsController', () => {
 
         (
           OrganisationsPresenter.prototype as DeepMocked<OrganisationsPresenter>
-        ).present.mockResolvedValue(templateParams);
+        ).present.mockReturnValue(templateParams);
 
         expect(await controller.index(request)).toEqual(templateParams);
 

--- a/src/organisations/admin/organisations.controller.spec.ts
+++ b/src/organisations/admin/organisations.controller.spec.ts
@@ -389,7 +389,7 @@ describe('OrganisationsController', () => {
 
           (
             OrganisationPresenter.prototype as DeepMocked<OrganisationPresenter>
-          ).summaryList.mockResolvedValue(summaryList);
+          ).summaryList.mockReturnValue(summaryList);
 
           const organisationId = 'some-uuid';
           const versionId = 'some-other-uuid';

--- a/src/organisations/admin/organisations.controller.ts
+++ b/src/organisations/admin/organisations.controller.ts
@@ -99,7 +99,7 @@ export class OrganisationsController {
       );
 
     const userOrganisation = showAllOrgs
-      ? await this.i18nService.translate('app.beis')
+      ? this.i18nService.translate<string>('app.beis')
       : actingUser.organisation.name;
 
     const presenter = new OrganisationsPresenter(
@@ -234,11 +234,11 @@ export class OrganisationsController {
 
     await this.organisationVersionsService.confirm(version);
 
-    const messageTitle = await this.i18nService.translate(
+    const messageTitle = this.i18nService.translate<string>(
       `organisations.admin.${action}.confirmation.heading`,
     );
 
-    const messageBody = await this.i18nService.translate(
+    const messageBody = this.i18nService.translate<string>(
       `organisations.admin.${action}.confirmation.body`,
       { args: { name: escape(version.organisation.name) } },
     );

--- a/src/organisations/admin/organisations.controller.ts
+++ b/src/organisations/admin/organisations.controller.ts
@@ -208,7 +208,7 @@ export class OrganisationsController {
 
       return this.showReviewPage(res, version, {
         ...updatedOrganisation,
-        summaryList: await organisationPresenter.summaryList({
+        summaryList: organisationPresenter.summaryList({
           classes: 'govuk-summary-list',
           removeBlank: false,
           includeName: true,

--- a/src/organisations/admin/presenters/organisations.presenter.spec.ts
+++ b/src/organisations/admin/presenters/organisations.presenter.spec.ts
@@ -46,7 +46,7 @@ jest.mock('../../../nations/nations-checkbox.presenter', () => {
 describe('OrganisationsPresenter', () => {
   describe('present', () => {
     describe('when called with empty `FilterInput`', () => {
-      it('returns `IndexTemplate` template data', async () => {
+      it('returns `IndexTemplate` template data', () => {
         mockTableRow.mockReturnValue([
           {
             text: 'Some text',
@@ -77,7 +77,7 @@ describe('OrganisationsPresenter', () => {
           organisations,
           i18nService,
         );
-        const result = await presenter.present('overview');
+        const result = presenter.present('overview');
 
         expect(OrganisationPresenter).toHaveBeenCalledTimes(5);
         expect(OrganisationPresenter).toHaveBeenLastCalledWith(
@@ -121,7 +121,7 @@ describe('OrganisationsPresenter', () => {
         expect(result.industriesCheckboxItems).toEqual(mockCheckboxItems());
       });
 
-      it('returns empty filter data', async () => {
+      it('returns empty filter data', () => {
         mockTableRow.mockReturnValue([]);
         mockCheckboxItems.mockReturnValue([]);
 
@@ -142,7 +142,7 @@ describe('OrganisationsPresenter', () => {
           i18nService,
         );
 
-        const result = await presenter.present('overview');
+        const result = presenter.present('overview');
 
         expect(NationsCheckboxPresenter).toBeCalledWith(
           nations,
@@ -167,7 +167,7 @@ describe('OrganisationsPresenter', () => {
 
     describe('when called with populated `FilterInput`', () => {
       describe('when called with `overview`', () => {
-        it('returns populated filter data', async () => {
+        it('returns populated filter data', () => {
           mockTableRow.mockReturnValue([]);
           mockCheckboxItems.mockReturnValue([]);
 
@@ -196,7 +196,7 @@ describe('OrganisationsPresenter', () => {
             i18nService,
           );
 
-          const result = await presenter.present('overview');
+          const result = presenter.present('overview');
 
           expect(NationsCheckboxPresenter).toBeCalledWith(
             nations,
@@ -224,7 +224,7 @@ describe('OrganisationsPresenter', () => {
       });
 
       describe('when called with `single-organisation`', () => {
-        it('returns populated filter data', async () => {
+        it('returns populated filter data', () => {
           mockTableRow.mockReturnValue([]);
           mockCheckboxItems.mockReturnValue([]);
 
@@ -253,7 +253,7 @@ describe('OrganisationsPresenter', () => {
             i18nService,
           );
 
-          const result = await presenter.present('single-organisation');
+          const result = presenter.present('single-organisation');
 
           expect(NationsCheckboxPresenter).toBeCalledWith(
             nations,
@@ -283,7 +283,7 @@ describe('OrganisationsPresenter', () => {
 
     describe('caption', () => {
       describe('when only one organisation is found', () => {
-        it('uses the singular text for a caption', async () => {
+        it('uses the singular text for a caption', () => {
           mockTableRow.mockReturnValue([
             {
               text: 'Some text',
@@ -314,7 +314,7 @@ describe('OrganisationsPresenter', () => {
             foundOrganisations,
             i18nService,
           );
-          const result = await presenter.present('overview');
+          const result = presenter.present('overview');
 
           expect(result.organisationsTable.caption).toEqual(
             `${translationOf('organisations.search.foundSingular')}`,
@@ -323,7 +323,7 @@ describe('OrganisationsPresenter', () => {
       });
 
       describe('when more than one profession is found', () => {
-        it('uses the plural text', async () => {
+        it('uses the plural text', () => {
           mockTableRow.mockReturnValue([
             {
               text: 'Some text',
@@ -354,7 +354,7 @@ describe('OrganisationsPresenter', () => {
             foundOrganisations,
             i18nService,
           );
-          const result = await presenter.present('overview');
+          const result = presenter.present('overview');
 
           expect(result.organisationsTable.caption).toEqual(
             `${translationOf('organisations.search.foundPlural')}`,

--- a/src/organisations/admin/presenters/organisations.presenter.ts
+++ b/src/organisations/admin/presenters/organisations.presenter.ts
@@ -42,7 +42,7 @@ export class OrganisationsPresenter {
   ) {}
 
   async present(view: OrganisationsPresenterView): Promise<IndexTemplate> {
-    const nationsCheckboxItems = await new NationsCheckboxPresenter(
+    const nationsCheckboxItems = new NationsCheckboxPresenter(
       this.allNations,
       this.filterInput.nations || [],
       this.i18nService,

--- a/src/organisations/admin/presenters/organisations.presenter.ts
+++ b/src/organisations/admin/presenters/organisations.presenter.ts
@@ -41,7 +41,7 @@ export class OrganisationsPresenter {
     private readonly i18nService: I18nService,
   ) {}
 
-  async present(view: OrganisationsPresenterView): Promise<IndexTemplate> {
+  present(view: OrganisationsPresenterView): IndexTemplate {
     const nationsCheckboxItems = new NationsCheckboxPresenter(
       this.allNations,
       this.filterInput.nations || [],
@@ -65,7 +65,7 @@ export class OrganisationsPresenter {
       nationsCheckboxItems,
       industriesCheckboxItems,
       regulationTypesCheckboxItems,
-      organisationsTable: await this.table(),
+      organisationsTable: this.table(),
       filters: {
         keywords: this.filterInput.keywords || '',
         nations: (this.filterInput.nations || []).map((nation) => nation.name),
@@ -77,7 +77,7 @@ export class OrganisationsPresenter {
     };
   }
 
-  private async table(firstCellIsHeader = true): Promise<Table> {
+  private table(firstCellIsHeader = true): Table {
     const rows = this.filteredOrganisations.map((organisation) =>
       new OrganisationPresenter(organisation, this.i18nService).tableRow(),
     );
@@ -86,33 +86,33 @@ export class OrganisationsPresenter {
 
     const caption =
       numberOfResults === 1
-        ? await this.i18nService.translate(
+        ? this.i18nService.translate<string>(
             'organisations.search.foundSingular',
             { args: { count: numberOfResults } },
           )
-        : await this.i18nService.translate('organisations.search.foundPlural', {
-            args: { count: numberOfResults },
-          });
+        : this.i18nService.translate<string>(
+            'organisations.search.foundPlural',
+            {
+              args: { count: numberOfResults },
+            },
+          );
 
     return {
       caption,
       captionClasses: 'govuk-table__caption--m',
       firstCellIsHeader: firstCellIsHeader,
-      head: await this.headers(),
+      head: this.headers(),
       rows: rows,
     };
   }
 
-  private async headers(): Promise<TableRow> {
-    return (
-      await Promise.all(
-        fields.map(
-          (field) =>
-            this.i18nService.translate(
-              `organisations.admin.tableHeading.${field}`,
-            ) as Promise<string>,
+  private headers(): TableRow {
+    return fields
+      .map((field) =>
+        this.i18nService.translate<string>(
+          `organisations.admin.tableHeading.${field}`,
         ),
       )
-    ).map((text) => ({ text }));
+      .map((text) => ({ text }));
   }
 }

--- a/src/organisations/admin/presenters/organisations.presenter.ts
+++ b/src/organisations/admin/presenters/organisations.presenter.ts
@@ -78,14 +78,8 @@ export class OrganisationsPresenter {
   }
 
   private async table(firstCellIsHeader = true): Promise<Table> {
-    const rows = await Promise.all(
-      this.filteredOrganisations.map(
-        async (organisation) =>
-          await new OrganisationPresenter(
-            organisation,
-            this.i18nService,
-          ).tableRow(),
-      ),
+    const rows = this.filteredOrganisations.map((organisation) =>
+      new OrganisationPresenter(organisation, this.i18nService).tableRow(),
     );
 
     const numberOfResults = rows.length;

--- a/src/organisations/admin/presenters/organisations.presenter.ts
+++ b/src/organisations/admin/presenters/organisations.presenter.ts
@@ -54,11 +54,10 @@ export class OrganisationsPresenter {
       this.i18nService,
     ).checkboxItems();
 
-    const regulationTypesCheckboxItems =
-      await new RegulationTypesCheckboxPresenter(
-        this.filterInput.regulationTypes || [],
-        this.i18nService,
-      ).checkboxItems();
+    const regulationTypesCheckboxItems = new RegulationTypesCheckboxPresenter(
+      this.filterInput.regulationTypes || [],
+      this.i18nService,
+    ).checkboxItems();
 
     return {
       view,

--- a/src/organisations/admin/presenters/organisations.presenter.ts
+++ b/src/organisations/admin/presenters/organisations.presenter.ts
@@ -48,7 +48,7 @@ export class OrganisationsPresenter {
       this.i18nService,
     ).checkboxItems();
 
-    const industriesCheckboxItems = await new IndustriesCheckboxPresenter(
+    const industriesCheckboxItems = new IndustriesCheckboxPresenter(
       this.allIndustries,
       this.filterInput.industries || [],
       this.i18nService,

--- a/src/organisations/organisations.controller.spec.ts
+++ b/src/organisations/organisations.controller.spec.ts
@@ -78,7 +78,7 @@ describe('OrganisationsController', () => {
         (profession) => profession,
       );
 
-      const expected = await new OrganisationSummaryPresenter(
+      const expected = new OrganisationSummaryPresenter(
         organisation,
         professions,
         i18nService,

--- a/src/organisations/presenters/organisation-summary.presenter.spec.ts
+++ b/src/organisations/presenters/organisation-summary.presenter.spec.ts
@@ -45,7 +45,7 @@ describe('OrganisationSummaryPresenter', () => {
   describe('present', () => {
     describe('when all relations are present on the organisation', () => {
       describe('when `showEmptyFields` is true', () => {
-        it("should return template variables contraining an organisation's summary, with blank fields preserved", async () => {
+        it("should return template variables contraining an organisation's summary, with blank fields preserved", () => {
           const organisation = organisationFactory.build();
 
           const professions = [
@@ -71,7 +71,7 @@ describe('OrganisationSummaryPresenter', () => {
             i18nService,
           );
 
-          expect(await presenter.present(true)).toEqual({
+          expect(presenter.present(true)).toEqual({
             organisation: organisation,
             presenter: organisationPresenter,
             summaryList: mockSummaryList(),
@@ -114,7 +114,7 @@ describe('OrganisationSummaryPresenter', () => {
       });
 
       describe('when `showEmptyFields` is false', () => {
-        it("should return template variables contraining an organisation's summary, with blank fields removed", async () => {
+        it("should return template variables contraining an organisation's summary, with blank fields removed", () => {
           const organisation = organisationFactory.build({});
 
           const professions = [
@@ -140,7 +140,7 @@ describe('OrganisationSummaryPresenter', () => {
             i18nService,
           );
 
-          expect(await presenter.present(false)).toEqual({
+          expect(presenter.present(false)).toEqual({
             organisation: organisation,
             presenter: organisationPresenter,
             summaryList: mockSummaryList(),

--- a/src/organisations/presenters/organisation-summary.presenter.ts
+++ b/src/organisations/presenters/organisation-summary.presenter.ts
@@ -31,17 +31,15 @@ export class OrganisationSummaryPresenter {
       summaryList: await organisationPresenter.summaryList({
         removeBlank: !showEmptyFields,
       }),
-      professions: await Promise.all(
-        professionPresenters.map(async (presenter) => {
-          return {
-            name: presenter.profession.name,
-            slug: presenter.profession.slug,
-            id: presenter.profession.id,
-            versionId: presenter.profession.versionId,
-            summaryList: await presenter.summaryList(),
-          };
-        }),
-      ),
+      professions: professionPresenters.map((presenter) => {
+        return {
+          name: presenter.profession.name,
+          slug: presenter.profession.slug,
+          id: presenter.profession.id,
+          versionId: presenter.profession.versionId,
+          summaryList: presenter.summaryList(),
+        };
+      }),
     };
   }
 }

--- a/src/organisations/presenters/organisation-summary.presenter.ts
+++ b/src/organisations/presenters/organisation-summary.presenter.ts
@@ -13,7 +13,7 @@ export class OrganisationSummaryPresenter {
     private readonly i18nService: I18nService,
   ) {}
 
-  async present(showEmptyFields: boolean): Promise<ShowTemplate> {
+  present(showEmptyFields: boolean): ShowTemplate {
     const organisationPresenter = new OrganisationPresenter(
       this.organisation,
       this.i18nService,
@@ -28,7 +28,7 @@ export class OrganisationSummaryPresenter {
     return {
       organisation: this.organisation,
       presenter: organisationPresenter,
-      summaryList: await organisationPresenter.summaryList({
+      summaryList: organisationPresenter.summaryList({
         removeBlank: !showEmptyFields,
       }),
       professions: professionPresenters.map((presenter) => {

--- a/src/organisations/presenters/organisation.presenter.spec.ts
+++ b/src/organisations/presenters/organisation.presenter.spec.ts
@@ -40,7 +40,7 @@ describe('OrganisationPresenter', () => {
   describe('tableRow', () => {
     describe('when all relations are present', () => {
       describe('when the professions share one industry', () => {
-        it('returns the table row data', async () => {
+        it('returns the table row data', () => {
           const industries = [industryFactory.build({ name: 'Industry 1' })];
 
           const professionToOrganisations = professionFactory
@@ -81,7 +81,7 @@ describe('OrganisationPresenter', () => {
             organisation,
             i18nService,
           );
-          const tableRow = await presenter.tableRow();
+          const tableRow = presenter.tableRow();
 
           expect(tableRow[0]).toEqual({ text: organisation.name });
           expect(tableRow[1]).toEqual({
@@ -131,7 +131,7 @@ describe('OrganisationPresenter', () => {
       });
 
       describe('when the professions share multiple industries', () => {
-        it('returns the table row data', async () => {
+        it('returns the table row data', () => {
           const industries = [
             industryFactory.build({ name: 'industry.1' }),
             industryFactory.build({ name: 'industry.2' }),
@@ -186,7 +186,7 @@ describe('OrganisationPresenter', () => {
             organisation,
             i18nService,
           );
-          const tableRow = await presenter.tableRow();
+          const tableRow = presenter.tableRow();
 
           expect(tableRow[0]).toEqual({ text: organisation.name });
           expect(tableRow[1]).toEqual({
@@ -229,7 +229,7 @@ describe('OrganisationPresenter', () => {
       });
 
       describe('when there are no professionToOrganisations on the regulator', () => {
-        it('returns empty text for industries', async () => {
+        it('returns empty text for industries', () => {
           const professionToOrganisations = [];
 
           const organisation = organisationFactory.build({
@@ -249,7 +249,7 @@ describe('OrganisationPresenter', () => {
             organisation,
             i18nService,
           );
-          const tableRow = await presenter.tableRow();
+          const tableRow = presenter.tableRow();
 
           expect(tableRow[2]).toEqual({ text: '' });
         });
@@ -259,7 +259,7 @@ describe('OrganisationPresenter', () => {
 
   describe('summaryList', () => {
     describe('when all fields are present', () => {
-      it('should return all fields', async () => {
+      it('should return all fields', () => {
         const i18nService = createMockI18nService();
         (escape as jest.Mock).mockImplementation(escapeOf);
 
@@ -267,7 +267,7 @@ describe('OrganisationPresenter', () => {
 
         const presenter = new OrganisationPresenter(organisation, i18nService);
 
-        expect(await presenter.summaryList()).toEqual({
+        expect(presenter.summaryList()).toEqual({
           classes: 'govuk-summary-list--no-border',
           rows: [
             {
@@ -317,7 +317,7 @@ describe('OrganisationPresenter', () => {
 
     describe('when a field is missing', () => {
       describe('when removeBlank is true', () => {
-        it('should filter out empty fields', async () => {
+        it('should filter out empty fields', () => {
           const i18nService = createMockI18nService();
           (escape as jest.Mock).mockImplementation(escapeOf);
           (formatMultilineString as jest.Mock).mockImplementation(multilineOf);
@@ -333,7 +333,7 @@ describe('OrganisationPresenter', () => {
             organisation,
             i18nService,
           );
-          const list = await presenter.summaryList({ removeBlank: true });
+          const list = presenter.summaryList({ removeBlank: true });
 
           expect(list.rows.length).toEqual(4);
           expect(
@@ -347,7 +347,7 @@ describe('OrganisationPresenter', () => {
       });
 
       describe('when removeBlank is false', () => {
-        it('keeps empty rows intact', async () => {
+        it('keeps empty rows intact', () => {
           const i18nService = createMockI18nService();
           (escape as jest.Mock).mockImplementation(escapeOf);
 
@@ -359,7 +359,7 @@ describe('OrganisationPresenter', () => {
             organisation,
             i18nService,
           );
-          const list = await presenter.summaryList({ removeBlank: false });
+          const list = presenter.summaryList({ removeBlank: false });
 
           expect(list.rows.length).toEqual(5);
 
@@ -376,7 +376,7 @@ describe('OrganisationPresenter', () => {
     });
 
     describe('when includeName is true', () => {
-      it('should include the name of the organisation', async () => {
+      it('should include the name of the organisation', () => {
         const i18nService = createMockI18nService();
         (escape as jest.Mock).mockImplementation(escapeOf);
 
@@ -385,7 +385,7 @@ describe('OrganisationPresenter', () => {
           .build({ name: 'My Organisation' });
 
         const presenter = new OrganisationPresenter(organisation, i18nService);
-        const list = await presenter.summaryList({ includeName: true });
+        const list = presenter.summaryList({ includeName: true });
 
         expect(list.rows.length).toEqual(6);
 
@@ -401,7 +401,7 @@ describe('OrganisationPresenter', () => {
     });
 
     describe('when includeActions is true', () => {
-      it('should include an actions column', async () => {
+      it('should include an actions column', () => {
         const i18nService = createMockI18nService();
         (escape as jest.Mock).mockImplementation(escapeOf);
 
@@ -412,7 +412,7 @@ describe('OrganisationPresenter', () => {
           .build({ name: 'My Organisation' });
 
         const presenter = new OrganisationPresenter(organisation, i18nService);
-        const list = await presenter.summaryList({ includeActions: true });
+        const list = presenter.summaryList({ includeActions: true });
 
         for (const row of list.rows) {
           const visuallyHiddenText =
@@ -432,14 +432,14 @@ describe('OrganisationPresenter', () => {
     });
 
     describe('when classes are specified', () => {
-      it('should return the specified class', async () => {
+      it('should return the specified class', () => {
         const i18nService = createMockI18nService();
         (escape as jest.Mock).mockImplementation(escapeOf);
 
         const organisation = organisationFactory.build();
 
         const presenter = new OrganisationPresenter(organisation, i18nService);
-        const list = await presenter.summaryList({ classes: 'foo' });
+        const list = presenter.summaryList({ classes: 'foo' });
 
         expect(list.classes).toEqual('foo');
       });

--- a/src/organisations/presenters/organisation.presenter.spec.ts
+++ b/src/organisations/presenters/organisation.presenter.spec.ts
@@ -69,7 +69,7 @@ describe('OrganisationPresenter', () => {
 
           const getNationsFromProfessionsSpy = jest
             .spyOn(nationsHelperModule, 'getNationsFromProfessions')
-            .mockResolvedValue(
+            .mockReturnValue(
               `${translationOf('nations.england')}, ${translationOf(
                 'nations.wales',
               )}`,
@@ -174,7 +174,7 @@ describe('OrganisationPresenter', () => {
 
           const getNationsFromProfessionsSpy = jest
             .spyOn(nationsHelperModule, 'getNationsFromProfessions')
-            .mockResolvedValue(
+            .mockReturnValue(
               `${translationOf('nations.wales')}, ${translationOf(
                 'nations.scotland',
               )}`,

--- a/src/organisations/presenters/organisation.presenter.ts
+++ b/src/organisations/presenters/organisation.presenter.ts
@@ -31,10 +31,7 @@ export class OrganisationPresenter {
         text: this.organisation.name,
       },
       {
-        text: await getNationsFromProfessions(
-          this.professions(),
-          this.i18nService,
-        ),
+        text: getNationsFromProfessions(this.professions(), this.i18nService),
       },
       {
         text: await this.industries(),

--- a/src/organisations/presenters/organisation.presenter.ts
+++ b/src/organisations/presenters/organisation.presenter.ts
@@ -25,7 +25,7 @@ export class OrganisationPresenter {
     private readonly i18nService: I18nService,
   ) {}
 
-  public async tableRow(): Promise<TableRow> {
+  public tableRow(): TableRow {
     return [
       {
         text: this.organisation.name,
@@ -34,7 +34,7 @@ export class OrganisationPresenter {
         text: getNationsFromProfessions(this.professions(), this.i18nService),
       },
       {
-        text: await this.industries(),
+        text: this.industries(),
       },
       {
         text: this.lastModified,
@@ -53,7 +53,7 @@ export class OrganisationPresenter {
           this.organisation.id
         }/versions/${
           this.organisation.versionId
-        }">${await this.i18nService.translate(
+        }">${this.i18nService.translate<string>(
           'organisations.admin.viewDetails',
           { args: { name: escape(this.organisation.name) } },
         )}
@@ -62,9 +62,9 @@ export class OrganisationPresenter {
     ];
   }
 
-  public async summaryList(
+  public summaryList(
     options: OrganisationSummaryListOptions = {},
-  ): Promise<SummaryList> {
+  ): SummaryList {
     const classes = options.classes || 'govuk-summary-list--no-border';
     const removeBlank = options.removeBlank || false;
     const includeName = options.includeName || false;
@@ -73,7 +73,7 @@ export class OrganisationPresenter {
     let rows = [
       {
         key: {
-          text: await this.i18nService.translate(
+          text: this.i18nService.translate<string>(
             'organisations.label.alternateName',
           ),
         },
@@ -83,7 +83,7 @@ export class OrganisationPresenter {
       },
       {
         key: {
-          text: await this.i18nService.translate('organisations.label.url'),
+          text: this.i18nService.translate<string>('organisations.label.url'),
         },
         value: {
           html: this.url(),
@@ -91,7 +91,9 @@ export class OrganisationPresenter {
       },
       {
         key: {
-          text: await this.i18nService.translate('organisations.label.address'),
+          text: this.i18nService.translate<string>(
+            'organisations.label.address',
+          ),
         },
         value: {
           html: this.address(),
@@ -99,7 +101,7 @@ export class OrganisationPresenter {
       },
       {
         key: {
-          text: await this.i18nService.translate('organisations.label.email'),
+          text: this.i18nService.translate<string>('organisations.label.email'),
         },
         value: {
           html: this.email(),
@@ -107,7 +109,7 @@ export class OrganisationPresenter {
       },
       {
         key: {
-          text: await this.i18nService.translate(
+          text: this.i18nService.translate<string>(
             'organisations.label.telephone',
           ),
         },
@@ -126,7 +128,7 @@ export class OrganisationPresenter {
     if (includeName) {
       rows.unshift({
         key: {
-          text: await this.i18nService.translate('organisations.label.name'),
+          text: this.i18nService.translate<string>('organisations.label.name'),
         },
         value: {
           text: this.organisation.name,
@@ -135,22 +137,20 @@ export class OrganisationPresenter {
     }
 
     if (includeActions) {
-      rows = await Promise.all(
-        rows.map(async (row) => {
-          return {
-            ...row,
-            actions: {
-              items: [
-                {
-                  href: `/admin/organisations/${this.organisation.id}/versions/${this.organisation.versionId}/edit`,
-                  text: await this.i18nService.translate('app.change'),
-                  visuallyHiddenText: row.key.text,
-                },
-              ],
-            },
-          };
-        }),
-      );
+      rows = rows.map((row) => {
+        return {
+          ...row,
+          actions: {
+            items: [
+              {
+                href: `/admin/organisations/${this.organisation.id}/versions/${this.organisation.versionId}/edit`,
+                text: this.i18nService.translate<string>('app.change'),
+                visuallyHiddenText: row.key.text,
+              },
+            ],
+          },
+        };
+      });
     }
 
     return {
@@ -190,16 +190,13 @@ export class OrganisationPresenter {
     return formatLink(this.organisation.url);
   }
 
-  private async industries(): Promise<string> {
+  private industries(): string {
     const industries = this.professions()
       .map((profession) => profession.industries)
       .flat();
 
-    const industryNames = await Promise.all(
-      industries.map(
-        (industry) =>
-          this.i18nService.translate(industry.name) as Promise<string>,
-      ),
+    const industryNames = industries.map((industry) =>
+      this.i18nService.translate<string>(industry.name),
     );
 
     return [...new Set(industryNames)].join(', ');

--- a/src/organisations/search/organisation-search-result.presenter.spec.ts
+++ b/src/organisations/search/organisation-search-result.presenter.spec.ts
@@ -11,7 +11,7 @@ import { OrganisationSearchResultPresenter } from './organisation-search-result.
 
 describe('OrganisationSearchResultPresenter', () => {
   describe('present', () => {
-    it('Returns a OrganisationSearchResultTemplate', async () => {
+    it('Returns a OrganisationSearchResultTemplate', () => {
       const i18nService = createMockI18nService();
 
       const professionToOrganisations = [
@@ -35,13 +35,13 @@ describe('OrganisationSearchResultPresenter', () => {
 
       const getNationsFromProfessionsSpy = jest
         .spyOn(nationsHelperModule, 'getNationsFromProfessions')
-        .mockResolvedValue(
+        .mockReturnValue(
           `${translationOf('nations.england')}, ${translationOf(
             'nations.wales',
           )}`,
         );
 
-      const result = await new OrganisationSearchResultPresenter(
+      const result = new OrganisationSearchResultPresenter(
         organisation,
         i18nService,
       ).present();

--- a/src/organisations/search/organisation-search-result.presenter.ts
+++ b/src/organisations/search/organisation-search-result.presenter.ts
@@ -11,7 +11,7 @@ export class OrganisationSearchResultPresenter {
     private readonly i18nService: I18nService,
   ) {}
 
-  async present(): Promise<OrganisationSearchResultTemplate> {
+  present(): OrganisationSearchResultTemplate {
     const professions = getProfessionsFromOrganisation(this.organisation)
       .map((profession) => Profession.withLatestLiveVersion(profession))
       .filter((n) => n);
@@ -19,7 +19,7 @@ export class OrganisationSearchResultPresenter {
     return {
       name: this.organisation.name,
       slug: this.organisation.slug,
-      nations: await getNationsFromProfessions(professions, this.i18nService),
+      nations: getNationsFromProfessions(professions, this.i18nService),
     };
   }
 }

--- a/src/organisations/search/search.controller.spec.ts
+++ b/src/organisations/search/search.controller.spec.ts
@@ -93,7 +93,7 @@ describe('SearchController', () => {
           request,
         );
 
-        const expected = await new SearchPresenter(
+        const expected = new SearchPresenter(
           {
             keywords: '',
             nations: [],
@@ -140,7 +140,7 @@ describe('SearchController', () => {
         request,
       );
 
-      const expected = await new SearchPresenter(
+      const expected = new SearchPresenter(
         {
           keywords: 'example search',
           industries: [industry1, industry2],

--- a/src/organisations/search/search.presenter.spec.ts
+++ b/src/organisations/search/search.presenter.spec.ts
@@ -55,7 +55,7 @@ describe('SearchPresenter', () => {
   });
 
   describe('present', () => {
-    it('should return a IndexTemplate', async () => {
+    it('should return a IndexTemplate', () => {
       const filterInput: FilterInput = {
         keywords: 'Example Keywords',
         nations: [nations[0]],
@@ -72,7 +72,7 @@ describe('SearchPresenter', () => {
       );
 
       (hasSelectedFilters as jest.Mock).mockReturnValue(true);
-      const result = await presenter.present();
+      const result = presenter.present();
 
       const nationsCheckboxItems = new NationsCheckboxPresenter(
         Nation.all(),
@@ -102,15 +102,15 @@ describe('SearchPresenter', () => {
         industriesCheckboxItems,
         regulationTypesCheckboxItems,
         organisations: [
-          await new OrganisationSearchResultPresenter(
+          new OrganisationSearchResultPresenter(
             organisation1,
             i18nService,
           ).present(),
-          await new OrganisationSearchResultPresenter(
+          new OrganisationSearchResultPresenter(
             organisation2,
             i18nService,
           ).present(),
-          await new OrganisationSearchResultPresenter(
+          new OrganisationSearchResultPresenter(
             organisation3,
             i18nService,
           ).present(),

--- a/src/organisations/search/search.presenter.spec.ts
+++ b/src/organisations/search/search.presenter.spec.ts
@@ -86,11 +86,10 @@ describe('SearchPresenter', () => {
         i18nService,
       ).checkboxItems();
 
-      const regulationTypesCheckboxItems =
-        await new RegulationTypesCheckboxPresenter(
-          [RegulationType.Accreditation],
-          i18nService,
-        ).checkboxItems();
+      const regulationTypesCheckboxItems = new RegulationTypesCheckboxPresenter(
+        [RegulationType.Accreditation],
+        i18nService,
+      ).checkboxItems();
 
       const expected: IndexTemplate = {
         filters: {

--- a/src/organisations/search/search.presenter.spec.ts
+++ b/src/organisations/search/search.presenter.spec.ts
@@ -80,7 +80,7 @@ describe('SearchPresenter', () => {
         i18nService,
       ).checkboxItems();
 
-      const industriesCheckboxItems = await new IndustriesCheckboxPresenter(
+      const industriesCheckboxItems = new IndustriesCheckboxPresenter(
         industries,
         [industry2],
         i18nService,

--- a/src/organisations/search/search.presenter.spec.ts
+++ b/src/organisations/search/search.presenter.spec.ts
@@ -74,7 +74,7 @@ describe('SearchPresenter', () => {
       (hasSelectedFilters as jest.Mock).mockReturnValue(true);
       const result = await presenter.present();
 
-      const nationsCheckboxItems = await new NationsCheckboxPresenter(
+      const nationsCheckboxItems = new NationsCheckboxPresenter(
         Nation.all(),
         [Nation.find('GB-ENG')],
         i18nService,

--- a/src/organisations/search/search.presenter.ts
+++ b/src/organisations/search/search.presenter.ts
@@ -19,7 +19,7 @@ export class SearchPresenter {
     private readonly i18nService: I18nService,
   ) {}
 
-  async present(): Promise<IndexTemplate> {
+  present(): IndexTemplate {
     const nationsCheckboxItems = new NationsCheckboxPresenter(
       this.allNations,
       this.filterInput.nations,
@@ -37,13 +37,13 @@ export class SearchPresenter {
       this.i18nService,
     ).checkboxItems();
 
-    const displayOrganisations = await Promise.all(
-      this.filteredOrganisations.map(async (organisation) => {
+    const displayOrganisations = this.filteredOrganisations.map(
+      (organisation) => {
         return new OrganisationSearchResultPresenter(
           organisation,
           this.i18nService,
         ).present();
-      }),
+      },
     );
 
     return {

--- a/src/organisations/search/search.presenter.ts
+++ b/src/organisations/search/search.presenter.ts
@@ -26,7 +26,7 @@ export class SearchPresenter {
       this.i18nService,
     ).checkboxItems();
 
-    const industriesCheckboxItems = await new IndustriesCheckboxPresenter(
+    const industriesCheckboxItems = new IndustriesCheckboxPresenter(
       this.allIndustries,
       this.filterInput.industries,
       this.i18nService,

--- a/src/organisations/search/search.presenter.ts
+++ b/src/organisations/search/search.presenter.ts
@@ -20,7 +20,7 @@ export class SearchPresenter {
   ) {}
 
   async present(): Promise<IndexTemplate> {
-    const nationsCheckboxItems = await new NationsCheckboxPresenter(
+    const nationsCheckboxItems = new NationsCheckboxPresenter(
       this.allNations,
       this.filterInput.nations,
       this.i18nService,

--- a/src/organisations/search/search.presenter.ts
+++ b/src/organisations/search/search.presenter.ts
@@ -32,11 +32,10 @@ export class SearchPresenter {
       this.i18nService,
     ).checkboxItems();
 
-    const regulationTypesCheckboxItems =
-      await new RegulationTypesCheckboxPresenter(
-        this.filterInput.regulationTypes,
-        this.i18nService,
-      ).checkboxItems();
+    const regulationTypesCheckboxItems = new RegulationTypesCheckboxPresenter(
+      this.filterInput.regulationTypes,
+      this.i18nService,
+    ).checkboxItems();
 
     const displayOrganisations = await Promise.all(
       this.filteredOrganisations.map(async (organisation) => {

--- a/src/professions/admin/check-your-answers.controller.spec.ts
+++ b/src/professions/admin/check-your-answers.controller.spec.ts
@@ -123,7 +123,7 @@ describe('CheckYourAnswersController', () => {
 
         (
           ProfessionToOrganisationsPresenter.prototype as DeepMocked<ProfessionToOrganisationsPresenter>
-        ).summaryLists.mockResolvedValue(expectedSummaryList);
+        ).summaryLists.mockReturnValue(expectedSummaryList);
 
         (NationsListPresenter.prototype.htmlList as jest.Mock).mockReturnValue(
           mockNationsHtml,
@@ -247,7 +247,7 @@ describe('CheckYourAnswersController', () => {
 
         (
           ProfessionToOrganisationsPresenter.prototype as DeepMocked<ProfessionToOrganisationsPresenter>
-        ).summaryLists.mockResolvedValue(expectedSummaryList);
+        ).summaryLists.mockReturnValue(expectedSummaryList);
 
         const request = createDefaultMockRequest({
           user: user,

--- a/src/professions/admin/check-your-answers.controller.spec.ts
+++ b/src/professions/admin/check-your-answers.controller.spec.ts
@@ -125,9 +125,9 @@ describe('CheckYourAnswersController', () => {
           ProfessionToOrganisationsPresenter.prototype as DeepMocked<ProfessionToOrganisationsPresenter>
         ).summaryLists.mockResolvedValue(expectedSummaryList);
 
-        (
-          NationsListPresenter.prototype.htmlList as jest.Mock
-        ).mockResolvedValue(mockNationsHtml);
+        (NationsListPresenter.prototype.htmlList as jest.Mock).mockReturnValue(
+          mockNationsHtml,
+        );
 
         const request = createDefaultMockRequest({
           user: user,
@@ -232,9 +232,9 @@ describe('CheckYourAnswersController', () => {
           .spyOn(sortLegislationsByIndexModule, 'sortLegislationsByIndex')
           .mockImplementation((legislations) => legislations);
 
-        (
-          NationsListPresenter.prototype.htmlList as jest.Mock
-        ).mockResolvedValue(mockNationsHtml);
+        (NationsListPresenter.prototype.htmlList as jest.Mock).mockReturnValue(
+          mockNationsHtml,
+        );
         const user = userFactory.build();
 
         const expectedSummaryList =

--- a/src/professions/admin/check-your-answers.controller.ts
+++ b/src/professions/admin/check-your-answers.controller.ts
@@ -75,7 +75,7 @@ export class CheckYourAnswersController {
       this.i18nService,
     );
 
-    const organisations = await new ProfessionToOrganisationsPresenter(
+    const organisations = new ProfessionToOrganisationsPresenter(
       profession,
       version,
       this.i18nService,

--- a/src/professions/admin/check-your-answers.controller.ts
+++ b/src/professions/admin/check-your-answers.controller.ts
@@ -86,7 +86,7 @@ export class CheckYourAnswersController {
       professionId,
       versionId,
       name: profession.name,
-      nations: await nations.htmlList(),
+      nations: nations.htmlList(),
       industries: industryNames,
       organisations: organisations,
       registrationRequirements: version.registrationRequirements,

--- a/src/professions/admin/check-your-answers.controller.ts
+++ b/src/professions/admin/check-your-answers.controller.ts
@@ -100,7 +100,7 @@ export class CheckYourAnswersController {
       legislations: version.legislations
         ? sortLegislationsByIndex(version.legislations)
         : [],
-      captionText: await ViewUtils.captionText(this.i18nService, profession),
+      captionText: ViewUtils.captionText(this.i18nService, profession),
       publicationBlockers: getPublicationBlockers(version),
       isUK: version.occupationLocations
         ? isUK(version.occupationLocations)

--- a/src/professions/admin/confirmation.controller.ts
+++ b/src/professions/admin/confirmation.controller.ts
@@ -50,11 +50,11 @@ export class ConfirmationController {
     }
     await this.professionVersionsService.confirm(version);
 
-    const messageTitle = await this.i18nService.translate(
+    const messageTitle = this.i18nService.translate<string>(
       `professions.admin.${action}.confirmation.heading`,
     );
 
-    const messageBody = await this.i18nService.translate(
+    const messageBody = this.i18nService.translate<string>(
       `professions.admin.${action}.confirmation.body`,
       { args: { name: escape(profession.name) } },
     );

--- a/src/professions/admin/legislation.controller.ts
+++ b/src/professions/admin/legislation.controller.ts
@@ -138,17 +138,17 @@ export class LegislationController {
     );
   }
 
-  private async renderForm(
+  private renderForm(
     res: Response,
     legislation: Legislation,
     secondLegislation: Legislation,
     profession: Profession,
     errors: object | undefined = undefined,
-  ): Promise<void> {
+  ): void {
     const templateArgs: LegislationTemplate = {
       legislation,
       secondLegislation,
-      captionText: await ViewUtils.captionText(this.i18nService, profession),
+      captionText: ViewUtils.captionText(this.i18nService, profession),
       errors,
     };
 

--- a/src/professions/admin/organisations.controller.ts
+++ b/src/professions/admin/organisations.controller.ts
@@ -171,7 +171,7 @@ export class OrganisationsController {
 
     const templateArgs: OrganisationsTemplate = {
       selectArgsArray,
-      captionText: await ViewUtils.captionText(this.i18nService, profession),
+      captionText: ViewUtils.captionText(this.i18nService, profession),
       change,
       errors,
     };

--- a/src/professions/admin/presenters/list-entry.presenter.spec.ts
+++ b/src/professions/admin/presenters/list-entry.presenter.spec.ts
@@ -17,7 +17,7 @@ jest.mock('../../presenters/profession.presenter');
 describe('ListEntryPresenter', () => {
   describe('tableRow', () => {
     describe('when the Profession is complete', () => {
-      it('returns a table row when called with `overview`', async () => {
+      it('returns a table row when called with `overview`', () => {
         const organisations = [
           organisationFactory.build({
             name: 'Example Organisation',
@@ -47,7 +47,7 @@ describe('ListEntryPresenter', () => {
         (ProfessionPresenter as jest.Mock).mockReturnValue({
           changedBy: 'Administrator',
           lastModified: '12-08-2003',
-          status: new Promise((res) => res('Published')),
+          status: 'Published',
         });
 
         const getOrganisationsFromProfessionSpy = jest.spyOn(
@@ -91,11 +91,11 @@ describe('ListEntryPresenter', () => {
           },
         ];
 
-        await expect(presenter.tableRow(`overview`)).resolves.toEqual(expected);
+        expect(presenter.tableRow(`overview`)).toEqual(expected);
         expect(getOrganisationsFromProfessionSpy).toBeCalledWith(profession);
       });
 
-      it('returns a table row when called with `single-organisation`', async () => {
+      it('returns a table row when called with `single-organisation`', () => {
         const profession = professionFactory.build(
           {
             name: 'Example Profession',
@@ -124,7 +124,7 @@ describe('ListEntryPresenter', () => {
         (ProfessionPresenter as jest.Mock).mockReturnValue({
           changedBy: { name: 'Editor' },
           lastModified: '12-08-2003',
-          status: new Promise((res) => res('Draft')),
+          status: 'Draft',
         });
 
         const presenter = new ListEntryPresenter(
@@ -154,14 +154,12 @@ describe('ListEntryPresenter', () => {
           },
         ];
 
-        await expect(
-          presenter.tableRow(`single-organisation`),
-        ).resolves.toEqual(expected);
+        expect(presenter.tableRow(`single-organisation`)).toEqual(expected);
       });
     });
 
     describe('when the Profession has just been created by a service owner user', () => {
-      it('returns a mostly empty table row', async () => {
+      it('returns a mostly empty table row', () => {
         const profession = professionFactory
           .justCreated('profession-id')
           .build({
@@ -184,7 +182,7 @@ describe('ListEntryPresenter', () => {
         (ProfessionPresenter as jest.Mock).mockReturnValue({
           changedBy: { name: 'Editor' },
           lastModified: '12-08-2003',
-          status: new Promise((res) => res('Archived')),
+          status: 'Archived',
         });
 
         const presenter = new ListEntryPresenter(
@@ -210,15 +208,13 @@ describe('ListEntryPresenter', () => {
           },
         ];
 
-        await expect(
-          presenter.tableRow(`single-organisation`),
-        ).resolves.toEqual(expected);
+        expect(presenter.tableRow(`single-organisation`)).toEqual(expected);
       });
     });
   });
 
   describe('headers', () => {
-    it('returns a table row of headings when called with `overview`', async () => {
+    it('returns a table row of headings when called with `overview`', () => {
       const expected = [
         { text: translationOf('professions.admin.tableHeading.profession') },
         { text: translationOf('professions.admin.tableHeading.organisation') },
@@ -229,12 +225,12 @@ describe('ListEntryPresenter', () => {
         { text: translationOf('professions.admin.tableHeading.actions') },
       ];
 
-      await expect(
+      expect(
         ListEntryPresenter.headings(createMockI18nService(), 'overview'),
-      ).resolves.toEqual(expected);
+      ).toEqual(expected);
     });
 
-    it('returns a table row of headings when called with `single-organisation`', async () => {
+    it('returns a table row of headings when called with `single-organisation`', () => {
       const expected = [
         { text: translationOf('professions.admin.tableHeading.profession') },
         { text: translationOf('professions.admin.tableHeading.nations') },
@@ -245,12 +241,12 @@ describe('ListEntryPresenter', () => {
         { text: translationOf('professions.admin.tableHeading.actions') },
       ];
 
-      await expect(
+      expect(
         ListEntryPresenter.headings(
           createMockI18nService(),
           'single-organisation',
         ),
-      ).resolves.toEqual(expected);
+      ).toEqual(expected);
     });
   });
 

--- a/src/professions/admin/presenters/list-entry.presenter.ts
+++ b/src/professions/admin/presenters/list-entry.presenter.ts
@@ -68,7 +68,7 @@ export class ListEntryPresenter {
       this.i18nService,
     );
 
-    const nations = await new NationsListPresenter(
+    const nations = new NationsListPresenter(
       (this.profession.occupationLocations || []).map((code) =>
         Nation.find(code),
       ),

--- a/src/professions/admin/presenters/list-entry.presenter.ts
+++ b/src/professions/admin/presenters/list-entry.presenter.ts
@@ -41,20 +41,17 @@ const fields = {
 } as { [K in ProfessionsPresenterView]: Field[] };
 
 export class ListEntryPresenter {
-  static async headings(
+  static headings(
     i18nService: I18nService,
     contents: ProfessionsPresenterView,
-  ): Promise<TableRow> {
-    return (
-      await Promise.all(
-        fields[contents].map(
-          (field) =>
-            i18nService.translate(
-              `professions.admin.tableHeading.${field}`,
-            ) as Promise<string>,
+  ): TableRow {
+    return fields[contents]
+      .map((field) =>
+        i18nService.translate<string>(
+          `professions.admin.tableHeading.${field}`,
         ),
       )
-    ).map((text) => ({ text }));
+      .map((text) => ({ text }));
   }
 
   constructor(
@@ -62,7 +59,7 @@ export class ListEntryPresenter {
     private readonly i18nService: I18nService,
   ) {}
 
-  async tableRow(contents: ProfessionsPresenterView): Promise<TableRow> {
+  tableRow(contents: ProfessionsPresenterView): TableRow {
     const presenter = new ProfessionPresenter(
       this.profession,
       this.i18nService,
@@ -75,21 +72,17 @@ export class ListEntryPresenter {
       this.i18nService,
     ).textList();
 
-    const industries = (
-      await Promise.all(
-        this.profession.industries.map(
-          (industry) =>
-            this.i18nService.translate(industry.name) as Promise<string>,
-        ),
-      )
-    ).join(', ');
+    const industries = this.profession.industries
+      .map((industry) => this.i18nService.translate<string>(industry.name))
+      .join(', ');
 
     const viewDetails = `<a class="govuk-link" href="/admin/professions/${
       this.profession.id
-    }/versions/${this.profession.versionId}">${await this.i18nService.translate(
-      'professions.admin.viewDetails',
-      { args: { name: escape(this.profession.name) } },
-    )}</a>`;
+    }/versions/${
+      this.profession.versionId
+    }">${this.i18nService.translate<string>('professions.admin.viewDetails', {
+      args: { name: escape(this.profession.name) },
+    })}</a>`;
 
     const organisations = getOrganisationsFromProfession(this.profession);
     const organisationsHtml = `<ul class="govuk-list">
@@ -112,7 +105,7 @@ export class ListEntryPresenter {
         html: organisationsHtml,
       },
       industry: { text: industries },
-      status: { html: await presenter.status },
+      status: { html: presenter.status },
       actions: { html: viewDetails },
     };
 

--- a/src/professions/admin/presenters/other-countries-recognition-routes-radio-buttons-presenter.spec.ts
+++ b/src/professions/admin/presenters/other-countries-recognition-routes-radio-buttons-presenter.spec.ts
@@ -7,7 +7,7 @@ import { OtherCountriesRecognitionRoutesRadioButtonsPresenter } from './other-co
 describe('OtherCountriesRecognitionRoutesRadioButtonsPresenter', () => {
   describe('radioButtonArgs', () => {
     describe('when the current route is empty', () => {
-      it('returns an array of `RadioButtonArgs`, with no option checked', async () => {
+      it('returns an array of `RadioButtonArgs`, with no option checked', () => {
         const i18nService = createMockI18nService();
 
         const presenter =
@@ -40,12 +40,12 @@ describe('OtherCountriesRecognitionRoutesRadioButtonsPresenter', () => {
           },
         ];
 
-        await expect(presenter.radioButtonArgs()).resolves.toEqual(expected);
+        expect(presenter.radioButtonArgs()).toEqual(expected);
       });
     });
 
     describe('when the route is non-empty', () => {
-      it('returns an array of `RadioButtonArgs`, with the route type checked', async () => {
+      it('returns an array of `RadioButtonArgs`, with the route type checked', () => {
         const i18nService = createMockI18nService();
 
         const presenter =
@@ -78,7 +78,7 @@ describe('OtherCountriesRecognitionRoutesRadioButtonsPresenter', () => {
           },
         ];
 
-        await expect(presenter.radioButtonArgs()).resolves.toEqual(expected);
+        expect(presenter.radioButtonArgs()).toEqual(expected);
       });
     });
   });

--- a/src/professions/admin/presenters/other-countries-recognition-routes-radio-buttons-presenter.ts
+++ b/src/professions/admin/presenters/other-countries-recognition-routes-radio-buttons-presenter.ts
@@ -8,15 +8,13 @@ export class OtherCountriesRecognitionRoutesRadioButtonsPresenter {
     private readonly i18nService: I18nService,
   ) {}
 
-  async radioButtonArgs(): Promise<RadioButtonArgs[]> {
-    return Promise.all(
-      Object.values(OtherCountriesRecognitionRoutes).map(async (route) => ({
-        text: await this.i18nService.translate(
-          `professions.form.label.qualifications.otherCountriesRecognition.routes.${route}`,
-        ),
-        value: route,
-        checked: this.selectedRecognitionRoute === route,
-      })),
-    );
+  radioButtonArgs(): RadioButtonArgs[] {
+    return Object.values(OtherCountriesRecognitionRoutes).map((route) => ({
+      text: this.i18nService.translate<string>(
+        `professions.form.label.qualifications.otherCountriesRecognition.routes.${route}`,
+      ),
+      value: route,
+      checked: this.selectedRecognitionRoute === route,
+    }));
   }
 }

--- a/src/professions/admin/presenters/profession-to-organisations.presenter.spec.ts
+++ b/src/professions/admin/presenters/profession-to-organisations.presenter.spec.ts
@@ -22,7 +22,7 @@ jest.mock('../../../users/helpers/get-permissions-from-user.helper');
 
 describe('ProfessionToOrganisationsPresenter', () => {
   describe('summaryLists', () => {
-    it('should return an array of summary list objects', async () => {
+    it('should return an array of summary list objects', () => {
       const organisation1 = organisationFactory.build({
         name: 'Organisation 1',
       });
@@ -59,7 +59,7 @@ describe('ProfessionToOrganisationsPresenter', () => {
           user,
         );
 
-      expect(await professionToOrganisationsPresenter.summaryLists()).toEqual([
+      expect(professionToOrganisationsPresenter.summaryLists()).toEqual([
         {
           attributes: {
             'data-cy': `profession-to-organisation-1`,
@@ -151,7 +151,7 @@ describe('ProfessionToOrganisationsPresenter', () => {
       ]);
     });
 
-    it("should not include the edit links if a user cannot edit a profession's organisation", async () => {
+    it("should not include the edit links if a user cannot edit a profession's organisation", () => {
       const organisation1 = organisationFactory.build({
         name: 'Organisation 1',
       });
@@ -188,7 +188,7 @@ describe('ProfessionToOrganisationsPresenter', () => {
           user,
         );
 
-      expect(await professionToOrganisationsPresenter.summaryLists()).toEqual([
+      expect(professionToOrganisationsPresenter.summaryLists()).toEqual([
         {
           attributes: {
             'data-cy': `profession-to-organisation-1`,
@@ -245,7 +245,7 @@ describe('ProfessionToOrganisationsPresenter', () => {
     });
 
     describe('when there are no profession to organisation relations', () => {
-      it('should return an array with one empty summary list object', async () => {
+      it('should return an array with one empty summary list object', () => {
         const profession = professionFactory.build({
           professionToOrganisations: [],
         });
@@ -261,32 +261,30 @@ describe('ProfessionToOrganisationsPresenter', () => {
             user,
           );
 
-        expect(await professionToOrganisationsPresenter.summaryLists()).toEqual(
-          [
-            {
-              rows: [
-                {
-                  key: {
-                    text: translationOf(
-                      'professions.form.label.organisations.name',
-                    ),
-                  },
-                  value: { text: '' },
+        expect(professionToOrganisationsPresenter.summaryLists()).toEqual([
+          {
+            rows: [
+              {
+                key: {
+                  text: translationOf(
+                    'professions.form.label.organisations.name',
+                  ),
                 },
-                {
-                  key: {
-                    text: translationOf(
-                      'professions.form.label.organisations.role',
-                    ),
-                  },
-                  value: {
-                    text: '',
-                  },
+                value: { text: '' },
+              },
+              {
+                key: {
+                  text: translationOf(
+                    'professions.form.label.organisations.role',
+                  ),
                 },
-              ],
-            },
-          ],
-        );
+                value: {
+                  text: '',
+                },
+              },
+            ],
+          },
+        ]);
       });
     });
   });

--- a/src/professions/admin/presenters/profession-to-organisations.presenter.ts
+++ b/src/professions/admin/presenters/profession-to-organisations.presenter.ts
@@ -21,40 +21,38 @@ export class ProfessionToOrganisationsPresenter {
     private readonly user: User,
   ) {}
 
-  public async summaryLists(): Promise<SummaryList[]> {
+  public summaryLists(): SummaryList[] {
     if (this.profession.professionToOrganisations.length) {
-      return await Promise.all(
-        this.profession.professionToOrganisations.map(
-          async (professionToOrganisation, index) =>
-            this.summaryList(professionToOrganisation, index),
-        ),
+      return this.profession.professionToOrganisations.map(
+        (professionToOrganisation, index) =>
+          this.summaryList(professionToOrganisation, index),
       );
     } else {
-      return [await this.emptySummaryList()];
+      return [this.emptySummaryList()];
     }
   }
 
-  private async summaryList(
+  private summaryList(
     professionToOrganisation: ProfessionToOrganisation,
     index: number,
-  ): Promise<SummaryList> {
+  ): SummaryList {
     return {
       attributes: {
         'data-cy': `profession-to-organisation-${index + 1}`,
       },
       rows: [
-        await this.summaryListItem(
-          await this.i18nService.translate(
+        this.summaryListItem(
+          this.i18nService.translate<string>(
             'professions.form.label.organisations.name',
           ),
           escape(professionToOrganisation.organisation.name),
           escape(professionToOrganisation.organisation.name),
         ),
-        await this.summaryListItem(
-          await this.i18nService.translate(
+        this.summaryListItem(
+          this.i18nService.translate<string>(
             'professions.form.label.organisations.role',
           ),
-          await this.i18nService.translate(
+          this.i18nService.translate<string>(
             `organisations.label.roles.${professionToOrganisation.role}`,
           ),
           escape(professionToOrganisation.organisation.name),
@@ -63,21 +61,36 @@ export class ProfessionToOrganisationsPresenter {
     };
   }
 
-  private async actionsColumn(
-    visuallyHiddenText: string,
-  ): Promise<SummaryListActionItem> {
+  private emptySummaryList(): SummaryList {
     return {
-      href: `/admin/professions/${this.profession.id}/versions/${this.professionVersion.id}/organisations/edit?change=true`,
-      text: await this.i18nService.translate('app.change'),
-      visuallyHiddenText: visuallyHiddenText,
+      rows: [
+        this.summaryListItem(
+          this.i18nService.translate<string>(
+            'professions.form.label.organisations.name',
+          ),
+          '',
+          this.i18nService.translate<string>(
+            'professions.form.label.topLevelInformation.regulatedAuthorities',
+          ),
+        ),
+        this.summaryListItem(
+          this.i18nService.translate<string>(
+            'professions.form.label.organisations.role',
+          ),
+          '',
+          this.i18nService.translate<string>(
+            'professions.form.label.topLevelInformation.regulatedAuthorities',
+          ),
+        ),
+      ],
     };
   }
 
-  private async summaryListItem(
+  private summaryListItem(
     key: string,
     value: string,
     visuallyHiddenText: string,
-  ): Promise<SummaryListItem> {
+  ): SummaryListItem {
     const item = {
       key: {
         text: key,
@@ -89,35 +102,18 @@ export class ProfessionToOrganisationsPresenter {
 
     if (this.userCanChangeOrganisations()) {
       item['actions'] = {
-        items: [await this.actionsColumn(visuallyHiddenText)],
+        items: [this.actionsColumn(visuallyHiddenText)],
       };
     }
 
     return item;
   }
 
-  private async emptySummaryList(): Promise<SummaryList> {
+  private actionsColumn(visuallyHiddenText: string): SummaryListActionItem {
     return {
-      rows: [
-        await this.summaryListItem(
-          await this.i18nService.translate(
-            'professions.form.label.organisations.name',
-          ),
-          '',
-          await this.i18nService.translate(
-            'professions.form.label.topLevelInformation.regulatedAuthorities',
-          ),
-        ),
-        await this.summaryListItem(
-          await this.i18nService.translate(
-            'professions.form.label.organisations.role',
-          ),
-          '',
-          await this.i18nService.translate(
-            'professions.form.label.topLevelInformation.regulatedAuthorities',
-          ),
-        ),
-      ],
+      href: `/admin/professions/${this.profession.id}/versions/${this.professionVersion.id}/organisations/edit?change=true`,
+      text: this.i18nService.translate<string>('app.change'),
+      visuallyHiddenText: visuallyHiddenText,
     };
   }
 

--- a/src/professions/admin/presenters/professions.presenter.spec.ts
+++ b/src/professions/admin/presenters/professions.presenter.spec.ts
@@ -108,12 +108,10 @@ describe('ProfessionsPresenter', () => {
           caption: `${translationOf('professions.search.foundPlural')}`,
           captionClasses: 'govuk-table__caption--m',
           firstCellIsHeader: true,
-          head: await ListEntryPresenter.headings(i18nService, 'overview'),
-          rows: await Promise.all(
-            [profession1, profession2, profession3].map((profession) =>
-              new ListEntryPresenter(profession, i18nService).tableRow(
-                'overview',
-              ),
+          head: ListEntryPresenter.headings(i18nService, 'overview'),
+          rows: [profession1, profession2, profession3].map((profession) =>
+            new ListEntryPresenter(profession, i18nService).tableRow(
+              'overview',
             ),
           ),
         },
@@ -160,15 +158,10 @@ describe('ProfessionsPresenter', () => {
           caption: `${translationOf('professions.search.foundPlural')}`,
           captionClasses: 'govuk-table__caption--m',
           firstCellIsHeader: true,
-          head: await ListEntryPresenter.headings(
-            i18nService,
-            'single-organisation',
-          ),
-          rows: await Promise.all(
-            [profession1, profession2, profession3].map((profession) =>
-              new ListEntryPresenter(profession, i18nService).tableRow(
-                'single-organisation',
-              ),
+          head: ListEntryPresenter.headings(i18nService, 'single-organisation'),
+          rows: [profession1, profession2, profession3].map((profession) =>
+            new ListEntryPresenter(profession, i18nService).tableRow(
+              'single-organisation',
             ),
           ),
         },

--- a/src/professions/admin/presenters/professions.presenter.spec.ts
+++ b/src/professions/admin/presenters/professions.presenter.spec.ts
@@ -134,7 +134,7 @@ describe('ProfessionsPresenter', () => {
           organisations,
           [organisation1],
         ).checkboxItems(),
-        industriesCheckboxItems: await new IndustriesCheckboxPresenter(
+        industriesCheckboxItems: new IndustriesCheckboxPresenter(
           industries,
           [transportIndustry],
           i18nService,
@@ -189,7 +189,7 @@ describe('ProfessionsPresenter', () => {
           organisations,
           [organisation1],
         ).checkboxItems(),
-        industriesCheckboxItems: await new IndustriesCheckboxPresenter(
+        industriesCheckboxItems: new IndustriesCheckboxPresenter(
           industries,
           [transportIndustry],
           i18nService,

--- a/src/professions/admin/presenters/professions.presenter.spec.ts
+++ b/src/professions/admin/presenters/professions.presenter.spec.ts
@@ -125,7 +125,7 @@ describe('ProfessionsPresenter', () => {
           regulationTypes: [RegulationType.Certification],
         },
 
-        nationsCheckboxItems: await new NationsCheckboxPresenter(
+        nationsCheckboxItems: new NationsCheckboxPresenter(
           nations,
           [Nation.find('GB-ENG')],
           i18nService,
@@ -180,7 +180,7 @@ describe('ProfessionsPresenter', () => {
           industries: ['industries.transport'],
           regulationTypes: [RegulationType.Certification],
         },
-        nationsCheckboxItems: await new NationsCheckboxPresenter(
+        nationsCheckboxItems: new NationsCheckboxPresenter(
           nations,
           [Nation.find('GB-ENG')],
           i18nService,

--- a/src/professions/admin/presenters/professions.presenter.spec.ts
+++ b/src/professions/admin/presenters/professions.presenter.spec.ts
@@ -139,11 +139,10 @@ describe('ProfessionsPresenter', () => {
           [transportIndustry],
           i18nService,
         ).checkboxItems(),
-        regulationTypesCheckboxItems:
-          await new RegulationTypesCheckboxPresenter(
-            [RegulationType.Certification],
-            i18nService,
-          ).checkboxItems(),
+        regulationTypesCheckboxItems: new RegulationTypesCheckboxPresenter(
+          [RegulationType.Certification],
+          i18nService,
+        ).checkboxItems(),
       };
 
       expect(result).toEqual(expected);
@@ -194,11 +193,10 @@ describe('ProfessionsPresenter', () => {
           [transportIndustry],
           i18nService,
         ).checkboxItems(),
-        regulationTypesCheckboxItems:
-          await new RegulationTypesCheckboxPresenter(
-            [RegulationType.Certification],
-            i18nService,
-          ).checkboxItems(),
+        regulationTypesCheckboxItems: new RegulationTypesCheckboxPresenter(
+          [RegulationType.Certification],
+          i18nService,
+        ).checkboxItems(),
       };
 
       expect(result).toEqual(expected);

--- a/src/professions/admin/presenters/professions.presenter.spec.ts
+++ b/src/professions/admin/presenters/professions.presenter.spec.ts
@@ -96,8 +96,8 @@ describe('ProfessionsPresenter', () => {
   });
 
   describe('present', () => {
-    it('returns template params when called with `overview`', async () => {
-      const result = await professionsPresenter.present('overview');
+    it('returns template params when called with `overview`', () => {
+      const result = professionsPresenter.present('overview');
 
       const nations = Nation.all();
 
@@ -146,8 +146,8 @@ describe('ProfessionsPresenter', () => {
       expect(result).toEqual(expected);
     });
 
-    it('returns template params when called with `single-organisation`', async () => {
-      const result = await professionsPresenter.present('single-organisation');
+    it('returns template params when called with `single-organisation`', () => {
+      const result = professionsPresenter.present('single-organisation');
 
       const nations = Nation.all();
 
@@ -197,7 +197,7 @@ describe('ProfessionsPresenter', () => {
 
     describe('captions', () => {
       describe('when only one profession is found', () => {
-        it('returns the singular professions found text', async () => {
+        it('returns the singular professions found text', () => {
           const i18nService = createMockI18nService();
           const industries = industryFactory.buildList(3);
           const filterInput: FilterInput = {};
@@ -221,7 +221,7 @@ describe('ProfessionsPresenter', () => {
             i18nService,
           );
 
-          const result = await presenter.present('overview');
+          const result = presenter.present('overview');
 
           expect(result.professionsTable.caption).toEqual(
             `${translationOf('professions.search.foundSingular')}`,
@@ -230,7 +230,7 @@ describe('ProfessionsPresenter', () => {
       });
 
       describe('when more than one profession is found', () => {
-        it('returns the singular professions found text', async () => {
+        it('returns the singular professions found text', () => {
           const i18nService = createMockI18nService();
           const industries = industryFactory.buildList(3);
           const filterInput: FilterInput = {};
@@ -254,7 +254,7 @@ describe('ProfessionsPresenter', () => {
             i18nService,
           );
 
-          const result = await presenter.present('overview');
+          const result = presenter.present('overview');
 
           expect(result.professionsTable.caption).toEqual(
             `${translationOf('professions.search.foundPlural')}`,

--- a/src/professions/admin/presenters/professions.presenter.ts
+++ b/src/professions/admin/presenters/professions.presenter.ts
@@ -25,12 +25,12 @@ export class ProfessionsPresenter {
     private readonly i18nService: I18nService,
   ) {}
 
-  async present(
+  present(
     view: ProfessionsPresenterView,
-  ): Promise<Omit<IndexTemplate, 'filterQuery' | 'sortMethod'>> {
+  ): Omit<IndexTemplate, 'filterQuery' | 'sortMethod'> {
     const organisation =
       view === 'overview'
-        ? await this.i18nService.translate('app.beis')
+        ? this.i18nService.translate<string>('app.beis')
         : this.userOrganisation.name;
 
     const nationsCheckboxItems = new NationsCheckboxPresenter(
@@ -58,7 +58,7 @@ export class ProfessionsPresenter {
     return {
       view,
       organisation,
-      professionsTable: await this.table(view),
+      professionsTable: this.table(view),
       nationsCheckboxItems,
       organisationsCheckboxItems,
       industriesCheckboxItems,
@@ -77,7 +77,7 @@ export class ProfessionsPresenter {
     };
   }
 
-  private async table(view: ProfessionsPresenterView): Promise<Table> {
+  private table(view: ProfessionsPresenterView): Table {
     const headings = ListEntryPresenter.headings(this.i18nService, view);
 
     const rows = this.filteredProfessions.map((profession) =>
@@ -88,10 +88,13 @@ export class ProfessionsPresenter {
 
     const caption =
       numberOfResults === 1
-        ? await this.i18nService.translate('professions.search.foundSingular', {
-            args: { count: numberOfResults },
-          })
-        : await this.i18nService.translate('professions.search.foundPlural', {
+        ? this.i18nService.translate<string>(
+            'professions.search.foundSingular',
+            {
+              args: { count: numberOfResults },
+            },
+          )
+        : this.i18nService.translate<string>('professions.search.foundPlural', {
             args: { count: numberOfResults },
           });
 

--- a/src/professions/admin/presenters/professions.presenter.ts
+++ b/src/professions/admin/presenters/professions.presenter.ts
@@ -44,7 +44,7 @@ export class ProfessionsPresenter {
       this.filterInput.organisations || [],
     ).checkboxItems();
 
-    const industriesCheckboxItems = await new IndustriesCheckboxPresenter(
+    const industriesCheckboxItems = new IndustriesCheckboxPresenter(
       this.allIndustries,
       this.filterInput.industries || [],
       this.i18nService,

--- a/src/professions/admin/presenters/professions.presenter.ts
+++ b/src/professions/admin/presenters/professions.presenter.ts
@@ -78,12 +78,10 @@ export class ProfessionsPresenter {
   }
 
   private async table(view: ProfessionsPresenterView): Promise<Table> {
-    const headings = await ListEntryPresenter.headings(this.i18nService, view);
+    const headings = ListEntryPresenter.headings(this.i18nService, view);
 
-    const rows = await Promise.all(
-      this.filteredProfessions.map(async (profession) =>
-        new ListEntryPresenter(profession, this.i18nService).tableRow(view),
-      ),
+    const rows = this.filteredProfessions.map((profession) =>
+      new ListEntryPresenter(profession, this.i18nService).tableRow(view),
     );
 
     const numberOfResults = rows.length;

--- a/src/professions/admin/presenters/professions.presenter.ts
+++ b/src/professions/admin/presenters/professions.presenter.ts
@@ -50,11 +50,10 @@ export class ProfessionsPresenter {
       this.i18nService,
     ).checkboxItems();
 
-    const regulationTypesCheckboxItems =
-      await new RegulationTypesCheckboxPresenter(
-        this.filterInput.regulationTypes || [],
-        this.i18nService,
-      ).checkboxItems();
+    const regulationTypesCheckboxItems = new RegulationTypesCheckboxPresenter(
+      this.filterInput.regulationTypes || [],
+      this.i18nService,
+    ).checkboxItems();
 
     return {
       view,

--- a/src/professions/admin/presenters/professions.presenter.ts
+++ b/src/professions/admin/presenters/professions.presenter.ts
@@ -33,7 +33,7 @@ export class ProfessionsPresenter {
         ? await this.i18nService.translate('app.beis')
         : this.userOrganisation.name;
 
-    const nationsCheckboxItems = await new NationsCheckboxPresenter(
+    const nationsCheckboxItems = new NationsCheckboxPresenter(
       this.allNations,
       this.filterInput.nations || [],
       this.i18nService,

--- a/src/professions/admin/presenters/regulation-type-radio-buttons.presenter.spec.ts
+++ b/src/professions/admin/presenters/regulation-type-radio-buttons.presenter.spec.ts
@@ -7,7 +7,7 @@ import { RegulationTypeRadioButtonsPresenter } from './regulation-type-radio-but
 describe('RegulationTypeRadioButtonsPresenter', () => {
   describe('radioButtonArgs', () => {
     describe('when the current regulation type is empty', () => {
-      it('returns an array of `RadioButtonArgs`, with no option checked', async () => {
+      it('returns an array of `RadioButtonArgs`, with no option checked', () => {
         const i18nService = createMockI18nService();
 
         const presenter = new RegulationTypeRadioButtonsPresenter(
@@ -50,12 +50,12 @@ describe('RegulationTypeRadioButtonsPresenter', () => {
           },
         ];
 
-        await expect(presenter.radioButtonArgs()).resolves.toEqual(expected);
+        expect(presenter.radioButtonArgs()).toEqual(expected);
       });
     });
 
     describe('when the current regulation type is non-empty', () => {
-      it('returns an array of `RadioButtonArgs`, with the current regulation type checked', async () => {
+      it('returns an array of `RadioButtonArgs`, with the current regulation type checked', () => {
         const i18nService = createMockI18nService();
 
         const presenter = new RegulationTypeRadioButtonsPresenter(
@@ -98,7 +98,7 @@ describe('RegulationTypeRadioButtonsPresenter', () => {
           },
         ];
 
-        await expect(presenter.radioButtonArgs()).resolves.toEqual(expected);
+        expect(presenter.radioButtonArgs()).toEqual(expected);
       });
     });
   });

--- a/src/professions/admin/presenters/regulation-type-radio-buttons.presenter.ts
+++ b/src/professions/admin/presenters/regulation-type-radio-buttons.presenter.ts
@@ -8,20 +8,18 @@ export class RegulationTypeRadioButtonsPresenter {
     private readonly i18nService: I18nService,
   ) {}
 
-  async radioButtonArgs(): Promise<RadioButtonArgs[]> {
-    return Promise.all(
-      Object.values(RegulationType).map(async (regulationType) => ({
-        text: await this.i18nService.translate(
-          `professions.regulationTypes.${regulationType}.name`,
+  radioButtonArgs(): RadioButtonArgs[] {
+    return Object.values(RegulationType).map((regulationType) => ({
+      text: this.i18nService.translate<string>(
+        `professions.regulationTypes.${regulationType}.name`,
+      ),
+      value: regulationType,
+      checked: this.selectedRegulationType === regulationType,
+      hint: {
+        text: this.i18nService.translate<string>(
+          `professions.regulationTypes.${regulationType}.hint`,
         ),
-        value: regulationType,
-        checked: this.selectedRegulationType === regulationType,
-        hint: {
-          text: await this.i18nService.translate(
-            `professions.regulationTypes.${regulationType}.hint`,
-          ),
-        },
-      })),
-    );
+      },
+    }));
   }
 }

--- a/src/professions/admin/presenters/regulation-types-checkbox.presenter.spec.ts
+++ b/src/professions/admin/presenters/regulation-types-checkbox.presenter.spec.ts
@@ -6,13 +6,13 @@ import { RegulationTypesCheckboxPresenter } from './regulation-types-checkbox.pr
 describe('RegulationTypesCheckboxPresenter', () => {
   describe('checkboxItems', () => {
     describe('when called with an empty list of regulation types', () => {
-      it('should return unchecked checkbox arguments', async () => {
+      it('should return unchecked checkbox arguments', () => {
         const presenter = new RegulationTypesCheckboxPresenter(
           [],
           createMockI18nService(),
         );
 
-        await expect(presenter.checkboxItems()).resolves.toEqual([
+        expect(presenter.checkboxItems()).toEqual([
           {
             text: translationOf(
               `professions.regulationTypes.${RegulationType.Licensing}.name`,
@@ -39,13 +39,13 @@ describe('RegulationTypesCheckboxPresenter', () => {
     });
 
     describe('when called with a non-empty list of regulation types', () => {
-      it('should return some checked checkbox arguments', async () => {
+      it('should return some checked checkbox arguments', () => {
         const presenter = new RegulationTypesCheckboxPresenter(
           [RegulationType.Accreditation, RegulationType.Certification],
           createMockI18nService(),
         );
 
-        await expect(presenter.checkboxItems()).resolves.toEqual([
+        expect(presenter.checkboxItems()).toEqual([
           {
             text: translationOf(
               `professions.regulationTypes.${RegulationType.Licensing}.name`,

--- a/src/professions/admin/presenters/regulation-types-checkbox.presenter.ts
+++ b/src/professions/admin/presenters/regulation-types-checkbox.presenter.ts
@@ -8,15 +8,13 @@ export class RegulationTypesCheckboxPresenter {
     private readonly i18nService: I18nService,
   ) {}
 
-  async checkboxItems(): Promise<CheckboxItems[]> {
-    return Promise.all(
-      Object.values(RegulationType).map(async (regulationType) => ({
-        text: await this.i18nService.translate(
-          `professions.regulationTypes.${regulationType}.name`,
-        ),
-        value: regulationType,
-        checked: this.checkedRegulationTypes.includes(regulationType),
-      })),
-    );
+  checkboxItems(): CheckboxItems[] {
+    return Object.values(RegulationType).map((regulationType) => ({
+      text: this.i18nService.translate<string>(
+        `professions.regulationTypes.${regulationType}.name`,
+      ),
+      value: regulationType,
+      checked: this.checkedRegulationTypes.includes(regulationType),
+    }));
   }
 }

--- a/src/professions/admin/profession-archive.controller.ts
+++ b/src/professions/admin/profession-archive.controller.ts
@@ -70,11 +70,11 @@ export class ProfessionArchiveController {
 
     await this.professionVersionsService.archive(versionToBeArchived);
 
-    const messageTitle = await this.i18nService.translate(
+    const messageTitle = this.i18nService.translate<string>(
       'professions.admin.archive.confirmation.heading',
     );
 
-    const messageBody = await this.i18nService.translate(
+    const messageBody = this.i18nService.translate<string>(
       'professions.admin.archive.confirmation.body',
       { args: { name: escape(version.profession.name) } },
     );

--- a/src/professions/admin/profession-publication.controller.ts
+++ b/src/professions/admin/profession-publication.controller.ts
@@ -91,11 +91,11 @@ export class ProfessionPublicationController {
 
     await this.professionVersionsService.publish(newVersion);
 
-    const messageTitle = await this.i18nService.translate(
+    const messageTitle = this.i18nService.translate<string>(
       'professions.admin.publish.confirmation.heading',
     );
 
-    const messageBody = await this.i18nService.translate(
+    const messageBody = this.i18nService.translate<string>(
       confirmed
         ? 'professions.admin.publish.confirmation.body'
         : 'professions.admin.publish.confirmation.bodyNew',

--- a/src/professions/admin/profession-versions.controller.spec.ts
+++ b/src/professions/admin/profession-versions.controller.spec.ts
@@ -196,7 +196,7 @@ describe('ProfessionVersionsController', () => {
           profession: professionWithVersion,
           presenter: {},
           hasLiveVersion: true,
-          qualifications: await new QualificationPresenter(
+          qualifications: new QualificationPresenter(
             professionWithVersion.qualification,
             createMockI18nService(),
             expectedAwardingBodies,
@@ -285,7 +285,7 @@ describe('ProfessionVersionsController', () => {
           profession: professionWithVersion,
           presenter: {},
           hasLiveVersion: true,
-          qualifications: await new QualificationPresenter(
+          qualifications: new QualificationPresenter(
             professionWithVersion.qualification,
             createMockI18nService(),
             [],
@@ -369,7 +369,7 @@ describe('ProfessionVersionsController', () => {
           profession: professionWithVersion,
           presenter: {},
           hasLiveVersion: true,
-          qualifications: await new QualificationPresenter(
+          qualifications: new QualificationPresenter(
             undefined,
             createMockI18nService(),
             [],

--- a/src/professions/admin/profession-versions.controller.spec.ts
+++ b/src/professions/admin/profession-versions.controller.spec.ts
@@ -182,9 +182,9 @@ describe('ProfessionVersionsController', () => {
               : expectedEnforcementBodies,
           );
 
-        (
-          NationsListPresenter.prototype.htmlList as jest.Mock
-        ).mockResolvedValue(mockNationsHtml);
+        (NationsListPresenter.prototype.htmlList as jest.Mock).mockReturnValue(
+          mockNationsHtml,
+        );
 
         const getPublicationBlockersSpy = jest
           .spyOn(getPublicationBlockersModule, 'getPublicationBlockers')
@@ -266,9 +266,9 @@ describe('ProfessionVersionsController', () => {
           )
           .mockReturnValue(expectedOrganisations);
 
-        (
-          NationsListPresenter.prototype.htmlList as jest.Mock
-        ).mockResolvedValue(mockNationsHtml);
+        (NationsListPresenter.prototype.htmlList as jest.Mock).mockReturnValue(
+          mockNationsHtml,
+        );
 
         const getPublicationBlockersSpy = jest
           .spyOn(getPublicationBlockersModule, 'getPublicationBlockers')
@@ -346,9 +346,9 @@ describe('ProfessionVersionsController', () => {
           )
           .mockReturnValue(expectedOrganisations);
 
-        (
-          NationsListPresenter.prototype.htmlList as jest.Mock
-        ).mockResolvedValue(mockNationsHtml);
+        (NationsListPresenter.prototype.htmlList as jest.Mock).mockReturnValue(
+          mockNationsHtml,
+        );
 
         const getPublicationBlockersSpy = jest
           .spyOn(getPublicationBlockersModule, 'getPublicationBlockers')

--- a/src/professions/admin/profession-versions.controller.ts
+++ b/src/professions/admin/profession-versions.controller.ts
@@ -112,7 +112,7 @@ export class ProfessionVersionsController {
           ? !isUK(profession.occupationLocations)
           : true,
       ),
-      nations: await nations.htmlList(),
+      nations: nations.htmlList(),
       industries,
       enforcementBodies: organisationList(enforcementBodies),
       organisations: tierOneOrganisations,

--- a/src/professions/admin/profession-versions.controller.ts
+++ b/src/professions/admin/profession-versions.controller.ts
@@ -106,7 +106,7 @@ export class ProfessionVersionsController {
       profession,
       presenter,
       hasLiveVersion,
-      qualifications: await qualification.summaryList(
+      qualifications: qualification.summaryList(
         true,
         profession.occupationLocations
           ? !isUK(profession.occupationLocations)

--- a/src/professions/admin/professions.controller.spec.ts
+++ b/src/professions/admin/professions.controller.spec.ts
@@ -222,7 +222,7 @@ describe('ProfessionsController', () => {
         const result = await controller.index(request);
 
         const expected: IndexTemplate = {
-          ...(await createPresenter(
+          ...createPresenter(
             {
               keywords: '',
               nations: [],
@@ -232,7 +232,7 @@ describe('ProfessionsController', () => {
             },
             null,
             [profession1, profession2, profession3],
-          ).present('overview')),
+          ).present('overview'),
           sortMethod: 'name',
           filterQuery: 'mock-query-string-with-removal',
         };
@@ -265,7 +265,7 @@ describe('ProfessionsController', () => {
         });
 
         const expected: IndexTemplate = {
-          ...(await createPresenter(
+          ...createPresenter(
             {
               keywords: '',
               nations: [],
@@ -275,7 +275,7 @@ describe('ProfessionsController', () => {
             },
             null,
             [profession1, profession2, profession3],
-          ).present('overview')),
+          ).present('overview'),
           sortMethod: 'last-updated',
           filterQuery: 'mock-query-string-with-removal',
         };
@@ -308,7 +308,7 @@ describe('ProfessionsController', () => {
         });
 
         const expected: IndexTemplate = {
-          ...(await createPresenter(
+          ...createPresenter(
             {
               keywords: '',
               nations: [],
@@ -318,7 +318,7 @@ describe('ProfessionsController', () => {
             },
             null,
             [profession1, profession2, profession3],
-          ).present('overview')),
+          ).present('overview'),
           sortMethod: 'status',
           filterQuery: 'mock-query-string-with-removal',
         };
@@ -350,7 +350,7 @@ describe('ProfessionsController', () => {
         });
 
         const expected: IndexTemplate = {
-          ...(await createPresenter(
+          ...createPresenter(
             {
               keywords: 'MARK',
               nations: [],
@@ -360,7 +360,7 @@ describe('ProfessionsController', () => {
             },
             null,
             [profession3],
-          ).present('overview')),
+          ).present('overview'),
           sortMethod: 'name',
           filterQuery: 'mock-query-string-with-removal',
         };
@@ -392,7 +392,7 @@ describe('ProfessionsController', () => {
         });
 
         const expected: IndexTemplate = {
-          ...(await createPresenter(
+          ...createPresenter(
             {
               keywords: '',
               nations: [Nation.find('GB-ENG')],
@@ -402,7 +402,7 @@ describe('ProfessionsController', () => {
             },
             null,
             [profession1],
-          ).present('overview')),
+          ).present('overview'),
           sortMethod: 'name',
           filterQuery: 'mock-query-string-with-removal',
         };
@@ -434,7 +434,7 @@ describe('ProfessionsController', () => {
         });
 
         const expected: IndexTemplate = {
-          ...(await createPresenter(
+          ...createPresenter(
             {
               keywords: '',
               nations: [],
@@ -444,7 +444,7 @@ describe('ProfessionsController', () => {
             },
             null,
             [profession3],
-          ).present('overview')),
+          ).present('overview'),
           sortMethod: 'name',
           filterQuery: 'mock-query-string-with-removal',
         };
@@ -476,7 +476,7 @@ describe('ProfessionsController', () => {
         });
 
         const expected: IndexTemplate = {
-          ...(await createPresenter(
+          ...createPresenter(
             {
               keywords: '',
               nations: [],
@@ -486,7 +486,7 @@ describe('ProfessionsController', () => {
             },
             null,
             [profession3],
-          ).present('overview')),
+          ).present('overview'),
           sortMethod: 'name',
           filterQuery: 'mock-query-string-with-removal',
         };
@@ -518,7 +518,7 @@ describe('ProfessionsController', () => {
         });
 
         const expected: IndexTemplate = {
-          ...(await createPresenter(
+          ...createPresenter(
             {
               keywords: '',
               nations: [],
@@ -528,7 +528,7 @@ describe('ProfessionsController', () => {
             },
             null,
             [profession1],
-          ).present('overview')),
+          ).present('overview'),
           sortMethod: 'name',
           filterQuery: 'mock-query-string-with-removal',
         };
@@ -565,7 +565,7 @@ describe('ProfessionsController', () => {
         const result = await controller.index(request);
 
         const expected: IndexTemplate = {
-          ...(await createPresenter(
+          ...createPresenter(
             {
               keywords: '',
               nations: [],
@@ -573,7 +573,7 @@ describe('ProfessionsController', () => {
             },
             organisation1,
             [profession1, profession2],
-          ).present('single-organisation')),
+          ).present('single-organisation'),
           sortMethod: null,
           filterQuery: 'mock-query-string-with-removal',
         };
@@ -602,7 +602,7 @@ describe('ProfessionsController', () => {
         });
 
         const expected: IndexTemplate = {
-          ...(await createPresenter(
+          ...createPresenter(
             {
               keywords: 'primary',
               nations: [],
@@ -610,7 +610,7 @@ describe('ProfessionsController', () => {
             },
             organisation1,
             [profession1],
-          ).present('single-organisation')),
+          ).present('single-organisation'),
           sortMethod: null,
           filterQuery: 'mock-query-string-with-removal',
         };
@@ -639,7 +639,7 @@ describe('ProfessionsController', () => {
         });
 
         const expected: IndexTemplate = {
-          ...(await createPresenter(
+          ...createPresenter(
             {
               keywords: '',
               nations: [Nation.find('GB-NIR')],
@@ -647,7 +647,7 @@ describe('ProfessionsController', () => {
             },
             organisation1,
             [profession2],
-          ).present('single-organisation')),
+          ).present('single-organisation'),
           sortMethod: null,
           filterQuery: 'mock-query-string-with-removal',
         };

--- a/src/professions/admin/professions.controller.ts
+++ b/src/professions/admin/professions.controller.ts
@@ -117,7 +117,7 @@ export class ProfessionsController {
     ).filter(filterInput);
 
     return {
-      ...(await new ProfessionsPresenter(
+      ...new ProfessionsPresenter(
         filterInput,
         userOrganisation,
         allNations,
@@ -125,7 +125,7 @@ export class ProfessionsController {
         allIndustries,
         filteredProfessions,
         this.i18nService,
-      ).present(view)),
+      ).present(view),
       sortMethod: view === 'overview' ? filterDto.sortBy || 'name' : null,
       filterQuery: removeFromQueryString(getQueryString(request), 'sortBy'),
     };

--- a/src/professions/admin/qualifications.controller.ts
+++ b/src/professions/admin/qualifications.controller.ts
@@ -127,17 +127,17 @@ export class QualificationsController {
     );
   }
 
-  private async renderForm(
+  private renderForm(
     res: Response,
     qualification: Qualification | null,
     version: ProfessionVersion | null,
     profession: Profession,
     errors: object | undefined = undefined,
-  ) {
+  ): void {
     const templateArgs: QualificationsTemplate = {
       routesToObtain: qualification?.routesToObtain,
       moreInformationUrl: qualification?.url,
-      captionText: await ViewUtils.captionText(this.i18nService, profession),
+      captionText: ViewUtils.captionText(this.i18nService, profession),
       ukRecognition: qualification?.ukRecognition,
       ukRecognitionUrl: qualification?.ukRecognitionUrl,
       otherCountriesRecognitionRoutesRadioButtonArgs:

--- a/src/professions/admin/qualifications.controller.ts
+++ b/src/professions/admin/qualifications.controller.ts
@@ -141,7 +141,7 @@ export class QualificationsController {
       ukRecognition: qualification?.ukRecognition,
       ukRecognitionUrl: qualification?.ukRecognitionUrl,
       otherCountriesRecognitionRoutesRadioButtonArgs:
-        await new OtherCountriesRecognitionRoutesRadioButtonsPresenter(
+        new OtherCountriesRecognitionRoutesRadioButtonsPresenter(
           qualification?.otherCountriesRecognitionRoutes,
           this.i18nService,
         ).radioButtonArgs(),

--- a/src/professions/admin/registration.controller.ts
+++ b/src/professions/admin/registration.controller.ts
@@ -116,15 +116,15 @@ export class RegistrationController {
     );
   }
 
-  private async renderForm(
+  private renderForm(
     res: Response,
     submittedValues: ProfessionVersion | RegistrationDto,
     profession: Profession,
     errors: object | undefined = undefined,
-  ): Promise<void> {
+  ): void {
     const templateArgs: RegistrationTemplate = {
       ...submittedValues,
-      captionText: await ViewUtils.captionText(this.i18nService, profession),
+      captionText: ViewUtils.captionText(this.i18nService, profession),
       errors,
     };
 

--- a/src/professions/admin/regulated-activities.controller.spec.ts
+++ b/src/professions/admin/regulated-activities.controller.spec.ts
@@ -86,7 +86,7 @@ describe(RegulatedActivitiesController, () => {
 
       const regulationTypeRadioButtonArgsSpy = jest
         .spyOn(RegulationTypeRadioButtonsPresenter.prototype, 'radioButtonArgs')
-        .mockResolvedValue(mockRegulationTypeRadioButtonArgs);
+        .mockReturnValue(mockRegulationTypeRadioButtonArgs);
 
       const request = createDefaultMockRequest({
         user: userFactory.build(),

--- a/src/professions/admin/regulated-activities.controller.ts
+++ b/src/professions/admin/regulated-activities.controller.ts
@@ -133,7 +133,7 @@ export class RegulatedActivitiesController {
     );
   }
 
-  private async renderForm(
+  private renderForm(
     res: Response,
     regulationSummary: string | null,
     regulationType: RegulationType | null,
@@ -142,7 +142,7 @@ export class RegulatedActivitiesController {
     regulationUrl: string | null,
     profession: Profession,
     errors: object | undefined = undefined,
-  ): Promise<void> {
+  ): void {
     const regulationTypePresenter = new RegulationTypeRadioButtonsPresenter(
       regulationType,
       this.i18nService,
@@ -157,7 +157,7 @@ export class RegulatedActivitiesController {
       reservedActivities,
       protectedTitles,
       regulationUrl,
-      captionText: await ViewUtils.captionText(this.i18nService, profession),
+      captionText: ViewUtils.captionText(this.i18nService, profession),
       errors,
     };
 

--- a/src/professions/admin/regulated-activities.controller.ts
+++ b/src/professions/admin/regulated-activities.controller.ts
@@ -149,7 +149,7 @@ export class RegulatedActivitiesController {
     );
 
     const regulationTypeRadioButtonArgs =
-      await regulationTypePresenter.radioButtonArgs();
+      regulationTypePresenter.radioButtonArgs();
 
     const templateArgs: RegulatedActivitiesTemplate = {
       regulationSummary,

--- a/src/professions/admin/scope.controller.ts
+++ b/src/professions/admin/scope.controller.ts
@@ -173,7 +173,7 @@ export class ScopeController {
       coversUK,
       industriesCheckboxItems,
       nationsCheckboxArgs,
-      captionText: await ViewUtils.captionText(this.i18nService, profession),
+      captionText: ViewUtils.captionText(this.i18nService, profession),
       errors,
     };
 

--- a/src/professions/admin/scope.controller.ts
+++ b/src/professions/admin/scope.controller.ts
@@ -163,7 +163,7 @@ export class ScopeController {
       this.i18nService,
     );
 
-    const nationsCheckboxArgs = await nationsCheckboxPresenter.checkboxArgs(
+    const nationsCheckboxArgs = nationsCheckboxPresenter.checkboxArgs(
       'nations',
       'nations[]',
       'professions.form.hint.scope.certainNations',

--- a/src/professions/admin/scope.controller.ts
+++ b/src/professions/admin/scope.controller.ts
@@ -151,7 +151,7 @@ export class ScopeController {
   ): Promise<void> {
     const industries = await this.industriesService.all();
 
-    const industriesCheckboxItems = await new IndustriesCheckboxPresenter(
+    const industriesCheckboxItems = new IndustriesCheckboxPresenter(
       industries,
       selectedIndustries,
       this.i18nService,

--- a/src/professions/admin/top-level-information.controller.ts
+++ b/src/professions/admin/top-level-information.controller.ts
@@ -118,16 +118,16 @@ export class TopLevelInformationController {
     );
   }
 
-  private async renderForm(
+  private renderForm(
     res: Response,
     name: string,
     profession: Profession,
     change: boolean,
     errors: object | undefined = undefined,
-  ): Promise<void> {
+  ): void {
     const templateArgs: TopLevelDetailsTemplate = {
       name,
-      captionText: await ViewUtils.captionText(this.i18nService, profession),
+      captionText: ViewUtils.captionText(this.i18nService, profession),
       change,
       errors,
     };

--- a/src/professions/admin/viewUtils.spec.ts
+++ b/src/professions/admin/viewUtils.spec.ts
@@ -10,42 +10,42 @@ describe(ViewUtils, () => {
   const mockI18nService = createMockI18nService();
   describe('captionText', () => {
     describe('when passed a profession that has been confirmed', () => {
-      it("returns the 'edit' text, including the Profession's name", async () => {
+      it("returns the 'edit' text, including the Profession's name", () => {
         const profession = professionFactory.build();
 
         (isConfirmed as jest.Mock).mockReturnValue(true);
 
-        expect(
-          await ViewUtils.captionText(mockI18nService, profession),
-        ).toEqual(translationOf('professions.form.captions.edit'));
+        expect(ViewUtils.captionText(mockI18nService, profession)).toEqual(
+          translationOf('professions.form.captions.edit'),
+        );
       });
     });
 
     describe('when passed a profession that has not yet been confirmed', () => {
       describe('when the profession has a name set', () => {
-        it("returns the 'add' text with the Profession's name", async () => {
+        it("returns the 'add' text with the Profession's name", () => {
           const profession = professionFactory.build({
             name: 'Example profession',
           });
 
           (isConfirmed as jest.Mock).mockReturnValue(false);
 
-          expect(
-            await ViewUtils.captionText(mockI18nService, profession),
-          ).toEqual(translationOf('professions.form.captions.addWithName'));
+          expect(ViewUtils.captionText(mockI18nService, profession)).toEqual(
+            translationOf('professions.form.captions.addWithName'),
+          );
         });
 
         describe('when the profession has no name set', () => {
-          it("returns the 'add' text", async () => {
+          it("returns the 'add' text", () => {
             const profession = professionFactory.build({
               name: null,
             });
 
             (isConfirmed as jest.Mock).mockReturnValue(false);
 
-            expect(
-              await ViewUtils.captionText(mockI18nService, profession),
-            ).toEqual(translationOf('professions.form.captions.add'));
+            expect(ViewUtils.captionText(mockI18nService, profession)).toEqual(
+              translationOf('professions.form.captions.add'),
+            );
           });
         });
       });

--- a/src/professions/admin/viewUtils.ts
+++ b/src/professions/admin/viewUtils.ts
@@ -3,22 +3,22 @@ import { isConfirmed } from '../../helpers/is-confirmed';
 import { Profession } from '../profession.entity';
 
 export default class ViewUtils {
-  static async captionText(
-    i18nService: I18nService,
-    profession: Profession,
-  ): Promise<string> {
+  static captionText(i18nService: I18nService, profession: Profession): string {
     if (isConfirmed(profession)) {
-      return i18nService.translate('professions.form.captions.edit', {
+      return i18nService.translate<string>('professions.form.captions.edit', {
         args: { professionName: profession.name },
       });
     }
 
     if (profession.name) {
-      return i18nService.translate('professions.form.captions.addWithName', {
-        args: { professionName: profession.name },
-      });
+      return i18nService.translate<string>(
+        'professions.form.captions.addWithName',
+        {
+          args: { professionName: profession.name },
+        },
+      );
     }
 
-    return i18nService.translate('professions.form.captions.add');
+    return i18nService.translate<string>('professions.form.captions.add');
   }
 }

--- a/src/professions/admin/yes-no-radio-buttons-presenter.spec.ts
+++ b/src/professions/admin/yes-no-radio-buttons-presenter.spec.ts
@@ -14,10 +14,10 @@ describe(YesNoRadioButtonArgsPresenter, () => {
   });
 
   describe('radioButtonArgs', () => {
-    it('should return translated values with unchecked radio buttons when called with a null Yes or No value', async () => {
+    it('should return translated values with unchecked radio buttons when called with a null Yes or No value', () => {
       const presenter = new YesNoRadioButtonArgsPresenter(null, i18nService);
 
-      await expect(presenter.radioButtonArgs()).resolves.toEqual([
+      expect(presenter.radioButtonArgs()).toEqual([
         {
           text: 'Yes',
           value: '1',
@@ -31,7 +31,7 @@ describe(YesNoRadioButtonArgsPresenter, () => {
       ]);
     });
 
-    it('should pre-check the relevant radio button for the relevant boolean value', async () => {
+    it('should pre-check the relevant radio button for the relevant boolean value', () => {
       const truePresenter = new YesNoRadioButtonArgsPresenter(
         true,
         i18nService,
@@ -42,7 +42,7 @@ describe(YesNoRadioButtonArgsPresenter, () => {
         i18nService,
       );
 
-      await expect(truePresenter.radioButtonArgs()).resolves.toEqual([
+      expect(truePresenter.radioButtonArgs()).toEqual([
         {
           text: 'Yes',
           value: '1',
@@ -55,7 +55,7 @@ describe(YesNoRadioButtonArgsPresenter, () => {
         },
       ]);
 
-      await expect(falsePresenter.radioButtonArgs()).resolves.toEqual([
+      expect(falsePresenter.radioButtonArgs()).toEqual([
         {
           text: 'Yes',
           value: '1',

--- a/src/professions/admin/yes-no-radio-buttons-presenter.ts
+++ b/src/professions/admin/yes-no-radio-buttons-presenter.ts
@@ -7,16 +7,16 @@ export class YesNoRadioButtonArgsPresenter {
     private readonly i18nService: I18nService,
   ) {}
 
-  async radioButtonArgs(): Promise<RadioButtonArgs[]> {
+  radioButtonArgs(): RadioButtonArgs[] {
     return [
       {
         value: '1',
-        text: await this.i18nService.translate('app.yes'),
+        text: this.i18nService.translate<string>('app.yes'),
         checked: this.yesOrNoValue === true,
       },
       {
         value: '0',
-        text: await this.i18nService.translate('app.no'),
+        text: this.i18nService.translate<string>('app.no'),
         checked: this.yesOrNoValue === false,
       },
     ];

--- a/src/professions/presenters/profession.presenter.spec.ts
+++ b/src/professions/presenters/profession.presenter.spec.ts
@@ -37,7 +37,7 @@ describe('ProfessionPresenter', () => {
               text: translationOf('professions.show.overview.nations'),
             },
             value: {
-              text: await presenter.occupationLocations(),
+              text: presenter.occupationLocations(),
             },
           },
           {
@@ -135,7 +135,7 @@ describe('ProfessionPresenter', () => {
 
   describe('occupationLocations', () => {
     describe('when occupationLocations is defined', () => {
-      it('should pass the locations to NationsListPresenter', async () => {
+      it('should pass the locations to NationsListPresenter', () => {
         const i18nService = createMockI18nService();
 
         profession = professionFactory.build({
@@ -147,14 +147,14 @@ describe('ProfessionPresenter', () => {
           Nation.find(code),
         );
 
-        await presenter.occupationLocations();
+        presenter.occupationLocations();
 
         expect(NationsListPresenter).toHaveBeenCalledWith(nations, i18nService);
       });
     });
 
     describe('when occupationLocations is undefined', () => {
-      it('should pass an empty array to NationsListPresenter', async () => {
+      it('should pass an empty array to NationsListPresenter', () => {
         const i18nService = createMockI18nService();
 
         profession = professionFactory.build({
@@ -163,7 +163,7 @@ describe('ProfessionPresenter', () => {
 
         const presenter = new ProfessionPresenter(profession, i18nService);
 
-        await presenter.occupationLocations();
+        presenter.occupationLocations();
 
         expect(NationsListPresenter).toHaveBeenCalledWith([], i18nService);
       });

--- a/src/professions/presenters/profession.presenter.spec.ts
+++ b/src/professions/presenters/profession.presenter.spec.ts
@@ -22,14 +22,14 @@ describe('ProfessionPresenter', () => {
   let profession: Profession;
 
   describe('summaryList', () => {
-    it('should return a summary list', async () => {
+    it('should return a summary list', () => {
       const i18nService = createMockI18nService();
 
       profession = professionFactory.build();
 
       const presenter = new ProfessionPresenter(profession, i18nService);
 
-      expect(await presenter.summaryList()).toEqual({
+      expect(presenter.summaryList()).toEqual({
         classes: 'govuk-summary-list--no-border',
         rows: [
           {
@@ -45,7 +45,7 @@ describe('ProfessionPresenter', () => {
               text: translationOf('professions.show.overview.industry'),
             },
             value: {
-              text: await presenter.industries(),
+              text: presenter.industries(),
             },
           },
         ],
@@ -171,7 +171,7 @@ describe('ProfessionPresenter', () => {
   });
 
   describe('industries', () => {
-    it('should return a comma-separated list of industry names', async () => {
+    it('should return a comma-separated list of industry names', () => {
       const i18nService = createMockI18nService();
 
       profession = professionFactory.build({
@@ -183,7 +183,7 @@ describe('ProfessionPresenter', () => {
 
       const presenter = new ProfessionPresenter(profession, i18nService);
 
-      expect(await presenter.industries()).toEqual(
+      expect(presenter.industries()).toEqual(
         `${translationOf('foo')}, ${translationOf('bar')}`,
       );
     });

--- a/src/professions/presenters/profession.presenter.ts
+++ b/src/professions/presenters/profession.presenter.ts
@@ -23,7 +23,7 @@ export class ProfessionPresenter {
             ),
           },
           value: {
-            text: await this.occupationLocations(),
+            text: this.occupationLocations(),
           },
         },
         {
@@ -59,8 +59,8 @@ export class ProfessionPresenter {
     return formatStatus(this.profession.status, this.i18nService);
   }
 
-  public async occupationLocations(): Promise<string> {
-    return await new NationsListPresenter(
+  public occupationLocations(): string {
+    return new NationsListPresenter(
       (this.profession.occupationLocations || []).map((code) =>
         Nation.find(code),
       ),

--- a/src/professions/presenters/profession.presenter.ts
+++ b/src/professions/presenters/profession.presenter.ts
@@ -12,13 +12,13 @@ export class ProfessionPresenter {
     private readonly i18nService: I18nService,
   ) {}
 
-  public async summaryList(): Promise<SummaryList> {
+  public summaryList(): SummaryList {
     return {
       classes: 'govuk-summary-list--no-border',
       rows: [
         {
           key: {
-            text: await this.i18nService.translate(
+            text: this.i18nService.translate<string>(
               'professions.show.overview.nations',
             ),
           },
@@ -28,12 +28,12 @@ export class ProfessionPresenter {
         },
         {
           key: {
-            text: await this.i18nService.translate(
+            text: this.i18nService.translate<string>(
               'professions.show.overview.industry',
             ),
           },
           value: {
-            text: await this.industries(),
+            text: this.industries(),
           },
         },
       ],
@@ -68,11 +68,9 @@ export class ProfessionPresenter {
     ).textList();
   }
 
-  public async industries(): Promise<string> {
-    const industries = await Promise.all(
-      this.profession.industries.map(
-        async (industry) => await this.i18nService.translate(industry.name),
-      ),
+  public industries(): string {
+    const industries = this.profession.industries.map((industry) =>
+      this.i18nService.translate<string>(industry.name),
     );
 
     return industries.join(', ');

--- a/src/professions/professions.controller.spec.ts
+++ b/src/professions/professions.controller.spec.ts
@@ -134,7 +134,7 @@ describe('ProfessionsController', () => {
 
       expect(result).toEqual({
         profession: profession,
-        qualifications: await new QualificationPresenter(
+        qualifications: new QualificationPresenter(
           profession.qualification,
           createMockI18nService(),
           expectedAwardingBodies,

--- a/src/professions/professions.controller.spec.ts
+++ b/src/professions/professions.controller.spec.ts
@@ -122,7 +122,7 @@ describe('ProfessionsController', () => {
         (organisation) => organisation,
       );
 
-      (NationsListPresenter.prototype.htmlList as jest.Mock).mockResolvedValue(
+      (NationsListPresenter.prototype.htmlList as jest.Mock).mockReturnValue(
         mockNationsHtml,
       );
 
@@ -249,7 +249,7 @@ describe('ProfessionsController', () => {
 
           (
             NationsListPresenter.prototype.htmlList as jest.Mock
-          ).mockResolvedValue(mockNationsHtml);
+          ).mockReturnValue(mockNationsHtml);
 
           const result = await controller.show('example-slug');
 

--- a/src/professions/professions.controller.ts
+++ b/src/professions/professions.controller.ts
@@ -101,7 +101,7 @@ export class ProfessionsController {
               : true,
           )
         : null,
-      nations: await nations.htmlList(),
+      nations: nations.htmlList(),
       industries,
       enforcementBodies: organisationList(enforcementBodies),
       organisations: tierOneOrganisations,

--- a/src/professions/professions.controller.ts
+++ b/src/professions/professions.controller.ts
@@ -94,7 +94,7 @@ export class ProfessionsController {
     return {
       profession,
       qualifications: qualification
-        ? await qualification.summaryList(
+        ? qualification.summaryList(
             false,
             profession.occupationLocations
               ? !isUK(profession.occupationLocations)

--- a/src/professions/search/profession-search-result.presenter.spec.ts
+++ b/src/professions/search/profession-search-result.presenter.spec.ts
@@ -16,7 +16,7 @@ describe('ProfessionSearchResultPresenter', () => {
   });
 
   describe('present', () => {
-    it('Returns a ProfessionSearchResultTemplate', async () => {
+    it('Returns a ProfessionSearchResultTemplate', () => {
       const organisations = [
         organisationFactory.build({
           name: 'Example Organisation',
@@ -44,7 +44,7 @@ describe('ProfessionSearchResultPresenter', () => {
         'getOrganisationsFromProfession',
       );
 
-      const result = await new ProfessionSearchResultPresenter(
+      const result = new ProfessionSearchResultPresenter(
         exampleProfession,
         i18nService,
       ).present();
@@ -68,7 +68,7 @@ describe('ProfessionSearchResultPresenter', () => {
     });
 
     describe('when the Profession is missing some fields', () => {
-      it('returns empty values', async () => {
+      it('returns empty values', () => {
         const exampleProfession = professionFactory.build({
           occupationLocations: undefined,
           industries: undefined,
@@ -79,7 +79,7 @@ describe('ProfessionSearchResultPresenter', () => {
           'getOrganisationsFromProfession',
         );
 
-        const result = await new ProfessionSearchResultPresenter(
+        const result = new ProfessionSearchResultPresenter(
           exampleProfession,
           i18nService,
         ).present();

--- a/src/professions/search/profession-search-result.presenter.ts
+++ b/src/professions/search/profession-search-result.presenter.ts
@@ -11,8 +11,8 @@ export class ProfessionSearchResultPresenter {
     private readonly i18nService: I18nService,
   ) {}
 
-  async present(): Promise<ProfessionSearchResultTemplate> {
-    const nations = await new NationsListPresenter(
+  present(): ProfessionSearchResultTemplate {
+    const nations = new NationsListPresenter(
       (this.profession.occupationLocations || []).map((code) =>
         Nation.find(code),
       ),

--- a/src/professions/search/search.controller.spec.ts
+++ b/src/professions/search/search.controller.spec.ts
@@ -77,7 +77,7 @@ describe('SearchController', () => {
           request,
         );
 
-        const expected = await new SearchPresenter(
+        const expected = new SearchPresenter(
           {
             keywords: '',
             nations: [],
@@ -139,7 +139,7 @@ describe('SearchController', () => {
         request,
       );
 
-      const expected = await new SearchPresenter(
+      const expected = new SearchPresenter(
         {
           keywords: 'example search',
           nations: [Nation.find('GB-SCT')],

--- a/src/professions/search/search.presenter.spec.ts
+++ b/src/professions/search/search.presenter.spec.ts
@@ -92,11 +92,10 @@ describe('SearchPresenter', () => {
         i18nService,
       ).checkboxItems();
 
-      const regulationTypesCheckboxItems =
-        await new RegulationTypesCheckboxPresenter(
-          [RegulationType.Certification, RegulationType.Licensing],
-          i18nService,
-        ).checkboxItems();
+      const regulationTypesCheckboxItems = new RegulationTypesCheckboxPresenter(
+        [RegulationType.Certification, RegulationType.Licensing],
+        i18nService,
+      ).checkboxItems();
 
       const expected: IndexTemplate = {
         filters: {

--- a/src/professions/search/search.presenter.spec.ts
+++ b/src/professions/search/search.presenter.spec.ts
@@ -80,7 +80,7 @@ describe('SearchPresenter', () => {
       (hasSelectedFilters as jest.Mock).mockReturnValue(true);
       const result = await presenter.present();
 
-      const nationsCheckboxItems = await new NationsCheckboxPresenter(
+      const nationsCheckboxItems = new NationsCheckboxPresenter(
         Nation.all(),
         [Nation.find('GB-ENG')],
         i18nService,

--- a/src/professions/search/search.presenter.spec.ts
+++ b/src/professions/search/search.presenter.spec.ts
@@ -86,7 +86,7 @@ describe('SearchPresenter', () => {
         i18nService,
       ).checkboxItems();
 
-      const industriesCheckboxItems = await new IndustriesCheckboxPresenter(
+      const industriesCheckboxItems = new IndustriesCheckboxPresenter(
         industries,
         [industry2],
         i18nService,

--- a/src/professions/search/search.presenter.spec.ts
+++ b/src/professions/search/search.presenter.spec.ts
@@ -58,7 +58,7 @@ describe('SearchPresenter', () => {
   });
 
   describe('present', () => {
-    it('should return a IndexTemplate', async () => {
+    it('should return a IndexTemplate', () => {
       const filterInput: FilterInput = {
         keywords: 'Example Keywords',
         nations: [nations[0]],
@@ -78,7 +78,7 @@ describe('SearchPresenter', () => {
       );
 
       (hasSelectedFilters as jest.Mock).mockReturnValue(true);
-      const result = await presenter.present();
+      const result = presenter.present();
 
       const nationsCheckboxItems = new NationsCheckboxPresenter(
         Nation.all(),
@@ -111,15 +111,15 @@ describe('SearchPresenter', () => {
         industriesCheckboxItems,
         regulationTypesCheckboxItems,
         professions: [
-          await new ProfessionSearchResultPresenter(
+          new ProfessionSearchResultPresenter(
             profession1,
             i18nService,
           ).present(),
-          await new ProfessionSearchResultPresenter(
+          new ProfessionSearchResultPresenter(
             profession2,
             i18nService,
           ).present(),
-          await new ProfessionSearchResultPresenter(
+          new ProfessionSearchResultPresenter(
             profession3,
             i18nService,
           ).present(),

--- a/src/professions/search/search.presenter.ts
+++ b/src/professions/search/search.presenter.ts
@@ -26,7 +26,7 @@ export class SearchPresenter {
       this.i18nService,
     ).checkboxItems();
 
-    const industriesCheckboxItems = await new IndustriesCheckboxPresenter(
+    const industriesCheckboxItems = new IndustriesCheckboxPresenter(
       this.allIndustries,
       this.filterInput.industries,
       this.i18nService,

--- a/src/professions/search/search.presenter.ts
+++ b/src/professions/search/search.presenter.ts
@@ -20,7 +20,7 @@ export class SearchPresenter {
   ) {}
 
   async present(): Promise<IndexTemplate> {
-    const nationsCheckboxItems = await new NationsCheckboxPresenter(
+    const nationsCheckboxItems = new NationsCheckboxPresenter(
       this.allNations,
       this.filterInput.nations,
       this.i18nService,

--- a/src/professions/search/search.presenter.ts
+++ b/src/professions/search/search.presenter.ts
@@ -32,11 +32,10 @@ export class SearchPresenter {
       this.i18nService,
     ).checkboxItems();
 
-    const regulationTypesCheckboxItems =
-      await new RegulationTypesCheckboxPresenter(
-        this.filterInput.regulationTypes,
-        this.i18nService,
-      ).checkboxItems();
+    const regulationTypesCheckboxItems = new RegulationTypesCheckboxPresenter(
+      this.filterInput.regulationTypes,
+      this.i18nService,
+    ).checkboxItems();
 
     const displayProfessions = await Promise.all(
       this.filteredProfessions.map(async (profession) =>

--- a/src/professions/search/search.presenter.ts
+++ b/src/professions/search/search.presenter.ts
@@ -19,7 +19,7 @@ export class SearchPresenter {
     private readonly i18nService: I18nService,
   ) {}
 
-  async present(): Promise<IndexTemplate> {
+  present(): IndexTemplate {
     const nationsCheckboxItems = new NationsCheckboxPresenter(
       this.allNations,
       this.filterInput.nations,
@@ -37,13 +37,11 @@ export class SearchPresenter {
       this.i18nService,
     ).checkboxItems();
 
-    const displayProfessions = await Promise.all(
-      this.filteredProfessions.map(async (profession) =>
-        new ProfessionSearchResultPresenter(
-          profession,
-          this.i18nService,
-        ).present(),
-      ),
+    const displayProfessions = this.filteredProfessions.map((profession) =>
+      new ProfessionSearchResultPresenter(
+        profession,
+        this.i18nService,
+      ).present(),
     );
 
     return {

--- a/src/qualifications/presenters/qualification.presenter.spec.ts
+++ b/src/qualifications/presenters/qualification.presenter.spec.ts
@@ -148,7 +148,7 @@ describe(QualificationPresenter, () => {
     describe('summaryList', () => {
       describe('when a Qualification has all fields', () => {
         describe('when the Qualifications are from a UK profession', () => {
-          it('returns a summary list of all relevant Qualification fields', async () => {
+          it('returns a summary list of all relevant Qualification fields', () => {
             (formatMultilineString as jest.Mock).mockImplementation(
               multilineOf,
             );
@@ -163,7 +163,7 @@ describe(QualificationPresenter, () => {
               createMockI18nService(),
             );
 
-            await expect(presenter.summaryList(true, false)).resolves.toEqual({
+            expect(presenter.summaryList(true, false)).toEqual({
               overviewSummaryList: {
                 classes: 'govuk-summary-list--no-border',
                 rows: [
@@ -231,7 +231,7 @@ describe(QualificationPresenter, () => {
           });
         });
         describe('when the Qualifications are from a non-UK profession', () => {
-          it('returns a summary list of all relevant Qualification fields', async () => {
+          it('returns a summary list of all relevant Qualification fields', () => {
             (formatMultilineString as jest.Mock).mockImplementation(
               multilineOf,
             );
@@ -249,7 +249,7 @@ describe(QualificationPresenter, () => {
               createMockI18nService(),
             );
 
-            await expect(presenter.summaryList(true, true)).resolves.toEqual({
+            expect(presenter.summaryList(true, true)).toEqual({
               overviewSummaryList: {
                 classes: 'govuk-summary-list--no-border',
                 rows: [
@@ -344,7 +344,7 @@ describe(QualificationPresenter, () => {
 
       describe('when a Qualification is missing fields', () => {
         describe('when `showEmptyFields` is true', () => {
-          it('returns summary lists of all Qualification fields', async () => {
+          it('returns summary lists of all Qualification fields', () => {
             (formatMultilineString as jest.Mock).mockImplementation(
               multilineOf,
             );
@@ -362,7 +362,7 @@ describe(QualificationPresenter, () => {
               createMockI18nService(),
             );
 
-            await expect(presenter.summaryList(true, false)).resolves.toEqual({
+            expect(presenter.summaryList(true, false)).toEqual({
               overviewSummaryList: {
                 classes: 'govuk-summary-list--no-border',
                 rows: [
@@ -428,7 +428,7 @@ describe(QualificationPresenter, () => {
           });
         });
         describe('when `showEmptyFields` is false', () => {
-          it('returns summary lists of all non-empty Qualification fields', async () => {
+          it('returns summary lists of all non-empty Qualification fields', () => {
             (formatMultilineString as jest.Mock).mockImplementation(
               multilineOf,
             );
@@ -446,7 +446,7 @@ describe(QualificationPresenter, () => {
               createMockI18nService(),
             );
 
-            await expect(presenter.summaryList(false, false)).resolves.toEqual({
+            expect(presenter.summaryList(false, false)).toEqual({
               overviewSummaryList: {
                 classes: 'govuk-summary-list--no-border',
                 rows: [
@@ -483,7 +483,7 @@ describe(QualificationPresenter, () => {
             organisations,
           );
 
-          const summaryList = await presenter.summaryList(true, false);
+          const summaryList = presenter.summaryList(true, false);
           const awardingBodyRole = summaryList.overviewSummaryList.rows.find(
             (r) =>
               r.key['text'] ===

--- a/src/qualifications/presenters/qualification.presenter.ts
+++ b/src/qualifications/presenters/qualification.presenter.ts
@@ -42,14 +42,14 @@ export default class QualificationPresenter {
     this.qualification && this.qualification.otherCountriesRecognitionUrl,
   );
 
-  async summaryList(
+  summaryList(
     showEmptyFields: boolean,
     showUKRecognitionFields: boolean,
-  ): Promise<{
+  ): {
     overviewSummaryList: SummaryList;
     ukSummaryList: SummaryList;
     otherCountriesSummaryList: SummaryList;
-  }> {
+  } {
     const overviewSummaryList: SummaryList = {
       classes: 'govuk-summary-list--no-border',
       rows: [],
@@ -66,7 +66,7 @@ export default class QualificationPresenter {
     };
 
     if (showEmptyFields || this.routesToObtain) {
-      await this.addHtmlRow(
+      this.addHtmlRow(
         overviewSummaryList,
         'professions.show.qualification.routesToObtain',
         this.routesToObtain,
@@ -74,7 +74,7 @@ export default class QualificationPresenter {
     }
 
     if (showEmptyFields || this.moreInformationUrl) {
-      await this.addHtmlRow(
+      this.addHtmlRow(
         overviewSummaryList,
         'professions.show.qualification.moreInformationUrl',
         this.moreInformationUrl,
@@ -82,7 +82,7 @@ export default class QualificationPresenter {
     }
 
     if (this.awardingBodies?.length) {
-      await this.addHtmlRow(
+      this.addHtmlRow(
         overviewSummaryList,
         'professions.show.qualification.awardingBodies',
         this.listAwardingBodies(),
@@ -91,7 +91,7 @@ export default class QualificationPresenter {
 
     if (showUKRecognitionFields) {
       if (showEmptyFields || this.ukRecognition) {
-        await this.addHtmlRow(
+        this.addHtmlRow(
           ukSummaryList,
           'professions.show.qualification.ukRecognition',
           this.ukRecognition,
@@ -99,7 +99,7 @@ export default class QualificationPresenter {
       }
 
       if (showEmptyFields || this.ukRecognitionUrl) {
-        await this.addHtmlRow(
+        this.addHtmlRow(
           ukSummaryList,
           'professions.show.qualification.ukRecognitionUrl',
           this.ukRecognitionUrl,
@@ -108,18 +108,18 @@ export default class QualificationPresenter {
     }
 
     if (showEmptyFields || this.publicOtherCountriesRecognitionRoutes) {
-      await this.addTextRow(
+      this.addTextRow(
         otherCountriesSummaryList,
         'professions.show.qualification.otherCountriesRecognition.routes.label',
         this.publicOtherCountriesRecognitionRoutes &&
-          (await this.i18nService.translate(
+          this.i18nService.translate<string>(
             `professions.show.qualification.otherCountriesRecognition.routes.${this.publicOtherCountriesRecognitionRoutes}`,
-          )),
+          ),
       );
     }
 
     if (showEmptyFields || this.otherCountriesRecognitionSummary) {
-      await this.addHtmlRow(
+      this.addHtmlRow(
         otherCountriesSummaryList,
         'professions.show.qualification.otherCountriesRecognition.summary',
         this.otherCountriesRecognitionSummary,
@@ -127,7 +127,7 @@ export default class QualificationPresenter {
     }
 
     if (showEmptyFields || this.otherCountriesRecognitionUrl) {
-      await this.addHtmlRow(
+      this.addHtmlRow(
         otherCountriesSummaryList,
         'professions.show.qualification.otherCountriesRecognition.url',
         this.otherCountriesRecognitionUrl,
@@ -151,24 +151,24 @@ export default class QualificationPresenter {
     };
   }
 
-  private async addTextRow(
+  private addTextRow(
     summaryList: SummaryList,
     key: string,
     value: string,
-  ): Promise<void> {
+  ): void {
     summaryList.rows.push({
-      key: { text: await this.i18nService.translate(key) },
+      key: { text: this.i18nService.translate<string>(key) },
       value: { text: value },
     });
   }
 
-  private async addHtmlRow(
+  private addHtmlRow(
     summaryList: SummaryList,
     key: string,
     value: string,
-  ): Promise<void> {
+  ): void {
     summaryList.rows.push({
-      key: { text: await this.i18nService.translate(key) },
+      key: { text: this.i18nService.translate<string>(key) },
       value: { html: value },
     });
   }

--- a/src/users/organisation/organisation.controller.spec.ts
+++ b/src/users/organisation/organisation.controller.spec.ts
@@ -107,7 +107,7 @@ describe('OrganisationController', () => {
         ).selectArgs.mockReturnValue(organisationsSelectArgs);
         (
           ServiceOwnerRadioButtonArgsPresenter.prototype as DeepMocked<ServiceOwnerRadioButtonArgsPresenter>
-        ).radioButtonArgs.mockResolvedValue(serviceOwnerRadioButtonArgs);
+        ).radioButtonArgs.mockReturnValue(serviceOwnerRadioButtonArgs);
 
         const serviceOwnerUser = userFactory.build({ serviceOwner: true });
 
@@ -257,7 +257,7 @@ describe('OrganisationController', () => {
         ).selectArgs.mockReturnValue(organisationsSelectArgs);
         (
           ServiceOwnerRadioButtonArgsPresenter.prototype as DeepMocked<ServiceOwnerRadioButtonArgsPresenter>
-        ).radioButtonArgs.mockResolvedValue(serviceOwnerRadioButtonArgs);
+        ).radioButtonArgs.mockReturnValue(serviceOwnerRadioButtonArgs);
 
         const user = userFactory.build();
 

--- a/src/users/organisation/organisation.controller.ts
+++ b/src/users/organisation/organisation.controller.ts
@@ -148,7 +148,7 @@ export class OrganisationController {
     ).selectArgs();
 
     const serviceOwnerRadioButtonArgs =
-      await new ServiceOwnerRadioButtonArgsPresenter(
+      new ServiceOwnerRadioButtonArgsPresenter(
         serviceOwner,
         this.i18nService,
       ).radioButtonArgs();

--- a/src/users/presenters/role-radio-buttons.presenter.spec.ts
+++ b/src/users/presenters/role-radio-buttons.presenter.spec.ts
@@ -10,7 +10,7 @@ jest.mock('../helpers/get-permissions-from-user.helper');
 describe('RoleRadioButtonsPresenter', () => {
   describe('radioButtonArgs', () => {
     describe('when we we are presenting roles for a service owner', () => {
-      it('returns an array of `RadioButtonArg`s with correct hints and checked values', async () => {
+      it('returns an array of `RadioButtonArg`s with correct hints and checked values', () => {
         (getPermissionsFromUser as jest.Mock).mockReturnValue([
           UserPermission.CreateOrganisation,
           UserPermission.CreateProfession,
@@ -24,7 +24,7 @@ describe('RoleRadioButtonsPresenter', () => {
           createMockI18nService(),
         );
 
-        const result = await presenter.radioButtonArgs();
+        const result = presenter.radioButtonArgs();
 
         const registrarHint = `${translationOf(
           'users.roleDescriptions.manageProfessionsAndOrganisations',
@@ -59,7 +59,7 @@ describe('RoleRadioButtonsPresenter', () => {
     });
 
     describe('when we we are presenting roles for a non-service owner', () => {
-      it('returns an array of `RadioButtonArg`s with correct hints and checked values', async () => {
+      it('returns an array of `RadioButtonArg`s with correct hints and checked values', () => {
         (getPermissionsFromUser as jest.Mock).mockReturnValue([
           UserPermission.CreateUser,
           UserPermission.EditProfession,
@@ -72,7 +72,7 @@ describe('RoleRadioButtonsPresenter', () => {
           createMockI18nService(),
         );
 
-        const result = await presenter.radioButtonArgs();
+        const result = presenter.radioButtonArgs();
 
         const administratorHint = `${translationOf(
           'users.roleDescriptions.manageUsers',

--- a/src/users/presenters/role-radio-buttons.preseter.ts
+++ b/src/users/presenters/role-radio-buttons.preseter.ts
@@ -37,43 +37,35 @@ export class RoleRadioButtonsPresenter {
     private readonly i18nService: I18nService,
   ) {}
 
-  async radioButtonArgs(): Promise<RadioButtonArgs[]> {
-    return Promise.all(
-      this.allRoles.map(async (role) => ({
-        text: await this.i18nService.translate(`users.roles.${role}`),
-        value: role,
-        checked: this.selectedRole === role,
-        hint: { html: await this.getHintHtml(role, this.serviceOwner) },
-      })),
-    );
+  radioButtonArgs(): RadioButtonArgs[] {
+    return this.allRoles.map((role) => ({
+      text: this.i18nService.translate<string>(`users.roles.${role}`),
+      value: role,
+      checked: this.selectedRole === role,
+      hint: { html: this.getHintHtml(role, this.serviceOwner) },
+    }));
   }
 
-  private async getHintHtml(
-    role: Role,
-    serviceOwner: boolean,
-  ): Promise<string> {
+  private getHintHtml(role: Role, serviceOwner: boolean): string {
     const permissions = getPermissionsFromUser({
       ...new User(),
       role,
       serviceOwner,
     });
 
-    const lines = await Promise.all(
-      descriptions
-        .filter((description) =>
-          description.permissions.every((permission) =>
-            permissions.includes(permission),
-          ),
-        )
-        .map(
-          (description) =>
-            this.i18nService.translate(
-              serviceOwner
-                ? description.serviceOwnerText
-                : description.nonServiceOwnerText,
-            ) as Promise<string>,
+    const lines = descriptions
+      .filter((description) =>
+        description.permissions.every((permission) =>
+          permissions.includes(permission),
         ),
-    );
+      )
+      .map((description) =>
+        this.i18nService.translate<string>(
+          serviceOwner
+            ? description.serviceOwnerText
+            : description.nonServiceOwnerText,
+        ),
+      );
 
     return lines.join('<br />');
   }

--- a/src/users/presenters/service-owner-radio-buttons.presenter.spec.ts
+++ b/src/users/presenters/service-owner-radio-buttons.presenter.spec.ts
@@ -4,13 +4,13 @@ import { ServiceOwnerRadioButtonArgsPresenter } from './service-owner-radio-butt
 
 describe('ServiceOwnerRadioButtonsPresenter', () => {
   describe('radioButtonArgs', () => {
-    it('returns an array of `RadioButtonArg`s', async () => {
+    it('returns an array of `RadioButtonArg`s', () => {
       const presenter = new ServiceOwnerRadioButtonArgsPresenter(
         true,
         createMockI18nService(),
       );
 
-      const result = await presenter.radioButtonArgs();
+      const result = presenter.radioButtonArgs();
 
       expect(result).toMatchObject([
         {

--- a/src/users/presenters/service-owner-radio-buttons.presenter.ts
+++ b/src/users/presenters/service-owner-radio-buttons.presenter.ts
@@ -7,18 +7,18 @@ export class ServiceOwnerRadioButtonArgsPresenter {
     private readonly i18nService: I18nService,
   ) {}
 
-  async radioButtonArgs(): Promise<RadioButtonArgs[]> {
+  radioButtonArgs(): RadioButtonArgs[] {
     return [
       {
         value: '1',
-        text: await this.i18nService.translate(
+        text: this.i18nService.translate<string>(
           'users.form.label.serviceOwner.yes',
         ),
         checked: this.serviceOwner === true,
       },
       {
         value: '0',
-        text: await this.i18nService.translate(
+        text: this.i18nService.translate<string>(
           'users.form.label.serviceOwner.no',
         ),
         checked: this.serviceOwner === false,

--- a/src/users/role/role.controller.spec.ts
+++ b/src/users/role/role.controller.spec.ts
@@ -58,7 +58,7 @@ describe('RoleController', () => {
 
       (
         RoleRadioButtonsPresenter.prototype as DeepMocked<RoleRadioButtonsPresenter>
-      ).radioButtonArgs.mockResolvedValue(roleRadioButtonArgs);
+      ).radioButtonArgs.mockReturnValue(roleRadioButtonArgs);
 
       const res = createMock<Response>();
 
@@ -205,7 +205,7 @@ describe('RoleController', () => {
 
       (
         RoleRadioButtonsPresenter.prototype as DeepMocked<RoleRadioButtonsPresenter>
-      ).radioButtonArgs.mockResolvedValue(roleRadioButtonArgs);
+      ).radioButtonArgs.mockReturnValue(roleRadioButtonArgs);
 
       const res = createMock<Response>();
 

--- a/src/users/role/role.controller.ts
+++ b/src/users/role/role.controller.ts
@@ -120,7 +120,7 @@ export class RoleController {
     res.redirect(`/admin/users/${id}/confirm`);
   }
 
-  private async renderForm(
+  private renderForm(
     res: Response,
     serviceOwner: boolean,
     role: Role | null,
@@ -128,8 +128,8 @@ export class RoleController {
     source: UserEditSource,
     action: ActionType,
     errors: object | undefined = undefined,
-  ): Promise<void> {
-    const roleRadioButtonArgs = await new RoleRadioButtonsPresenter(
+  ): void {
+    const roleRadioButtonArgs = new RoleRadioButtonsPresenter(
       this.getAllowedRoles(serviceOwner),
       serviceOwner,
       role,

--- a/src/users/users-archive.controller.ts
+++ b/src/users/users-archive.controller.ts
@@ -42,7 +42,7 @@ export class UsersArchiveController {
   @Permissions(UserPermission.DeleteUser)
   @Redirect('/admin/users')
   async delete(@Req() req, @Param('id') id): Promise<void> {
-    const messageTitle = await this.i18nService.translate(
+    const messageTitle = this.i18nService.translate<string>(
       'users.archive.confirmation.body',
     );
     const user = await this.usersService.find(id);


### PR DESCRIPTION
# Changes in this PR

- Remove unnecessary `awaits` from use of `I18nService.translate`

