### PR TITLE
refactor: update wording for links on home page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Update privacy notice
 - Re-enable decision data for non-service owner roles in production
 - Change licence finder text wording
+- Change link wording on home page
 
 ## [release-028] - 2023-05-11
 

--- a/src/i18n/en/app.json
+++ b/src/i18n/en/app.json
@@ -49,11 +49,11 @@
       "useThisService": {
         "heading": "You can use the Regulated Professions Register (RPR) service to: ",
         "checkProfessions": {
-          "text": "search a list of regulated professions and find out what qualifications or experience you may need to work",
+          "text": "search a list of regulated professions and find out what qualifications or experience you may need to work in the UK",
           "link": "/professions/search"
         },
         "findContactDetails": {
-          "text": "find contact details for the regulators of regulated profession in the UK",
+          "text": "find contact details for the regulators of regulated professions in the UK",
           "link": "/regulatory-authorities/search"
         }
       },


### PR DESCRIPTION
# Changes in this PR
[AB#25271](https://dev.azure.com/BEIS-DevOps/e0e9004c-3b64-4ea2-b749-b121c401c881/_workitems/edit/25271) - Update wording for links on the home page

## Screenshots of UI changes

### Before
![image](https://github.com/UKGovernmentBEIS/regulated-professions-register/assets/82883482/1557d081-209a-47a4-b99c-c591519c33cb)

### After
![image](https://github.com/UKGovernmentBEIS/regulated-professions-register/assets/82883482/680a8ac7-c5bf-4989-b645-6cfba32645ae)
