### PR TITLE
AB#28585 prevent external url from being rendered on staging

### DIFF
--- a/views/base.njk
+++ b/views/base.njk
@@ -10,7 +10,8 @@
 {% endblock %}
 
 {% block header %}
-  {% if environment === 'production' %}
+{# on staging, the "environment" var is set to "production". Because of this we need another way to check we're not on staging #}
+  {% if (environment === 'production') and (not site_domain.startsWith('staging')) %}
     {% set bannerUrl = ("app.externalUrl" | t) %}
   {% else %}
     {% set bannerUrl = "/" %}


### PR DESCRIPTION
This change only affects the staging environment.

It prevents the service URL redirecting to the DBT hosted environment.