### PR TITLE
fix: add undefined status to newVersion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- Prevent duplication of live versions of organisation when editing
+
 ## [release-030] - 22/06/2023
 
 ### Added

--- a/src/organisations/organisation-versions.service.spec.ts
+++ b/src/organisations/organisation-versions.service.spec.ts
@@ -197,6 +197,7 @@ describe('OrganisationVersionsService', () => {
         user: user,
         created_at: undefined,
         updated_at: undefined,
+        status: undefined,
         organisation: version.organisation,
       });
     });

--- a/src/organisations/organisation-versions.service.ts
+++ b/src/organisations/organisation-versions.service.ts
@@ -49,6 +49,7 @@ export class OrganisationVersionsService {
       user: user,
       created_at: undefined,
       updated_at: undefined,
+      status: undefined,
     } as OrganisationVersion;
 
     return this.save(newVersion);


### PR DESCRIPTION
[AB#23774](https://dev.azure.com/BEIS-DevOps/e0e9004c-3b64-4ea2-b749-b121c401c881/_workitems/edit/23774)

Forces new "edit" versions to be "unconfirmed" to prevent the duplication of "live" versions