### PR TITLE
(2300) Allow archived organisations to be unarchived

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [unreleased]
 
+### Added
+
+- Allow admins to unarchive an archived organisation
+
 ### Changed
 
 - Left align the decision data download button

--- a/cypress/integration/admin/organisations/archive.spec.ts
+++ b/cypress/integration/admin/organisations/archive.spec.ts
@@ -219,7 +219,9 @@ function archiveOrganisation(organisation: string): void {
     },
   );
 
-  cy.get('[data-cy=actions]').should('not.exist');
+  cy.translate('organisations.admin.button.unarchive').then((buttonText) => {
+    cy.get('a').contains(buttonText);
+  });
 
   cy.translate('app.status.archived').then((status) => {
     cy.get('h2[data-status]').should('contain', status);

--- a/cypress/integration/admin/organisations/unarchive.spec.ts
+++ b/cypress/integration/admin/organisations/unarchive.spec.ts
@@ -1,0 +1,80 @@
+import { format } from 'date-fns';
+
+describe('Unarchiving organisations', () => {
+  context('When I am logged in as a registrar', () => {
+    beforeEach(() => {
+      cy.loginAuth0('registrar');
+      cy.visitInternalDashboard();
+    });
+
+    it('Allows me to unarchive an archived organisation', () => {
+      cy.get('a').contains('Regulatory authorities').click();
+      cy.checkAccessibility();
+
+      cy.contains('Archived organisation')
+        .parent('tr')
+        .within(() => {
+          cy.get('a').contains('View details').click();
+        });
+
+      cy.translate('app.status.archived').then((status) => {
+        cy.get('h2[data-status]').should('contain', status);
+      });
+
+      cy.translate('organisations.admin.button.unarchive').then(
+        (unarchiveButton) => {
+          cy.get('a').contains(unarchiveButton).click();
+        },
+      );
+
+      cy.checkAccessibility();
+
+      cy.translate('organisations.admin.unarchive.caption').then(
+        (unarchiveCaption) => {
+          cy.get('body').should('contain', unarchiveCaption);
+        },
+      );
+
+      cy.translate('organisations.admin.unarchive.heading', {
+        organisationName: 'Archived organisation',
+      }).then((heading) => {
+        cy.get('body').should('contain', heading);
+      });
+
+      cy.translate('organisations.admin.button.unarchive').then(
+        (buttonText) => {
+          cy.get('button').contains(buttonText).click();
+        },
+      );
+
+      cy.checkAccessibility();
+
+      cy.translate('organisations.admin.unarchive.confirmation.heading').then(
+        (confirmation) => {
+          cy.get('html').should('contain', confirmation);
+        },
+      );
+
+      cy.get('h2').should('contain', 'Success');
+
+      cy.get('[data-cy=last-modified]').should(
+        'contain',
+        format(new Date(), 'd MMM yyyy'),
+      );
+
+      cy.visitAndCheckAccessibility('/admin/organisations');
+
+      cy.get('tr')
+        .contains('Archived organisation')
+        .then(($header) => {
+          const $row = $header.parent();
+
+          cy.translate(`app.status.draft`).then((status) => {
+            cy.wrap($row).should('contain', status);
+          });
+        });
+
+      cy.visit('/regulatory-authorities/search');
+    });
+  });
+});

--- a/seeds/development/organisations.json
+++ b/seeds/development/organisations.json
@@ -156,5 +156,20 @@
         "created_at": "2022-01-01"
       }
     ]
+  },
+  {
+    "name": "Archived organisation",
+    "slug": "archived-organisation",
+    "versions": [
+      {
+        "alternateName": "",
+        "address": "789 Fake Street\nLondon\nEC1 1AB",
+        "url": "www.example.com",
+        "email": "archived@example.com",
+        "telephone": "+44 0123 456789",
+        "status": "archived",
+        "created_at": "2022-01-01"
+      }
+    ]
   }
 ]

--- a/seeds/test/organisations.json
+++ b/seeds/test/organisations.json
@@ -156,5 +156,20 @@
         "created_at": "2022-01-01"
       }
     ]
+  },
+  {
+    "name": "Archived organisation",
+    "slug": "archived-organisation",
+    "versions": [
+      {
+        "alternateName": "",
+        "address": "789 Fake Street\nLondon\nEC1 1AB",
+        "url": "www.example.com",
+        "email": "archived@example.com",
+        "telephone": "+44 0123 456789",
+        "status": "archived",
+        "created_at": "2022-01-01"
+      }
+    ]
   }
 ]

--- a/src/i18n/en/organisations.json
+++ b/src/i18n/en/organisations.json
@@ -73,6 +73,14 @@
       },
       "forbidden": "This organisation cannot be archived yet. Before you can archive, remove the regulator from the following professions:"
     },
+    "unarchive": {
+      "heading": "Are you sure you want to unarchive {organisationName}?",
+      "caption": "Unarchiving an organisation",
+      "confirmation": {
+        "heading": "Regulatory authority unarchived",
+        "body": "The regulator <strong>{name}</strong> has been unarchived."
+      }
+    },
     "tableHeading": {
       "name": "Name",
       "nations": "Nations",
@@ -127,6 +135,7 @@
         "live": "Edit this regulatory authority"
       },
       "archive": "Archive this regulatory authority",
+      "unarchive": "Unarchive this regulatory authority",
       "saveAsDraft": "Save as draft",
       "publish": "Publish to register",
       "backToRegulator": "Back to regulator"

--- a/src/organisations/admin/organisation-unarchive.controller.spec.ts
+++ b/src/organisations/admin/organisation-unarchive.controller.spec.ts
@@ -1,0 +1,233 @@
+import { DeepMocked, createMock } from '@golevelup/ts-jest';
+import { TestingModule, Test } from '@nestjs/testing';
+import { Response } from 'express';
+import { I18nService } from 'nestjs-i18n';
+import { flashMessage } from '../../common/flash-message';
+import { createMockI18nService } from '../../testutils/create-mock-i18n-service';
+import { createDefaultMockRequest } from '../../testutils/factories/create-default-mock-request';
+import organisationFactory from '../../testutils/factories/organisation';
+import organisationVersionFactory from '../../testutils/factories/organisation-version';
+import userFactory from '../../testutils/factories/user';
+import { translationOf } from '../../testutils/translation-of';
+import * as checkCanViewOrganisationModule from '../../users/helpers/check-can-view-organisation';
+import * as getActingUser from '../../users/helpers/get-acting-user.helper';
+import * as escapeModule from '../../helpers/escape.helper';
+import { OrganisationVersionsService } from '../organisation-versions.service';
+import { OrganisationsService } from '../organisations.service';
+import { Organisation } from '../organisation.entity';
+import { OrganisationUnarchiveController } from './organisation-unarchive.controller';
+import { OrganisationVersionStatus } from '../organisation-version.entity';
+
+jest.mock('../../common/flash-message');
+jest.mock('../../users/helpers/check-can-view-organisation');
+jest.mock('../../users/helpers/get-acting-user.helper');
+jest.mock('../../helpers/escape.helper');
+
+describe('OrganisationUnarchiveController', () => {
+  let controller: OrganisationUnarchiveController;
+
+  let organisationsService: DeepMocked<OrganisationsService>;
+  let organisationVersionsService: DeepMocked<OrganisationVersionsService>;
+  let i18nService: DeepMocked<I18nService>;
+
+  beforeEach(async () => {
+    organisationsService = createMock<OrganisationsService>();
+    organisationVersionsService = createMock<OrganisationVersionsService>();
+    i18nService = createMockI18nService();
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [OrganisationUnarchiveController],
+      providers: [
+        {
+          provide: OrganisationsService,
+          useValue: organisationsService,
+        },
+        {
+          provide: OrganisationVersionsService,
+          useValue: organisationVersionsService,
+        },
+        {
+          provide: I18nService,
+          useValue: i18nService,
+        },
+      ],
+    }).compile();
+
+    controller = module.get<OrganisationUnarchiveController>(
+      OrganisationUnarchiveController,
+    );
+  });
+
+  describe('new', () => {
+    it('fetches the Organisation to render on the page', async () => {
+      const organisation = organisationFactory.build();
+      const version = organisationVersionFactory.build({
+        organisation,
+      });
+
+      organisationVersionsService.findByIdWithOrganisation.mockResolvedValue(
+        version,
+      );
+
+      const request = createDefaultMockRequest({
+        user: userFactory.build(),
+      });
+
+      jest
+        .spyOn(checkCanViewOrganisationModule, 'checkCanViewOrganisation')
+        .mockImplementation();
+
+      jest.spyOn(getActingUser, 'getActingUser').mockImplementation();
+
+      const result = await controller.new(organisation.id, version.id, request);
+
+      expect(result).toEqual({
+        organisation: Organisation.withVersion(organisation, version),
+      });
+
+      expect(
+        organisationVersionsService.findByIdWithOrganisation,
+      ).toHaveBeenCalledWith(organisation.id, version.id);
+    });
+
+    it('checks the acting user has permission to unarchive the Organisation', async () => {
+      const organisation = organisationFactory.build();
+      const version = organisationVersionFactory.build({
+        organisation,
+      });
+
+      organisationVersionsService.findByIdWithOrganisation.mockResolvedValue(
+        version,
+      );
+
+      const request = createDefaultMockRequest({
+        user: userFactory.build(),
+      });
+
+      const checkCanViewOrganisationSpy = jest
+        .spyOn(checkCanViewOrganisationModule, 'checkCanViewOrganisation')
+        .mockImplementation();
+
+      await controller.new(organisation.id, version.id, request);
+
+      expect(checkCanViewOrganisationSpy).toHaveBeenCalledWith(
+        request,
+        Organisation.withVersion(organisation, version),
+      );
+    });
+  });
+
+  describe('create', () => {
+    it('should unarchive the current version', async () => {
+      const organisation = organisationFactory.build();
+
+      const currentVersion = organisationVersionFactory.build({
+        organisation: organisation,
+        status: OrganisationVersionStatus.Archived,
+      });
+
+      const versionToUnarchive = organisationVersionFactory.build({
+        organisation: organisation,
+        status: OrganisationVersionStatus.Archived,
+      });
+
+      const unarchivedVersion = organisationVersionFactory.build({
+        organisation: organisation,
+        status: OrganisationVersionStatus.Draft,
+      });
+
+      const user = userFactory.build();
+
+      jest.spyOn(getActingUser, 'getActingUser').mockReturnValue(user);
+
+      jest
+        .spyOn(checkCanViewOrganisationModule, 'checkCanViewOrganisation')
+        .mockImplementation();
+
+      const escapeSpy = jest.spyOn(escapeModule, 'escape');
+
+      const req = createDefaultMockRequest({
+        user,
+      });
+
+      const res = createMock<Response>({});
+
+      const flashMock = flashMessage as jest.Mock;
+      flashMock.mockImplementation(() => 'STUB_FLASH_MESSAGE');
+
+      organisationVersionsService.findByIdWithOrganisation.mockResolvedValue(
+        currentVersion,
+      );
+      organisationVersionsService.create.mockResolvedValue(versionToUnarchive);
+      organisationVersionsService.unarchive.mockResolvedValue(
+        unarchivedVersion,
+      );
+
+      await controller.create(req, res, organisation.id, currentVersion.id);
+
+      expect(
+        organisationVersionsService.findByIdWithOrganisation,
+      ).toHaveBeenCalledWith(organisation.id, currentVersion.id);
+
+      expect(organisationVersionsService.create).toHaveBeenCalledWith(
+        currentVersion,
+        user,
+      );
+
+      expect(organisationVersionsService.unarchive).toHaveBeenCalledWith(
+        versionToUnarchive,
+      );
+
+      expect(flashMock).toHaveBeenCalledWith(
+        translationOf('organisations.admin.unarchive.confirmation.heading'),
+        translationOf('organisations.admin.unarchive.confirmation.body'),
+      );
+
+      expect(req.flash).toHaveBeenCalledWith('success', 'STUB_FLASH_MESSAGE');
+
+      expect(escapeSpy).toHaveBeenCalledWith(
+        unarchivedVersion.organisation.name,
+      );
+
+      expect(res.redirect).toHaveBeenCalledWith(
+        `/admin/organisations/${organisation.id}/versions/${versionToUnarchive.id}`,
+      );
+    });
+
+    it('checks the acting user has permission to unarchive the Organisation', async () => {
+      const organisation = organisationFactory.build();
+      const version = organisationVersionFactory.build({
+        organisation: organisation,
+      });
+
+      const req = createDefaultMockRequest({
+        user: userFactory.build(),
+      });
+
+      const checkCanViewOrganisationSpy = jest
+        .spyOn(checkCanViewOrganisationModule, 'checkCanViewOrganisation')
+        .mockImplementation();
+
+      const getActingUserSpy = jest.spyOn(getActingUser, 'getActingUser');
+
+      const res = createMock<Response>({});
+
+      organisationVersionsService.findByIdWithOrganisation.mockResolvedValue(
+        version,
+      );
+
+      await controller.create(req, res, organisation.id, version.id);
+
+      expect(checkCanViewOrganisationSpy).toHaveBeenCalledWith(
+        req,
+        organisation,
+      );
+
+      expect(getActingUserSpy).toHaveBeenCalledWith(req);
+    });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+});

--- a/src/organisations/admin/organisation-unarchive.controller.ts
+++ b/src/organisations/admin/organisation-unarchive.controller.ts
@@ -1,0 +1,89 @@
+import { Controller, Get, Param, Put, Render, Req, Res } from '@nestjs/common';
+import { Response } from 'express';
+import { I18nService } from 'nestjs-i18n';
+import { BackLink } from '../../common/decorators/back-link.decorator';
+import { flashMessage } from '../../common/flash-message';
+import { RequestWithAppSession } from '../../common/interfaces/request-with-app-session.interface';
+import { Permissions } from '../../common/permissions.decorator';
+import { escape } from '../../helpers/escape.helper';
+import { checkCanViewOrganisation } from '../../users/helpers/check-can-view-organisation';
+import { UserPermission } from '../../users/user-permission';
+import { OrganisationVersionsService } from '../organisation-versions.service';
+import { OrganisationsService } from '../organisations.service';
+import { Organisation } from '../organisation.entity';
+import { getActingUser } from '../../users/helpers/get-acting-user.helper';
+
+@Controller('/admin/organisations')
+export class OrganisationUnarchiveController {
+  constructor(
+    private organisationVersionsService: OrganisationVersionsService,
+    private organisationsService: OrganisationsService,
+    private i18nService: I18nService,
+  ) {}
+
+  @Get('/:organisationId/versions/:versionId/unarchive')
+  @Permissions(UserPermission.PublishOrganisation)
+  @Render('admin/organisations/unarchive/new')
+  @BackLink('/admin/organisations/:organisationId/versions/:versionId')
+  async new(
+    @Param('organisationId') organisationId: string,
+    @Param('versionId') versionId: string,
+    @Req() req: RequestWithAppSession,
+  ) {
+    const version =
+      await this.organisationVersionsService.findByIdWithOrganisation(
+        organisationId,
+        versionId,
+      );
+    const organisation = Organisation.withVersion(
+      version.organisation,
+      version,
+    );
+
+    checkCanViewOrganisation(req, organisation);
+
+    return { organisation };
+  }
+
+  @Put(':organisationId/versions/:versionId/unarchive')
+  @Permissions(UserPermission.PublishOrganisation)
+  async create(
+    @Req() req: RequestWithAppSession,
+    @Res() res: Response,
+    @Param('organisationId') organisationId: string,
+    @Param('versionId') versionId: string,
+  ): Promise<void> {
+    const organisation = await this.organisationsService.find(organisationId);
+    const user = getActingUser(req);
+
+    checkCanViewOrganisation(req, organisation);
+
+    const currentVersion =
+      await this.organisationVersionsService.findByIdWithOrganisation(
+        organisationId,
+        versionId,
+      );
+
+    const versionToUnarchive = await this.organisationVersionsService.create(
+      currentVersion,
+      user,
+    );
+
+    await this.organisationVersionsService.unarchive(versionToUnarchive);
+
+    const messageTitle = await this.i18nService.translate(
+      'organisations.admin.unarchive.confirmation.heading',
+    );
+
+    const messageBody = await this.i18nService.translate(
+      'organisations.admin.unarchive.confirmation.body',
+      { args: { name: escape(versionToUnarchive.organisation.name) } },
+    );
+
+    req.flash('success', flashMessage(messageTitle, messageBody));
+
+    res.redirect(
+      `/admin/organisations/${versionToUnarchive.organisation.id}/versions/${versionToUnarchive.id}`,
+    );
+  }
+}

--- a/src/organisations/organisation-versions.service.spec.ts
+++ b/src/organisations/organisation-versions.service.spec.ts
@@ -665,6 +665,25 @@ describe('OrganisationVersionsService', () => {
     });
   });
 
+  describe('unarchive', () => {
+    it('changes the status of the version from `archived` to `live`', () => {
+      const inputVersion = organisationVersionFactory.build({
+        status: OrganisationVersionStatus.Archived,
+      });
+      const unarchivedVersion = {
+        ...inputVersion,
+        status: OrganisationVersionStatus.Draft,
+      };
+
+      const saveSpy = jest
+        .spyOn(repo, 'save')
+        .mockResolvedValue(unarchivedVersion);
+
+      service.unarchive(inputVersion);
+      expect(saveSpy).toHaveBeenCalledWith(unarchivedVersion);
+    });
+  });
+
   describe('searchLive', () => {
     let versions: OrganisationVersion[];
     let queryBuilder: SelectQueryBuilder<OrganisationVersion>;

--- a/src/organisations/organisation-versions.service.ts
+++ b/src/organisations/organisation-versions.service.ts
@@ -286,6 +286,11 @@ export class OrganisationVersionsService {
     return version;
   }
 
+  async unarchive(version: OrganisationVersion): Promise<OrganisationVersion> {
+    version.status = OrganisationVersionStatus.Draft;
+    return await this.repository.save(version);
+  }
+
   private versionsWithJoins(
     professionVersionStatuses: ProfessionVersionStatus[] = undefined,
   ): SelectQueryBuilder<OrganisationVersion> {

--- a/src/organisations/organisations.module.ts
+++ b/src/organisations/organisations.module.ts
@@ -15,6 +15,7 @@ import { SearchController } from './search/search.controller';
 import { OrganisationsController } from './organisations.controller';
 import { OrganisationPublicationController } from './admin/organisation-publication.controller';
 import { OrganisationArchiveController } from './admin/organisation-archive.controller';
+import { OrganisationUnarchiveController } from './admin/organisation-unarchive.controller';
 import { ProfessionVersionsService } from '../professions/profession-versions.service';
 import { ProfessionsSearchService } from '../professions/professions-search.service';
 import { SearchModule } from '../search/search.module';
@@ -35,6 +36,7 @@ import { SearchModule } from '../search/search.module';
     OrganisationsController,
     OrganisationPublicationController,
     OrganisationArchiveController,
+    OrganisationUnarchiveController,
   ],
   imports: [
     TypeOrmModule.forFeature([Organisation]),

--- a/views/admin/organisations/show.njk
+++ b/views/admin/organisations/show.njk
@@ -35,15 +35,15 @@
         {% if hasLiveVersion %}
           <h2 class="govuk-heading-s" data-cy="currently-published-version-text">
             {{ "organisations.admin.publicFacingLink.heading" | t }}<br>
-            <span class="govuk-body" data-cy="currently-published-version"><a class="govuk-link" href="/regulatory-authorities/{{ organisation.slug }}">{{ "organisations.admin.publicFacingLink.label" | t }}</a></span>
+            <span class="govuk-body" data-cy="currently-published-version">
+              <a class="govuk-link" href="/regulatory-authorities/{{ organisation.slug }}">{{ "organisations.admin.publicFacingLink.label" | t }}</a>
+            </span>
           </h2>
         {% endif %}
 
-        {% if organisation.status !== 'archived' %}
-
-          <nav role="navigation" data-cy="actions">
-            <ul class="govuk-list">
-              {% if 'editOrganisation' in permissions %}
+        <nav role="navigation" data-cy="actions">
+          <ul class="govuk-list">
+            {% if organisation.status !== 'archived' and 'editOrganisation' in permissions %}
               <li>
                 <form method="post" action="/admin/organisations/{{ organisation.id }}/versions">
                   {{ govukButton({
@@ -54,8 +54,8 @@
                   }) }}
                 </form>
               </li>
-              {% endif %}
-              {% if organisation.status === 'draft' and 'publishOrganisation' in permissions %}
+            {% endif %}
+            {% if organisation.status === 'draft' and 'publishOrganisation' in permissions %}
               <li>
                 {{
                   govukButton({
@@ -68,8 +68,8 @@
                   })
                 }}
               </li>
-              {% endif %}
-              {% if 'deleteOrganisation' in permissions %}
+            {% endif %}
+            {% if organisation.status !== 'archived' and 'deleteOrganisation' in permissions %}
               <li>
                 {{
                   govukButton({
@@ -79,13 +79,23 @@
                   })
                 }}
               </li>
-              {% endif %}
+            {% endif %}
+            {% if organisation.status === 'archived' and 'createOrganisation' in permissions %}
+              <li>
+                {{
+                  govukButton({
+                    text: ("organisations.admin.button.unarchive" | t),
+                    href: "/admin/organisations/" + organisation.id + "/versions/" + organisation.versionId + "/unarchive",
+                    classes: "govuk-button--secondary"
+                  })
+                }}
+              </li>
+              {% endif%}
             </ul>
           </nav>
 
-        {% endif %}
-      </aside>
+        </aside>
+      </div>
     </div>
-  </div>
 
-{% endblock %}
+  {% endblock %}

--- a/views/admin/organisations/unarchive/new.njk
+++ b/views/admin/organisations/unarchive/new.njk
@@ -1,0 +1,27 @@
+{% extends "admin/base.njk" %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% set title = ("organisations.admin.archive.heading" | t) %}
+
+{% block title %}
+    {{ "organisations.admin.unarchive.heading" | t }}
+{% endblock %}
+
+{% block content %}
+    <span class="govuk-caption-l">{{ 'organisations.admin.unarchive.caption' | t }}</span>
+    <h1 class="govuk-heading-l">{{ ('organisations.admin.unarchive.heading' | t({organisationName: organisation.name})) }}</h1>
+
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <form action="/admin/organisations/{{ organisation.id }}/versions/{{ organisation.versionId }}/unarchive?_method=PUT" method="post">
+                {{
+            govukButton({
+              text: ("organisations.admin.button.unarchive" | t)
+            })
+          }}
+            </form>
+        </div>
+
+    </div>
+
+{% endblock %}


### PR DESCRIPTION
# Changes in this PR
This is a similar journey to archiving only when an org is unarchived its status is set to 'Live' instead of 'Archived'. 

I believe this necessitates a new method in the `organisation-versions.service` which I've created but with a very naïve implementation, there may be more work needed here?
 

## Screenshots of UI changes

### Before
![image](https://user-images.githubusercontent.com/44123869/171212114-990315e4-cdf3-4391-aef9-243c20a977cc.png)

### After
![image](https://user-images.githubusercontent.com/44123869/171211888-112becbd-6861-4773-abb4-4e1b67531f40.png)
![image](https://user-images.githubusercontent.com/44123869/171211926-2b6fc45f-f421-419b-9d51-b255c9701cb4.png)
![image](https://user-images.githubusercontent.com/44123869/171211963-f26ecfd3-7d3e-4ea7-8309-d46e313ee9cd.png)
