### PR TITLE
(2050) Prevent tests running in wrong environment

### DIFF
--- a/cypress/support/index.ts
+++ b/cypress/support/index.ts
@@ -103,6 +103,10 @@ import './commands';
 // Purge the Opensearch index and seed the database
 // before running the specs
 before(() => {
+  cy.visit('')
+    .get('[data-cy=environment-marker]')
+    .should('contain', 'test environment');
+
   cy.exec('npm run opensearch:test:purge');
   cy.exec('npm run seed:test');
 });

--- a/views/index.njk
+++ b/views/index.njk
@@ -4,7 +4,11 @@
 {% set feedbackFormUrl = "https://forms.office.com/Pages/ResponsePage.aspx?id=BXCsy8EC60O0l-ZJLRst2Hs7TwXbV7BKiF_b_DtnqB1UNFQxV0gxNEhMMzhVNDJVTVpLNzIzWlk5UCQlQCN0PWcu" %}
 
 {% block content %}
-<div class="govuk-grid-row">
+  {% if environment === 'test'%}
+    <div data-cy="environment-marker" class="govuk-visually-hidden">test environment</div>
+  {% endif %}
+
+  <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
       <h1 class="govuk-heading-xl">


### PR DESCRIPTION
There have been issues with users getting deleted because e2e tests have been run in the development environment.

This change adds a visually hidden test banner to the top of each page which Cypress checks exists before any test run.

Whilst this will prevent the tests running in a non-test environment there will be a performance penalty for running this assertion before every test
