### PR TITLE
Use login-action for docker ghcr login

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,8 +22,12 @@ jobs:
       docker_tag: ${{ steps.set_output.outputs.docker_tag }}
     steps:
       - uses: actions/checkout@v2
-      - name: Set Docker tag environment variable
-        run: echo "GITHUB_USERNAME=${{ github.actor }}" >> $GITHUB_ENV
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Set Docker tag environment variable
         run: echo "DOCKER_TAG=${GITHUB_RUN_ID}-${GITHUB_SHA}" >> $GITHUB_ENV
       - name: Tag and Push Docker Container

--- a/script/docker-push
+++ b/script/docker-push
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-echo "$GITHUB_TOKEN" | docker login ghcr.io -u "$GITHUB_USERNAME" --password-stdin
-
 docker build --target web \
          --build-arg current_sha="$GITHUB_SHA" \
          --build-arg time_of_build="$(date -u +'%Y-%m-%dT%H:%M:%SZ')" \


### PR DESCRIPTION
* It doesn't appear that the GITHUB_TOKEN is available as an environment
  variable within scripts. Using the login-action within the workflow,
  then running the script to build and push should work
