### PR TITLE
AB#25229 enable decision data global

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Update references to BEIS to DBT in confirmation, accessibility, and i18n
 - Update privacy notice
+- Re-enable decision data for non-service owner roles in production
 
 ## [release-028] - 2023-05-11
 

--- a/cypress/integration/admin/decisions/edit.spec.ts
+++ b/cypress/integration/admin/decisions/edit.spec.ts
@@ -337,111 +337,111 @@ describe('Editing a decision dataset', () => {
     });
   });
 
-  // context('When I am logged in as an org user', () => {
-  //   beforeEach(() => {
-  //     cy.loginAuth0('orgadmin');
-  //     cy.visitInternalDashboard();
-  //     cy.translate('app.pages.admin.dashboard.editDecisionDataRegulators').then(
-  //       (link) => {
-  //         cy.get('a').contains(link).click();
-  //         cy.checkAccessibility();
-  //       },
-  //     );
-  //   });
+  context('When I am logged in as an org user', () => {
+    beforeEach(() => {
+      cy.loginAuth0('orgadmin');
+      cy.visitInternalDashboard();
+      cy.translate('app.pages.admin.dashboard.editDecisionDataRegulators').then(
+        (link) => {
+          cy.get('a').contains(link).click();
+          cy.checkAccessibility();
+        },
+      );
+    });
 
-  //   it('I cannot publish decision data', () => {
-  //     cy.translate('app.status.draft').then((draft) => {
-  //       cy.get('tr')
-  //         .contains(
-  //           'Secondary School Teacher in State maintained schools (England)',
-  //         )
-  //         .parent()
-  //         .contains(draft)
-  //         .parent()
-  //         .parent()
-  //         .within(() => {
-  //           cy.get('a').contains('View details').click();
-  //         });
-  //     });
+    it('I cannot publish decision data', () => {
+      cy.translate('app.status.draft').then((draft) => {
+        cy.get('tr')
+          .contains(
+            'Secondary School Teacher in State maintained schools (England)',
+          )
+          .parent()
+          .contains(draft)
+          .parent()
+          .parent()
+          .within(() => {
+            cy.get('a').contains('View details').click();
+          });
+      });
 
-  //     cy.checkAccessibility();
+      cy.checkAccessibility();
 
-  //     cy.translate('decisions.admin.buttons.edit').then((edit) => {
-  //       cy.get('a').contains(edit).click();
-  //     });
+      cy.translate('decisions.admin.buttons.edit').then((edit) => {
+        cy.get('a').contains(edit).click();
+      });
 
-  //     cy.checkAccessibility();
+      cy.checkAccessibility();
 
-  //     cy.translate('decisions.admin.buttons.publish').then((publish) => {
-  //       cy.get('button').should('not.contain', publish);
-  //     });
-  //   });
+      cy.translate('decisions.admin.buttons.publish').then((publish) => {
+        cy.get('button').should('not.contain', publish);
+      });
+    });
 
-  //   it('I can submit decision data from the edit page', () => {
-  //     cy.translate('app.status.draft').then((draft) => {
-  //       cy.get('tr')
-  //         .contains(
-  //           'Secondary School Teacher in State maintained schools (England)',
-  //         )
-  //         .parent()
-  //         .contains(draft)
-  //         .parent()
-  //         .parent()
-  //         .within(() => {
-  //           cy.get('a').contains('View details').click();
-  //         });
-  //     });
+    it('I can submit decision data from the edit page', () => {
+      cy.translate('app.status.draft').then((draft) => {
+        cy.get('tr')
+          .contains(
+            'Secondary School Teacher in State maintained schools (England)',
+          )
+          .parent()
+          .contains(draft)
+          .parent()
+          .parent()
+          .within(() => {
+            cy.get('a').contains('View details').click();
+          });
+      });
 
-  //     cy.checkAccessibility();
+      cy.checkAccessibility();
 
-  //     cy.translate('decisions.admin.buttons.edit').then((edit) => {
-  //       cy.get('a').contains(edit).click();
-  //     });
+      cy.translate('decisions.admin.buttons.edit').then((edit) => {
+        cy.get('a').contains(edit).click();
+      });
 
-  //     cy.translate('decisions.admin.buttons.edit').then((editButton) => {
-  //       cy.get('a').contains(editButton).click();
-  //     });
+      cy.translate('decisions.admin.buttons.edit').then((editButton) => {
+        cy.get('a').contains(editButton).click();
+      });
 
-  //     cy.checkAccessibility();
+      cy.checkAccessibility();
 
-  //     cy.translate('decisions.admin.buttons.submit').then((submitButton) => {
-  //       cy.get('button').contains(submitButton).click();
-  //     });
+      cy.translate('decisions.admin.buttons.submit').then((submitButton) => {
+        cy.get('button').contains(submitButton).click();
+      });
 
-  //     cy.checkAccessibility();
+      cy.checkAccessibility();
 
-  //     cy.translate('decisions.admin.submission.caption').then(
-  //       (submitCaption) => {
-  //         cy.get('body').contains(submitCaption);
-  //       },
-  //     );
+      cy.translate('decisions.admin.submission.caption').then(
+        (submitCaption) => {
+          cy.get('body').contains(submitCaption);
+        },
+      );
 
-  //     cy.translate('decisions.admin.submission.heading').then((heading) => {
-  //       cy.contains(heading);
-  //     });
+      cy.translate('decisions.admin.submission.heading').then((heading) => {
+        cy.contains(heading);
+      });
 
-  //     cy.contains(
-  //       'Secondary School Teacher in State maintained schools (England)',
-  //     );
-  //     cy.contains('2019');
+      cy.contains(
+        'Secondary School Teacher in State maintained schools (England)',
+      );
+      cy.contains('2019');
 
-  //     cy.translate('decisions.admin.buttons.submit').then((submitButton) => {
-  //       cy.get('button').contains(submitButton).click();
-  //     });
+      cy.translate('decisions.admin.buttons.submit').then((submitButton) => {
+        cy.get('button').contains(submitButton).click();
+      });
 
-  //     cy.checkAccessibility();
+      cy.checkAccessibility();
 
-  //     cy.translate('decisions.show.heading').then((heading) => {
-  //       cy.get('body').should('contain', heading);
-  //     });
+      cy.translate('decisions.show.heading').then((heading) => {
+        cy.get('body').should('contain', heading);
+      });
 
-  //     cy.translate('decisions.admin.submission.confirmation.heading').then(
-  //       (confirmationHeading) => {
-  //         cy.get('body').should('contain', confirmationHeading);
-  //       },
-  //     );
-  //   });
-  // });
+      cy.translate('decisions.admin.submission.confirmation.heading').then(
+        (confirmationHeading) => {
+          cy.get('body').should('contain', confirmationHeading);
+        },
+      );
+    });
+  });
 });
 
 function withinEditTableDiv(tableName: string, func: () => void) {

--- a/cypress/integration/admin/decisions/index.spec.ts
+++ b/cypress/integration/admin/decisions/index.spec.ts
@@ -213,151 +213,151 @@ describe('Listing decision datasets', () => {
     });
   });
 
-  // context('When I am logged in as organisation editor', () => {
-  //   beforeEach(() => {
-  //     cy.loginAuth0('orgeditor');
-  //     cy.visitInternalDashboard();
-  //     cy.translate('app.pages.admin.dashboard.editDecisionDataRegulators').then(
-  //       (link) => {
-  //         cy.get('a').contains(link).click();
-  //         cy.checkAccessibility();
-  //       },
-  //     );
-  //   });
+  context('When I am logged in as organisation editor', () => {
+    beforeEach(() => {
+      cy.loginAuth0('orgeditor');
+      cy.visitInternalDashboard();
+      cy.translate('app.pages.admin.dashboard.editDecisionDataRegulators').then(
+        (link) => {
+          cy.get('a').contains(link).click();
+          cy.checkAccessibility();
+        },
+      );
+    });
 
-  //   it('Lists decision datasets for my organisation', () => {
-  //     cy.getDisplayedDatasets().then((datasets) => {
-  //       datasets = datasets.filter(
-  //         (dataset) => dataset.organisation === 'Department for Education',
-  //       );
+    it('Lists decision datasets for my organisation', () => {
+      cy.getDisplayedDatasets().then((datasets) => {
+        datasets = datasets.filter(
+          (dataset) => dataset.organisation === 'Department for Education',
+        );
 
-  //       cy.translate(
-  //         `decisions.admin.dashboard.search.${
-  //           datasets.length > 1 ? 'foundPlural' : 'foundSingular'
-  //         }`,
-  //         {
-  //           count: datasets.length,
-  //         },
-  //       ).then((foundText) => {
-  //         cy.get('body').should('contain', foundText);
-  //       });
+        cy.translate(
+          `decisions.admin.dashboard.search.${
+            datasets.length > 1 ? 'foundPlural' : 'foundSingular'
+          }`,
+          {
+            count: datasets.length,
+          },
+        ).then((foundText) => {
+          cy.get('body').should('contain', foundText);
+        });
 
-  //       datasets.forEach((dataset, index) => {
-  //         cy.get('tbody tr')
-  //           .eq(index)
-  //           .then(($row) => {
-  //             cy.wrap($row).should('contain', dataset.profession);
-  //             cy.wrap($row).should('not.contain', dataset.organisation);
-  //             cy.wrap($row).should('contain', dataset.year.toString());
+        datasets.forEach((dataset, index) => {
+          cy.get('tbody tr')
+            .eq(index)
+            .then(($row) => {
+              cy.wrap($row).should('contain', dataset.profession);
+              cy.wrap($row).should('not.contain', dataset.organisation);
+              cy.wrap($row).should('contain', dataset.year.toString());
 
-  //             cy.get('[data-cy=changed-by-text]').should('not.exist');
-  //             cy.wrap($row).should('contain', format(new Date(), 'd MMM yyyy'));
+              cy.get('[data-cy=changed-by-text]').should('not.exist');
+              cy.wrap($row).should('contain', format(new Date(), 'd MMM yyyy'));
 
-  //             cy.translate(`app.status.${dataset.status}`).then((status) => {
-  //               cy.wrap($row).should('contain', status);
-  //             });
-  //           });
-  //       });
-  //     });
+              cy.translate(`app.status.${dataset.status}`).then((status) => {
+                cy.wrap($row).should('contain', status);
+              });
+            });
+        });
+      });
 
-  //     checkCsvDownload(
-  //       (dataset) => dataset.organisation === 'Department for Education',
-  //     );
-  //   });
+      checkCsvDownload(
+        (dataset) => dataset.organisation === 'Department for Education',
+      );
+    });
 
-  //   it('I can filter by professions', () => {
-  //     cy.expandFilters('decisions.admin.dashboard');
+    it('I can filter by professions', () => {
+      cy.expandFilters('decisions.admin.dashboard');
 
-  //     cy.get('label')
-  //       .contains(
-  //         'Secondary School Teacher in State maintained schools (England)',
-  //       )
-  //       .parent()
-  //       .find('input')
-  //       .check();
+      cy.get('label')
+        .contains(
+          'Secondary School Teacher in State maintained schools (England)',
+        )
+        .parent()
+        .find('input')
+        .check();
 
-  //     cy.clickFilterButtonAndCheckAccessibility();
+      cy.clickFilterButtonAndCheckAccessibility();
 
-  //     cy.get('tbody tr').each(($tr) => {
-  //       cy.wrap($tr).should('contain', 'Secondary School');
-  //     });
+      cy.get('tbody tr').each(($tr) => {
+        cy.wrap($tr).should('contain', 'Secondary School');
+      });
 
-  //     cy.get('tbody tr').each(($tr) => {
-  //       cy.wrap($tr).should('not.contain', 'Primary School');
-  //     });
+      cy.get('tbody tr').each(($tr) => {
+        cy.wrap($tr).should('not.contain', 'Primary School');
+      });
 
-  //     cy.get('tbody tr').should('have.length.at.least', 2);
+      cy.get('tbody tr').should('have.length.at.least', 2);
 
-  //     checkCsvDownload(
-  //       (dataset) =>
-  //         dataset.profession.includes('Secondary School') &&
-  //         !dataset.profession.includes('Primary School'),
-  //     );
-  //   });
+      checkCsvDownload(
+        (dataset) =>
+          dataset.profession.includes('Secondary School') &&
+          !dataset.profession.includes('Primary School'),
+      );
+    });
 
-  //   it('Contains the expected columns and filters', () => {
-  //     cy.translate('decisions.admin.dashboard.tableHeading.profession').then(
-  //       (profession) => {
-  //         cy.get('thead tr').should('contain', profession);
-  //       },
-  //     );
+    it('Contains the expected columns and filters', () => {
+      cy.translate('decisions.admin.dashboard.tableHeading.profession').then(
+        (profession) => {
+          cy.get('thead tr').should('contain', profession);
+        },
+      );
 
-  //     cy.translate('decisions.admin.dashboard.tableHeading.regulator').then(
-  //       (regulator) => {
-  //         cy.get('thead tr').should('not.contain', regulator);
-  //       },
-  //     );
+      cy.translate('decisions.admin.dashboard.tableHeading.regulator').then(
+        (regulator) => {
+          cy.get('thead tr').should('not.contain', regulator);
+        },
+      );
 
-  //     cy.translate('decisions.admin.dashboard.tableHeading.year').then(
-  //       (year) => {
-  //         cy.get('thead tr').should('contain', year);
-  //       },
-  //     );
+      cy.translate('decisions.admin.dashboard.tableHeading.year').then(
+        (year) => {
+          cy.get('thead tr').should('contain', year);
+        },
+      );
 
-  //     cy.translate('decisions.admin.dashboard.tableHeading.lastModified').then(
-  //       (lastModified) => {
-  //         cy.get('thead tr').should('contain', lastModified);
-  //       },
-  //     );
+      cy.translate('decisions.admin.dashboard.tableHeading.lastModified').then(
+        (lastModified) => {
+          cy.get('thead tr').should('contain', lastModified);
+        },
+      );
 
-  //     cy.translate('decisions.admin.dashboard.tableHeading.status').then(
-  //       (status) => {
-  //         cy.get('thead tr').should('contain', status);
-  //       },
-  //     );
+      cy.translate('decisions.admin.dashboard.tableHeading.status').then(
+        (status) => {
+          cy.get('thead tr').should('contain', status);
+        },
+      );
 
-  //     cy.expandFilters('decisions.admin.dashboard');
+      cy.expandFilters('decisions.admin.dashboard');
 
-  //     cy.translate('decisions.admin.dashboard.filter.keywords.label').then(
-  //       (keywords) => {
-  //         cy.get('label').should('not.contain', keywords);
-  //       },
-  //     );
+      cy.translate('decisions.admin.dashboard.filter.keywords.label').then(
+        (keywords) => {
+          cy.get('label').should('not.contain', keywords);
+        },
+      );
 
-  //     cy.translate('decisions.admin.dashboard.filter.organisations.label').then(
-  //       (organisations) => {
-  //         cy.get('legend').should('not.contain', organisations);
-  //       },
-  //     );
-  //     cy.translate('decisions.admin.dashboard.filter.professions.label').then(
-  //       (professions) => {
-  //         cy.get('legend').should('contain', professions);
-  //       },
-  //     );
+      cy.translate('decisions.admin.dashboard.filter.organisations.label').then(
+        (organisations) => {
+          cy.get('legend').should('not.contain', organisations);
+        },
+      );
+      cy.translate('decisions.admin.dashboard.filter.professions.label').then(
+        (professions) => {
+          cy.get('legend').should('contain', professions);
+        },
+      );
 
-  //     cy.translate('decisions.admin.dashboard.filter.years.label').then(
-  //       (years) => {
-  //         cy.get('legend').should('contain', years);
-  //       },
-  //     );
+      cy.translate('decisions.admin.dashboard.filter.years.label').then(
+        (years) => {
+          cy.get('legend').should('contain', years);
+        },
+      );
 
-  //     cy.translate('decisions.admin.dashboard.filter.statuses.label').then(
-  //       (statuses) => {
-  //         cy.get('legend').should('contain', statuses);
-  //       },
-  //     );
-  //   });
-  // });
+      cy.translate('decisions.admin.dashboard.filter.statuses.label').then(
+        (statuses) => {
+          cy.get('legend').should('contain', statuses);
+        },
+      );
+    });
+  });
 });
 
 function checkCsvDownload(

--- a/cypress/integration/admin/decisions/new.spec.ts
+++ b/cypress/integration/admin/decisions/new.spec.ts
@@ -245,99 +245,99 @@ describe('Creating a decision dataset', () => {
     });
   });
 
-  // context('When I am logged in as an organisation editor', () => {
-  //   beforeEach(() => {
-  //     cy.loginAuth0('orgeditor');
-  //     cy.visitInternalDashboard();
-  //     cy.translate('app.pages.admin.dashboard.editDecisionDataRegulators').then(
-  //       (link) => {
-  //         cy.get('a').contains(link).click();
-  //         cy.checkAccessibility();
-  //       },
-  //     );
-  //   });
+  context('When I am logged in as an organisation editor', () => {
+    beforeEach(() => {
+      cy.loginAuth0('orgeditor');
+      cy.visitInternalDashboard();
+      cy.translate('app.pages.admin.dashboard.editDecisionDataRegulators').then(
+        (link) => {
+          cy.get('a').contains(link).click();
+          cy.checkAccessibility();
+        },
+      );
+    });
 
-  //   it('I can create a decision dataset for my organisation', () => {
-  //     cy.get('tbody').should('not.contain', '2020');
+    it('I can create a decision dataset for my organisation', () => {
+      cy.get('tbody').should('not.contain', '2020');
 
-  //     cy.translate('decisions.admin.dashboard.addButtonLabel').then((add) => {
-  //       cy.get('a').contains(add).click();
-  //     });
+      cy.translate('decisions.admin.dashboard.addButtonLabel').then((add) => {
+        cy.get('a').contains(add).click();
+      });
 
-  //     cy.checkAccessibility();
+      cy.checkAccessibility();
 
-  //     cy.translate('decisions.admin.new.labels.profession').then(
-  //       (profession) => {
-  //         cy.get('label')
-  //           .contains(profession)
-  //           .parent()
-  //           .within(() => {
-  //             cy.get('select').select(
-  //               'Secondary School Teacher in State maintained schools (England)',
-  //             );
-  //           });
-  //       },
-  //     );
+      cy.translate('decisions.admin.new.labels.profession').then(
+        (profession) => {
+          cy.get('label')
+            .contains(profession)
+            .parent()
+            .within(() => {
+              cy.get('select').select(
+                'Secondary School Teacher in State maintained schools (England)',
+              );
+            });
+        },
+      );
 
-  //     cy.translate('decisions.admin.new.labels.year').then((profession) => {
-  //       cy.get('label')
-  //         .contains(profession)
-  //         .parent()
-  //         .within(() => {
-  //           cy.get('select').select('2020');
-  //         });
-  //     });
+      cy.translate('decisions.admin.new.labels.year').then((profession) => {
+        cy.get('label')
+          .contains(profession)
+          .parent()
+          .within(() => {
+            cy.get('select').select('2020');
+          });
+      });
 
-  //     cy.translate('app.continue').then((continueLabel) => {
-  //       cy.get('button').contains(continueLabel).click();
-  //     });
+      cy.translate('app.continue').then((continueLabel) => {
+        cy.get('button').contains(continueLabel).click();
+      });
 
-  //     cy.get('h1').should(
-  //       'contain',
-  //       'Secondary School Teacher in State maintained schools (England)',
-  //     );
+      cy.get('h1').should(
+        'contain',
+        'Secondary School Teacher in State maintained schools (England)',
+      );
 
-  //     cy.checkSummaryListRowValue(
-  //       'decisions.admin.edit.regulator',
-  //       'Department for Education',
-  //     );
-  //     cy.checkSummaryListRowValue('decisions.admin.edit.year', '2020');
+      cy.checkSummaryListRowValue(
+        'decisions.admin.edit.regulator',
+        'Department for Education',
+      );
+      cy.checkSummaryListRowValue('decisions.admin.edit.year', '2020');
 
-  //     cy.get('input[name="routes[1]"]').type('New route');
-  //     cy.get('select[name="countries[1][1]"]').select('Brazil');
-  //     cy.get('input[name="yeses[1][1]"]').type('8');
-  //     cy.get('input[name="noes[1][1]"]').type('1');
-  //     cy.get('input[name="yesAfterComps[1][1]"]').type('2');
-  //     cy.get('input[name="noAfterComps[1][1]"]').type('3');
+      cy.get('input[name="routes[1]"]').type('New route');
+      cy.get('select[name="countries[1][1]"]').select('Brazil');
+      cy.get('input[name="yeses[1][1]"]').type('8');
+      cy.get('input[name="noes[1][1]"]').type('1');
+      cy.get('input[name="yesAfterComps[1][1]"]').type('2');
+      cy.get('input[name="noAfterComps[1][1]"]').type('3');
 
-  //     cy.translate('decisions.admin.buttons.saveAsDraft').then((save) => {
-  //       cy.get('button').contains(save).click();
-  //     });
+      cy.translate('decisions.admin.buttons.saveAsDraft').then((save) => {
+        cy.get('button').contains(save).click();
+      });
 
-  //     cy.get('caption').should('contain', 'New route');
+      cy.get('caption').should('contain', 'New route');
 
-  //     cy.checkVerticalTable(
-  //       [
-  //         'decisions.show.tableHeading.country',
-  //         'decisions.show.tableHeading.yes',
-  //         'decisions.show.tableHeading.yesAfterComp',
-  //         'decisions.show.tableHeading.no',
-  //         'decisions.show.tableHeading.noAfterComp',
-  //       ],
-  //       [['Brazil', '8', '2', '1', '3']],
-  //     );
+      cy.checkVerticalTable(
+        [
+          'decisions.show.tableHeading.country',
+          'decisions.show.tableHeading.yes',
+          'decisions.show.tableHeading.yesAfterComp',
+          'decisions.show.tableHeading.no',
+          'decisions.show.tableHeading.noAfterComp',
+        ],
+        [['Brazil', '8', '2', '1', '3']],
+      );
 
-  //     cy.visitAndCheckAccessibility('/admin/decisions');
+      cy.visitAndCheckAccessibility('/admin/decisions');
 
-  //     cy.get('td')
-  //       .contains('2020')
-  //       .parent()
-  //       .parent()
-  //       .within(($row) => {
-  //         cy.translate('app.status.draft').then((draft) => {
-  //           cy.wrap($row).contains(draft);
-  //         });
-  //       });
-  //   });
-  // });
+      cy.get('td')
+        .contains('2020')
+        .parent()
+        .parent()
+        .within(($row) => {
+          cy.translate('app.status.draft').then((draft) => {
+            cy.wrap($row).contains(draft);
+          });
+        });
+    });
+  });
 });

--- a/cypress/integration/admin/decisions/submit.spec.ts
+++ b/cypress/integration/admin/decisions/submit.spec.ts
@@ -1,87 +1,87 @@
 describe('Submiting a decision dataset', () => {
-  // context('When I am logged in as an organisation-level user', () => {
-  //   beforeEach(() => {
-  //     cy.loginAuth0('orgeditor');
-  //     cy.visitInternalDashboard();
-  //     cy.translate('app.pages.admin.dashboard.editDecisionDataRegulators').then(
-  //       (link) => {
-  //         cy.get('a').contains(link).click();
-  //         cy.checkAccessibility();
-  //       },
-  //     );
-  //   });
+  context('When I am logged in as an organisation-level user', () => {
+    beforeEach(() => {
+      cy.loginAuth0('orgeditor');
+      cy.visitInternalDashboard();
+      cy.translate('app.pages.admin.dashboard.editDecisionDataRegulators').then(
+        (link) => {
+          cy.get('a').contains(link).click();
+          cy.checkAccessibility();
+        },
+      );
+    });
 
-  //   it('I can submit a draft decision dataset', () => {
-  //     cy.get('tr')
-  //       .contains(
-  //         'Secondary School Teacher in State maintained schools (England)',
-  //       )
-  //       .parent()
-  //       .within(() => {
-  //         cy.translate('app.status.draft').then((draft) => {
-  //           cy.contains(draft);
-  //         });
-  //         cy.get('a').contains('View details').click();
-  //       });
+    it('I can submit a draft decision dataset', () => {
+      cy.get('tr')
+        .contains(
+          'Secondary School Teacher in State maintained schools (England)',
+        )
+        .parent()
+        .within(() => {
+          cy.translate('app.status.draft').then((draft) => {
+            cy.contains(draft);
+          });
+          cy.get('a').contains('View details').click();
+        });
 
-  //     cy.translate('decisions.admin.buttons.submit').then((submitButton) => {
-  //       cy.get('a').contains(submitButton).click();
-  //     });
+      cy.translate('decisions.admin.buttons.submit').then((submitButton) => {
+        cy.get('a').contains(submitButton).click();
+      });
 
-  //     cy.checkAccessibility();
+      cy.checkAccessibility();
 
-  //     cy.translate('decisions.admin.submission.caption').then(
-  //       (submitCaption) => {
-  //         cy.get('body').contains(submitCaption);
-  //       },
-  //     );
+      cy.translate('decisions.admin.submission.caption').then(
+        (submitCaption) => {
+          cy.get('body').contains(submitCaption);
+        },
+      );
 
-  //     cy.translate('decisions.admin.submission.heading').then((heading) => {
-  //       cy.contains(heading);
-  //     });
+      cy.translate('decisions.admin.submission.heading').then((heading) => {
+        cy.contains(heading);
+      });
 
-  //     cy.contains(
-  //       'Secondary School Teacher in State maintained schools (England)',
-  //     );
-  //     cy.contains('2019');
+      cy.contains(
+        'Secondary School Teacher in State maintained schools (England)',
+      );
+      cy.contains('2019');
 
-  //     cy.translate('decisions.admin.buttons.submit').then((submitButton) => {
-  //       cy.get('button').contains(submitButton).click();
-  //     });
+      cy.translate('decisions.admin.buttons.submit').then((submitButton) => {
+        cy.get('button').contains(submitButton).click();
+      });
 
-  //     cy.checkAccessibility();
+      cy.checkAccessibility();
 
-  //     cy.translate('decisions.show.heading').then((heading) => {
-  //       cy.get('body').should('contain', heading);
-  //     });
+      cy.translate('decisions.show.heading').then((heading) => {
+        cy.get('body').should('contain', heading);
+      });
 
-  //     cy.translate('decisions.admin.submission.confirmation.heading').then(
-  //       (confirmationHeading) => {
-  //         cy.get('body').should('contain', confirmationHeading);
-  //       },
-  //     );
+      cy.translate('decisions.admin.submission.confirmation.heading').then(
+        (confirmationHeading) => {
+          cy.get('body').should('contain', confirmationHeading);
+        },
+      );
 
-  //     // Temporary check until we display the status on the "show" page
-  //     cy.visitAndCheckAccessibility('/admin/decisions');
+      // Temporary check until we display the status on the "show" page
+      cy.visitAndCheckAccessibility('/admin/decisions');
 
-  //     cy.get('tr')
-  //       .contains(
-  //         'Secondary School Teacher in State maintained schools (England)',
-  //       )
-  //       .parent()
-  //       .within(() => {
-  //         cy.translate('app.status.submitted').then((submitted) => {
-  //           cy.contains(submitted);
-  //           cy.get('a').contains('View details').click();
-  //         });
-  //       });
+      cy.get('tr')
+        .contains(
+          'Secondary School Teacher in State maintained schools (England)',
+        )
+        .parent()
+        .within(() => {
+          cy.translate('app.status.submitted').then((submitted) => {
+            cy.contains(submitted);
+            cy.get('a').contains('View details').click();
+          });
+        });
 
-  //     cy.checkAccessibility();
-  //     cy.translate('decisions.admin.buttons.submit').then((submit) => {
-  //       cy.get('a').should('not.contain', submit);
-  //     });
-  //   });
-  // });
+      cy.checkAccessibility();
+      cy.translate('decisions.admin.buttons.submit').then((submit) => {
+        cy.get('a').should('not.contain', submit);
+      });
+    });
+  });
 
   context('When I am logged in as a central admin user', () => {
     beforeEach(() => {

--- a/src/users/helpers/get-permissions-from-user.helper.ts
+++ b/src/users/helpers/get-permissions-from-user.helper.ts
@@ -60,7 +60,7 @@ const permissions = {
       UserPermission.UploadDecisionData,
       UserPermission.SubmitDecisionData,
       UserPermission.DownloadDecisionData,
-      // UserPermission.ViewDecisionData,
+      UserPermission.ViewDecisionData,
     ],
     [Role.Editor]: [
       UserPermission.EditOrganisation,
@@ -70,7 +70,7 @@ const permissions = {
       UserPermission.UploadDecisionData,
       UserPermission.SubmitDecisionData,
       UserPermission.DownloadDecisionData,
-      // UserPermission.ViewDecisionData,
+      UserPermission.ViewDecisionData,
     ],
   },
 };


### PR DESCRIPTION
Re-enable decisions data for other non-service owner users (revert changes previously made during initial re-enabling)