### PR TITLE
fix: add REPLY variable to read

### DIFF
--- a/script/release
+++ b/script/release
@@ -21,7 +21,7 @@ next_tag="release-$next_version"
 
 if grep -Eq "$next_tag" CHANGELOG.md; then
   echo "Are you sure you want to push the tag \`$next_tag\` to origin? This will deploy the latest code to production. (y/n)"
-  read -r
+  read -r REPLY
   if expr "$REPLY" : "^[Yy]$" > /dev/null; then
     git tag "$next_tag"
     git push origin "$next_tag"


### PR DESCRIPTION
# Changes in this PR
Update release script to work in both WSL and Mac cmd.

WSL requires variable to be supplied after read -r

[AB#15657](https://dev.azure.com/BEIS-DevOps/e0e9004c-3b64-4ea2-b749-b121c401c881/_workitems/edit/15657)