### PR TITLE
feat: add licence finder link to home page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Update references to BEIS to DBT in confirmation, accessibility, and i18n
 - Update privacy notice
 - Re-enable decision data for non-service owner roles in production
+- Change licence finder text wording
 
 ## [release-028] - 2023-05-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- Add link to Licence Finder to home page
+
 ### Changed
 
 - Update references to BEIS to DBT in confirmation, accessibility, and i18n

--- a/src/i18n/en/professions.json
+++ b/src/i18n/en/professions.json
@@ -282,7 +282,7 @@
     "licenceFinder": {
       "heading": "Licence Finder",
       "url": "https://www.gov.uk/licence-finder",
-      "body": "You may need other authorisations to carry out certain activities in the UK. Use the <a href=\"$t(professions.show.licenceFinder.url)\">Licence Finder</a> to help you search for and find the licences and permits you may need."
+      "body": "You may need licences and permits to carry out certain activities in the UK. These are called authorisations. Use the <a href=\"$t(professions.show.licenceFinder.url)\">licence finder</a> to find what you need."
     }
   },
   "admin": {

--- a/views/index.njk
+++ b/views/index.njk
@@ -43,6 +43,12 @@
 
       <p class="govuk-body">{{ "app.pages.index.help.body" | t | safe }}</p>
 
+      <h2 class="govuk-heading-m">{{ "professions.show.licenceFinder.heading" | t}}</h2>
+
+      <div class="govuk-body">  
+      {{ "professions.show.licenceFinder.body" | t | safe }}
+      </div>
+
       <p class="govuk-body">{{ "app.pages.index.help.feedback" | t({feedbackFormUrl: feedbackFormUrl}) | safe }}</p>
     </div>
   </div>


### PR DESCRIPTION
[AB#25257](https://dev.azure.com/BEIS-DevOps/e0e9004c-3b64-4ea2-b749-b121c401c881/_workitems/edit/25257)

# Changes in this PR
Add licence finder link to home page - this also includes changes the text on the professions page

## Screenshots of UI changes

### Before
![image](https://github.com/UKGovernmentBEIS/regulated-professions-register/assets/82883482/a7dd57ef-1c5a-40f7-b7d1-3ef7897d11cc)
![image](https://github.com/UKGovernmentBEIS/regulated-professions-register/assets/82883482/d765c349-3561-4a59-a1e4-4617e9ac710c)


### After
![image](https://github.com/UKGovernmentBEIS/regulated-professions-register/assets/82883482/93d4eb6b-0021-4033-a5bc-98375952c766)
![image](https://github.com/UKGovernmentBEIS/regulated-professions-register/assets/82883482/541f1965-df47-4cd8-9474-265d076efa14)


