### PR TITLE
AB#34784 Add user id tracking to data later for logged in users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- Added user ID to data layer for logged in user tracking in GTM
+
 ### Changed
 
 ## [release-040] - 19/02/2025

--- a/views/admin/base.njk
+++ b/views/admin/base.njk
@@ -5,6 +5,16 @@
 {% extends "base.njk" %}
 
 {% block header %}
+    <!-- GTM User ID Push -->
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      window.dataLayer.push({
+      'event' : 'login',
+      'userId' : '{{ user.id }}'
+    })
+    </script>
+  <!-- End GTM User ID Push -->
+
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
   new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],


### PR DESCRIPTION
# Changes in this PR
Add user.id to data layer to enable logged in user tracking

## Screenshots of UI changes

### Before
![image](https://github.com/user-attachments/assets/b800aed7-0892-456b-ac93-c1d1b7d999a2)

### After
![image](https://github.com/user-attachments/assets/7f55a399-3c61-4bae-bf80-5e1c32482fa2)
