### PR TITLE
feat: add licence finder text and link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- Add link to Licence Finder to professions page
+
 ### Changed
 
 - Changed "Alternate name" to "Alternative name"

--- a/src/i18n/en/professions.json
+++ b/src/i18n/en/professions.json
@@ -278,6 +278,11 @@
     "decisions": {
       "heading": "Recognition decision data",
       "year": "Year"
+    },
+    "licenceFinder": {
+      "heading": "Licence Finder",
+      "url": "https://www.gov.uk/licence-finder",
+      "body": "You may need other authorisations to carry out certain activities in the UK. Use the <a href=\"$t(professions.show.licenceFinder.url)\">Licence Finder</a> to help you search for and find the licences and permits you may need."
     }
   },
   "admin": {

--- a/views/professions/_profession-details.njk
+++ b/views/professions/_profession-details.njk
@@ -297,3 +297,9 @@
   
   {{ govukSummaryList(decisionYears) }}
 {% endif %}
+
+<h2 class="govuk-heading-l">{{ "professions.show.licenceFinder.heading" | t}}</h2>
+
+<div class="govuk-body">  
+  {{ "professions.show.licenceFinder.body" | t | safe }}
+</div>


### PR DESCRIPTION
# Changes in this PR
Add licence finder text and link to https://www.gov.uk/licence-finder

### After
![image](https://user-images.githubusercontent.com/82883482/237024757-7649fcb2-d295-437e-bae1-218ac05f79fa.png)

[AB#22945](https://dev.azure.com/BEIS-DevOps/e0e9004c-3b64-4ea2-b749-b121c401c881/_workitems/edit/22945)