### PR TITLE
(2247) Tidy up how we fetch a users organisation

### DIFF
--- a/src/app.controller.spec.ts
+++ b/src/app.controller.spec.ts
@@ -1,9 +1,12 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { I18nService } from 'nestjs-i18n';
 
 import { AppController } from './app.controller';
+import { createMockI18nService } from './testutils/create-mock-i18n-service';
 import { createMockRequest } from './testutils/create-mock-request';
 import organisationFactory from './testutils/factories/organisation';
 import userFactory from './testutils/factories/user';
+import { translationOf } from './testutils/translation-of';
 import { getActingUser } from './users/helpers/get-acting-user.helper';
 
 jest.mock('./users/helpers/get-acting-user.helper');
@@ -12,8 +15,16 @@ describe('AppController', () => {
   let appController: AppController;
 
   beforeEach(async () => {
+    const i18nService = createMockI18nService();
+
     const app: TestingModule = await Test.createTestingModule({
       controllers: [AppController],
+      providers: [
+        {
+          provide: I18nService,
+          useValue: i18nService,
+        },
+      ],
     }).compile();
 
     appController = app.get<AppController>(AppController);
@@ -33,7 +44,7 @@ describe('AppController', () => {
         (getActingUser as jest.Mock).mockReturnValue(user);
 
         expect(appController.adminDashboard(request)).toEqual({
-          organisation: 'app.beis',
+          organisation: translationOf('app.beis'),
         });
       });
     });

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -1,5 +1,6 @@
 import { Controller, Get, Render, Req, UseGuards } from '@nestjs/common';
 import { Request } from 'express';
+import { I18nService } from 'nestjs-i18n';
 import { AuthenticationGuard } from './common/authentication.guard';
 import { BackLink } from './common/decorators/back-link.decorator';
 import { RequestWithAppSession } from './common/interfaces/request-with-app-session.interface';
@@ -8,6 +9,8 @@ import { getUserOrganisation } from './users/helpers/get-user-organisation';
 
 @Controller()
 export class AppController {
+  constructor(private readonly i18nService: I18nService) {}
+
   @Get('/admin/dashboard')
   @UseGuards(AuthenticationGuard)
   @Render('admin/dashboard')
@@ -15,7 +18,7 @@ export class AppController {
     const actingUser = getActingUser(request);
 
     return {
-      organisation: getUserOrganisation(actingUser),
+      organisation: getUserOrganisation(actingUser, this.i18nService),
     };
   }
 

--- a/src/decisions/admin/decisions.controller.spec.ts
+++ b/src/decisions/admin/decisions.controller.spec.ts
@@ -97,14 +97,14 @@ describe('DecisionsController', () => {
       it('presents all decision datasets', async () => {
         const request = createDefaultMockRequest();
 
+        const user = userFactory.build({
+          serviceOwner: true,
+          organisation: null,
+        });
+
         const getActingUserSpy = jest
           .spyOn(getActingUserModule, 'getActingUser')
-          .mockReturnValue(
-            userFactory.build({
-              serviceOwner: true,
-              organisation: null,
-            }),
-          );
+          .mockReturnValue(user);
 
         const createFilterInputSpy = jest
           .spyOn(createFilterInputModule, 'createFilterInput')
@@ -161,7 +161,7 @@ describe('DecisionsController', () => {
           {
             keywords: 'example keywords',
           },
-          null,
+          user,
           allOrganisations,
           2020,
           2024,
@@ -195,14 +195,14 @@ describe('DecisionsController', () => {
           name: 'Filtered Profession',
         });
 
+        const user = userFactory.build({
+          serviceOwner: false,
+          organisation: userOrganisation,
+        });
+
         const getActingUserSpy = jest
           .spyOn(getActingUserModule, 'getActingUser')
-          .mockReturnValue(
-            userFactory.build({
-              serviceOwner: false,
-              organisation: userOrganisation,
-            }),
-          );
+          .mockReturnValue(user);
 
         const createFilterInputSpy = jest
           .spyOn(createFilterInputModule, 'createFilterInput')
@@ -265,7 +265,7 @@ describe('DecisionsController', () => {
             keywords: 'example keywords',
             professions: [profession],
           },
-          userOrganisation,
+          user,
           allOrganisations,
           2020,
           2024,

--- a/src/decisions/admin/decisions.controller.ts
+++ b/src/decisions/admin/decisions.controller.ts
@@ -89,7 +89,7 @@ export class DecisionsController {
     return {
       ...new DecisionDatasetsPresenter(
         filterInput,
-        userOrganisation,
+        actingUser,
         allOrganisations,
         startYear,
         endYear,

--- a/src/decisions/admin/presenters/decision-datasets.presenter.spec.ts
+++ b/src/decisions/admin/presenters/decision-datasets.presenter.spec.ts
@@ -6,7 +6,9 @@ import { createMockI18nService } from '../../../testutils/create-mock-i18n-servi
 import decisionDatasetFactory from '../../../testutils/factories/decision-dataset';
 import organisationFactory from '../../../testutils/factories/organisation';
 import professionFactory from '../../../testutils/factories/profession';
+import userFactory from '../../../testutils/factories/user';
 import { translationOf } from '../../../testutils/translation-of';
+import * as getUserOrganisationModule from '../../../users/helpers/get-user-organisation';
 import { DecisionDatasetStatus } from '../../decision-dataset.entity';
 import { IndexTemplate } from '../interfaces/index-template.interface';
 import { DecisionDatasetStatusesCheckboxPresenter } from './decision-dataset-statuses-checkbox.presenter';
@@ -73,14 +75,14 @@ describe('DecisionDatasetsPresenter', () => {
 
         const i18nService = createMockI18nService();
 
-        const userOrganisation = organisationFactory.build();
+        const user = userFactory.build();
         const datasets = decisionDatasetFactory.buildList(3);
         const allOrganisations = organisationFactory.buildList(3);
         const professions = professionFactory.buildList(3);
 
         const presenter = new DecisionDatasetsPresenter(
           filterInput,
-          userOrganisation,
+          user,
           allOrganisations,
           2020,
           2023,
@@ -88,6 +90,10 @@ describe('DecisionDatasetsPresenter', () => {
           professions,
           i18nService,
         );
+
+        const getUserOrganisationSpy = jest
+          .spyOn(getUserOrganisationModule, 'getUserOrganisation')
+          .mockReturnValue('Example Organisation');
 
         (ListEntryPresenter.headings as jest.Mock).mockReturnValue(
           mockTableHeadingRow,
@@ -142,6 +148,8 @@ describe('DecisionDatasetsPresenter', () => {
 
         expect(result).toEqual(expected);
 
+        expect(getUserOrganisationSpy).toHaveBeenCalledWith(user, i18nService);
+
         expect(ListEntryPresenter.headings).toBeCalledWith(false, i18nService);
         expect(ListEntryPresenter.prototype.tableRow).toBeCalledTimes(3);
 
@@ -191,13 +199,14 @@ describe('DecisionDatasetsPresenter', () => {
 
         const i18nService = createMockI18nService();
 
+        const user = userFactory.build();
         const datasets = decisionDatasetFactory.buildList(3);
         const allOrganisations = organisationFactory.buildList(3);
         const professions = professionFactory.buildList(3);
 
         const presenter = new DecisionDatasetsPresenter(
           filterInput,
-          null,
+          user,
           allOrganisations,
           2020,
           2023,
@@ -205,6 +214,10 @@ describe('DecisionDatasetsPresenter', () => {
           professions,
           i18nService,
         );
+
+        const getUserOrganisationSpy = jest
+          .spyOn(getUserOrganisationModule, 'getUserOrganisation')
+          .mockReturnValue('Example Organisation');
 
         (ListEntryPresenter.headings as jest.Mock).mockReturnValue(
           mockTableHeadingRow,
@@ -232,7 +245,7 @@ describe('DecisionDatasetsPresenter', () => {
 
         const expected: Omit<IndexTemplate, 'filterQuery'> = {
           view: 'overview',
-          organisation: translationOf('app.beis'),
+          organisation: 'Example Organisation',
           decisionDatasetsTable: {
             caption: translationOf(
               'decisions.admin.dashboard.search.foundPlural',
@@ -258,6 +271,8 @@ describe('DecisionDatasetsPresenter', () => {
         const result = presenter.present('overview');
 
         expect(result).toEqual(expected);
+
+        expect(getUserOrganisationSpy).toHaveBeenCalledWith(user, i18nService);
 
         expect(ListEntryPresenter.headings).toBeCalledWith(true, i18nService);
         expect(ListEntryPresenter.prototype.tableRow).toBeCalledTimes(3);
@@ -296,5 +311,6 @@ describe('DecisionDatasetsPresenter', () => {
 
   afterEach(() => {
     jest.resetAllMocks();
+    jest.restoreAllMocks();
   });
 });

--- a/src/decisions/admin/presenters/decision-datasets.presenter.ts
+++ b/src/decisions/admin/presenters/decision-datasets.presenter.ts
@@ -10,13 +10,15 @@ import { YearsCheckboxPresenter } from './years-checkbox.presenter';
 import { DecisionDatasetStatusesCheckboxPresenter } from './decision-dataset-statuses-checkbox.presenter';
 import { Profession } from '../../../professions/profession.entity';
 import { ProfessionsCheckboxPresenter } from './professions-checkbox.presenter';
+import { getUserOrganisation } from '../../../users/helpers/get-user-organisation';
+import { User } from '../../../users/user.entity';
 
 export type DecisionDatasetsPresenterView = 'overview' | 'single-organisation';
 
 export class DecisionDatasetsPresenter {
   constructor(
     private readonly filterInput: FilterInput,
-    private readonly userOrganisation: Organisation | null,
+    private readonly user: User,
     private readonly allOrganisations: Organisation[],
     private readonly startYear: number,
     private readonly endYear: number,
@@ -28,10 +30,7 @@ export class DecisionDatasetsPresenter {
   present(
     view: DecisionDatasetsPresenterView,
   ): Omit<IndexTemplate, 'filterQuery'> {
-    const organisation =
-      view === 'overview'
-        ? this.i18nService.translate<string>('app.beis')
-        : this.userOrganisation.name;
+    const organisation = getUserOrganisation(this.user, this.i18nService);
 
     const organisationsCheckboxItems = new OrganisationsCheckboxPresenter(
       this.allOrganisations,

--- a/src/organisations/admin/organisations.controller.ts
+++ b/src/organisations/admin/organisations.controller.ts
@@ -46,6 +46,7 @@ import { getActingUser } from '../../users/helpers/get-acting-user.helper';
 import { escape } from '../../helpers/escape.helper';
 import { Nation } from '../../nations/nation';
 import { checkCanViewOrganisation } from '../../users/helpers/check-can-view-organisation';
+import { getUserOrganisation } from '../../users/helpers/get-user-organisation';
 
 @UseGuards(AuthenticationGuard)
 @Controller('/admin/organisations')
@@ -98,9 +99,7 @@ export class OrganisationsController {
         filterInput,
       );
 
-    const userOrganisation = showAllOrgs
-      ? this.i18nService.translate<string>('app.beis')
-      : actingUser.organisation.name;
+    const userOrganisation = getUserOrganisation(actingUser, this.i18nService);
 
     const presenter = new OrganisationsPresenter(
       userOrganisation,

--- a/src/professions/admin/presenters/professions.presenter.spec.ts
+++ b/src/professions/admin/presenters/professions.presenter.spec.ts
@@ -15,6 +15,8 @@ import professionFactory from '../../../testutils/factories/profession';
 import { translationOf } from '../../../testutils/translation-of';
 import { RegulationType } from '../../profession-version.entity';
 import { RegulationTypesCheckboxPresenter } from './regulation-types-checkbox.presenter';
+import userFactory from '../../../testutils/factories/user';
+import * as getUserOrganisationModule from '../../../users/helpers/get-user-organisation';
 
 const transportIndustry = industryFactory.build({
   id: 'transport',
@@ -70,6 +72,8 @@ const profession3 = professionFactory.build(
   { transient: { organisations: [organisation2] } },
 );
 
+const user = userFactory.build();
+
 describe('ProfessionsPresenter', () => {
   let professionsPresenter: ProfessionsPresenter;
   let i18nService: DeepMocked<I18nService>;
@@ -86,7 +90,7 @@ describe('ProfessionsPresenter', () => {
 
     professionsPresenter = new ProfessionsPresenter(
       filterInput,
-      organisation1,
+      user,
       Nation.all(),
       organisations,
       industries,
@@ -97,13 +101,17 @@ describe('ProfessionsPresenter', () => {
 
   describe('present', () => {
     it('returns template params when called with `overview`', () => {
+      const getUserOrganisationSpy = jest
+        .spyOn(getUserOrganisationModule, 'getUserOrganisation')
+        .mockReturnValue('Example Organisation');
+
       const result = professionsPresenter.present('overview');
 
       const nations = Nation.all();
 
       const expected: Omit<IndexTemplate, 'filterQuery' | 'sortMethod'> = {
         view: 'overview',
-        organisation: translationOf('app.beis'),
+        organisation: 'Example Organisation',
         professionsTable: {
           caption: `${translationOf('professions.search.foundPlural')}`,
           captionClasses: 'govuk-table__caption--m',
@@ -144,16 +152,21 @@ describe('ProfessionsPresenter', () => {
       };
 
       expect(result).toEqual(expected);
+      expect(getUserOrganisationSpy).toHaveBeenCalledWith(user, i18nService);
     });
 
     it('returns template params when called with `single-organisation`', () => {
+      const getUserOrganisationSpy = jest
+        .spyOn(getUserOrganisationModule, 'getUserOrganisation')
+        .mockReturnValue('Example Organisation');
+
       const result = professionsPresenter.present('single-organisation');
 
       const nations = Nation.all();
 
       const expected: Omit<IndexTemplate, 'filterQuery' | 'sortMethod'> = {
         view: 'single-organisation',
-        organisation: 'Example Organisation 1',
+        organisation: 'Example Organisation',
         professionsTable: {
           caption: `${translationOf('professions.search.foundPlural')}`,
           captionClasses: 'govuk-table__caption--m',
@@ -193,6 +206,7 @@ describe('ProfessionsPresenter', () => {
       };
 
       expect(result).toEqual(expected);
+      expect(getUserOrganisationSpy).toHaveBeenCalledWith(user, i18nService);
     });
 
     describe('captions', () => {
@@ -202,18 +216,13 @@ describe('ProfessionsPresenter', () => {
           const industries = industryFactory.buildList(3);
           const filterInput: FilterInput = {};
 
-          const organisation = organisationFactory.build({
-            id: 'example-organisation',
-            name: 'Example Organisation',
-          });
-
-          const organisations = [organisation, organisationFactory.build()];
+          const organisations = organisationFactory.buildList(2);
 
           const foundProfessions = professionFactory.buildList(1);
 
           const presenter = new ProfessionsPresenter(
             filterInput,
-            organisation,
+            user,
             Nation.all(),
             organisations,
             industries,
@@ -221,8 +230,16 @@ describe('ProfessionsPresenter', () => {
             i18nService,
           );
 
+          const getUserOrganisationSpy = jest
+            .spyOn(getUserOrganisationModule, 'getUserOrganisation')
+            .mockReturnValue('Example Organisation');
+
           const result = presenter.present('overview');
 
+          expect(getUserOrganisationSpy).toHaveBeenCalledWith(
+            user,
+            i18nService,
+          );
           expect(result.professionsTable.caption).toEqual(
             `${translationOf('professions.search.foundSingular')}`,
           );
@@ -235,18 +252,13 @@ describe('ProfessionsPresenter', () => {
           const industries = industryFactory.buildList(3);
           const filterInput: FilterInput = {};
 
-          const organisation = organisationFactory.build({
-            id: 'example-organisation',
-            name: 'Example Organisation',
-          });
-
-          const organisations = [organisation, organisationFactory.build()];
+          const organisations = organisationFactory.buildList(2);
 
           const foundProfessions = professionFactory.buildList(3);
 
           const presenter = new ProfessionsPresenter(
             filterInput,
-            organisation,
+            user,
             Nation.all(),
             organisations,
             industries,
@@ -254,13 +266,25 @@ describe('ProfessionsPresenter', () => {
             i18nService,
           );
 
+          const getUserOrganisationSpy = jest
+            .spyOn(getUserOrganisationModule, 'getUserOrganisation')
+            .mockReturnValue('Example Organisation');
+
           const result = presenter.present('overview');
 
+          expect(getUserOrganisationSpy).toHaveBeenCalledWith(
+            user,
+            i18nService,
+          );
           expect(result.professionsTable.caption).toEqual(
             `${translationOf('professions.search.foundPlural')}`,
           );
         });
       });
     });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
   });
 });

--- a/src/professions/admin/presenters/professions.presenter.ts
+++ b/src/professions/admin/presenters/professions.presenter.ts
@@ -11,13 +11,15 @@ import { Organisation } from '../../../organisations/organisation.entity';
 import { OrganisationsCheckboxPresenter } from '../../../organisations/organisations-checkbox-presenter';
 import { Table } from '../../../common/interfaces/table';
 import { RegulationTypesCheckboxPresenter } from './regulation-types-checkbox.presenter';
+import { User } from '../../../users/user.entity';
+import { getUserOrganisation } from '../../../users/helpers/get-user-organisation';
 
 export type ProfessionsPresenterView = 'overview' | 'single-organisation';
 
 export class ProfessionsPresenter {
   constructor(
     private readonly filterInput: FilterInput,
-    private readonly userOrganisation: Organisation | null,
+    private readonly user: User,
     private readonly allNations: Nation[],
     private readonly allOrganisations: Organisation[],
     private readonly allIndustries: Industry[],
@@ -28,10 +30,7 @@ export class ProfessionsPresenter {
   present(
     view: ProfessionsPresenterView,
   ): Omit<IndexTemplate, 'filterQuery' | 'sortMethod'> {
-    const organisation =
-      view === 'overview'
-        ? this.i18nService.translate<string>('app.beis')
-        : this.userOrganisation.name;
+    const organisation = getUserOrganisation(this.user, this.i18nService);
 
     const nationsCheckboxItems = new NationsCheckboxPresenter(
       this.allNations,

--- a/src/professions/admin/professions.controller.spec.ts
+++ b/src/professions/admin/professions.controller.spec.ts
@@ -5,7 +5,6 @@ import { I18nService } from 'nestjs-i18n';
 import { createMockI18nService } from '../../testutils/create-mock-i18n-service';
 import { IndustriesService } from '../../industries/industries.service';
 import { Nation } from '../../nations/nation';
-import { Organisation } from '../../organisations/organisation.entity';
 import { FilterInput } from '../../common/interfaces/filter-input.interface';
 import { Profession } from '../profession.entity';
 import { ProfessionsService } from '../professions.service';
@@ -25,6 +24,7 @@ import { RegulationType } from '../profession-version.entity';
 import * as removeFromQueryStringModule from '../../helpers/remove-from-query-string.helper';
 import * as getQueryStringModule from '../../helpers/get-query-string.helper';
 import { IndexTemplate } from './interfaces/index-template.interface';
+import { User } from '../../users/user.entity';
 
 jest.mock('../../users/helpers/get-acting-user.helper');
 
@@ -205,10 +205,11 @@ describe('ProfessionsController', () => {
 
   describe('index', () => {
     describe('when the user is a service owner', () => {
+      let user: User;
+
       beforeEach(() => {
-        (getActingUser as jest.Mock).mockReturnValue(
-          userFactory.build({ serviceOwner: true }),
-        );
+        user = userFactory.build({ serviceOwner: true });
+        (getActingUser as jest.Mock).mockReturnValue(user);
       });
 
       it('returns template params poulated to show an overview of professions', async () => {
@@ -230,7 +231,7 @@ describe('ProfessionsController', () => {
               industries: [],
               regulationTypes: [],
             },
-            null,
+            user,
             [profession1, profession2, profession3],
           ).present('overview'),
           sortMethod: 'name',
@@ -273,7 +274,7 @@ describe('ProfessionsController', () => {
               industries: [],
               regulationTypes: [],
             },
-            null,
+            user,
             [profession1, profession2, profession3],
           ).present('overview'),
           sortMethod: 'last-updated',
@@ -316,7 +317,7 @@ describe('ProfessionsController', () => {
               industries: [],
               regulationTypes: [],
             },
-            null,
+            user,
             [profession1, profession2, profession3],
           ).present('overview'),
           sortMethod: 'status',
@@ -358,7 +359,7 @@ describe('ProfessionsController', () => {
               industries: [],
               regulationTypes: [],
             },
-            null,
+            user,
             [profession3],
           ).present('overview'),
           sortMethod: 'name',
@@ -400,7 +401,7 @@ describe('ProfessionsController', () => {
               industries: [],
               regulationTypes: [],
             },
-            null,
+            user,
             [profession1],
           ).present('overview'),
           sortMethod: 'name',
@@ -442,7 +443,7 @@ describe('ProfessionsController', () => {
               industries: [],
               regulationTypes: [],
             },
-            null,
+            user,
             [profession3],
           ).present('overview'),
           sortMethod: 'name',
@@ -484,7 +485,7 @@ describe('ProfessionsController', () => {
               industries: [industry2],
               regulationTypes: [],
             },
-            null,
+            user,
             [profession3],
           ).present('overview'),
           sortMethod: 'name',
@@ -526,7 +527,7 @@ describe('ProfessionsController', () => {
               industries: [],
               regulationTypes: [RegulationType.Accreditation],
             },
-            null,
+            user,
             [profession1],
           ).present('overview'),
           sortMethod: 'name',
@@ -545,13 +546,14 @@ describe('ProfessionsController', () => {
     });
 
     describe('when the user is not a service owner', () => {
+      let user: User;
+
       beforeEach(() => {
-        (getActingUser as jest.Mock).mockReturnValue(
-          userFactory.build({
-            serviceOwner: false,
-            organisation: organisation1,
-          }),
-        );
+        user = userFactory.build({
+          serviceOwner: false,
+          organisation: organisation1,
+        });
+        (getActingUser as jest.Mock).mockReturnValue(user);
       });
 
       it('returns template params poulated to show professions for a single organisation', async () => {
@@ -571,7 +573,7 @@ describe('ProfessionsController', () => {
               nations: [],
               organisations: [],
             },
-            organisation1,
+            user,
             [profession1, profession2],
           ).present('single-organisation'),
           sortMethod: null,
@@ -608,7 +610,7 @@ describe('ProfessionsController', () => {
               nations: [],
               organisations: [],
             },
-            organisation1,
+            user,
             [profession1],
           ).present('single-organisation'),
           sortMethod: null,
@@ -645,7 +647,7 @@ describe('ProfessionsController', () => {
               nations: [Nation.find('GB-NIR')],
               organisations: [],
             },
-            organisation1,
+            user,
             [profession2],
           ).present('single-organisation'),
           sortMethod: null,
@@ -672,12 +674,12 @@ describe('ProfessionsController', () => {
 
 function createPresenter(
   filterInput: FilterInput,
-  userOrganisation: Organisation | null,
+  user: User,
   professions: Profession[],
 ): ProfessionsPresenter {
   return new ProfessionsPresenter(
     filterInput,
-    userOrganisation,
+    user,
     Nation.all(),
     organisations,
     industries,

--- a/src/professions/admin/professions.controller.ts
+++ b/src/professions/admin/professions.controller.ts
@@ -119,7 +119,7 @@ export class ProfessionsController {
     return {
       ...new ProfessionsPresenter(
         filterInput,
-        userOrganisation,
+        actingUser,
         allNations,
         allOrganisations,
         allIndustries,

--- a/src/users/helpers/get-user-organisation.spec.ts
+++ b/src/users/helpers/get-user-organisation.spec.ts
@@ -1,13 +1,20 @@
+import { createMockI18nService } from '../../testutils/create-mock-i18n-service';
 import organisationFactory from '../../testutils/factories/organisation';
 import userFactory from '../../testutils/factories/user';
+import { translationOf } from '../../testutils/translation-of';
 import { getUserOrganisation } from './get-user-organisation';
 
 describe('getUserOrganisation', () => {
   describe('when the user is a service owner', () => {
-    it('returns the BEIS team translation string', () => {
+    it('returns the BEIS team translated string', () => {
       const user = userFactory.build({ serviceOwner: true });
 
-      expect(getUserOrganisation(user)).toEqual('app.beis');
+      const i18nService = createMockI18nService();
+
+      expect(getUserOrganisation(user, i18nService)).toEqual(
+        translationOf('app.beis'),
+      );
+      expect(i18nService.translate).toHaveBeenCalledWith('app.beis');
     });
   });
 
@@ -20,7 +27,12 @@ describe('getUserOrganisation', () => {
         }),
       });
 
-      expect(getUserOrganisation(user)).toEqual('Department for Education');
+      const i18nService = createMockI18nService();
+
+      expect(getUserOrganisation(user, i18nService)).toEqual(
+        'Department for Education',
+      );
+      expect(i18nService.translate).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/users/helpers/get-user-organisation.ts
+++ b/src/users/helpers/get-user-organisation.ts
@@ -1,7 +1,13 @@
+import { I18nService } from 'nestjs-i18n';
 import { User } from '../user.entity';
 
-export function getUserOrganisation(user: User): string {
+export function getUserOrganisation(
+  user: User,
+  i18nService: I18nService,
+): string {
   const isBEISUser = user.serviceOwner;
 
-  return isBEISUser ? 'app.beis' : user.organisation.name;
+  return isBEISUser
+    ? i18nService.translate<string>('app.beis')
+    : user.organisation.name;
 }

--- a/src/users/users.controller.spec.ts
+++ b/src/users/users.controller.spec.ts
@@ -18,6 +18,7 @@ import organisationFactory from '../testutils/factories/organisation';
 import { getActingUser } from './helpers/get-acting-user.helper';
 import { createDefaultMockRequest } from '../testutils/factories/create-default-mock-request';
 import { checkCanViewUser } from './helpers/check-can-view-user';
+import { translationOf } from '../testutils/translation-of';
 
 jest.mock('./presenters/users.presenter');
 jest.mock('./presenters/user.presenter');
@@ -93,7 +94,7 @@ describe('UsersController', () => {
         usersService.allConfirmed.mockResolvedValue([user]);
 
         expect(await controller.index(request)).toEqual({
-          organisation: 'app.beis',
+          organisation: translationOf('app.beis'),
           ...[user],
           rows: tableRows,
         });

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -61,7 +61,7 @@ export class UsersController {
       ? this.usersService.allConfirmed()
       : this.usersService.allConfirmedForOrganisation(actingUser.organisation));
 
-    const organisation = getUserOrganisation(actingUser);
+    const organisation = getUserOrganisation(actingUser, this.i18nService);
 
     const usersPresenter = new UsersPresenter(users, this.i18nService);
 

--- a/views/admin/dashboard.njk
+++ b/views/admin/dashboard.njk
@@ -8,7 +8,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">
-      <span class="govuk-caption-l">{{ organisation | t }}</span>
+      <span class="govuk-caption-l">{{ organisation }}</span>
       {{ user.name }}
     </h1>
     <h2 class="govuk-heading-m">{{("app.pages.admin.dashboard.subHeading" | t)}}</h2>

--- a/views/admin/users/index.njk
+++ b/views/admin/users/index.njk
@@ -14,7 +14,7 @@
     <div class="govuk-grid-column-full">
 
       <h1 class="govuk-heading-xl">
-        <span class="govuk-caption-l">{{ organisation | t }}</span>
+        <span class="govuk-caption-l">{{ organisation }}</span>
         {{ "users.headings.index" | t }}
       </h1>
 


### PR DESCRIPTION
# Changes in this PR

- Consistently use `getUserOrganisation`, rather than having multiple places in code that are aware of the "app.beis" string