### PR TITLE
AB#28585 - Update link locations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- Update banner links; This includes a link to gov.uk and a link back to the DBT controlled landing page
+
 ## [release-033] - 03/08/2023
 
 ### Added

--- a/src/i18n/en/app.json
+++ b/src/i18n/en/app.json
@@ -1,5 +1,7 @@
 {
   "name": "Regulated Professions Register",
+  "govUkUrl": "https://gov.uk",
+  "externalUrl": "https://www.gov.uk/guidance/check-which-professions-are-regulated-in-the-uk",
   "superadmin": "You are a superadmin",
   "back": "Back",
   "backToSearch": "Back to search results",

--- a/views/admin/base.njk
+++ b/views/admin/base.njk
@@ -7,7 +7,7 @@
 {% block header %}
   {{
     govukHeader({
-      homepageUrl: "/admin/dashboard",
+      homepageUrl: ("app.govUkUrl" | t),
       serviceName: ("app.name" | t),
       serviceUrl: "/admin/dashboard",
       navigation: [

--- a/views/base.njk
+++ b/views/base.njk
@@ -10,11 +10,17 @@
 {% endblock %}
 
 {% block header %}
+  {% if environment === 'production' %}
+    {% set bannerUrl = ("app.externalUrl" | t) %}
+  {% else %}
+    {% set bannerUrl = "/" %}
+  {% endif %}
+  
   {{
     govukHeader({
-      homepageUrl: "/",
+      homepageUrl: ("app.govUkUrl" | t),
       serviceName: ("app.name" | t),
-      serviceUrl: "/"
+      serviceUrl:  (bannerUrl)
     })
   }}
 


### PR DESCRIPTION
# Changes in this PR
Change gov.uk image to link to https://gov.uk and change home page link (in public facing page) to DBT controlled URL "https://www.gov.uk/guidance/check-which-professions-are-regulated-in-the-uk"

## Screenshots of UI changes
No UI changes
